### PR TITLE
fix(api-proxy): add missing JS modules to Dockerfile COPY

### DIFF
--- a/containers/api-proxy/Dockerfile
+++ b/containers/api-proxy/Dockerfile
@@ -17,7 +17,9 @@ RUN npm ci --omit=dev
 # Copy application files
 COPY server.js logging.js metrics.js rate-limiter.js token-tracker.js \
      model-resolver.js proxy-utils.js anthropic-transforms.js \
-     proxy-request.js model-discovery.js management.js oidc-token-provider.js ./
+     proxy-request.js model-discovery.js management.js oidc-token-provider.js \
+     github-oidc.js aws-oidc-token-provider.js gcp-oidc-token-provider.js \
+     oidc-refresh-utils.js ./
 COPY providers/ ./providers/
 
 # Create non-root user


### PR DESCRIPTION
## Bug Fix

### What was the bug?

The api-proxy container has been crashing immediately on startup (exit code 1) since commit 7c25298, breaking all integration test runs on main since 2026-05-11T15:45Z.

The root cause: PR #2887 (and earlier PRs #2811, #2772) added new JS modules to `containers/api-proxy/` but did not update the Dockerfile's `COPY` command. When the container starts, Node.js fails with `Cannot find module './github-oidc'`.

### Missing files added to Dockerfile COPY

| File | Added by | Purpose |
|------|----------|---------|
| `github-oidc.js` | #2772 | Shared GitHub OIDC token minting |
| `aws-oidc-token-provider.js` | #2811 | AWS OIDC credential exchange |
| `gcp-oidc-token-provider.js` | #2811 | GCP OIDC credential exchange |
| `oidc-refresh-utils.js` | #2811 | Shared OIDC refresh/sleep utilities |

### How to verify

After this fix, all `tests/integration/api-proxy*.test.ts` integration tests should pass again.

### Impact

- **All integration tests on main have been failing** since 7c25298 was merged
- The 28 api-proxy integration test failures on PR #2895 are also caused by this same issue (not by #2895's changes)