### PR TITLE
fix: unexport test-only command option types

### DIFF
--- a/src/commands/logs-audit.test.ts
+++ b/src/commands/logs-audit.test.ts
@@ -2,7 +2,9 @@
  * Tests for logs-audit command
  */
 
-import { auditCommand, AuditCommandOptions } from './logs-audit';
+import { auditCommand } from './logs-audit';
+
+type AuditCommandOptions = Parameters<typeof auditCommand>[0];
 import * as logAggregator from '../logs/log-aggregator';
 import * as auditEnricher from '../logs/audit-enricher';
 import * as logsCommandHelpers from './logs-command-helpers';

--- a/src/commands/logs-audit.ts
+++ b/src/commands/logs-audit.ts
@@ -16,7 +16,7 @@ import {
 } from './logs-command-helpers';
 import { logger } from '../logger';
 
-export interface AuditCommandOptions {
+interface AuditCommandOptions {
   format: LogStatsFormat;
   source?: string;
   /** Filter to specific rule ID */

--- a/src/commands/logs-stats.test.ts
+++ b/src/commands/logs-stats.test.ts
@@ -2,7 +2,9 @@
  * Tests for logs-stats command
  */
 
-import { statsCommand, StatsCommandOptions } from './logs-stats';
+import { statsCommand } from './logs-stats';
+
+type StatsCommandOptions = Parameters<typeof statsCommand>[0];
 import { logger } from '../logger';
 import { createLogCommandTests, createLogCommandTestHarness } from './test-helpers.test-utils';
 

--- a/src/commands/logs-stats.ts
+++ b/src/commands/logs-stats.ts
@@ -13,7 +13,7 @@ type StatsFormat = LogStatsFormat;
 /**
  * Options for the stats command
  */
-export interface StatsCommandOptions {
+interface StatsCommandOptions {
   /** Output format: json, markdown, pretty */
   format: StatsFormat;
   /** Specific path to log directory or "running" for live container */

--- a/src/commands/logs-summary.test.ts
+++ b/src/commands/logs-summary.test.ts
@@ -2,7 +2,9 @@
  * Tests for logs-summary command
  */
 
-import { summaryCommand, SummaryCommandOptions } from './logs-summary';
+import { summaryCommand } from './logs-summary';
+
+type SummaryCommandOptions = Parameters<typeof summaryCommand>[0];
 import { logger } from '../logger';
 import { createLogCommandTests, createLogCommandTestHarness } from './test-helpers.test-utils';
 

--- a/src/commands/logs-summary.ts
+++ b/src/commands/logs-summary.ts
@@ -16,7 +16,7 @@ type SummaryFormat = LogStatsFormat;
 /**
  * Options for the summary command
  */
-export interface SummaryCommandOptions {
+interface SummaryCommandOptions {
   /** Output format: json, markdown, pretty (default: markdown) */
   format: SummaryFormat;
   /** Specific path to log directory or "running" for live container */

--- a/src/commands/predownload.test.ts
+++ b/src/commands/predownload.test.ts
@@ -1,4 +1,6 @@
-import { resolveImages, predownloadCommand, PredownloadOptions } from './predownload';
+import { resolveImages, predownloadCommand } from './predownload';
+
+type PredownloadOptions = Parameters<typeof resolveImages>[0];
 
 // Mock execa
 jest.mock('execa', () => {

--- a/src/commands/predownload.ts
+++ b/src/commands/predownload.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import { logger } from '../logger';
 import { buildRuntimeImageRef, parseImageTag } from '../image-tag';
 
-export interface PredownloadOptions {
+interface PredownloadOptions {
   imageRegistry: string;
   imageTag: string;
   agentImage: string;
@@ -25,6 +25,7 @@ function validateImageReference(image: string): void {
 
 /**
  * Resolves the list of image references to pull based on the given options.
+ * @internal Exported for testing only.
  */
 export function resolveImages(options: PredownloadOptions): string[] {
   const { imageRegistry, imageTag, agentImage, enableApiProxy } = options;


### PR DESCRIPTION
## Summary

Removes `export` from command option interfaces that are only consumed by test files, reducing the implied public API surface.

## Changes

- **`AuditCommandOptions`** → unexported; test uses `Parameters<typeof auditCommand>[0]`
- **`SummaryCommandOptions`** → unexported; test uses `Parameters<typeof summaryCommand>[0]`
- **`StatsCommandOptions`** → unexported; test uses `Parameters<typeof statsCommand>[0]`
- **`PredownloadOptions`** → unexported; test uses `Parameters<typeof resolveImages>[0]`
- **`resolveImages`** → kept exported with `@internal` tag (has 13 direct test references)

## Verification

All 50 tests across the 4 affected suites pass.

Closes #2816