### PR TITLE
refactor: remove dead exports from export audit

### DIFF
--- a/src/commands/main-action.ts
+++ b/src/commands/main-action.ts
@@ -62,7 +62,7 @@ import {
  * Injected to decouple the action handler from the global program instance,
  * enabling independent unit testing.
  */
-export type OptionSourceResolver = (optionName: string) => string | undefined;
+type OptionSourceResolver = (optionName: string) => string | undefined;
 
 /**
  * Creates the main `awf` action handler bound to a specific option-source

--- a/src/logs/index.ts
+++ b/src/logs/index.ts
@@ -2,7 +2,7 @@
  * Log viewing utilities for Squid proxy logs
  */
 
-export { parseLogLine, extractDomain, extractPort } from './log-parser';
+export { parseLogLine, extractDomain } from './log-parser';
 export { LogFormatter } from './log-formatter';
 export {
   discoverLogSources,

--- a/src/logs/log-parser.test.ts
+++ b/src/logs/log-parser.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for log-parser.ts
  */
 
-import { parseLogLine, extractDomain, extractPort, parseAuditJsonlLine } from './log-parser';
+import { parseLogLine, extractDomain, parseAuditJsonlLine } from './log-parser';
 
 describe('log-parser', () => {
   describe('parseLogLine', () => {
@@ -221,26 +221,6 @@ describe('log-parser', () => {
     it('should return original URL if parsing fails', () => {
       // Invalid URL that can't be parsed
       expect(extractDomain(':::invalid', '-', 'GET')).toBe(':::invalid');
-    });
-  });
-
-  describe('extractPort', () => {
-    it('should extract port from CONNECT URL', () => {
-      expect(extractPort('api.github.com:443', 'CONNECT')).toBe('443');
-      expect(extractPort('example.com:8080', 'CONNECT')).toBe('8080');
-    });
-
-    it('should return undefined for CONNECT URL without port', () => {
-      expect(extractPort('api.github.com', 'CONNECT')).toBeUndefined();
-    });
-
-    it('should return undefined for non-CONNECT methods', () => {
-      expect(extractPort('http://example.com:80/', 'GET')).toBeUndefined();
-      expect(extractPort('http://example.com/', 'POST')).toBeUndefined();
-    });
-
-    it('should not extract non-numeric port', () => {
-      expect(extractPort('api.github.com:abc', 'CONNECT')).toBeUndefined();
     });
   });
 

--- a/src/logs/log-parser.ts
+++ b/src/logs/log-parser.ts
@@ -143,26 +143,6 @@ export function extractDomain(url: string, host: string, method: string): string
 }
 
 /**
- * Extracts the port from a domain:port string or URL
- *
- * @param url - URL field or domain:port string
- * @param method - HTTP method
- * @returns Port number string or undefined
- */
-export function extractPort(url: string, method: string): string | undefined {
-  if (method === 'CONNECT') {
-    const colonIndex = url.lastIndexOf(':');
-    if (colonIndex !== -1) {
-      const possiblePort = url.substring(colonIndex + 1);
-      if (/^\d+$/.test(possiblePort)) {
-        return possiblePort;
-      }
-    }
-  }
-  return undefined;
-}
-
-/**
  * Parses a single line from the JSONL audit log (audit.jsonl).
  *
  * Format: {"ts":1761074374.646,"client":"172.30.0.20","host":"api.github.com:443","dest":"140.82.114.22:443","method":"CONNECT","status":200,"decision":"TCP_TUNNEL","url":"api.github.com:443"}

--- a/src/pid-tracker.ts
+++ b/src/pid-tracker.ts
@@ -24,9 +24,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { PidTrackResult } from './types';
 
-// Re-export PidTrackResult for convenience
-export { PidTrackResult } from './types';
-
 /**
  * Parsed entry from /proc/net/tcp
  */


### PR DESCRIPTION
## Summary

Removes three dead/redundant exports identified during the export audit:

1. **`OptionSourceResolver` type** (`main-action.ts`) — Not imported anywhere in production or tests. Closes #2927
2. **`extractPort` function** (`log-parser.ts`) — Dead code, never called internally or externally. Removes from barrel re-export and tests. Closes #2914
3. **`PidTrackResult` re-export** (`pid-tracker.ts`) — Redundant; the canonical export already lives in `types/index.ts`. Closes #2915

## Changes

- `src/commands/main-action.ts`: Remove `export` keyword from `OptionSourceResolver` type
- `src/logs/log-parser.ts`: Remove `extractPort` function entirely
- `src/logs/index.ts`: Remove `extractPort` from barrel re-exports
- `src/logs/log-parser.test.ts`: Remove `extractPort` tests
- `src/pid-tracker.ts`: Remove redundant `PidTrackResult` re-export

## Testing

- All affected tests pass (`log-parser.test.ts`, `pid-tracker.test.ts`)
- TypeScript build passes
- No production code depends on removed exports