### PR TITLE
fix: use awf.usage namespace for cache/reasoning OTEL attributes

### DIFF
--- a/containers/api-proxy/otel.js
+++ b/containers/api-proxy/otel.js
@@ -445,19 +445,21 @@ function setTokenAttributes(span, { provider, model, normalizedUsage, streaming 
       span.setAttribute('gen_ai.response.model', model);
     }
     span.setAttributes({
-      'gen_ai.usage.input_tokens':                normalizedUsage.input_tokens,
-      'gen_ai.usage.output_tokens':               normalizedUsage.output_tokens,
-      'gen_ai.usage.cache_read_input_tokens':     normalizedUsage.cache_read_tokens,
-      'gen_ai.usage.cache_creation_input_tokens': normalizedUsage.cache_write_tokens,
-      'gen_ai.usage.reasoning_output_tokens':     normalizedUsage.reasoning_tokens || 0,
-      'gen_ai.request.stream':                    streaming,
+      // Standard GenAI semconv (Sentry recognizes these)
+      'gen_ai.usage.input_tokens':      normalizedUsage.input_tokens,
+      'gen_ai.usage.output_tokens':     normalizedUsage.output_tokens,
+      'gen_ai.request.stream':          streaming,
+      // Cache and reasoning as custom attributes (Sentry drops unknown gen_ai.usage.* keys)
+      'awf.usage.cache_read_tokens':    normalizedUsage.cache_read_tokens,
+      'awf.usage.cache_write_tokens':   normalizedUsage.cache_write_tokens,
+      'awf.usage.reasoning_tokens':     normalizedUsage.reasoning_tokens || 0,
     });
     span.addEvent('gen_ai.usage', {
-      'gen_ai.usage.input_tokens':                normalizedUsage.input_tokens,
-      'gen_ai.usage.output_tokens':               normalizedUsage.output_tokens,
-      'gen_ai.usage.cache_read_input_tokens':     normalizedUsage.cache_read_tokens,
-      'gen_ai.usage.cache_creation_input_tokens': normalizedUsage.cache_write_tokens,
-      'gen_ai.usage.reasoning_output_tokens':     normalizedUsage.reasoning_tokens || 0,
+      'gen_ai.usage.input_tokens':      normalizedUsage.input_tokens,
+      'gen_ai.usage.output_tokens':     normalizedUsage.output_tokens,
+      'awf.usage.cache_read_tokens':    normalizedUsage.cache_read_tokens,
+      'awf.usage.cache_write_tokens':   normalizedUsage.cache_write_tokens,
+      'awf.usage.reasoning_tokens':     normalizedUsage.reasoning_tokens || 0,
     });
   } catch { /* best-effort */ }
 }

--- a/containers/api-proxy/otel.test.js
+++ b/containers/api-proxy/otel.test.js
@@ -235,14 +235,16 @@ describe('otel — setTokenAttributes', () => {
     expect(s.attributes['gen_ai.response.model']).toBe('gpt-4o');
     expect(s.attributes['gen_ai.usage.input_tokens']).toBe(1000);
     expect(s.attributes['gen_ai.usage.output_tokens']).toBe(500);
-    expect(s.attributes['gen_ai.usage.cache_read_input_tokens']).toBe(200);
-    expect(s.attributes['gen_ai.usage.cache_creation_input_tokens']).toBe(50);
+    expect(s.attributes['awf.usage.cache_read_tokens']).toBe(200);
+    expect(s.attributes['awf.usage.cache_write_tokens']).toBe(50);
     expect(s.attributes['gen_ai.request.stream']).toBe(false);
 
     const usageEvent = s.events.find(e => e.name === 'gen_ai.usage');
     expect(usageEvent).toBeDefined();
     expect(usageEvent.attributes['gen_ai.usage.input_tokens']).toBe(1000);
     expect(usageEvent.attributes['gen_ai.usage.output_tokens']).toBe(500);
+    expect(usageEvent.attributes['awf.usage.cache_read_tokens']).toBe(200);
+    expect(usageEvent.attributes['awf.usage.cache_write_tokens']).toBe(50);
   });
 
   test('does not set gen_ai.response.model when model is "unknown"', async () => {


### PR DESCRIPTION
Sentry only surfaces well-known `gen_ai.usage.*` attributes (`input_tokens`, `output_tokens`, `total_tokens`) and drops custom additions to that namespace.

Moves cache and reasoning attributes to `awf.usage.*` namespace:
- `awf.usage.cache_read_tokens`
- `awf.usage.cache_write_tokens`
- `awf.usage.reasoning_tokens`

These will appear as regular span tags in Sentry.