### PR TITLE
refactor: use pickEnvVars for OTEL environment variable forwarding

### DIFF
--- a/src/services/api-proxy-service.ts
+++ b/src/services/api-proxy-service.ts
@@ -125,19 +125,13 @@ export function buildApiProxyService(params: ApiProxyServiceParams): ApiProxyBui
       // parent trace context so api-proxy spans are children of the workflow trace.
       // OTEL_EXPORTER_OTLP_ENDPOINT activates OTLP/HTTP export (via Squid); when absent
       // spans are written to /var/log/api-proxy/otel.jsonl as a local file fallback.
-      ...(process.env.OTEL_EXPORTER_OTLP_ENDPOINT && {
-        OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-      }),
-      ...(process.env.OTEL_EXPORTER_OTLP_HEADERS && {
-        OTEL_EXPORTER_OTLP_HEADERS: process.env.OTEL_EXPORTER_OTLP_HEADERS,
-      }),
+      ...pickEnvVars(
+        'OTEL_EXPORTER_OTLP_ENDPOINT',
+        'OTEL_EXPORTER_OTLP_HEADERS',
+        'GITHUB_AW_OTEL_TRACE_ID',
+        'GITHUB_AW_OTEL_PARENT_SPAN_ID',
+      ),
       OTEL_SERVICE_NAME: process.env.OTEL_SERVICE_NAME || 'awf-api-proxy',
-      ...(process.env.GITHUB_AW_OTEL_TRACE_ID && {
-        GITHUB_AW_OTEL_TRACE_ID: process.env.GITHUB_AW_OTEL_TRACE_ID,
-      }),
-      ...(process.env.GITHUB_AW_OTEL_PARENT_SPAN_ID && {
-        GITHUB_AW_OTEL_PARENT_SPAN_ID: process.env.GITHUB_AW_OTEL_PARENT_SPAN_ID,
-      }),
       // Rate limiting configuration
       ...(config.rateLimitConfig && {
         AWF_RATE_LIMIT_ENABLED: String(config.rateLimitConfig.enabled),


### PR DESCRIPTION
## Summary

Replace verbose `...(process.env.X && { X: process.env.X })` patterns for OTEL/trace environment variables with the existing `pickEnvVars()` helper.

This reduces 12 lines of repetitive conditional spreads to a single 5-line `pickEnvVars()` call while preserving identical semantics (only set vars are forwarded).

## Verification

- `tsc --noEmit` passes
- All 112 api-proxy-service tests pass

Closes #3612