### PR TITLE
docs: add billing bug warning for retired releases v0.25.21–v0.25.39

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Agentic Workflow Firewall
 
+> [!WARNING]
+> Releases v0.25.21 through v0.25.39 were retired due to a bug that impacted billing. If you are running one of these versions, please upgrade to the latest release as soon as possible.
+
 A network firewall for agentic workflows that restricts outbound HTTP/HTTPS to an allowlist of domains.
 
 > [!TIP]


### PR DESCRIPTION
Adds a prominent warning banner at the top of the README advising users on retired releases v0.25.21 through v0.25.39 to upgrade due to a billing-impacting bug.