### PR TITLE
refactor: remove dead exports flagged by export audit

### DIFF
--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -329,9 +329,12 @@ function createCopilotAdapter(env, deps = {}) {
 
 module.exports = {
   createCopilotAdapter,
-  resolveCopilotAuthToken,
-  stripBearerPrefix,
-  deriveCopilotApiTarget,
-  deriveGitHubApiTarget,
-  deriveGitHubApiBasePath,
+  // Exported for unit-test access only; not part of the public API.
+  _testing: {
+    resolveCopilotAuthToken,
+    stripBearerPrefix,
+    deriveCopilotApiTarget,
+    deriveGitHubApiTarget,
+    deriveGitHubApiBasePath,
+  },
 };

--- a/containers/api-proxy/providers/opencode.js
+++ b/containers/api-proxy/providers/opencode.js
@@ -223,4 +223,8 @@ function createOpenCodeAdapter(env, { candidateAdapters = [] } = {}) {
   };
 }
 
-module.exports = { createOpenCodeAdapter, resolveOpenCodeRoute };
+module.exports = {
+  createOpenCodeAdapter,
+  // Exported for unit-test access only; not part of the public API.
+  _testing: { resolveOpenCodeRoute },
+};

--- a/containers/api-proxy/server.auth.test.js
+++ b/containers/api-proxy/server.auth.test.js
@@ -5,7 +5,7 @@
  */
 
 const { shouldStripHeader } = require('./proxy-utils');
-const { resolveCopilotAuthToken, stripBearerPrefix, createCopilotAdapter } = require('./providers/copilot');
+const { _testing: { resolveCopilotAuthToken, stripBearerPrefix }, createCopilotAdapter } = require('./providers/copilot');
 
 describe('shouldStripHeader', () => {
   it('should strip authorization header', () => {

--- a/containers/api-proxy/server.routing.test.js
+++ b/containers/api-proxy/server.routing.test.js
@@ -5,8 +5,8 @@
  */
 
 const { normalizeApiTarget, normalizeBasePath, buildUpstreamPath } = require('./proxy-utils');
-const { deriveCopilotApiTarget, deriveGitHubApiTarget, deriveGitHubApiBasePath } = require('./providers/copilot');
-const { resolveOpenCodeRoute } = require('./providers/opencode');
+const { _testing: { deriveCopilotApiTarget, deriveGitHubApiTarget, deriveGitHubApiBasePath } } = require('./providers/copilot');
+const { _testing: { resolveOpenCodeRoute } } = require('./providers/opencode');
 
 describe('normalizeApiTarget', () => {
   it('should strip https:// prefix', () => {

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -235,7 +235,7 @@
     },
     "environment": {
       "type": "object",
-      "description": "Environment variable propagation into the agent container. Variables are merged in precedence order: AWF-reserved (lowest) → envAll → envFile → CLI -e/--env (highest). When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for normative merge and credential isolation rules.",
+      "description": "Environment variable propagation into the agent container. Merge behavior is: AWF-reserved variables are set by AWF and are not overridden by envAll or envFile; if envAll is true, host environment variables are forwarded next; envFile is then applied only for variables not already present, so it does not override envAll; CLI -e/--env has highest precedence and may override any variable, including AWF-reserved ones. When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for credential isolation rules.",
       "additionalProperties": false,
       "properties": {
         "envFile": {

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -235,7 +235,7 @@
     },
     "environment": {
       "type": "object",
-      "description": "Environment variable propagation into the agent container. Variables are merged in precedence order: AWF-reserved (lowest) → envFile → envAll → CLI -e/--env (highest). When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for normative merge and credential isolation rules.",
+      "description": "Environment variable propagation into the agent container. Variables are merged in precedence order: AWF-reserved (lowest) → envAll → envFile → CLI -e/--env (highest). When apiProxy.enabled is true, source credentials (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are excluded from the agent and held in the API proxy sidecar. See docs/awf-config-spec.md §8–9 for normative merge and credential isolation rules.",
       "additionalProperties": false,
       "properties": {
         "envFile": {

--- a/src/types/docker.ts
+++ b/src/types/docker.ts
@@ -199,7 +199,7 @@ export interface DockerComposeConfig {
  * and dependency configurations.
  * @internal Internal sub-type of DockerComposeConfig; subject to change with Docker Compose spec updates
  */
-export interface DockerService {
+interface DockerService {
   /**
    * Pre-built Docker image to use
    * 
@@ -507,7 +507,7 @@ export interface DockerService {
  * static IP addresses for predictable iptables rules.
  * @internal Internal sub-type of DockerComposeConfig; subject to change with Docker Compose spec updates
  */
-export interface DockerNetwork {
+interface DockerNetwork {
   /**
    * Network driver to use
    * 
@@ -552,7 +552,7 @@ export interface DockerNetwork {
  * defaults. Fields map directly to the Docker Compose volume specification.
  * @internal Internal sub-type of DockerComposeConfig; subject to change with Docker Compose spec updates
  */
-export interface DockerVolume {
+interface DockerVolume {
   /**
    * Volume driver to use
    * 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,5 @@
 /**
  * Barrel re-export of public types from domain-scoped modules.
- *
- * Note: DockerService, DockerNetwork, and DockerVolume are not re-exported
- * here; import them directly from './types/docker' if needed.
  */
 
 export {


### PR DESCRIPTION
## Summary

Addresses three `[Export Audit]` issues by removing or namespacing dead exports.

### Changes

**`containers/api-proxy/providers/copilot.js`** (closes #2752)
- Moved 5 internal helpers (`stripBearerPrefix`, `resolveCopilotAuthToken`, `deriveCopilotApiTarget`, `deriveGitHubApiTarget`, `deriveGitHubApiBasePath`) from top-level exports to a `_testing` namespace
- Updated test imports in `server.auth.test.js` and `server.routing.test.js`

**`containers/api-proxy/providers/opencode.js`** (closes #2756)
- Moved `resolveOpenCodeRoute` from top-level export to `_testing` namespace
- Updated test import in `server.routing.test.js`

**`src/types/docker.ts`** (closes #2746)
- Removed `export` keyword from `DockerService`, `DockerNetwork`, `DockerVolume` interfaces — these are `@internal` sub-types used only within `DockerComposeConfig` in the same file and never imported elsewhere
- Removed stale comment in `src/types/index.ts`

### Testing

- All 129 api-proxy tests pass
- TypeScript build clean
- Schema sync test passes