### PR TITLE
fix: use Sentry measurement naming for cache token attributes

### DIFF
--- a/containers/api-proxy/otel.js
+++ b/containers/api-proxy/otel.js
@@ -449,17 +449,17 @@ function setTokenAttributes(span, { provider, model, normalizedUsage, streaming 
       'gen_ai.usage.input_tokens':      normalizedUsage.input_tokens,
       'gen_ai.usage.output_tokens':     normalizedUsage.output_tokens,
       'gen_ai.request.stream':          streaming,
-      // Cache and reasoning as custom attributes (Sentry drops unknown gen_ai.usage.* keys)
-      'awf.usage.cache_read_tokens':    normalizedUsage.cache_read_tokens,
-      'awf.usage.cache_write_tokens':   normalizedUsage.cache_write_tokens,
-      'awf.usage.reasoning_tokens':     normalizedUsage.reasoning_tokens || 0,
+      // Cache and reasoning — use Sentry measurement naming (no dots, _count suffix)
+      'cache_read_tokens_count':        normalizedUsage.cache_read_tokens,
+      'cache_write_tokens_count':       normalizedUsage.cache_write_tokens,
+      'reasoning_tokens_count':         normalizedUsage.reasoning_tokens || 0,
     });
     span.addEvent('gen_ai.usage', {
       'gen_ai.usage.input_tokens':      normalizedUsage.input_tokens,
       'gen_ai.usage.output_tokens':     normalizedUsage.output_tokens,
-      'awf.usage.cache_read_tokens':    normalizedUsage.cache_read_tokens,
-      'awf.usage.cache_write_tokens':   normalizedUsage.cache_write_tokens,
-      'awf.usage.reasoning_tokens':     normalizedUsage.reasoning_tokens || 0,
+      'cache_read_tokens_count':        normalizedUsage.cache_read_tokens,
+      'cache_write_tokens_count':       normalizedUsage.cache_write_tokens,
+      'reasoning_tokens_count':         normalizedUsage.reasoning_tokens || 0,
     });
   } catch { /* best-effort */ }
 }

--- a/containers/api-proxy/otel.test.js
+++ b/containers/api-proxy/otel.test.js
@@ -235,16 +235,16 @@ describe('otel — setTokenAttributes', () => {
     expect(s.attributes['gen_ai.response.model']).toBe('gpt-4o');
     expect(s.attributes['gen_ai.usage.input_tokens']).toBe(1000);
     expect(s.attributes['gen_ai.usage.output_tokens']).toBe(500);
-    expect(s.attributes['awf.usage.cache_read_tokens']).toBe(200);
-    expect(s.attributes['awf.usage.cache_write_tokens']).toBe(50);
+    expect(s.attributes['cache_read_tokens_count']).toBe(200);
+    expect(s.attributes['cache_write_tokens_count']).toBe(50);
     expect(s.attributes['gen_ai.request.stream']).toBe(false);
 
     const usageEvent = s.events.find(e => e.name === 'gen_ai.usage');
     expect(usageEvent).toBeDefined();
     expect(usageEvent.attributes['gen_ai.usage.input_tokens']).toBe(1000);
     expect(usageEvent.attributes['gen_ai.usage.output_tokens']).toBe(500);
-    expect(usageEvent.attributes['awf.usage.cache_read_tokens']).toBe(200);
-    expect(usageEvent.attributes['awf.usage.cache_write_tokens']).toBe(50);
+    expect(usageEvent.attributes['cache_read_tokens_count']).toBe(200);
+    expect(usageEvent.attributes['cache_write_tokens_count']).toBe(50);
   });
 
   test('does not set gen_ai.response.model when model is "unknown"', async () => {


### PR DESCRIPTION
Sentry only surfaces custom numeric span attributes that follow its measurement naming conventions (no dots, `_count`/`_ms`/`_bytes` suffix).

Renamed cache/reasoning attributes to flat names:
- `cache_read_tokens_count`
- `cache_write_tokens_count`
- `reasoning_tokens_count`

Previous attempts with dotted namespaces (`gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_read_input_tokens`, `awf.usage.cache_read_tokens`) were all silently dropped by Sentry's OTLP ingestion.