### PR TITLE
fix: unexport internal helpers from ssl-bump and host-iptables

### DIFF
--- a/src/host-iptables.test.ts
+++ b/src/host-iptables.test.ts
@@ -1,4 +1,4 @@
-import { ensureFirewallNetwork, setupHostIptables, cleanupHostIptables, cleanupFirewallNetwork, _resetIpv6State, HostAccessConfig, isValidPortSpec } from './host-iptables';
+import { ensureFirewallNetwork, setupHostIptables, cleanupHostIptables, cleanupFirewallNetwork, __testing, HostAccessConfig, isValidPortSpec } from './host-iptables';
 import execa from 'execa';
 
 // Mock execa
@@ -24,7 +24,7 @@ jest.mock('./logger', () => ({
 describe('host-iptables', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    _resetIpv6State();
+    __testing._resetIpv6State();
   });
 
   describe('ensureFirewallNetwork', () => {

--- a/src/host-iptables.ts
+++ b/src/host-iptables.ts
@@ -56,10 +56,13 @@ let ipv6DisabledViaSysctl = false;
 /**
  * Resets internal IPv6 state (for testing only).
  */
-export function _resetIpv6State(): void {
+function _resetIpv6State(): void {
   ip6tablesAvailableCache = null;
   ipv6DisabledViaSysctl = false;
 }
+
+// Exposed for testing only — not part of public API
+export const __testing = { _resetIpv6State };
 
 /**
  * Gets the bridge interface name for the firewall network
@@ -85,7 +88,7 @@ async function getNetworkBridgeName(): Promise<string | null> {
  * Gets the Docker default bridge gateway IP (e.g., 172.17.0.1).
  * This is the IP that host.docker.internal resolves to inside containers.
  */
-export async function getDockerBridgeGateway(): Promise<string | null> {
+async function getDockerBridgeGateway(): Promise<string | null> {
   try {
     const { stdout } = await execa('docker', [
       'network', 'inspect', 'bridge',

--- a/src/host-iptables.ts
+++ b/src/host-iptables.ts
@@ -61,8 +61,10 @@ function _resetIpv6State(): void {
   ipv6DisabledViaSysctl = false;
 }
 
-// Exposed for testing only — not part of public API
-export const __testing = { _resetIpv6State };
+/**
+ * @internal Exported for testing.
+ */
+export const __testing = Object.freeze({ _resetIpv6State });
 
 /**
  * Gets the bridge interface name for the firewall network

--- a/src/ssl-bump.ts
+++ b/src/ssl-bump.ts
@@ -52,7 +52,7 @@ export interface CaFiles {
  * @param sslDir - Directory path to mount tmpfs on
  * @returns true if tmpfs was mounted, false if fallback to disk
  */
-export async function mountSslTmpfs(sslDir: string): Promise<boolean> {
+async function mountSslTmpfs(sslDir: string): Promise<boolean> {
   try {
     // Mount tmpfs with restrictive options (4MB is more than enough for SSL keys)
     await execa('mount', [


### PR DESCRIPTION
## Summary

Removes unnecessary exports from internal helper functions in security-critical modules.

### Changes

1. **`mountSslTmpfs`** (`src/ssl-bump.ts`): Removed `export` — only called within the same file
2. **`getDockerBridgeGateway`** (`src/host-iptables.ts`): Removed `export` — only called within the same file
3. **`_resetIpv6State`** (`src/host-iptables.ts`): Moved behind `__testing` namespace — removes direct export of a mutable state reset function from the public API while preserving test access

### Verification

- `npm run build` ✅
- `host-iptables.test.ts` — 37 tests pass ✅
- `ssl-bump.test.ts` — 39 tests pass ✅

Closes #2524
Closes #2531