### PR TITLE
fix: use GitHub-token-shaped Copilot auth placeholder for CLI compatibility

### DIFF
--- a/containers/agent/api-proxy-health-check.sh
+++ b/containers/agent/api-proxy-health-check.sh
@@ -10,6 +10,8 @@
 
 set -e
 
+COPILOT_PLACEHOLDER_TOKEN="ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 echo "[health-check] API Proxy Pre-flight Check"
 echo "[health-check] =========================================="
 
@@ -119,9 +121,9 @@ if [ -n "$COPILOT_API_URL" ]; then
 
   # Verify COPILOT_GITHUB_TOKEN is placeholder (protected by one-shot-token)
   if [ -n "$COPILOT_GITHUB_TOKEN" ]; then
-    if [ "$COPILOT_GITHUB_TOKEN" != "placeholder-token-for-credential-isolation" ]; then
+    if [ "$COPILOT_GITHUB_TOKEN" != "$COPILOT_PLACEHOLDER_TOKEN" ]; then
       echo "[health-check][ERROR] COPILOT_GITHUB_TOKEN contains non-placeholder value!"
-      echo "[health-check][ERROR] Token should be 'placeholder-token-for-credential-isolation'"
+      echo "[health-check][ERROR] Token should be '$COPILOT_PLACEHOLDER_TOKEN'"
       exit 1
     fi
     echo "[health-check] ✓ COPILOT_GITHUB_TOKEN is placeholder value (correct)"
@@ -129,9 +131,9 @@ if [ -n "$COPILOT_API_URL" ]; then
 
   # Verify COPILOT_API_KEY (BYOK) is placeholder when api-proxy is enabled (if present)
   if [ -n "$COPILOT_API_KEY" ]; then
-    if [ "$COPILOT_API_KEY" != "placeholder-token-for-credential-isolation" ]; then
+    if [ "$COPILOT_API_KEY" != "$COPILOT_PLACEHOLDER_TOKEN" ]; then
       echo "[health-check][ERROR] COPILOT_API_KEY contains non-placeholder value!"
-      echo "[health-check][ERROR] Token should be 'placeholder-token-for-credential-isolation'"
+      echo "[health-check][ERROR] Token should be '$COPILOT_PLACEHOLDER_TOKEN'"
       exit 1
     fi
     echo "[health-check] ✓ COPILOT_API_KEY is placeholder value (correct)"
@@ -139,9 +141,9 @@ if [ -n "$COPILOT_API_URL" ]; then
 
   # Verify COPILOT_TOKEN is placeholder (if present)
   if [ -n "$COPILOT_TOKEN" ]; then
-    if [ "$COPILOT_TOKEN" != "placeholder-token-for-credential-isolation" ]; then
+    if [ "$COPILOT_TOKEN" != "$COPILOT_PLACEHOLDER_TOKEN" ]; then
       echo "[health-check][ERROR] COPILOT_TOKEN contains non-placeholder value!"
-      echo "[health-check][ERROR] Token should be 'placeholder-token-for-credential-isolation'"
+      echo "[health-check][ERROR] Token should be '$COPILOT_PLACEHOLDER_TOKEN'"
       exit 1
     fi
     echo "[health-check] ✓ COPILOT_TOKEN is placeholder value (correct)"
@@ -149,9 +151,9 @@ if [ -n "$COPILOT_API_URL" ]; then
 
   # Verify COPILOT_PROVIDER_API_KEY (offline+BYOK) is placeholder when api-proxy is enabled (if present)
   if [ -n "$COPILOT_PROVIDER_API_KEY" ]; then
-    if [ "$COPILOT_PROVIDER_API_KEY" != "placeholder-token-for-credential-isolation" ]; then
+    if [ "$COPILOT_PROVIDER_API_KEY" != "$COPILOT_PLACEHOLDER_TOKEN" ]; then
       echo "[health-check][ERROR] COPILOT_PROVIDER_API_KEY contains non-placeholder value!"
