### PR TITLE
fix(deps): patch high-severity vulnerabilities in babel and fast-uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,9 +1203,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5546,9 +5546,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Patches two high-severity vulnerabilities identified by `npm audit`.

## Vulnerabilities Fixed

### GHSA-fv7c-fp4j-7gwp — `@babel/plugin-transform-modules-systemjs`
- **Severity**: High
- **Impact**: Arbitrary code execution when compiling malicious input
- **Fix**: `7.29.0` → `7.29.4`

### GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc — `fast-uri`
- **Severity**: High
- **Impact**: Path traversal via percent-encoded dot segments; host confusion via percent-encoded authority delimiters
- **Fix**: `3.1.0` → `3.1.2`

## Changes

Only `package-lock.json` is modified (6 lines changed). No source code changes.

## Verification

- `npm audit` reports 0 vulnerabilities after fix
- `npm run build` succeeds
- Both are transitive dev dependencies; no runtime behavior change

Closes #2790
Closes #2791