### PR TITLE
refactor: extract log path resolution into shared log-paths module

### DIFF
--- a/src/compose-generator.ts
+++ b/src/compose-generator.ts
@@ -5,6 +5,7 @@ import { DEFAULT_DNS_SERVERS } from './dns-resolver';
 import { parseImageTag } from './image-tag';
 import { SslConfig } from './host-env';
 import { getRealUserHome } from './host-identity';
+import { resolveLogPaths } from './log-paths';
 import { buildSquidService } from './services/squid-service';
 import { buildAgentEnvironment, buildAgentVolumes, buildAgentService, buildIptablesInitService } from './services/agent-service';
 import { buildApiProxyService } from './services/api-proxy-service';
@@ -45,27 +46,8 @@ export function generateDockerCompose(
 
   // ── Log / state paths ──────────────────────────────────────────────────────
 
-  // Squid logs path: use proxyLogsDir if specified (direct write), otherwise workDir/squid-logs
-  const squidLogsPath = config.proxyLogsDir || `${config.workDir}/squid-logs`;
-
-  // Session state path: use sessionStateDir if specified (timeout-safe, predictable path),
-  // otherwise workDir/agent-session-state (will be moved to /tmp after cleanup)
-  const sessionStatePath = config.sessionStateDir || `${config.workDir}/agent-session-state`;
-
-  // Agent logs path: always workDir/agent-logs (moved to /tmp after cleanup)
-  const agentLogsPath = `${config.workDir}/agent-logs`;
-
-  // API proxy logs path: if proxyLogsDir is specified, write inside it as a subdirectory
-  // so that token-usage.jsonl is included in the firewall-audit-logs artifact automatically.
-  // Otherwise, write to workDir/api-proxy-logs (will be moved to /tmp after cleanup)
-  const apiProxyLogsPath = config.proxyLogsDir
-    ? path.join(config.proxyLogsDir, 'api-proxy-logs')
-    : path.join(config.workDir, 'api-proxy-logs');
-
-  // CLI proxy logs path: write to workDir/cli-proxy-logs (will be moved to /tmp after cleanup)
-  const cliProxyLogsPath = config.proxyLogsDir
-    ? path.join(config.proxyLogsDir, 'cli-proxy-logs')
-    : path.join(config.workDir, 'cli-proxy-logs');
+  const logPaths = resolveLogPaths(config);
+  const { squidLogs: squidLogsPath, sessionState: sessionStatePath, agentLogs: agentLogsPath, apiProxyLogs: apiProxyLogsPath, cliProxyLogs: cliProxyLogsPath } = logPaths;
 
   // ── Init-signal directory ──────────────────────────────────────────────────
 

--- a/src/config-writer.ts
+++ b/src/config-writer.ts
@@ -7,6 +7,7 @@ import { generatePolicyManifest, generateSquidConfig } from './squid-config';
 import { generateSessionCa, initSslDb, parseUrlPatterns, isOpenSslAvailable } from './ssl-bump';
 import { SslConfig, SQUID_PORT, getSafeHostUid, getSafeHostGid, getRealUserHome } from './host-env';
 import { generateDockerCompose, redactDockerComposeSecrets } from './compose-generator';
+import { resolveLogPaths } from './log-paths';
 
 // When bundled with esbuild, this global is replaced at build time with the
 // JSON content of containers/agent/seccomp-profile.json.  In normal (tsc)
@@ -61,31 +62,32 @@ export async function writeConfigs(config: WrapperConfig): Promise<void> {
     onExists: () => fs.chmodSync(config.workDir, 0o700),
   });
 
+  // Resolve all log/state directory paths from a single source of truth
+  const logPaths = resolveLogPaths(config);
+
   // Create agent logs directory for persistence
   // Chown to host user so Copilot CLI can write logs (AWF runs as root, agent runs as host user)
