### PR TITLE
fix(dind-probe): address review feedback from #3554

### DIFF
--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -351,7 +351,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Environment variable names to exclude when envAll is true."
+          "description": "Environment variable names to exclude when envAll is true. IMPORTANT: Excluding LLM API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) without setting apiProxy.enabled=true will cause agent authentication failures. Use apiProxy.enabled=true for credential isolation instead of manual exclusion."
         }
       }
     },

--- a/src/dind-probe.test.ts
+++ b/src/dind-probe.test.ts
@@ -23,7 +23,18 @@ describe('probeSplitFilesystem', () => {
     fs.rmSync(probeDir, { recursive: true, force: true });
   });
 
+  /** Helper: mock docker info (connectivity check) as successful */
+  function mockDockerReachable() {
+    mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
+  }
+
+  /** Helper: mock docker info as unreachable */
+  function mockDockerUnreachable() {
+    mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
+  }
+
   it('returns no prefix when daemon can see runner filesystem directly', async () => {
+    mockDockerReachable();
     // Direct mount succeeds (exit code 0)
     mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
 
@@ -31,14 +42,14 @@ describe('probeSplitFilesystem', () => {
 
     expect(result.prefix).toBeUndefined();
     expect(result.splitDetected).toBe(false);
-    expect(mockedExeca).toHaveBeenCalledTimes(1);
-    // Verify the mount source is the probeDir (no prefix)
-    const callArgs = mockedExeca.mock.calls[0][1] as string[];
-    expect(callArgs).toContain(`${probeDir}:/probe:ro`);
+    expect(result.inconclusive).toBe(false);
+    // 1 docker info + 1 probe
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
   });
 
   it('returns /host when direct mount fails but /host prefix works', async () => {
-    // Direct mount fails
+    mockDockerReachable();
+    // Direct mount: file not found (exit code 1)
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
     // /host prefix succeeds
     mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
@@ -47,16 +58,19 @@ describe('probeSplitFilesystem', () => {
 
     expect(result.prefix).toBe('/host');
     expect(result.splitDetected).toBe(true);
-    expect(mockedExeca).toHaveBeenCalledTimes(2);
-    // Verify second call uses /host prefix
-    const secondCallArgs = mockedExeca.mock.calls[1][1] as string[];
-    expect(secondCallArgs).toContain(`/host${probeDir}:/probe:ro`);
+    expect(result.inconclusive).toBe(false);
+    // 1 docker info + 1 direct + 1 /host
+    expect(mockedExeca).toHaveBeenCalledTimes(3);
+    // Verify /host call uses prefixed path
+    const hostCallArgs = mockedExeca.mock.calls[2][1] as string[];
+    expect(hostCallArgs).toContain(`/host${probeDir}:/probe:ro`);
   });
 
   it('returns /runner when /host fails but /runner prefix works', async () => {
-    // Direct mount fails
+    mockDockerReachable();
+    // Direct mount: file not found
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
-    // /host prefix fails
+    // /host prefix: file not found
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
     // /runner prefix succeeds
     mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
@@ -65,57 +79,105 @@ describe('probeSplitFilesystem', () => {
 
     expect(result.prefix).toBe('/runner');
     expect(result.splitDetected).toBe(true);
-    expect(mockedExeca).toHaveBeenCalledTimes(3);
+    expect(result.inconclusive).toBe(false);
+    // 1 docker info + 3 probes
+    expect(mockedExeca).toHaveBeenCalledTimes(4);
   });
 
-  it('returns undefined with splitDetected=true when no candidate works', async () => {
-    // Direct mount fails
+  it('returns splitDetected=true when no candidate prefix works', async () => {
+    mockDockerReachable();
+    // Direct mount: file not found
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
-    // /host prefix fails
+    // /host prefix: file not found
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
-    // /runner prefix fails
+    // /runner prefix: file not found
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
 
     const result = await probeSplitFilesystem(probeDir);
 
     expect(result.prefix).toBeUndefined();
     expect(result.splitDetected).toBe(true);
-    expect(mockedExeca).toHaveBeenCalledTimes(3);
+    expect(result.inconclusive).toBe(false);
   });
 
-  it('handles timeout gracefully', async () => {
-    // Direct mount times out
+  it('returns inconclusive when Docker daemon is unreachable (fail-fast)', async () => {
+    mockDockerUnreachable();
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    // Only 1 call (docker info) — no probe attempts
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns inconclusive when docker info times out', async () => {
     mockedExeca.mockRejectedValueOnce(new Error('timed out'));
 
     const result = await probeSplitFilesystem(probeDir);
 
-    // Timeout on direct probe means we can't determine — treat as not split
-    // because the probe function catches errors in runProbe and returns false
-    // Then it tries /host and /runner candidates
-    expect(result.splitDetected).toBe(true);
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
   });
 
-  it('handles error during probe setup gracefully', async () => {
-    // Use a non-existent directory that can't be created
-    const badDir = '/proc/nonexistent/probe-dir';
-    
-    const result = await probeSplitFilesystem(badDir);
+  it('returns inconclusive when direct probe gets infrastructure error (exit 125)', async () => {
+    mockDockerReachable();
+    // Direct mount: infrastructure error (e.g., image pull failure)
+    mockedExeca.mockResolvedValueOnce({ exitCode: 125 } as any);
+
+    const result = await probeSplitFilesystem(probeDir);
 
     expect(result.prefix).toBeUndefined();
     expect(result.splitDetected).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    // Stops after infra error — doesn't try prefixes
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns inconclusive when direct probe throws (timeout/ENOENT)', async () => {
+    mockDockerReachable();
+    // Direct mount throws (e.g., execa timeout)
+    mockedExeca.mockRejectedValueOnce(new Error('ETIMEDOUT'));
+
+    const result = await probeSplitFilesystem(probeDir);
+
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles error during probe setup gracefully', async () => {
+    // Use a temp dir, then remove write permissions to force writeFileSync to fail
+    const restrictedDir = path.join(probeDir, 'restricted');
+    fs.mkdirSync(restrictedDir);
+    fs.chmodSync(restrictedDir, 0o444);
+
+    const result = await probeSplitFilesystem(path.join(restrictedDir, 'sub'));
+
+    expect(result.prefix).toBeUndefined();
+    expect(result.splitDetected).toBe(false);
+    expect(result.inconclusive).toBe(true);
+
+    // Restore permissions for cleanup
+    fs.chmodSync(restrictedDir, 0o755);
   });
 
   it('cleans up sentinel file after successful probe', async () => {
+    mockDockerReachable();
     mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
 
     await probeSplitFilesystem(probeDir);
 
-    // Sentinel should be cleaned up
     const files = fs.readdirSync(probeDir).filter(f => f.startsWith('.awf-fs-probe-'));
     expect(files).toHaveLength(0);
   });
 
   it('cleans up sentinel file after failed probe', async () => {
+    mockDockerReachable();
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
     mockedExeca.mockResolvedValueOnce({ exitCode: 1 } as any);
@@ -127,21 +189,29 @@ describe('probeSplitFilesystem', () => {
   });
 
   it('uses busybox image for the probe', async () => {
+    mockDockerReachable();
     mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
 
     await probeSplitFilesystem(probeDir);
 
-    const callArgs = mockedExeca.mock.calls[0][1] as string[];
+    // Second call is the actual probe (first is docker info)
+    const callArgs = mockedExeca.mock.calls[1][1] as string[];
     expect(callArgs).toContain('busybox:latest');
   });
 
-  it('passes timeout option to execa', async () => {
+  it('uses 10s timeout for probe and 5s for connectivity check', async () => {
+    mockDockerReachable();
     mockedExeca.mockResolvedValueOnce({ exitCode: 0 } as any);
 
     await probeSplitFilesystem(probeDir);
 
-    const callOptions = (mockedExeca.mock.calls[0] as any)[2];
-    expect(callOptions.timeout).toBe(15000);
-    expect(callOptions.reject).toBe(false);
+    // First call: docker info (5s timeout)
+    const infoOptions = (mockedExeca.mock.calls[0] as any)[2];
+    expect(infoOptions.timeout).toBe(5000);
+    // Second call: probe (10s timeout)
+    const probeOptions = (mockedExeca.mock.calls[1] as any)[2];
+    expect(probeOptions.timeout).toBe(10000);
+    expect(probeOptions.reject).toBe(false);
   });
 });
+

--- a/src/dind-probe.ts
+++ b/src/dind-probe.ts
@@ -26,7 +26,10 @@ import { logger } from './logger';
 const CANDIDATE_PREFIXES = ['/host', '/runner'];
 
 /** Timeout for each docker run probe (ms) */
-const PROBE_TIMEOUT_MS = 15000;
+const PROBE_TIMEOUT_MS = 10000;
+
+/** Timeout for Docker connectivity check (ms) */
+const DOCKER_PING_TIMEOUT_MS = 5000;
 
 /** Lightweight image for the probe — busybox is smaller than alpine */
 const PROBE_IMAGE = 'busybox:latest';
@@ -36,11 +39,17 @@ export interface ProbeResult {
   prefix: string | undefined;
   /** Whether the probe detected a split filesystem */
   splitDetected: boolean;
+  /** Whether the probe was inconclusive (Docker unreachable, timeout, etc.) */
+  inconclusive: boolean;
 }
 
 /**
  * Probes whether the Docker daemon can see the runner's filesystem,
  * and if not, discovers the correct path prefix for bind-mount translation.
+ *
+ * Returns inconclusive (without splitDetected) when Docker is unreachable
+ * or the probe encounters infrastructure errors — as opposed to a confirmed
+ * split where the daemon runs but can't see runner paths.
  *
  * @param probeDir - Directory to probe (should be the AWF workDir or a subdir)
  * @returns The discovered prefix, or undefined if same-fs or undetectable
@@ -54,32 +63,42 @@ export async function probeSplitFilesystem(probeDir: string): Promise<ProbeResul
     fs.mkdirSync(probeDir, { recursive: true });
     fs.writeFileSync(sentinelPath, 'awf-probe');
 
-    // Step 1: Check if daemon can see the file directly (no prefix)
-    const directVisible = await runProbe(probeDir, sentinelName);
-    if (directVisible) {
-      logger.debug('DinD probe: daemon can see runner filesystem directly (no prefix needed)');
-      return { prefix: undefined, splitDetected: false };
+    // Step 0: Verify Docker daemon is reachable (fail-fast)
+    const dockerReachable = await checkDockerReachable();
+    if (!dockerReachable) {
+      logger.debug('DinD probe: Docker daemon unreachable, skipping filesystem probe');
+      return { prefix: undefined, splitDetected: false, inconclusive: true };
     }
 
-    // Split filesystem detected
+    // Step 1: Check if daemon can see the file directly (no prefix)
+    const directResult = await runProbe(probeDir, sentinelName);
+    if (directResult === 'visible') {
+      logger.debug('DinD probe: daemon can see runner filesystem directly (no prefix needed)');
+      return { prefix: undefined, splitDetected: false, inconclusive: false };
+    }
+    if (directResult === 'error') {
+      // Infrastructure error (not just file-not-found) — inconclusive
+      logger.debug('DinD probe: infrastructure error during direct probe, result inconclusive');
+      return { prefix: undefined, splitDetected: false, inconclusive: true };
+    }
+
+    // directResult === 'not-visible': Split filesystem confirmed
     logger.debug('DinD probe: daemon cannot see runner filesystem — split topology detected');
 
     // Step 2: Try candidate prefixes
     for (const candidate of CANDIDATE_PREFIXES) {
       const prefixedDir = `${candidate}${probeDir}`;
-      const prefixVisible = await runProbe(prefixedDir, sentinelName);
-      if (prefixVisible) {
-        logger.info(`DinD probe: auto-detected --docker-host-path-prefix ${candidate}`);
-        return { prefix: candidate, splitDetected: true };
+      const prefixResult = await runProbe(prefixedDir, sentinelName);
+      if (prefixResult === 'visible') {
+        return { prefix: candidate, splitDetected: true, inconclusive: false };
       }
     }
 
     // No candidate worked
-    logger.debug('DinD probe: split filesystem detected but no candidate prefix worked');
-    return { prefix: undefined, splitDetected: true };
+    return { prefix: undefined, splitDetected: true, inconclusive: false };
   } catch (error) {
     logger.debug(`DinD probe: error during filesystem probe: ${error instanceof Error ? error.message : String(error)}`);
-    return { prefix: undefined, splitDetected: false };
+    return { prefix: undefined, splitDetected: false, inconclusive: true };
   } finally {
     // Clean up sentinel
     try {
@@ -90,10 +109,39 @@ export async function probeSplitFilesystem(probeDir: string): Promise<ProbeResul
   }
 }
 
+/** Probe outcome distinguishing file-not-found from infrastructure errors */
+type ProbeOutcome = 'visible' | 'not-visible' | 'error';
+
+/**
+ * Checks if the Docker daemon is reachable via `docker info`.
+ * This is a fast connectivity check to avoid long timeouts on subsequent probes.
+ */
+async function checkDockerReachable(): Promise<boolean> {
+  try {
+    const result = await execa(
+      'docker',
+      ['info', '--format', '{{.ID}}'],
+      {
+        env: getLocalDockerEnv(),
+        timeout: DOCKER_PING_TIMEOUT_MS,
+        reject: false,
+      },
+    );
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Runs a single probe: mounts the given directory and checks for the sentinel file.
+ *
+ * Returns:
+ *  - 'visible' if the sentinel file was found (exit code 0)
+ *  - 'not-visible' if the container ran but file was absent (exit code 1)
+ *  - 'error' if the container failed to start (exit code 125/126/127, timeout, etc.)
  */
-async function runProbe(mountSource: string, sentinelName: string): Promise<boolean> {
+async function runProbe(mountSource: string, sentinelName: string): Promise<ProbeOutcome> {
   try {
     const volumeMount = [mountSource, '/probe:ro'].join(':');
     const targetPath = ['/probe', sentinelName].join('/');
@@ -106,9 +154,20 @@ async function runProbe(mountSource: string, sentinelName: string): Promise<bool
         reject: false,
       },
     );
-    return result.exitCode === 0;
+
+    if (result.exitCode === 0) {
+      return 'visible';
+    }
+    // Exit codes 125, 126, 127 indicate Docker/container infrastructure errors
+    // (e.g., image pull failure, mount error, command not found)
+    if (result.exitCode !== undefined && result.exitCode >= 125) {
+      return 'error';
+    }
+    // Exit code 1 from `test -f` means file not found — legitimate split-fs signal
+    return 'not-visible';
   } catch {
-    // Timeout or other error — treat as not visible
-    return false;
+    // Timeout or ENOENT (docker binary missing) — infrastructure error
+    return 'error';
   }
 }
+


### PR DESCRIPTION
Follow-up to #3554 addressing review comments that arrived after merge.

## Changes

### 1. Distinguish inconclusive from split-detected (comment #1)
`runProbe()` now returns a 3-state `ProbeOutcome`: `'visible'` | `'not-visible'` | `'error'`. Infrastructure errors (exit ≥125, timeout, ENOENT) are distinguished from legitimate file-not-found. `ProbeResult` adds an `inconclusive` field — the caller only warns about split FS when it's confirmed.

### 2. Fail-fast Docker connectivity check (comment #2)
Added a `checkDockerReachable()` step (`docker info`, 5s timeout) before running any probe containers. If Docker is unreachable, returns immediately with `inconclusive: true` — no 45s worst-case delay.

### 3. Fix brittle timeout test (comment #3)
All execa calls are now explicitly mocked in every test, including the connectivity check. The old test that only mocked one rejection is replaced with proper multi-mock sequences.

### 4. Fix OS-specific test (comment #4)
Replaced `/proc/nonexistent/probe-dir` with `chmod 0o444` on a temp dir to deterministically force permission errors. Portable across Linux/macOS.

### 5. Remove duplicate logging (comment #5)
Probe module now uses `logger.debug()` exclusively. Only `main-action.ts` emits user-facing info/warn messages about the detected prefix.

## Test Results
- 13 tests pass (up from 10) covering all probe outcomes including inconclusive states
- Build passes cleanly