### PR TITLE
fix: remove unused exported interfaces from services and pid-tracker

### DIFF
--- a/src/pid-tracker.ts
+++ b/src/pid-tracker.ts
@@ -31,7 +31,7 @@ export { PidTrackResult } from './types';
 /**
  * Parsed entry from /proc/net/tcp
  */
-export interface NetTcpEntry {
+interface NetTcpEntry {
   /** Local IP address in hex format */
   localAddressHex: string;
   /** Local port number */

--- a/src/services/agent-environment.ts
+++ b/src/services/agent-environment.ts
@@ -21,7 +21,7 @@ import { NetworkConfig } from './squid-service';
 
 // ─── Agent Environment ────────────────────────────────────────────────────────
 
-export interface AgentEnvironmentParams {
+interface AgentEnvironmentParams {
   config: WrapperConfig;
   networkConfig: NetworkConfig;
   dnsServers: string[];

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -12,13 +12,13 @@ import { logger } from '../logger';
 import { WrapperConfig } from '../types';
 import { NetworkConfig, ImageBuildConfig } from './squid-service';
 
-// Re-export for backwards compatibility
-export { AgentEnvironmentParams, buildAgentEnvironment } from './agent-environment';
-export { AgentVolumesParams, buildAgentVolumes } from './agent-volumes';
+// Re-export functions for backwards compatibility
+export { buildAgentEnvironment } from './agent-environment';
+export { buildAgentVolumes } from './agent-volumes';
 
 // ─── Agent Service ────────────────────────────────────────────────────────────
 
-export interface AgentServiceParams {
+interface AgentServiceParams {
   config: WrapperConfig;
   networkConfig: NetworkConfig;
   environment: Record<string, string>;
@@ -201,7 +201,7 @@ export function buildAgentService(params: AgentServiceParams): any {
 
 // ─── iptables-init Service ────────────────────────────────────────────────────
 
-export interface IptablesInitServiceParams {
+interface IptablesInitServiceParams {
   agentService: any;
   environment: Record<string, string>;
   networkConfig: NetworkConfig;

--- a/src/services/agent-volumes.ts
+++ b/src/services/agent-volumes.ts
@@ -7,7 +7,7 @@ import { WrapperConfig } from '../types';
 
 // ─── Agent Volumes ────────────────────────────────────────────────────────────
 
-export interface AgentVolumesParams {
+interface AgentVolumesParams {
   config: WrapperConfig;
   sslConfig?: SslConfig;
   effectiveHome: string;


### PR DESCRIPTION
## Summary

Removes 5 unnecessarily exported interfaces that were only used internally within their own modules.

### Changes

- **`src/pid-tracker.ts`**: `NetTcpEntry` → unexported (used only by `parseNetTcp` and `findInodeForPort` internally)
- **`src/services/agent-service.ts`**: `AgentServiceParams`, `IptablesInitServiceParams` → unexported
- **`src/services/agent-volumes.ts`**: `AgentVolumesParams` → unexported
- **`src/services/agent-environment.ts`**: `AgentEnvironmentParams` → unexported
- Removed `*Params` type re-exports from the agent-service barrel

### Verification

- `npm run build` ✅
- 181 related tests pass ✅

Closes #2694, closes #2695