### PR TITLE
fix: remove unused public exports (expandRule, IMAGE_DIGEST_KEYS)

### DIFF
--- a/src/image-tag.test.ts
+++ b/src/image-tag.test.ts
@@ -1,4 +1,6 @@
-import { parseImageTag, buildRuntimeImageRef, IMAGE_DIGEST_KEYS } from './image-tag';
+import { parseImageTag, buildRuntimeImageRef } from './image-tag';
+
+const IMAGE_DIGEST_KEYS = ['squid', 'agent', 'agent-act', 'api-proxy', 'cli-proxy'] as const;
 
 const VALID_DIGEST = 'sha256:' + 'a'.repeat(64);
 

--- a/src/image-tag.ts
+++ b/src/image-tag.ts
@@ -1,4 +1,4 @@
-export const IMAGE_DIGEST_KEYS = ['squid', 'agent', 'agent-act', 'api-proxy', 'cli-proxy'] as const;
+const IMAGE_DIGEST_KEYS = ['squid', 'agent', 'agent-act', 'api-proxy', 'cli-proxy'] as const;
 
 type ImageDigestKey = typeof IMAGE_DIGEST_KEYS[number];
 

--- a/src/rules.test.ts
+++ b/src/rules.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { loadRuleSet, mergeRuleSets, expandRule, loadAndMergeDomains, RuleSet } from './rules';
+import { loadRuleSet, mergeRuleSets, loadAndMergeDomains, RuleSet } from './rules';
 
 describe('rules', () => {
   let testDir: string;
@@ -149,20 +149,6 @@ rules: []
 `);
       const result = loadRuleSet(filePath);
       expect(result.rules).toHaveLength(0);
-    });
-  });
-
-  describe('expandRule', () => {
-    it('should return the domain for subdomains: true', () => {
-      expect(expandRule({ domain: 'github.com', subdomains: true })).toEqual([
-        'github.com',
-      ]);
-    });
-
-    it('should return the domain for subdomains: false', () => {
-      expect(expandRule({ domain: 'github.com', subdomains: false })).toEqual([
-        'github.com',
-      ]);
     });
   });
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -145,7 +145,7 @@ export function loadRuleSet(filePath: string): RuleSet {
  * @param rule - A single domain rule
  * @returns Array of domain strings
  */
-export function expandRule(rule: Rule): string[] {
+function expandRule(rule: Rule): string[] {
   // The existing system already handles subdomain matching when a plain
   // domain is provided (e.g., "github.com" matches both github.com and
   // *.github.com in Squid config). So we just return the domain.


### PR DESCRIPTION
## Summary

Removes unnecessary `export` keywords from two internal symbols that are never imported by production code outside their own files.

### Changes

| File | Symbol | Action |
|------|--------|--------|
| `src/rules.ts` | `expandRule` | Removed `export` — only used internally by `mergeRuleSets` |
| `src/image-tag.ts` | `IMAGE_DIGEST_KEYS` | Removed `export` — only used internally |

### Test Updates

- `rules.test.ts`: Removed direct `expandRule` tests (behavior covered through `mergeRuleSets` tests)
- `image-tag.test.ts`: Inlined `IMAGE_DIGEST_KEYS` as a local test constant

All 46 tests pass.

Closes #3111
Closes #3112