### PR TITLE
fix: block Shocker container-escape syscalls in seccomp profile (CVE-2014-9357)

### DIFF
--- a/containers/agent/seccomp-profile.json
+++ b/containers/agent/seccomp-profile.json
@@ -189,11 +189,9 @@
         "munlock",
         "munlockall",
         "munmap",
-        "name_to_handle_at",
         "nanosleep",
         "newfstatat",
         "open",
-        "open_by_handle_at",
         "openat",
         "openat2",
         "pause",
@@ -395,7 +393,9 @@
         "get_kernel_syms",
         "query_module",
         "create_module",
-        "nfsservctl"
+        "nfsservctl",
+        "name_to_handle_at",
+        "open_by_handle_at"
       ],
       "action": "SCMP_ACT_ERRNO",
       "errnoRet": 1,

--- a/src/seccomp-profile.test.ts
+++ b/src/seccomp-profile.test.ts
@@ -133,7 +133,8 @@ describe('seccomp-profile', () => {
       .filter(r => r.action === 'SCMP_ACT_ERRNO')
       .flatMap(r => r.names);
 
-    // Both syscalls must be explicitly denied, not just absent from allow list
+    // Explicitly listed in ERRNO rules for defense-in-depth regression protection
+    // (deny-by-default means absence alone would block them, but explicit denial is more robust)
     expect(blockedSyscalls).toContain('name_to_handle_at');
     expect(blockedSyscalls).toContain('open_by_handle_at');
     expect(allowedSyscalls.has('name_to_handle_at')).toBe(false);

--- a/src/seccomp-profile.test.ts
+++ b/src/seccomp-profile.test.ts
@@ -79,6 +79,7 @@ describe('seccomp-profile', () => {
       'pivot_root', 'umount', 'umount2',
       'swapon', 'swapoff', 'syslog',
       'add_key', 'request_key', 'keyctl',
+      'name_to_handle_at', 'open_by_handle_at',
     ];
 
     for (const syscall of dangerousSyscalls) {
@@ -119,6 +120,24 @@ describe('seccomp-profile', () => {
     for (const blocked of blockedSyscalls) {
       expect(allowedSyscalls.has(blocked)).toBe(false);
     }
+  });
+
+  test('should block Shocker container-escape syscalls (CVE-2014-9357)', () => {
+    const allowedSyscalls = new Set(
+      profile.syscalls
+        .filter(r => r.action === 'SCMP_ACT_ALLOW')
+        .flatMap(r => r.names)
+    );
+
+    const blockedSyscalls = profile.syscalls
+      .filter(r => r.action === 'SCMP_ACT_ERRNO')
+      .flatMap(r => r.names);
+
+    // Both syscalls must be explicitly denied, not just absent from allow list
+    expect(blockedSyscalls).toContain('name_to_handle_at');
+    expect(blockedSyscalls).toContain('open_by_handle_at');
+    expect(allowedSyscalls.has('name_to_handle_at')).toBe(false);
+    expect(allowedSyscalls.has('open_by_handle_at')).toBe(false);
   });
 
   test('should have valid JSON structure', () => {


### PR DESCRIPTION
## Summary

Removes `name_to_handle_at` (NR 303) and `open_by_handle_at` (NR 304) from the seccomp ALLOW list and adds them to the ERRNO deny list, matching Docker's default seccomp hardening posture.

## Problem

The [Shocker container-escape attack](https://blog.docker.com/2014/11/docker-1-3-1-security-and-bugfixes/) (CVE-2014-9357) uses `name_to_handle_at` to obtain a raw inode handle and `open_by_handle_at` to open it in a privileged context, escaping the container namespace. Docker's default seccomp profile blocks both syscalls for exactly this reason.

Our custom seccomp profile previously allowed both syscalls, relying solely on the capability bounding set (missing `CAP_DAC_READ_SEARCH`) as a single defense layer. While effective today, any future configuration drift — capability grant, privilege escalation, or kernel bypass — would leave the escape path fully open.

## Changes

- **`containers/agent/seccomp-profile.json`**: Moved `name_to_handle_at` and `open_by_handle_at` from SCMP_ACT_ALLOW to SCMP_ACT_ERRNO
- **`src/seccomp-profile.test.ts`**: Added dedicated test for Shocker syscalls + added both to the existing dangerous-syscalls assertions

## Defense-in-depth

With this change, the Shocker attack chain is blocked at **two independent layers**:
1. **Seccomp** — kernel refuses the syscalls (EPERM)
2. **Capabilities** — `CAP_DAC_READ_SEARCH` absent from bounding set

Closes #2265