-      echo "[health-check][ERROR] Token should be 'placeholder-token-for-credential-isolation'"
+      echo "[health-check][ERROR] Token should be '$COPILOT_PLACEHOLDER_TOKEN'"
       exit 1
     fi
     echo "[health-check] ✓ COPILOT_PROVIDER_API_KEY is placeholder value (correct)"

--- a/containers/agent/api-proxy-health-check.sh
+++ b/containers/agent/api-proxy-health-check.sh
@@ -10,6 +10,7 @@
 
 set -e
 
+# Must match src/constants/placeholders.ts (COPILOT_PLACEHOLDER_TOKEN)
 COPILOT_PLACEHOLDER_TOKEN="ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 echo "[health-check] API Proxy Pre-flight Check"

--- a/docs/api-proxy-sidecar.md
+++ b/docs/api-proxy-sidecar.md
@@ -143,12 +143,12 @@ The agent container receives **redacted placeholders** and proxy URLs:
 | `ANTHROPIC_AUTH_TOKEN` | `placeholder-token-for-credential-isolation` | `ANTHROPIC_API_KEY` provided to host | Placeholder token (real auth via BASE_URL) |
 | `CLAUDE_CODE_API_KEY_HELPER` | `/usr/local/bin/get-claude-key.sh` | `ANTHROPIC_API_KEY` provided to host | Helper script for Claude Code CLI |
 | `COPILOT_API_URL` | `http://172.30.0.30:10002` | `COPILOT_GITHUB_TOKEN` or `COPILOT_API_KEY` provided to host | Redirects Copilot CLI to proxy |
-| `COPILOT_TOKEN` | `placeholder-token-for-credential-isolation` | `COPILOT_GITHUB_TOKEN` or `COPILOT_API_KEY` provided to host | Placeholder token (real auth via API_URL) |
-| `COPILOT_GITHUB_TOKEN` | `placeholder-token-for-credential-isolation` | `COPILOT_GITHUB_TOKEN` provided to host | Placeholder token protected by one-shot-token |
-| `COPILOT_API_KEY` | `placeholder-token-for-credential-isolation` | `COPILOT_API_KEY` provided to host | BYOK placeholder token protected by one-shot-token |
+| `COPILOT_TOKEN` | `ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` | `COPILOT_GITHUB_TOKEN` or `COPILOT_API_KEY` provided to host | Placeholder token (real auth via API_URL) |
+| `COPILOT_GITHUB_TOKEN` | `ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` | `COPILOT_GITHUB_TOKEN` provided to host | Placeholder token protected by one-shot-token |
+| `COPILOT_API_KEY` | `ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` | `COPILOT_API_KEY` provided to host | BYOK placeholder token protected by one-shot-token |
 | `COPILOT_OFFLINE` | `true` | `COPILOT_API_KEY` provided to host | Enables offline+BYOK mode (skips GitHub OAuth handshake) |
 | `COPILOT_PROVIDER_BASE_URL` | `http://172.30.0.30:10002` | `COPILOT_API_KEY` provided to host | Points Copilot CLI BYOK provider at sidecar |
-| `COPILOT_PROVIDER_API_KEY` | `placeholder-token-for-credential-isolation` | `COPILOT_API_KEY` provided to host | BYOK provider API key placeholder (real key in sidecar) |
+| `COPILOT_PROVIDER_API_KEY` | `ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` | `COPILOT_API_KEY` provided to host | BYOK provider API key placeholder (real key in sidecar) |
 | `GOOGLE_GEMINI_BASE_URL` | `http://172.30.0.30:10003` | `GEMINI_API_KEY` provided to host | Redirects Gemini CLI to proxy (primary var read by Gemini CLI) |
 | `GEMINI_API_BASE_URL` | `http://172.30.0.30:10003` | `GEMINI_API_KEY` provided to host | Redirects Gemini SDK to proxy (kept for backward compatibility) |
 | `GEMINI_API_KEY` | `gemini-api-key-placeholder-for-credential-isolation` | `GEMINI_API_KEY` provided to host | Placeholder so Gemini CLI auth check passes (real key in sidecar) |
@@ -169,7 +169,7 @@ The agent container receives **redacted placeholders** and proxy URLs:
 :::
 
 :::tip[Placeholder tokens]
