### PR TITLE
fix: flatten OTEL cache attribute names for Sentry compatibility

### DIFF
--- a/containers/api-proxy/otel.js
+++ b/containers/api-proxy/otel.js
@@ -447,17 +447,17 @@ function setTokenAttributes(span, { provider, model, normalizedUsage, streaming 
     span.setAttributes({
       'gen_ai.usage.input_tokens':                normalizedUsage.input_tokens,
       'gen_ai.usage.output_tokens':               normalizedUsage.output_tokens,
-      'gen_ai.usage.cache_read.input_tokens':     normalizedUsage.cache_read_tokens,
-      'gen_ai.usage.cache_creation.input_tokens': normalizedUsage.cache_write_tokens,
-      'gen_ai.usage.reasoning.output_tokens':     normalizedUsage.reasoning_tokens || 0,
+      'gen_ai.usage.cache_read_input_tokens':     normalizedUsage.cache_read_tokens,
+      'gen_ai.usage.cache_creation_input_tokens': normalizedUsage.cache_write_tokens,
+      'gen_ai.usage.reasoning_output_tokens':     normalizedUsage.reasoning_tokens || 0,
       'gen_ai.request.stream':                    streaming,
     });
     span.addEvent('gen_ai.usage', {
       'gen_ai.usage.input_tokens':                normalizedUsage.input_tokens,
       'gen_ai.usage.output_tokens':               normalizedUsage.output_tokens,
-      'gen_ai.usage.cache_read.input_tokens':     normalizedUsage.cache_read_tokens,
-      'gen_ai.usage.cache_creation.input_tokens': normalizedUsage.cache_write_tokens,
-      'gen_ai.usage.reasoning.output_tokens':     normalizedUsage.reasoning_tokens || 0,
+      'gen_ai.usage.cache_read_input_tokens':     normalizedUsage.cache_read_tokens,
+      'gen_ai.usage.cache_creation_input_tokens': normalizedUsage.cache_write_tokens,
+      'gen_ai.usage.reasoning_output_tokens':     normalizedUsage.reasoning_tokens || 0,
     });
   } catch { /* best-effort */ }
 }

--- a/containers/api-proxy/otel.test.js
+++ b/containers/api-proxy/otel.test.js
@@ -235,8 +235,8 @@ describe('otel — setTokenAttributes', () => {
     expect(s.attributes['gen_ai.response.model']).toBe('gpt-4o');
     expect(s.attributes['gen_ai.usage.input_tokens']).toBe(1000);
     expect(s.attributes['gen_ai.usage.output_tokens']).toBe(500);
-    expect(s.attributes['gen_ai.usage.cache_read.input_tokens']).toBe(200);
-    expect(s.attributes['gen_ai.usage.cache_creation.input_tokens']).toBe(50);
+    expect(s.attributes['gen_ai.usage.cache_read_input_tokens']).toBe(200);
+    expect(s.attributes['gen_ai.usage.cache_creation_input_tokens']).toBe(50);
     expect(s.attributes['gen_ai.request.stream']).toBe(false);
 
     const usageEvent = s.events.find(e => e.name === 'gen_ai.usage');


### PR DESCRIPTION
Sentry's OTLP ingestion drops span attributes with deeply nested dot notation (4+ segments). This flattens cache/reasoning attribute names so they appear in Sentry.

- `gen_ai.usage.cache_read.input_tokens` → `gen_ai.usage.cache_read_input_tokens`
- `gen_ai.usage.cache_creation.input_tokens` → `gen_ai.usage.cache_creation_input_tokens`
- `gen_ai.usage.reasoning.output_tokens` → `gen_ai.usage.reasoning_output_tokens`

Tests: 32/32 pass