### PR TITLE
fix: resolve test failures on macOS

### DIFF
--- a/src/docker-manager-cleanup.test.ts
+++ b/src/docker-manager-cleanup.test.ts
@@ -11,6 +11,17 @@ import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
+// Mock host identity functions so chownSync uses the real uid/gid
+// (on macOS, gid < 1000 gets clamped to 1000 which causes EPERM)
+jest.mock('./host-env', () => {
+  const actual = jest.requireActual('./host-env');
+  return {
+    ...actual,
+    getSafeHostUid: () => String(process.getuid?.() ?? 1000),
+    getSafeHostGid: () => String(process.getgid?.() ?? 1000),
+  };
+});
+
 describe('docker-manager writeConfigs and cleanup', () => {
   describe('writeConfigs', () => {
     let testDir: string;

--- a/src/docker-manager-utils.test.ts
+++ b/src/docker-manager-utils.test.ts
@@ -217,8 +217,12 @@ describe('docker-manager utilities', () => {
       process.env.SUDO_USER = 'root';
       process.env.HOME = '/some/other/path';
 
-      // Should find root's home directory from /etc/passwd
-      expect(getRealUserHome()).toBe('/root');
+      // Read actual root home from /etc/passwd (differs by platform: /root on Linux, /var/root on macOS)
+      const passwd = fs.readFileSync('/etc/passwd', 'utf-8');
+      const rootLine = passwd.split('\n').find(line => line.startsWith('root:'));
+      const expectedRootHome = rootLine ? rootLine.split(':')[5] : '/root';
+
+      expect(getRealUserHome()).toBe(expectedRootHome);
     });
 
     it('should fall back to HOME when SUDO_USER not found in /etc/passwd', () => {
@@ -236,9 +240,13 @@ describe('docker-manager utilities', () => {
       process.env.SUDO_USER = 'root';
       process.env.HOME = '/custom/home';
 
+      // Read actual root home from /etc/passwd (differs by platform)
+      const passwd = fs.readFileSync('/etc/passwd', 'utf-8');
+      const rootLine = passwd.split('\n').find(line => line.startsWith('root:'));
+      const expectedRootHome = rootLine ? rootLine.split(':')[5] : '/root';
+
       // With getuid undefined, uid is undefined (falsy), so it attempts passwd lookup
-      // Should find root's home directory from /etc/passwd
-      expect(getRealUserHome()).toBe('/root');
+      expect(getRealUserHome()).toBe(expectedRootHome);
     });
   });
 


### PR DESCRIPTION
Fixes 4 test failures (in 2 suites) that occur on macOS due to platform differences:

### docker-manager-utils.test.ts (2 failures)
Tests hardcoded `/root` as root's home directory, but macOS uses `/var/root`. Fixed by reading the actual root home from `/etc/passwd` at test time.

### docker-manager-cleanup.test.ts (2 failures)
`writeConfigs()` calls `chownSync(dir, uid, gid)` where `gid` comes from `getSafeHostGid()`. On macOS, the real gid (501) is below 1000 and gets clamped to 1000, but the current user doesn't belong to gid 1000, causing EPERM. Fixed by mocking `getSafeHostUid/Gid` in the test to return the actual process uid/gid.

**Note:** The `workflow-engine-install-security` failure (missing `--ignore-scripts` in Claude Code installs) is a gh-aw compiler issue in generated lock files — not addressed here since lock files should not be edited directly.