-Token variables in the agent are set to `placeholder-token-for-credential-isolation` instead of real values. This ensures:
+Token variables in the agent are set to placeholder values (for Copilot, `ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`) instead of real values. This ensures:
 - Agent code cannot exfiltrate credentials
 - CLI tools that check for token presence still work
 - Real authentication happens via the `*_BASE_URL` or `*_API_URL` environment variables

--- a/docs/test-analysis/protocol-security.md
+++ b/docs/test-analysis/protocol-security.md
@@ -129,7 +129,7 @@ GitHub Actions runners may have IPv6 enabled. The firewall must handle IPv6 DNS 
 | **Health endpoint with Anthropic-only** | Verifies port 10000 health shows `openai:false, anthropic:true` when only Anthropic key is provided. |
 | **Copilot healthcheck** | Starts with `COPILOT_GITHUB_TOKEN` on port 10002. |
 | **COPILOT_API_URL set** | Verifies `COPILOT_API_URL=http://172.30.0.30:10002`. |
-| **COPILOT_TOKEN placeholder** | Verifies `COPILOT_TOKEN=placeholder-token-for-credential-isolation`. |
+| **COPILOT_TOKEN placeholder** | Verifies `COPILOT_TOKEN=ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`. |
 | **Copilot in health providers** | Verifies health endpoint reports `copilot:true`. |
 
 ### Real-World Mapping

--- a/src/constants/placeholders.test.ts
+++ b/src/constants/placeholders.test.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { COPILOT_PLACEHOLDER_TOKEN } from './placeholders';
+
+describe('COPILOT_PLACEHOLDER_TOKEN', () => {
+  it('matches the health-check shell placeholder value', () => {
+    const healthCheckScriptPath = path.resolve(__dirname, '../../containers/agent/api-proxy-health-check.sh');
+    const scriptContent = fs.readFileSync(healthCheckScriptPath, 'utf8');
+    const match = scriptContent.match(/COPILOT_PLACEHOLDER_TOKEN="([^"]+)"/);
+
+    expect(match?.[1]).toBe(COPILOT_PLACEHOLDER_TOKEN);
+  });
+});

--- a/src/constants/placeholders.ts
+++ b/src/constants/placeholders.ts
@@ -1,0 +1,6 @@
+/**
+ * GitHub-token-shaped Copilot placeholder used when api-proxy credential isolation is enabled.
+ * The `ghu_` prefix plus 36 alphanumeric characters allows Copilot CLI auth prechecks to pass,
+ * while real credentials remain isolated in the api-proxy sidecar and are injected only upstream.
+ */
+export const COPILOT_PLACEHOLDER_TOKEN = 'ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';

