### PR TITLE
refactor: remove dead exports from preflight, network-setup, domain-acl, and logs barrel

### DIFF
--- a/src/commands/network-setup.ts
+++ b/src/commands/network-setup.ts
@@ -7,7 +7,7 @@ import { UpstreamProxyConfig } from '../types';
 /**
  * The resolved network configuration produced by {@link resolveNetworkConfig}.
  */
-export interface NetworkSetupResult {
+interface NetworkSetupResult {
   upstreamProxy: UpstreamProxyConfig | undefined;
   dnsServers: string[];
   dnsOverHttps: string | undefined;

--- a/src/commands/preflight.ts
+++ b/src/commands/preflight.ts
@@ -20,7 +20,7 @@ type OptionSourceResolver = (optionName: string) => string | undefined;
 /**
  * The result produced by {@link resolveAllowedDomains}.
  */
-export interface AllowedDomainsResult {
+interface AllowedDomainsResult {
   allowedDomains: string[];
   localhostResult: ReturnType<typeof processLocalhostKeyword>;
   resolvedCopilotApiTarget: string | undefined;

--- a/src/logs/index.ts
+++ b/src/logs/index.ts
@@ -2,23 +2,8 @@
  * Log viewing utilities for Squid proxy logs
  */
 
-export { parseLogLine, extractDomain } from './log-parser';
 export { LogFormatter } from './log-formatter';
 export {
-  discoverLogSources,
-  selectMostRecent,
-  isContainerRunning,
-  validateSource,
   listLogSources,
 } from './log-discovery';
 export { streamLogs } from './log-streamer';
-export {
-  aggregateLogs,
-  loadAllLogs,
-  loadAndAggregate,
-  AggregatedStats,
-  DomainStats,
-} from './log-aggregator';
-export {
-  formatStats,
-} from './stats-formatter';

--- a/src/squid/domain-acl.ts
+++ b/src/squid/domain-acl.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Groups domains by their protocol restriction
  */
-export interface DomainsByProtocol {
+interface DomainsByProtocol {
   http: string[];
   https: string[];
   both: string[];
@@ -18,7 +18,7 @@ export interface DomainsByProtocol {
 /**
  * Groups patterns by their protocol restriction
  */
-export interface PatternsByProtocol {
+interface PatternsByProtocol {
   http: DomainPattern[];
   https: DomainPattern[];
   both: DomainPattern[];
@@ -50,7 +50,7 @@ export function formatDomainForSquid(domain: string): string {
 /**
  * Group plain domains by protocol
  */
-export function groupDomainsByProtocol(domains: PlainDomainEntry[]): DomainsByProtocol {
+function groupDomainsByProtocol(domains: PlainDomainEntry[]): DomainsByProtocol {
   const result: DomainsByProtocol = { http: [], https: [], both: [] };
   for (const entry of domains) {
     result[entry.protocol].push(entry.domain);
@@ -61,7 +61,7 @@ export function groupDomainsByProtocol(domains: PlainDomainEntry[]): DomainsByPr
 /**
  * Group patterns by protocol
  */
-export function groupPatternsByProtocol(patterns: DomainPattern[]): PatternsByProtocol {
+function groupPatternsByProtocol(patterns: DomainPattern[]): PatternsByProtocol {
   const result: PatternsByProtocol = { http: [], https: [], both: [] };
   for (const pattern of patterns) {
     result[pattern.protocol].push(pattern);


### PR DESCRIPTION
## Summary

Remove dead exports identified by export audit issues. No behavioral changes — all modifications are `export` keyword removals or barrel trimming.

### Changes

**`src/commands/preflight.ts`** — Unexport `AllowedDomainsResult` interface (never imported outside the file; the function `resolveAllowedDomains` remains exported since it is used by `main-action.ts` and tests).

**`src/commands/network-setup.ts`** — Unexport `NetworkSetupResult` interface (never imported outside the file; `resolveNetworkConfig` remains exported).

**`src/squid/domain-acl.ts`** — Unexport 4 symbols only used internally:
- `DomainsByProtocol` interface
- `PatternsByProtocol` interface
- `groupDomainsByProtocol()` function
- `groupPatternsByProtocol()` function

`assertSafeForSquidConfig`, `formatDomainForSquid`, and `parseDomainConfig` remain exported (used by other modules).

**`src/logs/index.ts`** — Trim barrel from 12 re-exports to the 3 actually consumed via the barrel (`listLogSources`, `LogFormatter`, `streamLogs`). All other consumers already import directly from source modules.

### Verification
- `npx tsc --noEmit` — passes
- 221 tests across 7 relevant suites — all pass

Closes #3044, #3041, #3047, #3048, #3050, #3025