### PR TITLE
fix: remove unused exports from public API surface (batch 2)

### DIFF
--- a/src/commands/subcommands.ts
+++ b/src/commands/subcommands.ts
@@ -17,7 +17,7 @@ function validateFormat(format: string, validFormats: string[]): void {
 }
 
 /**
- * Predownload action handler — exported for testing.
+ * Module-internal action handler for the `predownload` subcommand.
  */
 async function handlePredownloadAction(options: {
   imageRegistry: string;

--- a/src/commands/subcommands.ts
+++ b/src/commands/subcommands.ts
@@ -9,7 +9,7 @@ import { OutputFormat } from '../types';
  * @param validFormats - Array of valid format options
  * @throws Exits process with error if format is invalid
  */
-export function validateFormat(format: string, validFormats: string[]): void {
+function validateFormat(format: string, validFormats: string[]): void {
   if (!validFormats.includes(format)) {
     logger.error(`Invalid format: ${format}. Must be one of: ${validFormats.join(', ')}`);
     process.exit(1);
@@ -19,7 +19,7 @@ export function validateFormat(format: string, validFormats: string[]): void {
 /**
  * Predownload action handler — exported for testing.
  */
-export async function handlePredownloadAction(options: {
+async function handlePredownloadAction(options: {
   imageRegistry: string;
   imageTag: string;
   agentImage: string;

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { validateWithSchema } from './schema-validator';
 
-export interface AwfFileConfig {
+/** @internal Used only within config-file.ts — not part of public API */
+interface AwfFileConfig {
   $schema?: string;
   network?: {
     allowDomains?: string[];

--- a/src/host-iptables-network.test.ts
+++ b/src/host-iptables-network.test.ts
@@ -1,7 +1,9 @@
 import { execaResult, mockedExeca, setupHostIptablesTestSuite } from './test-helpers/host-iptables-test-setup';
-import { cleanupFirewallNetwork } from './host-iptables-network';
+import { testHelpers as networkTestHelpers } from './host-iptables-network';
 import { ensureFirewallNetwork } from './host-iptables';
 import { testHelpers } from './host-iptables-shared';
+
+const { cleanupFirewallNetwork } = networkTestHelpers;
 
 describe('host-iptables (network)', () => {
   setupHostIptablesTestSuite(testHelpers.resetIpv6State);

--- a/src/host-iptables-network.ts
+++ b/src/host-iptables-network.ts
@@ -51,7 +51,7 @@ export async function ensureFirewallNetwork(): Promise<{
 /**
  * Removes the firewall network
  */
-export async function cleanupFirewallNetwork(): Promise<void> {
+async function cleanupFirewallNetwork(): Promise<void> {
   logger.debug(`Removing firewall network '${NETWORK_NAME}'...`);
 
   try {
@@ -62,3 +62,6 @@ export async function cleanupFirewallNetwork(): Promise<void> {
     // Don't throw - cleanup should be best-effort
   }
 }
+
+/** @internal Exposed for testing only */
+export const testHelpers = { cleanupFirewallNetwork };


### PR DESCRIPTION
## Summary

Removes three unnecessary exports from the public API surface, addressing the remaining open [Export Audit] issues.

### Changes

| Issue | File | Symbol | Fix |
|-------|------|--------|-----|
| #3242 | `src/config-file.ts` | `AwfFileConfig` | Removed `export` — callers use type inference, no external imports |
| #3244 | `src/host-iptables-network.ts` | `cleanupFirewallNetwork` | Made module-private, exposed via `testHelpers` for tests |
| #3245 | `src/commands/subcommands.ts` | `validateFormat`, `handlePredownloadAction` | Removed `export` — internal helpers, existing tests already assert these must not be in public API |

### Verification

- Build passes (`npm run build`)
- All 135 affected tests pass
- No external consumers of any removed export

Closes #3242, closes #3244, closes #3245