### PR TITLE
fix: AWF_ENABLE_HOST_ACCESS safety net sets '1' instead of 'true'

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -1980,6 +1980,15 @@ describe('docker-manager', () => {
 
         expect(env.AWF_ENABLE_HOST_ACCESS).toBeUndefined();
       });
+
+      it('should set AWF_ENABLE_HOST_ACCESS to 1 via safety net when allowHostServicePorts is set without enableHostAccess', () => {
+        const config = { ...mockConfig, allowHostServicePorts: '5432,6379' };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        expect(env.AWF_ENABLE_HOST_ACCESS).toBe('1');
+        expect(env.AWF_HOST_SERVICE_PORTS).toBe('5432,6379');
+      });
     });
 
     describe('NO_PROXY baseline', () => {

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -1067,7 +1067,7 @@ export function generateDockerCompose(
     // Ensure host access is enabled (setup-iptables.sh requires AWF_ENABLE_HOST_ACCESS)
     // The CLI auto-enables this, but this is a safety net for programmatic usage
     if (!environment.AWF_ENABLE_HOST_ACCESS) {
-      environment.AWF_ENABLE_HOST_ACCESS = 'true';
+      environment.AWF_ENABLE_HOST_ACCESS = '1';
     }
   }
 


### PR DESCRIPTION
## Problem

The `allowHostServicePorts` safety net in `docker-manager.ts` (line 1070) was setting:
```typescript
environment.AWF_ENABLE_HOST_ACCESS = 'true';
```

But `containers/agent/entrypoint.sh:567` checks:
```bash
if [ "${AWF_ENABLE_HOST_ACCESS}" = "1" ]; then
```

This mismatch meant host access features silently failed when `allowHostServicePorts` was set without explicit `enableHostAccess`.

## Fix

Changed `'true'` → `'1'` to match the convention used everywhere else (the primary path at line 1603, `setup-iptables.sh`, and `entrypoint.sh`).

## Testing

- Added test: `should set AWF_ENABLE_HOST_ACCESS to 1 via safety net when allowHostServicePorts is set without enableHostAccess`
- All 383 existing tests pass (4 pre-existing failures unrelated to this change)

Fixes #1728