### PR TITLE
refactor: eliminate duplicate code patterns

### DIFF
--- a/containers/agent/one-shot-token/one-shot-token.c
+++ b/containers/agent/one-shot-token/one-shot-token.c
@@ -338,7 +338,15 @@ static char *cache_and_unset_token(int token_idx, const char *name, char *result
         /* Cache the value so subsequent reads succeed after unsetenv */
         /* Note: This memory is intentionally never freed - it must persist
          * for the lifetime of the process */
-        token_cache[token_idx] = strdup(result);
+        char *cached = strdup(result);
+        if (cached == NULL) {
+            fprintf(stderr, "[one-shot-token] Failed to cache token %s: out of memory\n", name);
+            /* Still unset and mark as accessed, but return NULL to signal failure */
+            unsetenv(name);
+            token_accessed[token_idx] = 1;
+            return NULL;
+        }
+        token_cache[token_idx] = cached;
 
         /* Unset the variable from the environment so /proc/self/environ is cleared */
         unsetenv(name);

--- a/containers/agent/one-shot-token/one-shot-token.c
+++ b/containers/agent/one-shot-token/one-shot-token.c
@@ -327,6 +327,35 @@ static int get_token_index(const char *name) {
  *
  * For all other variables: passes through to real getenv
  */
+
+/**
+ * Shared cache-and-unset logic for sensitive token interception.
+ * Caches the value, removes it from the environment, logs if debug is on,
+ * and marks the token as accessed. Must be called with token_mutex held.
+ */
+static char *cache_and_unset_token(int token_idx, const char *name, char *result, const char *via_suffix) {
+    if (result != NULL) {
+        /* Cache the value so subsequent reads succeed after unsetenv */
+        /* Note: This memory is intentionally never freed - it must persist
+         * for the lifetime of the process */
+        token_cache[token_idx] = strdup(result);
+
+        /* Unset the variable from the environment so /proc/self/environ is cleared */
+        unsetenv(name);
+
+        if (debug_enabled) {
+            fprintf(stderr, "[one-shot-token] Token %s accessed and cached (length: %zu)%s\n",
+                    name, strlen(token_cache[token_idx]), via_suffix);
+        }
+
+        result = token_cache[token_idx];
+    }
+
+    /* Mark as accessed even if NULL (prevents repeated log messages) */
+    token_accessed[token_idx] = 1;
+    return result;
+}
+
 __attribute__((visibility("default")))
 char *getenv(const char *name) {
     ensure_real_getenv();
@@ -354,26 +383,7 @@ char *getenv(const char *name) {
     if (!token_accessed[token_idx]) {
         /* First access - get the real value and cache it */
         result = real_getenv(name);
-
-        if (result != NULL) {
-            /* Cache the value so subsequent reads succeed after unsetenv */
-            /* Note: This memory is intentionally never freed - it must persist
-             * for the lifetime of the process */
-            token_cache[token_idx] = strdup(result);
-
-            /* Unset the variable from the environment so /proc/self/environ is cleared */
-            unsetenv(name);
-
-            if (debug_enabled) {
-                fprintf(stderr, "[one-shot-token] Token %s accessed and cached (length: %zu)\n",
-                        name, strlen(token_cache[token_idx]));
-            }
-
-            result = token_cache[token_idx];
-        }
-
-        /* Mark as accessed even if NULL (prevents repeated log messages) */
-        token_accessed[token_idx] = 1;
+        result = cache_and_unset_token(token_idx, name, result, "");
     } else {
         /* Already accessed - return cached value */
         result = token_cache[token_idx];
@@ -428,26 +438,7 @@ char *secure_getenv(const char *name) {
     if (!token_accessed[token_idx]) {
         /* First access - get the real value using secure_getenv */
         result = real_secure_getenv(name);
-
-        if (result != NULL) {
-            /* Cache the value so subsequent reads succeed after unsetenv */
-            /* Note: This memory is intentionally never freed - it must persist
-             * for the lifetime of the process */
-            token_cache[token_idx] = strdup(result);
-
-            /* Unset the variable from the environment so /proc/self/environ is cleared */
-            unsetenv(name);
-
-            if (debug_enabled) {
-                fprintf(stderr, "[one-shot-token] Token %s accessed and cached (length: %zu) (via secure_getenv)\n",
-                        name, strlen(token_cache[token_idx]));
-            }
-
-            result = token_cache[token_idx];
-        }
-
-        /* Mark as accessed even if NULL (prevents repeated log messages) */
-        token_accessed[token_idx] = 1;
+        result = cache_and_unset_token(token_idx, name, result, " (via secure_getenv)");
     } else {
         /* Already accessed - return cached value */
         result = token_cache[token_idx];

--- a/src/compose-generator.test.ts
+++ b/src/compose-generator.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/compose-generator.test.ts
+++ b/src/compose-generator.test.ts
@@ -6,15 +6,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/copilot-api-resolver.ts
+++ b/src/copilot-api-resolver.ts
@@ -9,12 +9,10 @@ export function resolveCopilotApiKey(
 }
 
 /**
- * Derive a Copilot API target hostname from COPILOT_PROVIDER_BASE_URL.
- * Returns undefined when the value is empty or not a valid URL/host.
+ * Parse a provider base URL into a URL object, handling missing schemes.
+ * Returns undefined if the input is empty or unparseable.
  */
-export function deriveCopilotApiTargetFromProviderBaseUrl(
-  providerBaseUrl: string | undefined
-): string | undefined {
+function parseProviderBaseUrl(providerBaseUrl: string | undefined): URL | undefined {
   const trimmed = providerBaseUrl?.trim();
   if (!trimmed) return undefined;
 
@@ -23,10 +21,20 @@ export function deriveCopilotApiTargetFromProviderBaseUrl(
     : `https://${trimmed}`;
 
   try {
-    return new URL(candidate).hostname || undefined;
+    return new URL(candidate);
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Derive a Copilot API target hostname from COPILOT_PROVIDER_BASE_URL.
+ * Returns undefined when the value is empty or not a valid URL/host.
+ */
+export function deriveCopilotApiTargetFromProviderBaseUrl(
+  providerBaseUrl: string | undefined
+): string | undefined {
+  return parseProviderBaseUrl(providerBaseUrl)?.hostname || undefined;
 }
 
 /**
@@ -36,20 +44,12 @@ export function deriveCopilotApiTargetFromProviderBaseUrl(
 export function deriveCopilotApiBasePathFromProviderBaseUrl(
   providerBaseUrl: string | undefined
 ): string | undefined {
-  const trimmed = providerBaseUrl?.trim();
-  if (!trimmed) return undefined;
+  const url = parseProviderBaseUrl(providerBaseUrl);
+  if (!url) return undefined;
 
-  const candidate = trimmed.includes('://')
-    ? trimmed
-    : `https://${trimmed}`;
-
-  try {
-    const pathname = new URL(candidate).pathname.replace(/\/+$/, '');
-    if (!pathname || pathname === '/') return undefined;
-    return pathname.startsWith('/') ? pathname : `/${pathname}`;
-  } catch {
-    return undefined;
-  }
+  const pathname = url.pathname.replace(/\/+$/, '');
+  if (!pathname || pathname === '/') return undefined;
+  return pathname.startsWith('/') ? pathname : `/${pathname}`;
 }
 
 /**

--- a/src/docker-manager-cleanup.test.ts
+++ b/src/docker-manager-cleanup.test.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 
 // Mock execa module
 import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 describe('docker-manager writeConfigs and cleanup', () => {

--- a/src/docker-manager-cleanup.test.ts
+++ b/src/docker-manager-cleanup.test.ts
@@ -5,15 +5,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Create mock functions
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 describe('docker-manager writeConfigs and cleanup', () => {
   describe('writeConfigs', () => {

--- a/src/docker-manager-lifecycle.test.ts
+++ b/src/docker-manager-lifecycle.test.ts
@@ -7,7 +7,8 @@ import * as os from 'os';
 // Create mock functions
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+import { mockExecaFn } from './test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 describe('docker-manager lifecycle', () => {

--- a/src/docker-manager-lifecycle.test.ts
+++ b/src/docker-manager-lifecycle.test.ts
@@ -5,15 +5,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Create mock functions
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 describe('docker-manager lifecycle', () => {
   describe('startContainers', () => {

--- a/src/docker-manager-utils.test.ts
+++ b/src/docker-manager-utils.test.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 // Create mock functions
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 describe('docker-manager utilities', () => {

--- a/src/docker-manager-utils.test.ts
+++ b/src/docker-manager-utils.test.ts
@@ -4,15 +4,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Create mock functions
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
 describe('docker-manager utilities', () => {
   describe('subnetsOverlap', () => {

--- a/src/services/agent-environment.test.ts
+++ b/src/services/agent-environment.test.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/agent-environment.test.ts
+++ b/src/services/agent-environment.test.ts
@@ -6,15 +6,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -6,15 +6,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/services/agent-volumes.test.ts
+++ b/src/services/agent-volumes.test.ts
@@ -6,15 +6,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/services/agent-volumes.test.ts
+++ b/src/services/agent-volumes.test.ts
@@ -8,7 +8,8 @@ import * as os from 'os';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+import { mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/api-proxy-service.test.ts
+++ b/src/services/api-proxy-service.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/api-proxy-service.test.ts
+++ b/src/services/api-proxy-service.test.ts
@@ -6,15 +6,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/services/cli-proxy-service.test.ts
+++ b/src/services/cli-proxy-service.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/cli-proxy-service.test.ts
+++ b/src/services/cli-proxy-service.test.ts
@@ -6,15 +6,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/services/doh-proxy-service.test.ts
+++ b/src/services/doh-proxy-service.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/doh-proxy-service.test.ts
+++ b/src/services/doh-proxy-service.test.ts
@@ -6,15 +6,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/services/squid-service.test.ts
+++ b/src/services/squid-service.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
 
 // Mock execa module
-import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;

--- a/src/services/squid-service.test.ts
+++ b/src/services/squid-service.test.ts
@@ -6,15 +6,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Create mock functions (must remain per-file — jest.mock() is hoisted before imports)
-const mockExecaFn = jest.fn();
-const mockExecaSync = jest.fn();
 
 // Mock execa module
-jest.mock('execa', () => {
-  const fn = (...args: any[]) => mockExecaFn(...args);
-  fn.sync = (...args: any[]) => mockExecaSync(...args);
-  return fn;
-});
+import { mockExecaFn, mockExecaSync } from '../test-helpers/mock-execa.test-utils';
+jest.mock('execa', () => require('../test-helpers/mock-execa.test-utils').execaMockFactory());
 
 let mockConfig: WrapperConfig;
 

--- a/src/test-helpers/mock-execa.test-utils.ts
+++ b/src/test-helpers/mock-execa.test-utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared jest.mock factory for the 'execa' module.
+ *
+ * Usage in test files:
+ *   import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
+ *   jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
+ */
+
+export const mockExecaFn = jest.fn();
+export const mockExecaSync = jest.fn();
+
+export function execaMockFactory() {
+  const fn = (...args: any[]) => mockExecaFn(...args);
+  fn.sync = (...args: any[]) => mockExecaSync(...args);
+  return fn;
+}


### PR DESCRIPTION
## Summary

Addresses three duplicate code issues with minimal, focused extractions:

### 1. Shared execa mock factory (#2673)
Creates `src/test-helpers/mock-execa.test-utils.ts` with a reusable `execaMockFactory()` and shared `mockExecaFn`/`mockExecaSync` instances. Updates 12 test files that previously copy-pasted an identical 7-line mock block.

### 2. URL normalization helper (#2674)
Extracts `parseProviderBaseUrl()` in `src/copilot-api-resolver.ts` — the two `derive*` functions shared an identical 7-line URL parsing prologue (trim, scheme injection, `new URL()`).

### 3. Token cache helper in C (#2675)
Extracts `cache_and_unset_token()` in `containers/agent/one-shot-token/one-shot-token.c` — the 18-line cache-store/unsetenv/log/mark-accessed tail was duplicated between `getenv` and `secure_getenv`.

### Verification
- ✅ Build passes (`npm run build`)
- ✅ All tests pass (pre-existing macOS-specific failures only)
- Net reduction: 48 lines removed

Closes #2673
Closes #2674
Closes #2675