### PR TITLE
feat: auto-detect DinD split filesystem via sentinel probe

### DIFF
--- a/src/commands/main-action.ts
+++ b/src/commands/main-action.ts
@@ -21,6 +21,7 @@ import { joinShellArgs } from '../option-parsers';
 import { applyConfigFilePrecedence } from './preflight';
 import { registerSignalHandlers } from './signal-handler';
 import { validateOptions } from './validate-options';
+import { probeSplitFilesystem } from '../dind-probe';
 
 /**
  * Resolves the Commander option-value source for a given option name.
@@ -81,6 +82,21 @@ export function createMainAction(getOptionValueSource: OptionSourceResolver) {
   // Apply --docker-host override for AWF's own container operations.
   // This must be called before startContainers/stopContainers/runAgentCommand.
   setAwfDockerHost(config.awfDockerHost);
+
+  // Auto-detect split filesystem in DinD environments when no explicit prefix is set.
+  // This probe runs a lightweight container to check if the daemon can see runner paths.
+  if (!config.dockerHostPathPrefix) {
+    const probeResult = await probeSplitFilesystem(config.workDir);
+    if (probeResult.prefix) {
+      config.dockerHostPathPrefix = probeResult.prefix;
+      logger.info(`Auto-applied --docker-host-path-prefix ${probeResult.prefix} (DinD split filesystem detected)`);
+    } else if (probeResult.splitDetected) {
+      logger.warn(
+        '⚠️  Split runner/daemon filesystem detected but no known prefix worked. ' +
+        'Set --docker-host-path-prefix manually if bind mounts fail.',
+      );
+    }
+  }
 
   // Log config with redacted secrets - remove API keys entirely
   // to prevent sensitive data from flowing to logger (CodeQL sensitive data logging)

--- a/src/dind-probe.test.ts
+++ b/src/dind-probe.test.ts
@@ -1,0 +1,147 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import execa from 'execa';
+import { probeSplitFilesystem } from './dind-probe';
+
+jest.mock('execa');
+jest.mock('./docker-host', () => ({
+  getLocalDockerEnv: () => ({ ...process.env }),
+}));
+
+const mockedExeca = execa as jest.MockedFunction<typeof execa>;
+
+describe('probeSplitFilesystem', () => {
+  let probeDir: string;
+
+  beforeEach(() => {
+    probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-probe-test-'));
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  });
+
+  it('returns no prefix when daemon can see runner filesystem directly', async () => {
+    // Direct mount succeeds (exit code 0)
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(false);
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
+    // Verify the mount source is the probeDir (no prefix)
+    const callArgs = mockedExeca.mock.calls[0][1] as string[];
+    expect(callArgs).toContain(`${probeDir}:/probe:ro`);
+  });
+
+  it('returns /host when direct mount fails but /host prefix works', async () => {
+    // Direct mount fails
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    // /host prefix succeeds
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    expect(result.prefix).toBe('/host');
+    expect(result.splitDetected).toBe(true);
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+    // Verify second call uses /host prefix
+    const secondCallArgs = mockedExeca.mock.calls[1][1] as string[];
+    expect(secondCallArgs).toContain(`/host${probeDir}:/probe:ro`);
+  });
+
+  it('returns /runner when /host fails but /runner prefix works', async () => {
+    // Direct mount fails
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    // /host prefix fails
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    // /runner prefix succeeds
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    expect(result.prefix).toBe('/runner');
+    expect(result.splitDetected).toBe(true);
+    expect(mockedExeca).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns undefined with splitDetected=true when no candidate works', async () => {
+    // Direct mount fails
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    // /host prefix fails
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    // /runner prefix fails
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(true);
+    expect(mockedExeca).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles timeout gracefully', async () => {
+    // Direct mount times out
+    mockedExeca.mockRejectedValueOnce(new Error('timed out'));
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    // Timeout on direct probe means we can't determine — treat as not split
+    // because the probe function catches errors in runProbe and returns false
+    // Then it tries /host and /runner candidates
+    expect(result.splitDetected).toBe(true);
+  });
+
+  it('handles error during probe setup gracefully', async () => {
+    // Use a non-existent directory that can't be created
+    const badDir = '/proc/nonexistent/probe-dir';
+    
+    const result = await probeSplitFilesystem(badDir);
+
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(false);
+  });
+
+  it('cleans up sentinel file after successful probe', async () => {
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+
+    await probeSplitFilesystem(probeDir);
+
+    // Sentinel should be cleaned up
+    const files = fs.readdirSync(probeDir).filter(f => f.startsWith('.awf-fs-probe-'));
+    expect(files).toHaveLength(0);
+  });
+
+  it('cleans up sentinel file after failed probe', async () => {
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+
+    await probeSplitFilesystem(probeDir);
+
+    const files = fs.readdirSync(probeDir).filter(f => f.startsWith('.awf-fs-probe-'));
+    expect(files).toHaveLength(0);
+  });
+
+  it('uses busybox image for the probe', async () => {
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+
+    await probeSplitFilesystem(probeDir);
+
+    const callArgs = mockedExeca.mock.calls[0][1] as string[];
+    expect(callArgs).toContain('busybox:latest');
+  });
+
+  it('passes timeout option to execa', async () => {
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+
+    await probeSplitFilesystem(probeDir);
+
+    const callOptions = (mockedExeca.mock.calls[0] as any)[2];
+    expect(callOptions.timeout).toBe(15000);
+    expect(callOptions.reject).toBe(false);
+  });
+});

--- a/src/dind-probe.ts
+++ b/src/dind-probe.ts
@@ -1,0 +1,114 @@
+/**
+ * Probes whether the Docker daemon shares a filesystem with the runner.
+ *
+ * In ARC/DinD setups, the runner and Docker daemon may have separate
+ * filesystems. When this is the case, bind-mount source paths resolved on
+ * the runner won't exist inside containers. This probe detects that condition
+ * and discovers the correct path prefix so AWF can translate mount paths.
+ *
+ * Strategy:
+ *  1. Write a sentinel file to the probe directory.
+ *  2. Run `docker run --rm -v <dir>:/probe:ro <image> test -f /probe/<sentinel>`.
+ *  3. If the file IS visible → shared filesystem → no prefix needed.
+ *  4. If the file is NOT visible → split filesystem → try candidate prefixes.
+ *  5. For each candidate prefix, try mounting `<prefix><dir>:/probe:ro` and
+ *     check if the sentinel is visible.
+ *  6. Return the first working prefix, or undefined if none works.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import execa from 'execa';
+import { getLocalDockerEnv } from './docker-host';
+import { logger } from './logger';
+
+/** Candidate prefixes to try when split filesystem is detected */
+const CANDIDATE_PREFIXES = ['/host', '/runner'];
+
+/** Timeout for each docker run probe (ms) */
+const PROBE_TIMEOUT_MS = 15000;
+
+/** Lightweight image for the probe — busybox is smaller than alpine */
+const PROBE_IMAGE = 'busybox:latest';
+
+export interface ProbeResult {
+  /** The detected prefix, or undefined if filesystem is shared or undetectable */
+  prefix: string | undefined;
+  /** Whether the probe detected a split filesystem */
+  splitDetected: boolean;
+}
+
+/**
+ * Probes whether the Docker daemon can see the runner's filesystem,
+ * and if not, discovers the correct path prefix for bind-mount translation.
+ *
+ * @param probeDir - Directory to probe (should be the AWF workDir or a subdir)
+ * @returns The discovered prefix, or undefined if same-fs or undetectable
+ */
+export async function probeSplitFilesystem(probeDir: string): Promise<ProbeResult> {
+  const sentinelName = `.awf-fs-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const sentinelPath = path.join(probeDir, sentinelName);
+
+  try {
+    // Ensure probe dir exists
+    fs.mkdirSync(probeDir, { recursive: true });
+    fs.writeFileSync(sentinelPath, 'awf-probe');
+
+    // Step 1: Check if daemon can see the file directly (no prefix)
+    const directVisible = await runProbe(probeDir, sentinelName);
+    if (directVisible) {
+      logger.debug('DinD probe: daemon can see runner filesystem directly (no prefix needed)');
+      return { prefix: undefined, splitDetected: false };
+    }
+
+    // Split filesystem detected
+    logger.debug('DinD probe: daemon cannot see runner filesystem — split topology detected');
+
+    // Step 2: Try candidate prefixes
+    for (const candidate of CANDIDATE_PREFIXES) {
+      const prefixedDir = `${candidate}${probeDir}`;
+      const prefixVisible = await runProbe(prefixedDir, sentinelName);
+      if (prefixVisible) {
+        logger.info(`DinD probe: auto-detected --docker-host-path-prefix ${candidate}`);
+        return { prefix: candidate, splitDetected: true };
+      }
+    }
+
+    // No candidate worked
+    logger.debug('DinD probe: split filesystem detected but no candidate prefix worked');
+    return { prefix: undefined, splitDetected: true };
+  } catch (error) {
+    logger.debug(`DinD probe: error during filesystem probe: ${error instanceof Error ? error.message : String(error)}`);
+    return { prefix: undefined, splitDetected: false };
+  } finally {
+    // Clean up sentinel
+    try {
+      fs.unlinkSync(sentinelPath);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+}
+
+/**
+ * Runs a single probe: mounts the given directory and checks for the sentinel file.
+ */
+async function runProbe(mountSource: string, sentinelName: string): Promise<boolean> {
+  try {
+    const volumeMount = [mountSource, '/probe:ro'].join(':');
+    const targetPath = ['/probe', sentinelName].join('/');
+    const result = await execa(
+      'docker',
+      ['run', '--rm', '-v', volumeMount, PROBE_IMAGE, 'test', '-f', targetPath],
+      {
+        env: getLocalDockerEnv(),
+        timeout: PROBE_TIMEOUT_MS,
+        reject: false,
+      },
+    );
+    return result.exitCode === 0;
+  } catch {
+    // Timeout or other error — treat as not visible
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Auto-detects split runner/daemon filesystems in ARC/DinD setups without requiring manual `--docker-host-path-prefix` configuration.

## Problem

In ARC deployments where the Docker socket is bind-mounted from a sibling daemon pod, the runner and daemon have separate filesystems. AWF's bind-mount source paths (resolved on the runner) don't exist inside the daemon, causing container startup failures. Previously, users had to manually set `--docker-host-path-prefix /host` — but many didn't know about this flag.

The existing detection only keyed on TCP `DOCKER_HOST` values, missing sibling-DinD setups that use unix sockets.

## Solution

Added a setup-time **inode probe** that:

1. Writes a sentinel file to the AWF work directory
2. Runs `docker run --rm -v <workDir>:/probe:ro busybox test -f /probe/<sentinel>`
3. If the daemon **cannot** see it → split filesystem detected
4. Tries candidate prefixes (`/host`, `/runner`) by mounting `<prefix><workDir>:/probe:ro`
5. Auto-applies the first working prefix

This handles all DinD shapes uniformly — TCP, unix-socket sibling pods, and any future topology — by testing the actual condition (filesystem visibility) rather than parsing env vars.

## Key Design Decisions

| Decision | Choice |
|----------|--------|
| When to probe | Only when no explicit `--docker-host-path-prefix` is set |
| Probe image | `busybox:latest` (small, commonly cached) |
| Timeout | 15s per probe attempt |
| Fallback | If no candidate works, emit warning (don't break existing behavior) |
| Verification | Don't blindly assume `/host` — verify prefix actually works before applying |

## Files Changed

- `src/dind-probe.ts` — New module with `probeSplitFilesystem()` function
- `src/dind-probe.test.ts` — 10 unit tests covering all paths
- `src/commands/main-action.ts` — Integration: run probe after Docker host setup

## Testing

- 10 unit tests pass covering: direct visibility, /host prefix, /runner prefix, no prefix works, timeout, setup error, cleanup, image choice, timeout option
- Build passes cleanly
- Lint passes (only expected fs security warnings for dynamic paths)

Closes #3553