### PR TITLE
docs: credential exclusion requires apiProxy.enabled

### DIFF
--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -345,6 +345,27 @@ When the API proxy sidecar is disabled (the default):
    directly to the agent container.
 2. No proxy-routing variables or placeholder values SHALL be injected.
 
+### 9.4 Credential Exclusion Requires API Proxy
+
+*This constraint is normative for tools generating AWF configurations.*
+
+A conforming configuration MUST NOT exclude a source credential (§9.1) via
+`environment.excludeEnv` unless `apiProxy.enabled` is `true`. Excluding a
+credential without enabling the API proxy leaves the agent with no key and
+no placeholder, causing authentication failures at runtime.
+
+Tools that compile AWF configurations (e.g., `gh-aw`) MUST ensure that when
+an LLM agent requires an API key (OpenAI, Anthropic, Gemini, etc.), **one**
+of the following holds:
+
+1. `apiProxy.enabled = true` — the real key is held by the sidecar, and a
+   placeholder is injected for tool compatibility; or
+2. The key is forwarded directly to the agent container (non-proxy mode).
+
+Emitting `excludeEnv: ["OPENAI_API_KEY"]` without `apiProxy.enabled: true`
+is a configuration error. A conforming implementation MAY emit a warning
+when this condition is detected.
+
 ### 9.4 One-Shot Token Protection
 
 Real credentials forwarded to the agent — whether source credentials in

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -351,7 +351,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Environment variable names to exclude when envAll is true."
+          "description": "Environment variable names to exclude when envAll is true. IMPORTANT: Excluding LLM API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) without setting apiProxy.enabled=true will cause agent authentication failures. Use apiProxy.enabled=true for credential isolation instead of manual exclusion."
         }
       }
     },


### PR DESCRIPTION
Add normative §9.4 to the AWF config spec requiring that tools MUST NOT exclude LLM API keys via `excludeEnv` without enabling the api-proxy sidecar.

Without the proxy, the agent gets no key and no placeholder, causing authentication failures at runtime.

This codifies the root cause of github/gh-aw#32446 and github/gh-aw#33766 where Codex workflows failed because `OPENAI_API_KEY` was excluded without enabling the api-proxy that provides placeholder injection.

Also updates the JSON schema description for `excludeEnv` to warn about this constraint.

Ref: https://github.com/github/gh-aw/pull/33833#issuecomment-4511597199