### PR TITLE
docs: add missing apiProxy CLI mappings and sync schema descriptions

### DIFF
--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -97,7 +97,7 @@ the corresponding CLI flag.
 - `apiProxy.enabled` → `--enable-api-proxy`
 - `apiProxy.enableOpenCode` → `--enable-opencode`
 - `apiProxy.anthropicAutoCache` → `--anthropic-auto-cache`
-- `apiProxy.anthropicCacheTailTtl` → `--anthropic-cache-tail-ttl`
+- `apiProxy.anthropicCacheTailTtl` → `--anthropic-cache-tail-ttl <5m|1h>`
 - `apiProxy.maxEffectiveTokens` → *(config-only; no CLI equivalent)*
 - `apiProxy.modelMultipliers` → *(config-only; no CLI equivalent)*
 - `apiProxy.models` → *(config-only; model alias rewriting)*

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -96,8 +96,11 @@ the corresponding CLI flag.
 - `network.upstreamProxy` → `--upstream-proxy`
 - `apiProxy.enabled` → `--enable-api-proxy`
 - `apiProxy.enableOpenCode` → `--enable-opencode`
+- `apiProxy.anthropicAutoCache` → `--anthropic-auto-cache`
+- `apiProxy.anthropicCacheTailTtl` → `--anthropic-cache-tail-ttl`
 - `apiProxy.maxEffectiveTokens` → *(config-only; no CLI equivalent)*
 - `apiProxy.modelMultipliers` → *(config-only; no CLI equivalent)*
+- `apiProxy.models` → *(config-only; model alias rewriting)*
 - `apiProxy.targets.<provider>.host` → `--<provider>-api-target`
 - `apiProxy.targets.openai.basePath` → `--openai-api-base-path`
 - `apiProxy.targets.anthropic.basePath` → `--anthropic-api-base-path`

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -49,7 +49,7 @@
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Enable the API proxy sidecar container."
+          "description": "Enable the API proxy sidecar container. When enabled, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, COPILOT_GITHUB_TOKEN, COPILOT_API_KEY, GEMINI_API_KEY) are held exclusively in the sidecar and excluded from the agent environment. The agent receives proxy-routing base URLs instead. See docs/awf-config-spec.md §9 for credential isolation semantics."
         },
         "enableOpenCode": {
           "type": "boolean",
@@ -235,7 +235,7 @@
     },
     "environment": {
       "type": "object",
-      "description": "Environment variable propagation into the agent container.",
+      "description": "Environment variable propagation into the agent container. Variables are merged in precedence order: AWF-reserved (lowest) → envAll → envFile → CLI -e/--env (highest). When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for normative merge and credential isolation rules.",
       "additionalProperties": false,
       "properties": {
         "envFile": {

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -235,7 +235,7 @@
     },
     "environment": {
       "type": "object",
-      "description": "Environment variable propagation into the agent container. Variables are merged in precedence order: AWF-reserved (lowest) → envAll → envFile → CLI -e/--env (highest). When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for normative merge and credential isolation rules.",
+      "description": "Environment variable propagation into the agent container. Variables are merged in precedence order: AWF-reserved (lowest) → envFile → envAll → CLI -e/--env (highest). When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for normative merge and credential isolation rules.",
       "additionalProperties": false,
       "properties": {
         "envFile": {


### PR DESCRIPTION
## Summary

Integrates the changes from #2753 (which was closed without merging) into a clean PR.

### Changes

**`docs/awf-config-spec.md`** — three missing rows added to §5 CLI mapping:

| Config path | CLI flag / note |
|---|---|
| `apiProxy.anthropicAutoCache` | `--anthropic-auto-cache` |
| `apiProxy.anthropicCacheTailTtl` | `--anthropic-cache-tail-ttl` |
| `apiProxy.models` | config-only (model alias rewriting) |

**`src/awf-config-schema.json`** — synced descriptions to match `docs/awf-config.schema.json`:
- `apiProxy.enabled` — now references §9 credential isolation semantics
- `environment` — now references §8–9 merge and credential isolation rules

Supersedes #2753.