### PR TITLE
docs: document effective token budget enforcement behavior

### DIFF
--- a/docs/api-proxy-sidecar.md
+++ b/docs/api-proxy-sidecar.md
@@ -602,7 +602,7 @@ If no model multiplier is configured, it defaults to `1`.
 After each successful upstream response, the proxy accumulates the effective tokens. Before forwarding the *next* request, the proxy checks the running total:
 
 - **Under budget**: Request is forwarded normally.
-- **Budget exceeded**: Request is rejected immediately with:
+- **Budget reached or exceeded**: Request is rejected immediately with:
   - **HTTP `429 Too Many Requests`**
   - **Error body**:
 
@@ -617,24 +617,24 @@ After each successful upstream response, the proxy accumulates the effective tok
     }
     ```
 
-WebSocket upgrade requests are also rejected with `429` when the budget is exceeded.
+WebSocket upgrade requests are also rejected with `429` when the budget is reached or exceeded.
 
 :::caution
-Once the budget is exceeded, **all subsequent requests in the run are rejected**. The budget is not recoverable — there is no way to "free up" tokens within a single run.
+Once the budget is reached or exceeded, **all subsequent requests in the run are rejected**. The budget is not recoverable — there is no way to "free up" tokens within a single run.
 :::
 
-### Threshold warnings
+### Threshold tracking
 
-The proxy emits structured log warnings as usage approaches the limit:
+The proxy tracks which usage thresholds have been crossed:
 
-| Threshold | Warning emitted |
-|-----------|-----------------|
-| 50% | Yes (once) |
-| 75% | Yes (once) |
-| 90% | Yes (once) |
-| 95% | Yes (once) |
+| Threshold | Tracked once per run |
+|-----------|-----------------------|
+| 50% | Yes |
+| 75% | Yes |
+| 90% | Yes |
+| 95% | Yes |
 
-These appear in the api-proxy container logs as `effective_tokens_threshold` events.
+Crossed thresholds are exposed via `/reflect` in `effective_tokens.thresholds_crossed`.
 
 ### Introspection
 

--- a/docs/api-proxy-sidecar.md
+++ b/docs/api-proxy-sidecar.md
@@ -556,6 +556,123 @@ jobs:
 Azure OpenAI deployments use a different base URL format from OpenAI. Set `--openai-api-target` to your Azure endpoint hostname and add it to `--allow-domains`.
 :::
 
+## Effective token budget
+
+The API proxy can enforce a cumulative **effective token budget** per run. When enabled, the proxy tracks weighted token usage across all LLM requests and rejects new requests once the budget is exhausted.
+
+### Configuration
+
+Set in the AWF config file (not available as a CLI flag):
+
+```json
+{
+  "apiProxy": {
+    "maxEffectiveTokens": 500000,
+    "modelMultipliers": {
+      "o3-pro": 15,
+      "o3": 4,
+      "claude-sonnet-4-20250514": 1,
+      "gpt-4.1-mini": 0.5
+    }
+  }
+}
+```
+
+### How tokens are weighted
+
+Raw token counts from upstream responses are not treated equally. Each category has a fixed weight that reflects its relative cost:
+
+| Category | Weight | Example fields |
+|----------|--------|----------------|
+| Input | ×1.0 | `prompt_tokens`, `input_tokens` |
+| Cache read | ×0.1 | `cache_read_input_tokens` |
+| Output | ×4.0 | `completion_tokens`, `output_tokens` |
+| Reasoning | ×4.0 | `reasoning_tokens` |
+
+The formula for a single response is:
+
+```
+effective_tokens = model_multiplier × (1.0×input + 0.1×cache_read + 4.0×output + 4.0×reasoning)
+```
+
+If no model multiplier is configured, it defaults to `1`.
+
+### Enforcement
+
+After each successful upstream response, the proxy accumulates the effective tokens. Before forwarding the *next* request, the proxy checks the running total:
+
+- **Under budget**: Request is forwarded normally.
+- **Budget exceeded**: Request is rejected immediately with:
+  - **HTTP `429 Too Many Requests`**
+  - **Error body**:
+
+    ```json
+    {
+      "error": {
+        "type": "effective_tokens_limit_exceeded",
+        "message": "Maximum effective tokens exceeded (512345.67 / 500000).",
+        "total_effective_tokens": 512345.67,
+        "max_effective_tokens": 500000
+      }
+    }
+    ```
+
+WebSocket upgrade requests are also rejected with `429` when the budget is exceeded.
+
+:::caution
+Once the budget is exceeded, **all subsequent requests in the run are rejected**. The budget is not recoverable — there is no way to "free up" tokens within a single run.
+:::
+
+### Threshold warnings
+
+The proxy emits structured log warnings as usage approaches the limit:
+
+| Threshold | Warning emitted |
+|-----------|-----------------|
+| 50% | Yes (once) |
+| 75% | Yes (once) |
+| 90% | Yes (once) |
+| 95% | Yes (once) |
+
+These appear in the api-proxy container logs as `effective_tokens_threshold` events.
+
+### Introspection
+
+Query the `/reflect` endpoint on any provider port to see the current budget state:
+
+```bash
+curl http://172.30.0.30:10000/reflect
+```
+
+The response includes:
+
+```json
+{
+  "effective_tokens": {
+    "enabled": true,
+    "max_effective_tokens": 500000,
+    "total_effective_tokens": 234567.89,
+    "remaining_effective_tokens": 265432.11,
+    "percent_used": 46.91,
+    "thresholds_crossed": []
+  }
+}
+```
+
+### Detecting budget exhaustion
+
+Agents and orchestrators should detect the `429` response and the `effective_tokens_limit_exceeded` error type. The error body is structured JSON and can be parsed programmatically:
+
+```javascript
+if (response.status === 429) {
+  const body = await response.json();
+  if (body.error?.type === 'effective_tokens_limit_exceeded') {
+    // Budget exhausted — stop making API calls
+    console.log(`Token budget exceeded: ${body.error.total_effective_tokens} / ${body.error.max_effective_tokens}`);
+  }
+}
+```
+
 ## Limitations
 
 - Keys must be set as environment variables (not file-based)

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -331,6 +331,115 @@ When `security.difcProxy.host` is set, `GITHUB_TOKEN` and `GH_TOKEN` MUST
 be excluded from the agent environment. These tokens SHALL be held
 exclusively by the external DIFC proxy.
 
+## 10. Effective Token Budget Enforcement
+
+*This section is normative.*
+
+When `apiProxy.maxEffectiveTokens` is configured, the API proxy MUST enforce
+a cumulative effective-token budget across all LLM API requests in a single
+run. The budget limits total *weighted* token consumption, not raw token
+counts.
+
+### 10.1 Token Weighting
+
+Each upstream response's `usage` object is decomposed into four categories,
+each with a fixed weight:
+
+| Category | Weight | Usage field |
+|----------|--------|-------------|
+| Input | 1.0 | `input_tokens` / `prompt_tokens` |
+| Cache read | 0.1 | `cache_read_input_tokens` / `prompt_tokens_details.cached_tokens` |
+| Output | 4.0 | `output_tokens` / `completion_tokens` |
+| Reasoning | 4.0 | `reasoning_tokens` / `completion_tokens_details.reasoning_tokens` |
+
+The base weighted tokens for a single response are:
+
+```
+base = (1.0 × input) + (0.1 × cache_read) + (4.0 × output) + (4.0 × reasoning)
+```
+
+### 10.2 Model Multipliers
+
+When `apiProxy.modelMultipliers` is configured, each model name MAY have
+an associated positive multiplier. The effective tokens for a response are:
+
+```
+effective_tokens = model_multiplier × base_weighted_tokens
+```
+
+If no multiplier is configured for a given model, the multiplier defaults
+to `1`.
+
+### 10.3 Enforcement Behavior
+
+The API proxy MUST enforce the budget as follows:
+
+1. **Accumulation**: After each successful upstream response, the proxy
+   extracts the `usage` object, computes effective tokens, and adds them
+   to a running total for the session.
+
+2. **Pre-request check**: Before forwarding each subsequent request to the
+   upstream provider, the proxy checks whether the cumulative total has
+   reached or exceeded `maxEffectiveTokens`.
+
+3. **Rejection**: When the budget is exceeded, the proxy MUST reject the
+   request with:
+   - **HTTP status**: `429 Too Many Requests`
+   - **Content-Type**: `application/json`
+   - **Response body**:
+     ```json
+     {
+       "error": {
+         "type": "effective_tokens_limit_exceeded",
+         "message": "Maximum effective tokens exceeded (1234.56 / 1000).",
+         "total_effective_tokens": 1234.56,
+         "max_effective_tokens": 1000
+       }
+     }
+     ```
+
+4. **WebSocket rejection**: For WebSocket upgrade requests, the proxy MUST
+   reject with `HTTP/1.1 429 Too Many Requests` and include the same JSON
+   error body before destroying the socket.
+
+5. **Finality**: Once the budget is exceeded, all subsequent requests in
+   the same run MUST be rejected. The budget is not recoverable.
+
+### 10.4 Threshold Warnings
+
+The proxy SHOULD emit structured log warnings when the cumulative effective
+tokens cross the following percentage thresholds of `maxEffectiveTokens`:
+
+| Threshold | Log level |
+|-----------|-----------|
+| 50% | `warn` |
+| 75% | `warn` |
+| 90% | `warn` |
+| 95% | `warn` |
+
+Each threshold MUST be emitted at most once per run.
+
+### 10.5 Introspection
+
+When the API proxy `/reflect` endpoint is queried, the response MUST
+include the current effective-token state:
+
+```json
+{
+  "effective_tokens": {
+    "enabled": true,
+    "max_effective_tokens": 1000,
+    "total_effective_tokens": 456.78,
+    "remaining_effective_tokens": 543.22,
+    "percent_used": 45.68,
+    "thresholds_crossed": [50]
+  }
+}
+```
+
+When `maxEffectiveTokens` is not configured, the `enabled` field MUST be
+`false` and numeric fields MUST be `0` or `null`.
+
 ## Normative References
 
 - [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) — Key words for use in

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -444,7 +444,45 @@ When `maxEffectiveTokens` is not configured, the `enabled` field MUST be
 
 - [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) — Key words for use in
   RFCs to Indicate Requirement Levels
-- `docs/awf-config.schema.json` — Machine-readable JSON Schema (normative)
+- `docs/awf-config.schema.json` — Machine-readable JSON Schema for
+  configuration documents (normative)
+
+## Runtime JSONL Schemas
+
+AWF emits structured JSONL artifact files at runtime. Each record type has
+a corresponding JSON Schema in the `schemas/` directory:
+
+| Schema | JSONL file | Description |
+|--------|------------|-------------|
+| [`schemas/audit.schema.json`](../schemas/audit.schema.json) | `audit.jsonl` | L7 HTTP/HTTPS traffic decisions (allowed/denied) from the Squid proxy |
+| [`schemas/token-usage.schema.json`](../schemas/token-usage.schema.json) | `token-usage.jsonl` | Per-API-call token usage records from the api-proxy sidecar |
+
+### Versioning
+
+Schema files do not carry an independent version. The repository release
+tag serves as the version:
+
+- The `$id` field in each schema resolves to a stable release download URL.
+- Each JSONL record includes a `_schema` wire-format field encoding the
+  record type and AWF version (e.g., `"_schema": "audit/v0.26.0"`).
+- Consumers SHOULD use a prefix match (`_schema.startsWith("audit/")`)
+  rather than an exact match to handle future versions gracefully.
+
+### Published locations
+
+**Versioned (release assets):**
+```
+https://github.com/github/gh-aw-firewall/releases/download/<tag>/awf-config.schema.json
+https://github.com/github/gh-aw-firewall/releases/download/<tag>/audit.schema.json
+https://github.com/github/gh-aw-firewall/releases/download/<tag>/token-usage.schema.json
+```
+
+**Latest (main branch):**
+```
+https://raw.githubusercontent.com/github/gh-aw-firewall/main/docs/awf-config.schema.json
+https://raw.githubusercontent.com/github/gh-aw-firewall/main/schemas/audit.schema.json
+https://raw.githubusercontent.com/github/gh-aw-firewall/main/schemas/token-usage.schema.json
+```
 
 ## Informative References
 
@@ -452,3 +490,5 @@ When `maxEffectiveTokens` is not configured, the `enabled` field MUST be
   variables
 - [docs/authentication-architecture.md](authentication-architecture.md) —
   Credential isolation architecture and diagrams
+- [schemas/README.md](../schemas/README.md) — JSONL schema directory with
+  validation examples and versioning policy

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -382,7 +382,7 @@ The API proxy MUST enforce the budget as follows:
    upstream provider, the proxy checks whether the cumulative total has
    reached or exceeded `maxEffectiveTokens`.
 
-3. **Rejection**: When the budget is exceeded, the proxy MUST reject the
+3. **Rejection**: When the budget is reached or exceeded, the proxy MUST reject the
    request with:
    - **HTTP status**: `429 Too Many Requests`
    - **Content-Type**: `application/json`
@@ -402,22 +402,22 @@ The API proxy MUST enforce the budget as follows:
    reject with `HTTP/1.1 429 Too Many Requests` and include the same JSON
    error body before destroying the socket.
 
-5. **Finality**: Once the budget is exceeded, all subsequent requests in
+5. **Finality**: Once the budget is reached or exceeded, all subsequent requests in
    the same run MUST be rejected. The budget is not recoverable.
 
-### 10.4 Threshold Warnings
+### 10.4 Threshold Tracking
 
-The proxy SHOULD emit structured log warnings when the cumulative effective
-tokens cross the following percentage thresholds of `maxEffectiveTokens`:
+The proxy MUST track when cumulative effective tokens cross the following
+percentage thresholds of `maxEffectiveTokens`:
 
-| Threshold | Log level |
-|-----------|-----------|
-| 50% | `warn` |
-| 75% | `warn` |
-| 90% | `warn` |
-| 95% | `warn` |
+| Threshold |
+|-----------|
+| 50% |
+| 75% |
+| 90% |
+| 95% |
 
-Each threshold MUST be emitted at most once per run.
+Each threshold MUST be recorded at most once per run.
 
 ### 10.5 Introspection
 
@@ -432,7 +432,7 @@ include the current effective-token state:
     "total_effective_tokens": 456.78,
     "remaining_effective_tokens": 543.22,
     "percent_used": 45.68,
-    "thresholds_crossed": [50]
+    "thresholds_crossed": []
   }
 }
 ```

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -70,11 +70,11 @@
         "maxEffectiveTokens": {
           "type": "integer",
           "minimum": 1,
-          "description": "Maximum cumulative effective tokens allowed for a run. When reached, the API proxy rejects additional requests."
+          "description": "Maximum cumulative effective tokens allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'effective_tokens_limit_exceeded'. Tokens are weighted: input ×1, cache-read ×0.1, output ×4, reasoning ×4. See spec §10."
         },
         "modelMultipliers": {
           "type": "object",
-          "description": "Per-model multipliers used for effective token accounting. Keys are model names and values are positive multipliers.",
+          "description": "Per-model multipliers for effective token accounting. Each model's weighted tokens are multiplied by this value before accumulation. Defaults to 1 for unlisted models. See spec §10.2.",
           "additionalProperties": {
             "type": "number",
             "exclusiveMinimum": 0

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -70,11 +70,11 @@
         "maxEffectiveTokens": {
           "type": "integer",
           "minimum": 1,
-          "description": "Maximum cumulative effective tokens allowed for a run. When reached, the API proxy rejects additional requests."
+          "description": "Maximum cumulative effective tokens allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'effective_tokens_limit_exceeded'. Tokens are weighted: input ×1, cache-read ×0.1, output ×4, reasoning ×4. See spec §10."
         },
         "modelMultipliers": {
           "type": "object",
-          "description": "Per-model multipliers used for effective token accounting. Keys are model names and values are positive multipliers.",
+          "description": "Per-model multipliers for effective token accounting. Each model's weighted tokens are multiplied by this value before accumulation. Defaults to 1 for unlisted models. See spec §10.2.",
           "additionalProperties": {
             "type": "number",
             "exclusiveMinimum": 0


### PR DESCRIPTION
## Summary

Documents the runtime behavior when `apiProxy.maxEffectiveTokens` is configured. This behavior was previously implemented but undocumented — users and downstream tools (like gh-aw) had no spec to reference for detecting or handling budget exhaustion.

## Changes

### Spec (`docs/awf-config-spec.md`)
- Added **§10 Effective Token Budget Enforcement** with normative language covering:
  - §10.1 Token weighting formula (input ×1, cache-read ×0.1, output ×4, reasoning ×4)
  - §10.2 Model multiplier semantics
  - §10.3 Enforcement behavior (HTTP 429, error type `effective_tokens_limit_exceeded`, WebSocket rejection), with **reached or exceeded (`>=`)** wording aligned to runtime behavior
  - §10.4 Threshold **tracking** (50%, 75%, 90%, 95%) via `thresholds_crossed`
  - §10.5 Introspection via `/reflect` endpoint
- Corrected `/reflect` example values so `percent_used` and `thresholds_crossed` are internally consistent.

### Schema (`docs/awf-config.schema.json` + `src/awf-config-schema.json`)
- Enhanced `maxEffectiveTokens` description to reference HTTP 429 status, error type, and spec §10
- Enhanced `modelMultipliers` description to clarify default behavior and reference spec §10.2

### API Proxy Sidecar docs (`docs/api-proxy-sidecar.md`)
- Added comprehensive **Effective token budget** section with:
  - Configuration examples with model multipliers
  - Token weighting table and formula
  - Enforcement behavior and error response format (using **reached or exceeded** semantics)
  - Threshold **tracking** table
  - `/reflect` endpoint introspection examples
  - Detection code sample for agents/orchestrators
- Corrected wording to match current implementation: threshold state is surfaced via `/reflect`; no `effective_tokens_threshold` log event is documented.

## Motivation

- Issue #2769 identified that gh-aw's ET budget detection patterns don't match AWF's error format — this documents the canonical format so downstream tools can align
- Users configuring `maxEffectiveTokens` had no docs explaining what happens when the limit is reached
- The weighting formula and model multiplier mechanics were only discoverable by reading source code

## Testing

Documentation-only changes. Markdown lint passes for updated docs.