-  const agentLogsDir = path.join(config.workDir, 'agent-logs');
-  ensureDirectory(agentLogsDir, {
+  ensureDirectory(logPaths.agentLogs, {
     onAfterEnsure: () => {
       try {
-        fs.chownSync(agentLogsDir, parseInt(getSafeHostUid()), parseInt(getSafeHostGid()));
+        fs.chownSync(logPaths.agentLogs, parseInt(getSafeHostUid()), parseInt(getSafeHostGid()));
       } catch { /* ignore chown failures in non-root context */ }
     },
   });
-  logger.debug(`Agent logs directory created at: ${agentLogsDir}`);
+  logger.debug(`Agent logs directory created at: ${logPaths.agentLogs}`);
 
   // Create agent session-state directory for persistence (events.jsonl, session data)
   // If sessionStateDir is specified, write directly there (timeout-safe, predictable path)
   // Otherwise, use workDir/agent-session-state (will be moved to /tmp after cleanup)
   // Chown to host user so Copilot CLI can create session subdirs and write events.jsonl
-  const agentSessionStateDir = config.sessionStateDir || path.join(config.workDir, 'agent-session-state');
-  ensureDirectory(agentSessionStateDir, {
+  ensureDirectory(logPaths.sessionState, {
     onAfterEnsure: () => {
       try {
-        fs.chownSync(agentSessionStateDir, parseInt(getSafeHostUid()), parseInt(getSafeHostGid()));
+        fs.chownSync(logPaths.sessionState, parseInt(getSafeHostUid()), parseInt(getSafeHostGid()));
       } catch { /* ignore chown failures in non-root context */ }
     },
   });
-  logger.debug(`Agent session-state directory created at: ${agentSessionStateDir}`);
+  logger.debug(`Agent session-state directory created at: ${logPaths.sessionState}`);
 
   // Create squid logs directory for persistence
   // If proxyLogsDir is specified, write directly there (timeout-safe)
@@ -96,47 +98,40 @@ export async function writeConfigs(config: WrapperConfig): Promise<void> {
   // Set ownership so proxy user can write logs without root privileges
   const SQUID_PROXY_UID = 13;
   const SQUID_PROXY_GID = 13;
-  const squidLogsDir = config.proxyLogsDir || path.join(config.workDir, 'squid-logs');
-  ensureDirectory(squidLogsDir, {
+  ensureDirectory(logPaths.squidLogs, {
     mode: 0o755,
     onCreate: () => {
       try {
-        fs.chownSync(squidLogsDir, SQUID_PROXY_UID, SQUID_PROXY_GID);
+        fs.chownSync(logPaths.squidLogs, SQUID_PROXY_UID, SQUID_PROXY_GID);
       } catch {
         // Fallback to world-writable if chown fails (e.g., non-root context)
-        fs.chmodSync(squidLogsDir, 0o777);
+        fs.chmodSync(logPaths.squidLogs, 0o777);
       }
     },
   });
-  logger.debug(`Squid logs directory created at: ${squidLogsDir}`);
+  logger.debug(`Squid logs directory created at: ${logPaths.squidLogs}`);
 
   // Create api-proxy logs directory for persistence
   // If proxyLogsDir is specified, write inside it as a subdirectory (timeout-safe,
   // and included in the firewall-audit-logs artifact upload automatically)
   // Otherwise, write to workDir/api-proxy-logs (will be moved to /tmp after cleanup)
   // Note: API proxy runs as user 'apiproxy' (non-root)
-  const apiProxyLogsDir = config.proxyLogsDir
-    ? path.join(config.proxyLogsDir, 'api-proxy-logs')
-    : path.join(config.workDir, 'api-proxy-logs');
-  ensureDirectory(apiProxyLogsDir, {
+  ensureDirectory(logPaths.apiProxyLogs, {
     mode: 0o777,
     onCreate: () => {
       // Explicitly set permissions to 0o777 (not affected by umask)
-      fs.chmodSync(apiProxyLogsDir, 0o777);
+      fs.chmodSync(logPaths.apiProxyLogs, 0o777);
     },
   });
-  logger.debug(`API proxy logs directory created at: ${apiProxyLogsDir}`);
+  logger.debug(`API proxy logs directory created at: ${logPaths.apiProxyLogs}`);
 
   // Create CLI proxy logs directory for persistence
   // Note: CLI proxy runs as user 'cliproxy' (non-root)
-  const cliProxyLogsDir = config.proxyLogsDir
-    ? path.join(config.proxyLogsDir, 'cli-proxy-logs')
-    : path.join(config.workDir, 'cli-proxy-logs');
-  ensureDirectory(cliProxyLogsDir, {
+  ensureDirectory(logPaths.cliProxyLogs, {
     mode: 0o777,
-    onCreate: () => fs.chmodSync(cliProxyLogsDir, 0o777),
+    onCreate: () => fs.chmodSync(logPaths.cliProxyLogs, 0o777),
   });
-  logger.debug(`CLI proxy logs directory created at: ${cliProxyLogsDir}`);
+  logger.debug(`CLI proxy logs directory created at: ${logPaths.cliProxyLogs}`);
 
   // Create /tmp/gh-aw/mcp-logs directory
   // This directory exists on the HOST for MCP gateway to write logs

--- a/src/log-paths.test.ts
+++ b/src/log-paths.test.ts
@@ -1,0 +1,36 @@
+import { resolveLogPaths } from './log-paths';
+import { WrapperConfig } from './types';
+
+function makeConfig(overrides: Partial<WrapperConfig> = {}): WrapperConfig {
+  return {
+    workDir: '/tmp/awf-test',
+    allowedDomains: [],
+    blockedDomains: [],
+    ...overrides,
+  } as WrapperConfig;
+}
+
+describe('resolveLogPaths', () => {
+  it('uses workDir-relative paths when proxyLogsDir and sessionStateDir are not set', () => {
+    const paths = resolveLogPaths(makeConfig());
+    expect(paths.squidLogs).toBe('/tmp/awf-test/squid-logs');
+    expect(paths.sessionState).toBe('/tmp/awf-test/agent-session-state');
+    expect(paths.agentLogs).toBe('/tmp/awf-test/agent-logs');
+    expect(paths.apiProxyLogs).toBe('/tmp/awf-test/api-proxy-logs');
+    expect(paths.cliProxyLogs).toBe('/tmp/awf-test/cli-proxy-logs');
+  });
+
+  it('uses proxyLogsDir for squid/api-proxy/cli-proxy when specified', () => {
+    const paths = resolveLogPaths(makeConfig({ proxyLogsDir: '/var/logs/firewall' }));
+    expect(paths.squidLogs).toBe('/var/logs/firewall');
+    expect(paths.apiProxyLogs).toBe('/var/logs/firewall/api-proxy-logs');
+    expect(paths.cliProxyLogs).toBe('/var/logs/firewall/cli-proxy-logs');
+    // agentLogs always in workDir
+    expect(paths.agentLogs).toBe('/tmp/awf-test/agent-logs');
+  });
+
+  it('uses sessionStateDir when specified', () => {
+    const paths = resolveLogPaths(makeConfig({ sessionStateDir: '/persist/session' }));
+    expect(paths.sessionState).toBe('/persist/session');
+  });
+});

--- a/src/log-paths.ts
+++ b/src/log-paths.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+import { WrapperConfig } from './types';
+
+export interface LogPaths {
+  squidLogs: string;
+  sessionState: string;
+  agentLogs: string;
+  apiProxyLogs: string;
+  cliProxyLogs: string;
+}
+
+/**
+ * Resolves all log/state directory paths from WrapperConfig.
+ * Centralizes the conditional proxyLogsDir/sessionStateDir/workDir logic
+ * so compose-generator and config-writer always agree on paths.
+ */
+export function resolveLogPaths(config: WrapperConfig): LogPaths {
+  return {
+    squidLogs: config.proxyLogsDir || path.join(config.workDir, 'squid-logs'),
+    sessionState: config.sessionStateDir || path.join(config.workDir, 'agent-session-state'),
+    agentLogs: path.join(config.workDir, 'agent-logs'),
+    apiProxyLogs: config.proxyLogsDir
+      ? path.join(config.proxyLogsDir, 'api-proxy-logs')
+      : path.join(config.workDir, 'api-proxy-logs'),
+    cliProxyLogs: config.proxyLogsDir
+      ? path.join(config.proxyLogsDir, 'cli-proxy-logs')
+      : path.join(config.workDir, 'cli-proxy-logs'),
+  };
+}


### PR DESCRIPTION
## Summary

Extracts duplicated log/state directory path resolution logic from `compose-generator.ts` and `config-writer.ts` into a shared `src/log-paths.ts` module.

Both files previously computed the same 5 paths using identical conditional logic:
- `squidLogs`: `proxyLogsDir || workDir/squid-logs`
- `sessionState`: `sessionStateDir || workDir/agent-session-state`
- `agentLogs`: always `workDir/agent-logs`
- `apiProxyLogs`: `proxyLogsDir/api-proxy-logs || workDir/api-proxy-logs`
- `cliProxyLogs`: `proxyLogsDir/cli-proxy-logs || workDir/cli-proxy-logs`

Now both consumers call `resolveLogPaths(config)` and get the same paths.

## Changes

- **New**: `src/log-paths.ts` — `resolveLogPaths()` function + `LogPaths` interface
- **New**: `src/log-paths.test.ts` — Unit tests for the new module
- **Updated**: `src/compose-generator.ts` — uses `resolveLogPaths()`
- **Updated**: `src/config-writer.ts` — uses `resolveLogPaths()` for path values, keeps directory creation logic

## Verification

- `tsc --noEmit` passes
- All existing tests pass (25 in compose-generator + config-writer suites)
- New log-paths tests pass (3 tests)

Closes #3658