### PR TITLE
fix: add resilient gh-aw installer and --ignore-scripts to lock files

### DIFF
--- a/.github/workflows/ci-cd-gaps-assessment.lock.yml
+++ b/.github/workflows/ci-cd-gaps-assessment.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1769f2dcec0b20b0740dd55c5ee9639457a8427787794ddeb8b4d380e1ce1664","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"alpine:latest","digest":"sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11","pinned_image":"alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"},{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29","digest":"sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29","digest":"sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29","digest":"sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5235ad4afb84401b4418097a2c2d38cbd5a77bf064a6eaff1c236787ea98df33","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"},{"repo":"github/gh-aw/actions/setup-cli","sha":"v0.72.1","version":"v0.72.1"}],"containers":[{"image":"alpine:latest","digest":"sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11","pinned_image":"alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"},{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29","digest":"sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29","digest":"sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29","digest":"sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -27,6 +27,7 @@
 # Resolved workflow manifest:
 #   Imports:
 #     - shared/mcp-pagination.md
+#     - shared/mcp/gh-aw.md
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -41,6 +42,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@d3abfe96a194bce3a523ed2093ddedd5704cdf62 # v0.74.4
+#   - github/gh-aw/actions/setup-cli@v0.72.1
 #
 # Container images used:
 #   - alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
@@ -181,21 +183,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7e2e1c42945f3b53_EOF'
+          cat << 'GH_AW_PROMPT_05bca8f6b72504ad_EOF'
           <system>
-          GH_AW_PROMPT_7e2e1c42945f3b53_EOF
+          GH_AW_PROMPT_05bca8f6b72504ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/agentic_workflows_guide.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7e2e1c42945f3b53_EOF'
+          cat << 'GH_AW_PROMPT_05bca8f6b72504ad_EOF'
           <safe-output-tools>
           Tools: create_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_7e2e1c42945f3b53_EOF
+          GH_AW_PROMPT_05bca8f6b72504ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7e2e1c42945f3b53_EOF'
+          cat << 'GH_AW_PROMPT_05bca8f6b72504ad_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -224,13 +226,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7e2e1c42945f3b53_EOF
+          GH_AW_PROMPT_05bca8f6b72504ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7e2e1c42945f3b53_EOF'
+          cat << 'GH_AW_PROMPT_05bca8f6b72504ad_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/mcp-pagination.md}}
+          {{#runtime-import .github/workflows/shared/mcp/gh-aw.md}}
           {{#runtime-import .github/workflows/ci-cd-gaps-assessment.md}}
-          GH_AW_PROMPT_7e2e1c42945f3b53_EOF
+          GH_AW_PROMPT_05bca8f6b72504ad_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -363,12 +366,21 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup gh-aw CLI
+        uses: github/gh-aw/actions/setup-cli@v0.72.1
+        with:
+          version: 'v0.74.4'
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        name: Install gh-aw extension
+        run: "# Install gh-aw if binary not already present.\n# NOTE: Do NOT use 'gh aw --version' to detect installation — newer gh CLI versions\n# return exit code 0 with an \"available as official extension\" message even when the\n# extension binary is not installed, which would silently skip the install step.\nGH_AW_BIN=$(command -v gh-aw 2>/dev/null || find \"${HOME}/.local/share/gh/extensions/gh-aw\" -name 'gh-aw' -type f -executable 2>/dev/null | head -1)\nif [ -z \"$GH_AW_BIN\" ] || [ ! -x \"$GH_AW_BIN\" ]; then\n  echo \"Installing gh-aw extension...\"\n  # Download to a temp file first so curl failures are detected (avoids silent pipe failure)\n  curl -fsSL https://raw.githubusercontent.com/github/gh-aw/refs/heads/main/install-gh-aw.sh -o /tmp/install-gh-aw.sh\n  bash /tmp/install-gh-aw.sh\n  rm -f /tmp/install-gh-aw.sh\n  GH_AW_BIN=$(command -v gh-aw 2>/dev/null || find \"${HOME}/.local/share/gh/extensions/gh-aw\" -name 'gh-aw' -type f -executable 2>/dev/null | head -1)\nfi\ngh aw --version\n# Copy the gh-aw binary to RUNNER_TEMP for MCP server containerization\nmkdir -p \"${RUNNER_TEMP}/gh-aw\"\nif [ -n \"$GH_AW_BIN\" ] && [ -x \"$GH_AW_BIN\" ]; then\n  cp \"$GH_AW_BIN\" \"${RUNNER_TEMP}/gh-aw/gh-aw\"\n  chmod +x \"${RUNNER_TEMP}/gh-aw/gh-aw\"\n  echo \"Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw\"\nelse\n  echo \"::error::Failed to find gh-aw binary for MCP server\"\n  exit 1\nfi\n"
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -453,42 +465,14 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_inline_sub_agents.sh"
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6 ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53 ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388 ghcr.io/github/github-mcp-server:v1.0.4 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
-      - name: Install gh-aw extension
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if gh-aw extension is already installed
-          if gh extension list | grep -qE '(^|[[:space:]])gh-aw($|[[:space:]])'; then
-            echo "gh-aw extension already installed, upgrading..."
-            gh extension upgrade gh-aw || true
-          else
-            echo "Installing gh-aw extension..."
-            gh extension install github/gh-aw
-          fi
-          gh aw --version
-          # Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization
-          mkdir -p "${RUNNER_TEMP}/gh-aw"
-          GH_AW_BIN=""
-          GH_AW_BIN=$(command -v gh-aw 2>/dev/null) || true
-          if [ -z "$GH_AW_BIN" ]; then
-            GH_AW_BIN=$(find "${HOME}/.local/share/gh/extensions/gh-aw" -name 'gh-aw' -type f 2>/dev/null | head -1) || true
-          fi
-          if [ -n "$GH_AW_BIN" ] && [ -f "$GH_AW_BIN" ]; then
-            cp "$GH_AW_BIN" "${RUNNER_TEMP}/gh-aw/gh-aw"
-            chmod +x "${RUNNER_TEMP}/gh-aw/gh-aw"
-            echo "Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw"
-          else
-            echo "::error::Failed to find gh-aw binary for MCP server"
-            exit 1
-          fi
       - name: Generate Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f7aaaa48b3135ef5_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a7406463d7ec1f15_EOF'
           {"create_discussion":{"category":"general","expires":168,"fallback_to_issue":true,"max":1,"title_prefix":"[CI/CD Assessment] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f7aaaa48b3135ef5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a7406463d7ec1f15_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -687,7 +671,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8e8b258224265c5b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_be87c2ace6457973_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -749,7 +733,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8e8b258224265c5b_EOF
+          GH_AW_MCP_CONFIG_be87c2ace6457973_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/ci-cd-gaps-assessment.md
+++ b/.github/workflows/ci-cd-gaps-assessment.md
@@ -10,6 +10,7 @@ permissions:
   pull-requests: read
 imports:
   - shared/mcp-pagination.md
+  - uses: shared/mcp/gh-aw.md
 sandbox:
   agent:
     id: awf

--- a/.github/workflows/pelis-agent-factory-advisor.lock.yml
+++ b/.github/workflows/pelis-agent-factory-advisor.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0c9e4e260012b2f8a2d154ce9065d1c98620b0bc32dad079095a1c67ec620bb9","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"alpine:latest","digest":"sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11","pinned_image":"alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"},{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29","digest":"sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29","digest":"sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29","digest":"sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"127d1076f2a052c40767759983c2a6f11b96097ee859ca6099b5586e584cc055","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"},{"repo":"github/gh-aw/actions/setup-cli","sha":"v0.72.1","version":"v0.72.1"}],"containers":[{"image":"alpine:latest","digest":"sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11","pinned_image":"alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"},{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29","digest":"sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29","digest":"sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29","digest":"sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -24,6 +24,10 @@
 #
 # Daily advisor that analyzes the repository for opportunities to add, enhance, or improve agentic workflows based on Pelis Agent Factory patterns
 #
+# Resolved workflow manifest:
+#   Imports:
+#     - shared/mcp/gh-aw.md
+#
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
@@ -39,6 +43,7 @@
 #   - actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@d3abfe96a194bce3a523ed2093ddedd5704cdf62 # v0.74.4
+#   - github/gh-aw/actions/setup-cli@v0.72.1
 #
 # Container images used:
 #   - alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
@@ -179,22 +184,22 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_10506c22bfab14e2_EOF'
+          cat << 'GH_AW_PROMPT_d72b75ac0592f8bb_EOF'
           <system>
-          GH_AW_PROMPT_10506c22bfab14e2_EOF
+          GH_AW_PROMPT_d72b75ac0592f8bb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/agentic_workflows_guide.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_10506c22bfab14e2_EOF'
+          cat << 'GH_AW_PROMPT_d72b75ac0592f8bb_EOF'
           <safe-output-tools>
           Tools: create_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_10506c22bfab14e2_EOF
+          GH_AW_PROMPT_d72b75ac0592f8bb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_10506c22bfab14e2_EOF'
+          cat << 'GH_AW_PROMPT_d72b75ac0592f8bb_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -223,12 +228,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_10506c22bfab14e2_EOF
+          GH_AW_PROMPT_d72b75ac0592f8bb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_10506c22bfab14e2_EOF'
+          cat << 'GH_AW_PROMPT_d72b75ac0592f8bb_EOF'
           </system>
+          {{#runtime-import .github/workflows/shared/mcp/gh-aw.md}}
           {{#runtime-import .github/workflows/pelis-agent-factory-advisor.md}}
-          GH_AW_PROMPT_10506c22bfab14e2_EOF
+          GH_AW_PROMPT_d72b75ac0592f8bb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -368,6 +374,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup gh-aw CLI
+        uses: github/gh-aw/actions/setup-cli@v0.72.1
+        with:
+          version: 'v0.74.4'
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -378,6 +388,10 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        name: Install gh-aw extension
+        run: "# Install gh-aw if binary not already present.\n# NOTE: Do NOT use 'gh aw --version' to detect installation — newer gh CLI versions\n# return exit code 0 with an \"available as official extension\" message even when the\n# extension binary is not installed, which would silently skip the install step.\nGH_AW_BIN=$(command -v gh-aw 2>/dev/null || find \"${HOME}/.local/share/gh/extensions/gh-aw\" -name 'gh-aw' -type f -executable 2>/dev/null | head -1)\nif [ -z \"$GH_AW_BIN\" ] || [ ! -x \"$GH_AW_BIN\" ]; then\n  echo \"Installing gh-aw extension...\"\n  # Download to a temp file first so curl failures are detected (avoids silent pipe failure)\n  curl -fsSL https://raw.githubusercontent.com/github/gh-aw/refs/heads/main/install-gh-aw.sh -o /tmp/install-gh-aw.sh\n  bash /tmp/install-gh-aw.sh\n  rm -f /tmp/install-gh-aw.sh\n  GH_AW_BIN=$(command -v gh-aw 2>/dev/null || find \"${HOME}/.local/share/gh/extensions/gh-aw\" -name 'gh-aw' -type f -executable 2>/dev/null | head -1)\nfi\ngh aw --version\n# Copy the gh-aw binary to RUNNER_TEMP for MCP server containerization\nmkdir -p \"${RUNNER_TEMP}/gh-aw\"\nif [ -n \"$GH_AW_BIN\" ] && [ -x \"$GH_AW_BIN\" ]; then\n  cp \"$GH_AW_BIN\" \"${RUNNER_TEMP}/gh-aw/gh-aw\"\n  chmod +x \"${RUNNER_TEMP}/gh-aw/gh-aw\"\n  echo \"Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw\"\nelse\n  echo \"::error::Failed to find gh-aw binary for MCP server\"\n  exit 1\nfi\n"
       - id: fetch-docs
         name: Fetch Pelis Agent Factory Docs
         run: "set -o pipefail\nBASE=\"https://github.github.io/gh-aw\"\nOUTFILE=\"${GITHUB_WORKSPACE}/.pelis-agent-factory-docs.txt\"\n: > \"$OUTFILE\"\nfor PATH_SUFFIX in \\\n  \"/blog/2026-01-12-welcome-to-pelis-agent-factory/\" \\\n  \"/introduction/overview/\" \\\n  \"/guides/workflow-patterns/\" \\\n  \"/guides/best-practices/\"; do\n  echo \"### ${BASE}${PATH_SUFFIX}\" >> \"$OUTFILE\"\n  curl -sf \"${BASE}${PATH_SUFFIX}\" \\\n    | python3 -c \"import sys,html,re;t=sys.stdin.read();print(html.unescape(re.sub('<[^>]+>','',t))[:3500])\" \\\n    >> \"$OUTFILE\" 2>/dev/null \\\n    || echo \"(not found)\" >> \"$OUTFILE\"\n  echo \"\" >> \"$OUTFILE\"\ndone\n"
@@ -509,42 +523,14 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_inline_sub_agents.sh"
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 ghcr.io/github/gh-aw-firewall/agent:0.25.29@sha256:e68f37e36962dcb3f3d1de680a49bc2302cefd001b941a7dc377155ec7ce42f4 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.29@sha256:d1219e4110684402aabbeb5a43858f26790c9d0be210581cf3f7a521bd2c87b6 ghcr.io/github/gh-aw-firewall/squid:0.25.29@sha256:8a71ad9e40454051672312917e51567abfb8251d7c294d086c48f63d84e4cb53 ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388 ghcr.io/github/github-mcp-server:v1.0.4 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
-      - name: Install gh-aw extension
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if gh-aw extension is already installed
-          if gh extension list | grep -qE '(^|[[:space:]])gh-aw($|[[:space:]])'; then
-            echo "gh-aw extension already installed, upgrading..."
-            gh extension upgrade gh-aw || true
-          else
-            echo "Installing gh-aw extension..."
-            gh extension install github/gh-aw
-          fi
-          gh aw --version
-          # Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization
-          mkdir -p "${RUNNER_TEMP}/gh-aw"
-          GH_AW_BIN=""
-          GH_AW_BIN=$(command -v gh-aw 2>/dev/null) || true
-          if [ -z "$GH_AW_BIN" ]; then
-            GH_AW_BIN=$(find "${HOME}/.local/share/gh/extensions/gh-aw" -name 'gh-aw' -type f 2>/dev/null | head -1) || true
-          fi
-          if [ -n "$GH_AW_BIN" ] && [ -f "$GH_AW_BIN" ]; then
-            cp "$GH_AW_BIN" "${RUNNER_TEMP}/gh-aw/gh-aw"
-            chmod +x "${RUNNER_TEMP}/gh-aw/gh-aw"
-            echo "Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw"
-          else
-            echo "::error::Failed to find gh-aw binary for MCP server"
-            exit 1
-          fi
       - name: Generate Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_70ef7ddccf6cee1f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8a8196bb8871136c_EOF'
           {"create_discussion":{"category":"general","expires":168,"fallback_to_issue":true,"max":1,"title_prefix":"[Pelis Agent Factory Advisor] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_70ef7ddccf6cee1f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8a8196bb8871136c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -743,7 +729,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6c1ef3ad9c318980_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_5162fa6bdb3b70a7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -805,7 +791,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6c1ef3ad9c318980_EOF
+          GH_AW_MCP_CONFIG_5162fa6bdb3b70a7_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/pelis-agent-factory-advisor.md
+++ b/.github/workflows/pelis-agent-factory-advisor.md
@@ -9,6 +9,8 @@ permissions:
   issues: read
   pull-requests: read
   discussions: read
+imports:
+  - uses: shared/mcp/gh-aw.md
 tools:
   agentic-workflows:
   bash:

--- a/.github/workflows/secret-digger-claude.lock.yml
+++ b/.github/workflows/secret-digger-claude.lock.yml
@@ -389,7 +389,7 @@ jobs:
           EOF
           sudo chmod +x /usr/local/bin/awf
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.142
+        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.142
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
           EOF
           sudo chmod +x /usr/local/bin/awf
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.142
+        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.142
       - name: Execute Claude Code CLI
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true

--- a/.github/workflows/security-guard.lock.yml
+++ b/.github/workflows/security-guard.lock.yml
@@ -482,7 +482,7 @@ jobs:
           EOF
           sudo chmod +x /usr/local/bin/awf
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.142
+        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.142
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -479,7 +479,7 @@ jobs:
           EOF
           sudo chmod +x /usr/local/bin/awf
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.142
+        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.142
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)

--- a/scripts/ci/postprocess-smoke-workflows.ts
+++ b/scripts/ci/postprocess-smoke-workflows.ts
@@ -94,6 +94,12 @@ const sessionStateDirInjectionRegex =
   /--audit-dir \/tmp\/gh-aw\/sandbox\/firewall\/audit(?! --session-state-dir)/g;
 const SESSION_STATE_DIR = '/tmp/gh-aw/sandbox/agent/session-state';
 
+// Ensure engine CLI installs include --ignore-scripts for supply-chain security.
+// The gh-aw compiler omits this flag for Claude Code (though Codex has it).
+// Match: "npm install -g @anthropic-ai/claude-code@<version>" without --ignore-scripts
+const claudeCodeInstallRegex =
+  /run: npm install(?! --ignore-scripts) -g (@anthropic-ai\/claude-code@[\d.]+)/g;
+
 // Work around gh-aw compiler bug (gh-aw#26565) where Copilot model fallback is
 // emitted as an empty string:
 //   COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
@@ -418,6 +424,17 @@ for (const workflowPath of workflowPaths) {
     );
   } else {
     console.log(`  --session-state-dir already present (or no awf invocation found)`);
+  }
+
+  // Inject --ignore-scripts into Claude Code npm install commands for supply-chain security
+  claudeCodeInstallRegex.lastIndex = 0;
+  const claudeCodeMatches = content.match(claudeCodeInstallRegex);
+  if (claudeCodeMatches) {
+    content = content.replace(claudeCodeInstallRegex, 'run: npm install --ignore-scripts -g $1');
+    modified = true;
+    console.log(
+      `  Injected --ignore-scripts in ${claudeCodeMatches.length} Claude Code install(s)`
+    );
   }
 
   // Replace the "Copy Copilot session state files to logs" step with an inline

--- a/scripts/ci/postprocess-smoke-workflows.ts
+++ b/scripts/ci/postprocess-smoke-workflows.ts
@@ -96,9 +96,11 @@ const SESSION_STATE_DIR = '/tmp/gh-aw/sandbox/agent/session-state';
 
 // Ensure engine CLI installs include --ignore-scripts for supply-chain security.
 // The gh-aw compiler omits this flag for Claude Code (though Codex has it).
-// Match: "npm install -g @anthropic-ai/claude-code@<version>" without --ignore-scripts
+// Match a Claude Code npm install line that does not already include
+// --ignore-scripts, while tolerating additional npm install flags before `-g`.
+// Capture only the package spec so existing replacement logic can keep using $1.
 const claudeCodeInstallRegex =
-  /run: npm install(?! --ignore-scripts) -g (@anthropic-ai\/claude-code@[\d.]+)/g;
+  /run: npm install\b(?![^\n]*\s--ignore-scripts\b)(?:[^\n]*?\s-g\s+)(@anthropic-ai\/claude-code@[\d.]+)/g;
 
 // Work around gh-aw compiler bug (gh-aw#26565) where Copilot model fallback is
 // emitted as an empty string:


### PR DESCRIPTION
Fixes 2 failing npm tests (workflow-gh-aw-install and workflow-engine-install-security).

## Root Cause

1. **Legacy gh-aw installer**: `ci-cd-gaps-assessment` and `pelis-agent-factory-advisor` workflows didn't import `shared/mcp/gh-aw.md`, so the compiler emitted the legacy `gh extension install/upgrade` pattern instead of the resilient `install-gh-aw.sh` installer.

2. **Missing `--ignore-scripts`**: The gh-aw compiler emits Claude Code installs without `--ignore-scripts`, unlike Codex installs which include it.

## Fix

- Added `shared/mcp/gh-aw.md` import to both affected workflow `.md` files
- Added `--ignore-scripts` injection for Claude Code installs in `postprocess-smoke-workflows.ts`
- Recompiled affected lock files

All 1952 tests pass.