### PR TITLE
refactor: remove dead re-exports from providers/index.js

### DIFF
--- a/containers/api-proxy/providers/index.js
+++ b/containers/api-proxy/providers/index.js
@@ -121,9 +121,7 @@ function createAllAdapters(env, deps = {}) {
 
 module.exports = {
   createAllAdapters,
-  createOpenAIAdapter,
-  createAnthropicAdapter,
-  createCopilotAdapter,
-  createGeminiAdapter,
-  createOpenCodeAdapter,
+  // Individual adapter factories are intentionally NOT re-exported here.
+  // Import them directly from their provider modules (e.g., ./openai, ./copilot).
+  // Only createAllAdapters is the public API of this module.
 };


### PR DESCRIPTION
## Summary

Removes 5 individual adapter factory re-exports from `providers/index.js` that are never imported from that path.

## Problem

`providers/index.js` re-exported all 5 individual adapter factories (`createOpenAIAdapter`, `createAnthropicAdapter`, `createCopilotAdapter`, `createGeminiAdapter`, `createOpenCodeAdapter`), but:
- `server.js` only imports `createAllAdapters`
- All test files import individual adapters directly from their provider modules (e.g., `./providers/copilot`)

## Changes

- Removed 5 dead re-exports from `module.exports` in `providers/index.js`
- Added comment clarifying the public API boundary

## Verification

- All 627 api-proxy tests pass
- `npm run build` succeeds
- Grep confirms no file imports individual adapters via `./providers` (index.js)

Closes #2775