### PR TITLE
fix: use gh CLI for reliable API access in issue duplication detector

### DIFF
--- a/.github/workflows/issue-duplication-detector.lock.yml
+++ b/.github/workflows/issue-duplication-detector.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9b2c446c6a999604b393348adcb55005bad1b555018c2297e9e355f226a83115","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"24f721f6212305b759793da111232795899ec96882bc436d9a1563f12058a0ae","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29","digest":"sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29","digest":"sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29","digest":"sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/gh.md
 #     - shared/mcp-pagination.md
 #
 # Secrets used:
@@ -195,21 +196,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_6c439f69eb5f2e75_EOF'
+          cat << 'GH_AW_PROMPT_93279e90062c87a0_EOF'
           <system>
-          GH_AW_PROMPT_6c439f69eb5f2e75_EOF
+          GH_AW_PROMPT_93279e90062c87a0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c439f69eb5f2e75_EOF'
+          cat << 'GH_AW_PROMPT_93279e90062c87a0_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_6c439f69eb5f2e75_EOF
+          GH_AW_PROMPT_93279e90062c87a0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_6c439f69eb5f2e75_EOF'
+          cat << 'GH_AW_PROMPT_93279e90062c87a0_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -238,13 +239,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6c439f69eb5f2e75_EOF
+          GH_AW_PROMPT_93279e90062c87a0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c439f69eb5f2e75_EOF'
+          cat << 'GH_AW_PROMPT_93279e90062c87a0_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/mcp-pagination.md}}
+          {{#runtime-import .github/workflows/shared/gh.md}}
           {{#runtime-import .github/workflows/issue-duplication-detector.md}}
-          GH_AW_PROMPT_6c439f69eb5f2e75_EOF
+          GH_AW_PROMPT_93279e90062c87a0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -504,9 +506,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_78b39acf1c79290a_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_af52cb0549947b00_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_78b39acf1c79290a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_af52cb0549947b00_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +697,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9f3e4c35ae3816c1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ec1fa4237fa8bf3a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -736,7 +738,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9f3e4c35ae3816c1_EOF
+          GH_AW_MCP_CONFIG_ec1fa4237fa8bf3a_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/issue-duplication-detector.md
+++ b/.github/workflows/issue-duplication-detector.md
@@ -9,6 +9,7 @@ permissions:
   issues: read
 imports:
   - shared/mcp-pagination.md
+  - shared/gh.md
 sandbox:
   agent:
     id: awf
@@ -40,10 +41,8 @@ When a new issue is opened, analyze it to determine if it might be a duplicate o
 
    **Cold start handling**: If the file does not exist or is empty, this is a normal cold start — the cache has not been populated yet. Do NOT report `missing_data`. Still continue to step 2 to fetch the new issue details, skip step 3 because there is no cache to compare against, and then proceed to step 4 to search for issues via the GitHub API and populate the cache for future runs.
 
-2. **Fetch the new issue**: Use the `gh` CLI to get the issue details, since it has reliable authentication:
-   ```bash
-   gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json number,title,body,labels,createdAt
-   ```
+2. **Fetch the new issue**: Use the `safeinputs-gh` tool to get the issue details with reliable authentication:
+   - Use the `safeinputs-gh` tool with args: `issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json number,title,body,labels,createdAt`
 
 3. **Compare with cached issues** (skip if cache was empty):
    - Compare the new issue's title and body against cached issue data
@@ -51,11 +50,9 @@ When a new issue is opened, analyze it to determine if it might be a duplicate o
    - Look for similar problem descriptions in the body
    - Consider keyword overlap and semantic similarity
 
-4. **Search for potential duplicates via GitHub API**: Always search GitHub for issues with similar keywords, whether or not the cache had data. Use the `gh` CLI for reliable API access:
-   ```bash
-   gh search issues "<key terms>" --repo ${{ github.repository }} --state open --limit 10 --json number,title,body
-   gh issue list --repo ${{ github.repository }} --state open --limit 20 --json number,title,body,labels
-   ```
+4. **Search for potential duplicates via GitHub API**: Always search GitHub for issues with similar keywords, whether or not the cache had data. Use the `safeinputs-gh` tool for reliable API access:
+   - Use the `safeinputs-gh` tool with args: `search issues "<key terms>" --repo ${{ github.repository }} --state open --limit 10 --json number,title,body`
+   - Use the `safeinputs-gh` tool with args: `issue list --repo ${{ github.repository }} --state open --limit 20 --json number,title,body,labels`
    - Focus on open issues first, then consider recently closed ones
 
 5. **Update the cache**: Store the new issue's signature in the cache-memory for future comparisons:
@@ -101,5 +98,5 @@ If one of these addresses your concern, please consider closing this issue as a 
 - Provide value: Don't spam with low-confidence matches
 - Be helpful: Always explain why issues appear related
 - Respect the cache: Keep stored data minimal and relevant
-- Use pagination: Always use `perPage` parameter when listing/searching issues
-- **Prefer `gh` CLI over MCP tools for GitHub API access**: The `gh` CLI uses the automatic `GITHUB_TOKEN` which is always valid, whereas MCP tools may use a separate token that can expire. Use `gh issue view`, `gh issue list`, `gh search issues`, and `gh api` for reliable access.
+- Use pagination: Always use `--limit` when listing/searching issues with `gh issue list` or `gh search issues`, and `--paginate` or `--per-page` when using `gh api`
+- **Prefer `safeinputs-gh` tool over MCP tools for GitHub API access**: The `safeinputs-gh` tool uses the automatic `GITHUB_TOKEN` which is always valid, whereas MCP tools may use a separate token that can expire. Use `safeinputs-gh` with args like `issue view`, `issue list`, `search issues`, and `api` for reliable access.

--- a/.github/workflows/issue-duplication-detector.md
+++ b/.github/workflows/issue-duplication-detector.md
@@ -40,7 +40,10 @@ When a new issue is opened, analyze it to determine if it might be a duplicate o
 
    **Cold start handling**: If the file does not exist or is empty, this is a normal cold start — the cache has not been populated yet. Do NOT report `missing_data`. Still continue to step 2 to fetch the new issue details, skip step 3 because there is no cache to compare against, and then proceed to step 4 to search for issues via the GitHub API and populate the cache for future runs.
 
-2. **Fetch the new issue**: Get the details of issue #${{ github.event.issue.number }} in repository ${{ github.repository }}.
+2. **Fetch the new issue**: Use the `gh` CLI to get the issue details, since it has reliable authentication:
+   ```bash
+   gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json number,title,body,labels,createdAt
+   ```
 
 3. **Compare with cached issues** (skip if cache was empty):
    - Compare the new issue's title and body against cached issue data
@@ -48,10 +51,12 @@ When a new issue is opened, analyze it to determine if it might be a duplicate o
    - Look for similar problem descriptions in the body
    - Consider keyword overlap and semantic similarity
 
-4. **Search for potential duplicates via GitHub API**: Always search GitHub for issues with similar keywords, whether or not the cache had data:
-   - Search for issues with similar titles or key terms
+4. **Search for potential duplicates via GitHub API**: Always search GitHub for issues with similar keywords, whether or not the cache had data. Use the `gh` CLI for reliable API access:
+   ```bash
+   gh search issues "<key terms>" --repo ${{ github.repository }} --state open --limit 10 --json number,title,body
+   gh issue list --repo ${{ github.repository }} --state open --limit 20 --json number,title,body,labels
+   ```
    - Focus on open issues first, then consider recently closed ones
-   - Use `perPage: 10` initially to avoid token limits, paginate if needed
 
 5. **Update the cache**: Store the new issue's signature in the cache-memory for future comparisons:
    - Write to `/tmp/gh-aw/cache-memory/issues.json` using bash (e.g., write the JSON content with `cat > /tmp/gh-aw/cache-memory/issues.json << 'EOF'`)
@@ -97,3 +102,4 @@ If one of these addresses your concern, please consider closing this issue as a 
 - Be helpful: Always explain why issues appear related
 - Respect the cache: Keep stored data minimal and relevant
 - Use pagination: Always use `perPage` parameter when listing/searching issues
+- **Prefer `gh` CLI over MCP tools for GitHub API access**: The `gh` CLI uses the automatic `GITHUB_TOKEN` which is always valid, whereas MCP tools may use a separate token that can expire. Use `gh issue view`, `gh issue list`, `gh search issues`, and `gh api` for reliable access.

--- a/.github/workflows/secret-digger-codex.lock.yml
+++ b/.github/workflows/secret-digger-codex.lock.yml
@@ -1336,18 +1336,18 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_ddb2177a5929b768_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_10bbb38712b6fb7a_EOF
           [history]
           persistence = "none"
           
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_MCP_CONFIG_ddb2177a5929b768_EOF
+          GH_AW_MCP_CONFIG_10bbb38712b6fb7a_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c86abaa2690a701b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f0f2672ec810d756_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1358,11 +1358,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c86abaa2690a701b_EOF
+          GH_AW_MCP_CONFIG_f0f2672ec810d756_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_80514efd14ac68cd_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_c6e66ea99d618be4_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1372,7 +1372,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_CODEX_SHELL_POLICY_80514efd14ac68cd_EOF
+          GH_AW_CODEX_SHELL_POLICY_c6e66ea99d618be4_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }


### PR DESCRIPTION
## Problem

The Issue Duplication Detector has been failing on **every single run** since at least May 11 with `401 Bad Credentials` from the GitHub MCP server. Analysis of 10+ runs confirms this is a persistent failure, not transient.

### Root Cause

The GitHub MCP server receives its token via the secret chain:
```
secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN
```

The `GH_AW_GITHUB_MCP_SERVER_TOKEN` secret appears to be expired/revoked. Since it exists and is non-empty, it takes priority in the `||` chain, preventing the fallback to the working automatic `GITHUB_TOKEN`.

### Fix

Updated the workflow prompt to use the `gh` CLI (which uses the automatic `GITHUB_TOKEN` via `GH_TOKEN` env var) for all GitHub API operations instead of relying on the GitHub MCP server tools. The `gh` CLI is available in the AWF sandbox via the `bash` tool and has reliable authentication.

### Recommendation

Additionally, the `GH_AW_GITHUB_MCP_SERVER_TOKEN` repo secret should be either:
1. **Deleted** — so all workflows using the GitHub MCP server fall through to the automatic `GITHUB_TOKEN` (sufficient for read-only operations)
2. **Rotated** — with a fresh, valid PAT

This would fix the MCP tool authentication for ALL workflows that use `tools.github`, not just this one.

### Evidence

Every run since May 11 shows:
```
GET https://api.github.com/repos/github/gh-aw-firewall/issues/XXXX: 401 Bad credentials
```

Fixes #3233