### PR TITLE
refactor: extract shared logger mock factory to test-utils

### DIFF
--- a/src/commands/logs-audit.test.ts
+++ b/src/commands/logs-audit.test.ts
@@ -13,14 +13,8 @@ import { EnrichedLogEntry } from '../logs/audit-enricher';
 jest.mock('./logs-command-helpers');
 jest.mock('../logs/log-aggregator');
 jest.mock('../logs/audit-enricher');
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 const mockedHelpers = logsCommandHelpers as jest.Mocked<typeof logsCommandHelpers>;
 const mockedAggregator = logAggregator as jest.Mocked<typeof logAggregator>;

--- a/src/commands/logs-stats.test.ts
+++ b/src/commands/logs-stats.test.ts
@@ -10,14 +10,8 @@ import { createLogCommandTests, createLogCommandTestHarness } from './test-helpe
 jest.mock('../logs/log-discovery');
 jest.mock('../logs/log-aggregator');
 jest.mock('../logs/stats-formatter');
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 createLogCommandTests<StatsCommandOptions>(
   'stats',

--- a/src/commands/logs-summary.test.ts
+++ b/src/commands/logs-summary.test.ts
@@ -10,14 +10,8 @@ import { createLogCommandTests, createLogCommandTestHarness } from './test-helpe
 jest.mock('../logs/log-discovery');
 jest.mock('../logs/log-aggregator');
 jest.mock('../logs/stats-formatter');
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 createLogCommandTests<SummaryCommandOptions>(
   'summary',

--- a/src/commands/logs.test.ts
+++ b/src/commands/logs.test.ts
@@ -11,14 +11,8 @@ import { logger } from '../logger';
 // Mock the log modules
 jest.mock('../logs/log-discovery');
 jest.mock('../logs/log-streamer');
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 const mockedDiscovery = logDiscovery as jest.Mocked<typeof logDiscovery>;
 const mockedStreamer = logStreamer as jest.Mocked<typeof logStreamer>;

--- a/src/host-iptables.test.ts
+++ b/src/host-iptables.test.ts
@@ -11,15 +11,8 @@ jest.mock('./docker-manager', () => ({
 }));
 
 // Mock logger to avoid console output during tests
-jest.mock('./logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    success: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('./logger', () => require('./test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 describe('host-iptables', () => {
   beforeEach(() => {

--- a/src/logs/log-aggregator.test.ts
+++ b/src/logs/log-aggregator.test.ts
@@ -10,14 +10,8 @@ import * as fs from 'fs';
 // Mock dependencies
 jest.mock('execa');
 jest.mock('fs');
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 const mockedExeca = execa as jest.MockedFunction<typeof execa>;
 const mockedFs = fs as jest.Mocked<typeof fs>;

--- a/src/logs/log-discovery.test.ts
+++ b/src/logs/log-discovery.test.ts
@@ -20,14 +20,8 @@ import { LogSource } from '../types';
 jest.mock('execa');
 jest.mock('glob');
 jest.mock('fs');
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 const mockedExeca = execa as jest.MockedFunction<typeof execa>;
 const mockedGlob = glob as jest.MockedFunction<typeof glob>;

--- a/src/logs/log-streamer.test.ts
+++ b/src/logs/log-streamer.test.ts
@@ -17,14 +17,8 @@ jest.mock('../pid-tracker', () => ({
   trackPidForPortSync: jest.fn().mockReturnValue({ pid: -1, cmdline: '', comm: '', inode: 0 }),
   isPidTrackingAvailable: jest.fn().mockReturnValue(true),
 }));
-jest.mock('../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 const mockedExeca = execa as jest.MockedFunction<typeof execa>;
 const mockedFs = fs as jest.Mocked<typeof fs>;

--- a/src/test-helpers/mock-logger.test-utils.ts
+++ b/src/test-helpers/mock-logger.test-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared jest.mock factory for the logger module.
+ *
+ * Usage in test files (adjust relative path as needed):
+ *   jest.mock('./logger', () => require('./test-helpers/mock-logger.test-utils').loggerMockFactory());
+ *   jest.mock('../logger', () => require('../test-helpers/mock-logger.test-utils').loggerMockFactory());
+ *
+ * Then import the spies to assert on calls:
+ *   import { mockLogger } from './test-helpers/mock-logger.test-utils';
+ *   expect(mockLogger.warn).toHaveBeenCalledWith(...);
+ */
+
+export const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+};
+
+export function loggerMockFactory() {
+  return { logger: mockLogger };
+}

--- a/src/upstream-proxy.test.ts
+++ b/src/upstream-proxy.test.ts
@@ -1,14 +1,8 @@
 import { parseProxyUrl, parseNoProxy, detectUpstreamProxy, PROXY_ENV_VARS } from './upstream-proxy';
 
 // Suppress logger output in tests
-jest.mock('./logger', () => ({
-  logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    debug: jest.fn(),
-    error: jest.fn(),
-  },
-}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('./logger', () => require('./test-helpers/mock-logger.test-utils').loggerMockFactory());
 
 describe('PROXY_ENV_VARS', () => {
   it('includes all standard proxy environment variable names', () => {


### PR DESCRIPTION
## Summary

Replaces 9 identical `jest.mock('./logger')` blocks across test files with a shared `loggerMockFactory()` in `src/test-helpers/mock-logger.test-utils.ts`.

## Problem

Every test file that mocks the logger had its own inline 6-line mock factory:
```typescript
jest.mock('../logger', () => ({
  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
}));
```

## Solution

- Created `src/test-helpers/mock-logger.test-utils.ts` with shared `loggerMockFactory()` and `mockLogger` spy object
- Follows the same pattern as the existing `mock-execa.test-utils.ts`
- Updated 9 test files to use the shared factory
- Includes `success` method for `host-iptables.test.ts` which needs it

## Files Changed

- `src/test-helpers/mock-logger.test-utils.ts` (new)
- `src/commands/logs-stats.test.ts`
- `src/commands/logs-summary.test.ts`
- `src/commands/logs-audit.test.ts`
- `src/commands/logs.test.ts`
- `src/logs/log-aggregator.test.ts`
- `src/logs/log-discovery.test.ts`
- `src/logs/log-streamer.test.ts`
- `src/host-iptables.test.ts`
- `src/upstream-proxy.test.ts`

## Verification

All 176 tests across 9 affected files pass.

Closes #2786