### PR TITLE
docs(spec): add port information to /reflect endpoint sections

### DIFF
--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -620,8 +620,13 @@ pending warning per subsequent request):
 
 ### 10.6 Introspection
 
-When the API proxy `/reflect` endpoint is queried, the response MUST
-include the current effective-token state:
+The API proxy exposes a `GET /reflect` endpoint on every provider port
+(10000–10004). Each port returns reflection metadata for its own provider
+adapter. The management port (10000, OpenAI) additionally serves `/health`
+and `/metrics`.
+
+When the `/reflect` endpoint is queried, the response MUST include the
+current effective-token state:
 
 ```json
 {
@@ -685,8 +690,8 @@ The API proxy MUST enforce the max-runs limit as follows:
 
 ### 11.3 Introspection
 
-When the API proxy `/reflect` endpoint is queried, the response MUST include
-the current max-runs state:
+The `/reflect` endpoint (available on all provider ports 10000–10004; see
+§10.6) MUST include the current max-runs state:
 
 ```json
 {

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -621,9 +621,10 @@ pending warning per subsequent request):
 ### 10.6 Introspection
 
 The API proxy exposes a `GET /reflect` endpoint on every provider port
-(10000–10004). Each port returns reflection metadata for its own provider
-adapter. The management port (10000, OpenAI) additionally serves `/health`
-and `/metrics`.
+(10000–10004). Each port returns the same aggregate reflection payload, whose
+`endpoints` array lists all provider adapters. Only the management port
+(10000, OpenAI) serves `/metrics` and the aggregate `/health`; non-management
+ports still serve provider-local `/health` responses.
 
 When the `/reflect` endpoint is queried, the response MUST include the
 current effective-token state:


### PR DESCRIPTION
Clarifies that `GET /reflect` is available on all provider ports (10000–10004), with each port returning reflection metadata for its own adapter. Notes that port 10000 (OpenAI) is the management port also serving `/health` and `/metrics`.

**Changes:**
- §10.6: Added introductory paragraph documenting port availability
- §11.3: Cross-references §10.6 for port details