### PR TITLE
fix: skip node --version check under QEMU emulation in agent Dockerfile

### DIFF
--- a/containers/agent/Dockerfile
+++ b/containers/agent/Dockerfile
@@ -59,14 +59,23 @@ RUN set -eux; \
     export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH" && \
     # Install Node.js 22 from NodeSource
     # Check if Node.js 22 is already installed (common in runner images)
-    if ! command -v node >/dev/null 2>&1 || ! node --version | grep -qE '^v22\.'; then \
+    # Note: node --version segfaults under QEMU arm64 emulation, so detect QEMU
+    # and skip the pre-check — just always install from NodeSource on QEMU.
+    UNDER_QEMU=false && \
+    if [ -f /dev/.buildkit_qemu_emulator ] || [ -n "${QEMU_CPU:-}" ]; then UNDER_QEMU=true; fi && \
+    if [ "$UNDER_QEMU" = "true" ] || ! command -v node >/dev/null 2>&1 || ! node --version 2>/dev/null | grep -qE '^v22\.'; then \
         # Remove any existing nodejs packages first to avoid conflicts
         apt-get remove -y nodejs npm || true && \
         curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
         apt-get install -y nodejs && \
-        # Verify Node.js 22 was installed correctly
-        node --version | grep -q "^v22\." || (echo "ERROR: Node.js 22 not installed correctly" && exit 1) && \
-        npx --version || (echo "ERROR: npx not found" && exit 1); \
+        # Verify Node.js 22 was installed correctly (skip under QEMU — node segfaults)
+        if [ "$UNDER_QEMU" = "true" ]; then \
+            echo "Skipping node --version check (QEMU emulation detected)" && \
+            dpkg -l nodejs | grep -q "22\." || (echo "ERROR: nodejs 22 package not installed" && exit 1); \
+        else \
+            node --version | grep -q "^v22\." || (echo "ERROR: Node.js 22 not installed correctly" && exit 1) && \
+            npx --version || (echo "ERROR: npx not found" && exit 1); \
+        fi; \
     fi && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The Release workflow fails at the "Build Agent Image" job when building the `linux/arm64` image. Node.js 22.22.2 segfaults when running under QEMU arm64 emulation:

```
#11 226.2 Setting up nodejs (22.22.2-1nodesource1) ...
#11 226.3 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#11 227.1 ERROR: Node.js 22 not installed correctly
```

**Failed run:** https://github.com/github/gh-aw-firewall/actions/runs/25843758602/job/75934292564

## Root Cause

The `node --version` verification check in the Dockerfile runs the Node.js binary during `docker buildx` cross-compilation. Under QEMU emulation (x86_64 host building arm64 image), the arm64 Node.js binary segfaults — this is a known QEMU/Node.js incompatibility.

## Fix

Detect QEMU emulation via `/dev/.buildkit_qemu_emulator` (injected by BuildKit) and:
1. Skip the pre-install `node --version` check (always install fresh)
2. Replace the post-install `node --version` verification with `dpkg -l nodejs` package check
3. On native builds, behavior is unchanged

The `apt-get install -y nodejs` succeeding is sufficient proof the package installed correctly; the `dpkg` check confirms the right version was unpacked.