### PR TITLE
fix: remove sandbox.mcp.version from strict-mode workflows

### DIFF
--- a/.github/workflows/smoke-gemini.md
+++ b/.github/workflows/smoke-gemini.md
@@ -43,8 +43,6 @@ timeout-minutes: 5
 sandbox:
   agent:
     version: v0.25.29
-  mcp:
-    version: v0.3.1
 strict: true
 steps:
   - name: Pre-compute smoke test data

--- a/.github/workflows/smoke-opencode.md
+++ b/.github/workflows/smoke-opencode.md
@@ -19,8 +19,6 @@ engine:
 sandbox:
   agent:
     version: v0.25.29
-  mcp:
-    version: v0.3.1
 strict: true
 imports:
   - shared/gh.md

--- a/.github/workflows/smoke-services.md
+++ b/.github/workflows/smoke-services.md
@@ -38,8 +38,6 @@ timeout-minutes: 10
 sandbox:
   agent:
     version: v0.25.29
-  mcp:
-    version: v0.3.1
 strict: true
 steps:
   - name: Pre-install service client tools

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -11,8 +11,6 @@ permissions:
 sandbox:
   agent:
     version: v0.25.29
-  mcp:
-    version: v0.3.1
 tools:
   github:
     toolsets: [default]


### PR DESCRIPTION
Removes `sandbox.mcp.version` from 4 strict-mode workflows where it was incorrectly added (causes compilation error):

- `smoke-services.md`
- `smoke-gemini.md`  
- `smoke-opencode.md`
- `update-release-notes.md`

Only `sandbox.agent.version` is needed — mcpg version uses the compiler default in strict mode.