### PR TITLE
fix: wire MCP gateway into Gemini CLI settings (localhost)

### DIFF
--- a/.github/workflows/smoke-gemini.lock.yml
+++ b/.github/workflows/smoke-gemini.lock.yml
@@ -691,6 +691,22 @@ jobs:
           else
             echo "$BASE_CONFIG" > "$SETTINGS"
           fi
+
+          # Fix MCP gateway URLs: Gemini runs on the host (not in a container),
+          # so host.docker.internal doesn't resolve. Replace with localhost.
+          if [ -f "$SETTINGS" ] && grep -q "host.docker.internal" "$SETTINGS"; then
+            sed -i 's|host\.docker\.internal|localhost|g' "$SETTINGS"
+            echo "Replaced host.docker.internal with localhost in Gemini settings"
+          fi
+
+          # Ensure MCP servers are trusted (auto-approve tool calls in --yolo mode)
+          if [ -f "$SETTINGS" ] && jq -e '.mcpServers' "$SETTINGS" > /dev/null 2>&1; then
+            jq '.mcpServers |= with_entries(.value.trust = true)' "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
+            echo "Set trust=true on all MCP servers"
+          fi
+
+          echo "Final Gemini settings:"
+          cat "$SETTINGS"
         env:
           GH_AW_GEMINI_BASE_CONFIG: '{"context":{"includeDirectories":["/tmp/"]},"tools":{"core":["glob","grep_search","list_directory","read_file","read_many_files","run_shell_command"]}}'
       - name: Execute Gemini CLI


### PR DESCRIPTION
## Problem

The smoke-gemini workflow fails at "Validate safe outputs were invoked" because Gemini CLI can't reach MCP tools (github, safeoutputs).

**Root cause**: The MCP gateway correctly writes MCP server config to `.gemini/settings.json` with URLs like `http://host.docker.internal:8080/mcp/github`. However, `host.docker.internal` only resolves inside Docker containers. Unlike Claude (which runs inside AWF), **Gemini runs directly on the host runner** where `host.docker.internal` doesn't resolve.

The gateway log shows it wrote the config:
```
[info] Gemini configuration written to .gemini/settings.json
[info] "github": { "url": "http://host.docker.internal:8080/mcp/github" }
[info] "safeoutputs": { "url": "http://host.docker.internal:8080/mcp/safeoutputs" }
```

But Gemini reported: `MCP issues detected. Run /mcp list for status.`

## Fix

Modifies the "Write Gemini Config" step in the lock file to:
1. **Replace `host.docker.internal` with `localhost`** in MCP server URLs
2. **Set `trust: true`** on MCP servers for yolo mode compatibility
3. **Log final settings** for debugging

## Note

This is a **manual lock file patch** to test the diagnosis. The proper fix belongs in gh-aw's Gemini engine compiler. If this works, we should file a gh-aw issue.

## Failed run
https://github.com/github/gh-aw-firewall/actions/runs/25259025540