### PR TITLE
fix: add --ignore-scripts to security-guard Claude Code install

### DIFF
--- a/.github/workflows/security-guard.lock.yml
+++ b/.github/workflows/security-guard.lock.yml
@@ -454,7 +454,7 @@ jobs:
       - name: Install AWF binary
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.41
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.126
+        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.126
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
The `security-guard.lock.yml` was missing `--ignore-scripts` on the `npm install` command for Claude Code CLI, causing the `workflow-engine-install-security` test to fail on main.

This was the root cause of the Test Coverage Reporter failure (#2959) — the coverage workflow runs `npm test` against main and this test was failing.

Closes #2959