--- a/src/services/agent-environment-credentials.test.ts
+++ b/src/services/agent-environment-credentials.test.ts
@@ -59,7 +59,7 @@ describe('agent environment: credentials', () => {
       const result = generateDockerCompose(configWithProxy, proxyNetworkConfig);
       const env = result.services.agent.environment as Record<string, string>;
       // Placeholder is set to prevent --env-all from leaking the real key
-      expect(env.COPILOT_API_KEY).toBe('placeholder-token-for-credential-isolation');
+      expect(env.COPILOT_API_KEY).toBe('ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     } finally {
       if (original !== undefined) process.env.COPILOT_API_KEY = original;
       else delete process.env.COPILOT_API_KEY;
@@ -90,7 +90,7 @@ describe('agent environment: credentials', () => {
       const proxyNetworkConfig = { ...mockNetworkConfig, proxyIp: '172.30.0.30' };
       const result = generateDockerCompose(configWithProxy, proxyNetworkConfig);
       const env = result.services.agent.environment as Record<string, string>;
-      expect(env.COPILOT_PROVIDER_API_KEY).toBe('placeholder-token-for-credential-isolation');
+      expect(env.COPILOT_PROVIDER_API_KEY).toBe('ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     } finally {
       if (original !== undefined) process.env.COPILOT_PROVIDER_API_KEY = original;
       else delete process.env.COPILOT_PROVIDER_API_KEY;
@@ -105,7 +105,7 @@ describe('agent environment: credentials', () => {
       const proxyNetworkConfig = { ...mockNetworkConfig, proxyIp: '172.30.0.30' };
       const result = generateDockerCompose(configWithProxy, proxyNetworkConfig);
       const env = result.services.agent.environment as Record<string, string>;
-      expect(env.COPILOT_API_KEY).toBe('placeholder-token-for-credential-isolation');
+      expect(env.COPILOT_API_KEY).toBe('ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     } finally {
       if (original !== undefined) process.env.COPILOT_API_KEY = original;
       else delete process.env.COPILOT_API_KEY;

--- a/src/services/agent-environment.ts
+++ b/src/services/agent-environment.ts
@@ -28,6 +28,10 @@ interface AgentEnvironmentParams {
   sslConfig?: SslConfig;
 }
 
+// Use a GitHub-token-shaped placeholder so Copilot CLI auth prechecks pass
+// before requests are routed to the api-proxy sidecar for real token injection.
+const COPILOT_PLACEHOLDER_TOKEN = 'ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 /**
  * Builds the environment variable map for the agent container.
  * Returns a mutable object; callers (api-proxy, cli-proxy service builders)
@@ -152,13 +156,13 @@ export function buildAgentEnvironment(params: AgentEnvironmentParams): Record<st
   // When api-proxy is enabled with Copilot, set placeholder tokens early
   // so --env-all won't override them with real values from host environment
   if (config.enableApiProxy && config.copilotGithubToken) {
-    environment.COPILOT_GITHUB_TOKEN = 'placeholder-token-for-credential-isolation';
+    environment.COPILOT_GITHUB_TOKEN = COPILOT_PLACEHOLDER_TOKEN;
     logger.debug('COPILOT_GITHUB_TOKEN set to placeholder value (early) to prevent --env-all override');
   }
   if (config.enableApiProxy && config.copilotApiKey) {
-    environment.COPILOT_API_KEY = 'placeholder-token-for-credential-isolation';
+    environment.COPILOT_API_KEY = COPILOT_PLACEHOLDER_TOKEN;
     logger.debug('COPILOT_API_KEY set to placeholder value (early) to prevent --env-all override');
-    environment.COPILOT_PROVIDER_API_KEY = 'placeholder-token-for-credential-isolation';
+    environment.COPILOT_PROVIDER_API_KEY = COPILOT_PLACEHOLDER_TOKEN;
     logger.debug('COPILOT_PROVIDER_API_KEY set to placeholder value (early) to prevent --env-all override');
   }
 

--- a/src/services/agent-environment.ts
+++ b/src/services/agent-environment.ts
@@ -17,6 +17,7 @@ import {
 import { logger } from '../logger';
 import { PROXY_ENV_VARS } from '../upstream-proxy';
 import { WrapperConfig } from '../types';
+import { COPILOT_PLACEHOLDER_TOKEN } from '../constants/placeholders';
 import { NetworkConfig } from './squid-service';
 
 // ─── Agent Environment ────────────────────────────────────────────────────────
@@ -27,10 +28,6 @@ interface AgentEnvironmentParams {
   dnsServers: string[];
   sslConfig?: SslConfig;
 }
-
-// Use a GitHub-token-shaped placeholder so Copilot CLI auth prechecks pass
-// before requests are routed to the api-proxy sidecar for real token injection.
-const COPILOT_PLACEHOLDER_TOKEN = 'ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 /**
  * Builds the environment variable map for the agent container.

--- a/src/services/api-proxy-service.test.ts
+++ b/src/services/api-proxy-service.test.ts
@@ -773,7 +773,7 @@ describe('API proxy sidecar', () => {
         const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
         const agent = result.services.agent;
         const env = agent.environment as Record<string, string>;
-        expect(env.COPILOT_TOKEN).toBe('placeholder-token-for-credential-isolation');
+        expect(env.COPILOT_TOKEN).toBe('ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
       });
 
       it('should set COPILOT_OFFLINE=true in agent when copilotApiKey is provided (offline+BYOK mode)', () => {
@@ -797,7 +797,7 @@ describe('API proxy sidecar', () => {
         const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
         const agent = result.services.agent;
         const env = agent.environment as Record<string, string>;
-        expect(env.COPILOT_PROVIDER_API_KEY).toBe('placeholder-token-for-credential-isolation');
+        expect(env.COPILOT_PROVIDER_API_KEY).toBe('ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
       });
 
       it.each(['gpt-5', 'openai/o3-mini', 'provider:gpt-5_preview', 'GPT-5', 'O3'])('should set COPILOT_PROVIDER_WIRE_API=responses in BYOK mode when COPILOT_MODEL is %s', (copilotModel) => {

--- a/src/services/api-proxy-service.ts
+++ b/src/services/api-proxy-service.ts
@@ -9,6 +9,7 @@ import { buildRuntimeImageRef } from '../image-tag';
 import { logger } from '../logger';
 import { WrapperConfig, API_PROXY_PORTS, API_PROXY_HEALTH_PORT } from '../types';
 import { pickEnvVars } from '../env-utils';
+import { COPILOT_PLACEHOLDER_TOKEN } from '../constants/placeholders';
 import { NetworkConfig, ImageBuildConfig } from './squid-service';
 
 interface ApiProxyBuildResult {
@@ -33,8 +34,6 @@ interface ApiProxyServiceParams {
 // "copilot/o3-mini"). Prefix is intentionally broad because model providers/prefixes
 // are runtime-configurable and not limited to a fixed allowlist.
 const RESPONSES_WIRE_API_MODEL_PATTERN = /(^|[/:])(gpt-5|o3)([-_.]|$)/i;
-const COPILOT_PLACEHOLDER_TOKEN = 'ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-
 function getCopilotModel(config: WrapperConfig): string | undefined {
   const envFileModel = config.envFile
     ? readEnvFile(config.envFile).COPILOT_MODEL

--- a/src/services/api-proxy-service.ts
+++ b/src/services/api-proxy-service.ts
@@ -33,6 +33,7 @@ interface ApiProxyServiceParams {
 // "copilot/o3-mini"). Prefix is intentionally broad because model providers/prefixes
 // are runtime-configurable and not limited to a fixed allowlist.
 const RESPONSES_WIRE_API_MODEL_PATTERN = /(^|[/:])(gpt-5|o3)([-_.]|$)/i;
+const COPILOT_PLACEHOLDER_TOKEN = 'ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 function getCopilotModel(config: WrapperConfig): string | undefined {
   const envFileModel = config.envFile
@@ -267,7 +268,7 @@ export function buildApiProxyService(params: ApiProxyServiceParams): ApiProxyBui
 
     // Set placeholder token for GitHub Copilot CLI compatibility
     // Real authentication happens via COPILOT_API_URL pointing to api-proxy
-    agentEnvAdditions.COPILOT_TOKEN = 'placeholder-token-for-credential-isolation';
+    agentEnvAdditions.COPILOT_TOKEN = COPILOT_PLACEHOLDER_TOKEN;
     logger.debug('COPILOT_TOKEN set to placeholder value for credential isolation');
 
     // Note: COPILOT_GITHUB_TOKEN and COPILOT_API_KEY placeholders are set early (before --env-all)

--- a/tests/integration/api-proxy.test.ts
+++ b/tests/integration/api-proxy.test.ts
@@ -231,7 +231,7 @@ describe('API Proxy Sidecar', () => {
     );
 
     expect(result).toSucceed();
-    expect(result.stdout).toContain('COPILOT_TOKEN=placeholder-token-for-credential-isolation');
+    expect(result.stdout).toContain('COPILOT_TOKEN=ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
   }, 180000);
 
   test('should report copilot in health providers when Copilot token is provided', async () => {


### PR DESCRIPTION
The Copilot CLI validates token format before making API calls. The old placeholder `"placeholder-token-for-credential-isolation"` fails this check, causing the CLI to error with "No authentication information found" before ever reaching the API proxy where real credentials are injected.

Changes the placeholder to `ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` — a `ghu_`-prefixed value that passes the CLI format validation. Centralizes the constant in `src/constants/placeholders.ts` to prevent mismatches between TS and shell.

Fixes github/gh-aw#31701