### PR TITLE
refactor: remove unused exports (AgentEnvironmentParams barrel, AgentVolumesParams, EMPTY_STATS)

### DIFF
--- a/src/commands/test-helpers.test-utils.ts
+++ b/src/commands/test-helpers.test-utils.ts
@@ -8,7 +8,7 @@ import * as statsFormatter from '../logs/stats-formatter';
 import { LogSource } from '../types';
 import { AggregatedStats } from '../logs/log-aggregator';
 
-export const EMPTY_STATS: AggregatedStats = {
+const EMPTY_STATS: AggregatedStats = {
   totalRequests: 0,
   allowedRequests: 0,
   deniedRequests: 0,

--- a/src/services/agent-environment.ts
+++ b/src/services/agent-environment.ts
@@ -1,2 +1,1 @@
 export { buildAgentEnvironment } from './agent-environment/environment-builder';
-export type { AgentEnvironmentParams } from './agent-environment/types';

--- a/src/services/agent-volumes/volume-builder.ts
+++ b/src/services/agent-volumes/volume-builder.ts
@@ -11,7 +11,7 @@ import { buildSslMounts } from './ssl-mounts';
 import { buildSystemMounts } from './system-mounts';
 import { buildCustomVolumeMounts, buildWorkspaceMounts } from './workspace-mounts';
 
-export interface AgentVolumesParams {
+interface AgentVolumesParams {
   config: WrapperConfig;
   sslConfig?: SslConfig;
   projectRoot: string;


### PR DESCRIPTION
## Summary

Remove three unused exports identified by the Export Audit workflow:

1. **`AgentEnvironmentParams` barrel re-export** (#3733) — removed from `src/services/agent-environment.ts`. The type remains exported from `types.ts` for internal use within the `agent-environment/` folder.

2. **`AgentVolumesParams` interface export** (#3732) — made module-private in `volume-builder.ts`. Only used within that file.

3. **`EMPTY_STATS` export** (#3648) — made module-private in `test-helpers.test-utils.ts`. Only used within the same file via `createEmptyStats()`.

## Verification

- `tsc --noEmit` passes
- All affected test suites pass (48 tests)

Closes #3733
Closes #3732
Closes #3648