### PR TITLE
fix: remove unused exports from public API surface

### DIFF
--- a/src/api-proxy-config.ts
+++ b/src/api-proxy-config.ts
@@ -8,7 +8,7 @@ import {
 /**
  * Result of validating API proxy configuration
  */
-export interface ApiProxyValidationResult {
+interface ApiProxyValidationResult {
   /** Whether the API proxy should be enabled */
   enabled: boolean;
   /** Warning messages to display */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ export {
   DEFAULT_GEMINI_API_TARGET,
   DEFAULT_COPILOT_API_TARGET,
 } from './domain-utils';
-export type { AgentImageResult } from './domain-utils';
+
 
 // Re-export API proxy config (extracted to api-proxy-config.ts)
 export {
@@ -61,7 +61,7 @@ export {
   extractGhesDomainsFromEngineApiTarget,
   resolveApiTargetsToAllowedDomains,
 } from './api-proxy-config';
-export type { ApiProxyValidationResult } from './api-proxy-config';
+
 
 // Re-export option parsers (extracted to option-parsers.ts)
 export {
@@ -87,7 +87,7 @@ export {
   parseVolumeMounts,
   formatItem,
 } from './option-parsers';
-export type { FlagValidationResult, LocalhostProcessingResult } from './option-parsers';
+
 
 /**
  * Default DNS servers (Google Public DNS)

--- a/src/commands/logs-command-helpers.ts
+++ b/src/commands/logs-command-helpers.ts
@@ -19,7 +19,7 @@ import { formatStats } from '../logs/stats-formatter';
 /**
  * Options for determining which logs to show (based on log level)
  */
-export interface LoggingOptions {
+interface LoggingOptions {
   /** The output format being used */
   format: LogStatsFormat;
   /** Callback to determine if info logs should be shown */
@@ -124,7 +124,7 @@ export function findPolicyManifestForSource(source: LogSource): PolicyManifest |
  * @param source - Log source to load from
  * @returns Aggregated statistics
  */
-export async function loadLogsWithErrorHandling(
+async function loadLogsWithErrorHandling(
   source: LogSource
 ): Promise<AggregatedStats> {
   try {

--- a/src/commands/logs-stats.ts
+++ b/src/commands/logs-stats.ts
@@ -8,7 +8,7 @@ import { runLogsCommand } from './logs-command-helpers';
 /**
  * Output format type for stats command (alias for shared type)
  */
-export type StatsFormat = LogStatsFormat;
+type StatsFormat = LogStatsFormat;
 
 /**
  * Options for the stats command

--- a/src/commands/logs-summary.ts
+++ b/src/commands/logs-summary.ts
@@ -11,7 +11,7 @@ import { runLogsCommand } from './logs-command-helpers';
 /**
  * Output format type for summary command (alias for shared type)
  */
-export type SummaryFormat = LogStatsFormat;
+type SummaryFormat = LogStatsFormat;
 
 /**
  * Options for the summary command

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -16,7 +16,7 @@ import {
 /**
  * Options for the logs command
  */
-export interface LogsCommandOptions {
+interface LogsCommandOptions {
   /** Follow log output in real-time */
   follow?: boolean;
   /** Output format: raw, pretty, json */

--- a/src/domain-patterns.ts
+++ b/src/domain-patterns.ts
@@ -29,12 +29,12 @@ export const SQUID_DANGEROUS_CHARS = /[\s\0"'`;#]/;
 /**
  * Protocol restriction for a domain
  */
-export type DomainProtocol = 'http' | 'https' | 'both';
+type DomainProtocol = 'http' | 'https' | 'both';
 
 /**
  * Parsed domain with protocol information
  */
-export interface ParsedDomain {
+interface ParsedDomain {
   /** The domain name without protocol prefix */
   domain: string;
   /** Which protocol(s) are allowed */
@@ -243,7 +243,7 @@ export interface PlainDomainEntry {
   protocol: DomainProtocol;
 }
 
-export interface ParsedDomainList {
+interface ParsedDomainList {
   /** Plain domains without wildcards */
   plainDomains: PlainDomainEntry[];
   /** Wildcard patterns with regex */

--- a/src/domain-utils.ts
+++ b/src/domain-utils.ts
@@ -146,7 +146,7 @@ export function validateAgentImage(image: string): { valid: boolean; error?: str
 /**
  * Result of processing the agent image option
  */
-export interface AgentImageResult {
+interface AgentImageResult {
   /** The resolved agent image value */
   agentImage: string;
   /** Whether this is a preset (default, act) or custom image */

--- a/src/image-tag.ts
+++ b/src/image-tag.ts
@@ -1,8 +1,8 @@
 export const IMAGE_DIGEST_KEYS = ['squid', 'agent', 'agent-act', 'api-proxy', 'cli-proxy'] as const;
 
-export type ImageDigestKey = typeof IMAGE_DIGEST_KEYS[number];
+type ImageDigestKey = typeof IMAGE_DIGEST_KEYS[number];
 
-export interface ParsedImageTag {
+interface ParsedImageTag {
   tag: string;
   digests: Partial<Record<ImageDigestKey, string>>;
 }

--- a/src/logs/index.ts
+++ b/src/logs/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { parseLogLine, extractDomain, extractPort } from './log-parser';
-export { LogFormatter, LogFormatterOptions } from './log-formatter';
+export { LogFormatter } from './log-formatter';
 export {
   discoverLogSources,
   selectMostRecent,
@@ -11,7 +11,7 @@ export {
   validateSource,
   listLogSources,
 } from './log-discovery';
-export { streamLogs, StreamOptions } from './log-streamer';
+export { streamLogs } from './log-streamer';
 export {
   aggregateLogs,
   loadAllLogs,

--- a/src/logs/log-formatter.ts
+++ b/src/logs/log-formatter.ts
@@ -8,7 +8,7 @@ import { ParsedLogEntry, OutputFormat, EnhancedLogEntry } from '../types';
 /**
  * Options for log formatting
  */
-export interface LogFormatterOptions {
+interface LogFormatterOptions {
   /** Output format */
   format: OutputFormat;
   /** Whether to colorize output (for pretty format). Defaults to true if stdout is TTY */

--- a/src/logs/log-streamer.ts
+++ b/src/logs/log-streamer.ts
@@ -15,7 +15,7 @@ import { trackPidForPortSync, isPidTrackingAvailable } from '../pid-tracker';
 /**
  * Options for streaming logs
  */
-export interface StreamOptions {
+interface StreamOptions {
   /** Follow log output in real-time (like tail -f) */
   follow: boolean;
   /** Log source to stream from */

--- a/src/option-parsers.ts
+++ b/src/option-parsers.ts
@@ -80,7 +80,7 @@ export function validateEnableOpenCodeFlag(enableApiProxy: boolean, enableOpenCo
 /**
  * Result of validating flag combinations
  */
-export interface FlagValidationResult {
+interface FlagValidationResult {
   /** Whether the validation passed */
   valid: boolean;
   /** Error message if validation failed */
@@ -353,7 +353,7 @@ export function parseDnsOverHttps(
 /**
  * Result of processing the localhost keyword in allowed domains
  */
-export interface LocalhostProcessingResult {
+interface LocalhostProcessingResult {
   /** Updated array of allowed domains with localhost replaced by host.docker.internal */
   allowedDomains: string[];
   /** Whether the localhost keyword was found and processed */

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -11,7 +11,7 @@ import * as yaml from 'js-yaml';
 /**
  * A single domain rule within a ruleset
  */
-export interface Rule {
+interface Rule {
   /** Domain name to allow (e.g., "github.com") */
   domain: string;
   /**


### PR DESCRIPTION
## Summary

Remove `export` keywords from symbols that are never imported externally, reducing the public API surface and preventing unintended coupling across 11 files.

### Symbols un-exported (18 total)

| Symbol | File |
|--------|------|
| `LogsCommandOptions` | `src/commands/logs.ts` |
| `StreamOptions` | `src/logs/log-streamer.ts` + re-export in `src/logs/index.ts` |
| `ParsedDomainList` | `src/domain-patterns.ts` |
| `DomainProtocol`, `ParsedDomain` | `src/domain-patterns.ts` |
| `Rule` | `src/rules.ts` |
| `ImageDigestKey`, `ParsedImageTag` | `src/image-tag.ts` |
| `AgentImageResult`, `ApiProxyValidationResult`, `FlagValidationResult`, `LocalhostProcessingResult` | `src/cli.ts` |
| `StatsFormat` | `src/commands/logs-stats.ts` |
| `SummaryFormat` | `src/commands/logs-summary.ts` |
| `LoggingOptions`, `loadLogsWithErrorHandling` | `src/commands/logs-command-helpers.ts` |
| `LogFormatterOptions` | `src/logs/log-formatter.ts` + re-export in `src/logs/index.ts` |

### Skipped (verified as imported externally)

- `SslConfig` (#2490) — imported by `container-lifecycle.ts`, `compose-generator.ts`
- `DockerService`/`DockerNetwork` (#2489) — re-exported from `types/index.ts`
- pid-tracker helpers (#2491) — imported by test files
- `discoverAndSelectSource`/`findPolicyManifestForSource` (#2488 partial) — imported by `logs-audit.ts`

### Verification

- `npm run build` ✅
- `npm test` ✅ (6 pre-existing failures, no new failures)

Closes #2488, closes #2492, closes #2499, closes #2500, closes #2502, closes #2504, closes #2505