### PR TITLE
refactor: extract shared OIDC refresh/sleep utilities

### DIFF
--- a/containers/api-proxy/aws-oidc-token-provider.js
+++ b/containers/api-proxy/aws-oidc-token-provider.js
@@ -21,6 +21,7 @@
 
 const { mintGitHubOidcToken, httpGet } = require('./github-oidc');
 const { logRequest } = require('./logging');
+const { scheduleRefresh, sleep } = require('./oidc-refresh-utils');
 
 // Refresh at 75% of credential lifetime (STS default is 3600s)
 const REFRESH_FACTOR = 0.75;
@@ -235,29 +236,12 @@ class AwsOidcTokenProvider {
 
   /** @param {number} delayMs */
   _scheduleRefresh(delayMs) {
-    if (this._refreshTimer) clearTimeout(this._refreshTimer);
-    this._refreshTimer = setTimeout(() => {
-      this._refreshInFlight = this._refreshCredentials()
-        .then(() => {
-          logRequest('info', 'aws_oidc_refresh_success', {
-            expires_in_secs: this._expiresAt - Math.floor(Date.now() / 1000),
-          });
-        })
-        .catch((err) => {
-          logRequest('error', 'aws_oidc_refresh_failed', { error: err.message });
-          const now = Math.floor(Date.now() / 1000);
-          if (this._expiresAt > now) {
-            this._scheduleRefresh(this._retryDelayMs);
-          }
-        })
-        .finally(() => { this._refreshInFlight = null; });
-    }, delayMs);
-    if (this._refreshTimer.unref) this._refreshTimer.unref();
+    scheduleRefresh(this, delayMs, () => this._refreshCredentials(), 'aws_oidc');
   }
 
   /** @param {number} ms */
   _sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return sleep(ms);
   }
 }
 

--- a/containers/api-proxy/gcp-oidc-token-provider.js
+++ b/containers/api-proxy/gcp-oidc-token-provider.js
@@ -17,6 +17,7 @@
 
 const { mintGitHubOidcToken, httpPost } = require('./github-oidc');
 const { logRequest } = require('./logging');
+const { scheduleRefresh, sleep } = require('./oidc-refresh-utils');
 
 // Refresh at 75% of token lifetime
 const REFRESH_FACTOR = 0.75;
@@ -232,29 +233,12 @@ class GcpOidcTokenProvider {
 
   /** @param {number} delayMs */
   _scheduleRefresh(delayMs) {
-    if (this._refreshTimer) clearTimeout(this._refreshTimer);
-    this._refreshTimer = setTimeout(() => {
-      this._refreshInFlight = this._refreshToken()
-        .then(() => {
-          logRequest('info', 'gcp_oidc_refresh_success', {
-            expires_in_secs: this._expiresAt - Math.floor(Date.now() / 1000),
-          });
-        })
-        .catch((err) => {
-          logRequest('error', 'gcp_oidc_refresh_failed', { error: err.message });
-          const now = Math.floor(Date.now() / 1000);
-          if (this._expiresAt > now) {
-            this._scheduleRefresh(this._retryDelayMs);
-          }
-        })
-        .finally(() => { this._refreshInFlight = null; });
-    }, delayMs);
-    if (this._refreshTimer.unref) this._refreshTimer.unref();
+    scheduleRefresh(this, delayMs, () => this._refreshToken(), 'gcp_oidc');
   }
 
   /** @param {number} ms */
   _sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return sleep(ms);
   }
 }
 

--- a/containers/api-proxy/oidc-refresh-utils.js
+++ b/containers/api-proxy/oidc-refresh-utils.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Shared refresh/scheduling utilities for OIDC token providers.
+ *
+ * Both AwsOidcTokenProvider and GcpOidcTokenProvider use identical logic for:
+ * - Scheduling proactive credential/token refresh before expiry
+ * - Retry on failed refresh while credentials/tokens are still valid
+ * - Sleep helper for retry backoff
+ *
+ * Each provider passes a `refreshFn` and a `providerPrefix` (e.g., 'aws_oidc'
+ * or 'gcp_oidc') so log events remain provider-specific.
+ */
+
+const { logRequest } = require('./logging');
+
+/**
+ * Schedule a proactive refresh of credentials/tokens.
+ *
+ * Clears any existing timer, schedules `refreshFn` after `delayMs`,
+ * logs success/failure with provider-specific event names, and retries
+ * on failure if credentials are still valid.
+ *
+ * @param {Object} state - Provider state object (must have _refreshTimer,
+ *   _refreshInFlight, _expiresAt, _retryDelayMs properties)
+ * @param {number} delayMs - Milliseconds before running the refresh
+ * @param {Function} refreshFn - Async function that refreshes credentials/tokens
+ * @param {string} providerPrefix - Log event prefix (e.g., 'aws_oidc' or 'gcp_oidc')
+ */
+function scheduleRefresh(state, delayMs, refreshFn, providerPrefix) {
+  if (state._refreshTimer) clearTimeout(state._refreshTimer);
+  state._refreshTimer = setTimeout(() => {
+    state._refreshInFlight = refreshFn()
+      .then(() => {
+        logRequest('info', `${providerPrefix}_refresh_success`, {
+          expires_in_secs: state._expiresAt - Math.floor(Date.now() / 1000),
+        });
+      })
+      .catch((err) => {
+        logRequest('error', `${providerPrefix}_refresh_failed`, { error: err.message });
+        const now = Math.floor(Date.now() / 1000);
+        if (state._expiresAt > now) {
+          scheduleRefresh(state, state._retryDelayMs, refreshFn, providerPrefix);
+        }
+      })
+      .finally(() => { state._refreshInFlight = null; });
+  }, delayMs);
+  if (state._refreshTimer.unref) state._refreshTimer.unref();
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = { scheduleRefresh, sleep };


### PR DESCRIPTION
## Summary

Extracts duplicated `_scheduleRefresh()` and `_sleep()` methods from `AwsOidcTokenProvider` and `GcpOidcTokenProvider` into a shared `oidc-refresh-utils.js` module.

## Problem

Both OIDC token providers had identical 20-line `_scheduleRefresh()` methods and 2-line `_sleep()` helpers, differing only in provider-specific log event names.

## Solution

New `containers/api-proxy/oidc-refresh-utils.js` exports:
- `scheduleRefresh(state, delayMs, refreshFn, providerPrefix)` — shared scheduling with provider-specific log events
- `sleep(ms)` — shared sleep helper

Both providers now delegate to the shared implementation through thin wrapper methods.

## Verification

- All 20 OIDC tests pass (12 AWS + 8 GCP)
- Full api-proxy suite (627 tests) passes

Closes #2787