### PR TITLE
fix: remove unused export from normalizeDockerHostPathPrefix

### DIFF
--- a/src/services/host-path-prefix.ts
+++ b/src/services/host-path-prefix.ts
@@ -12,7 +12,7 @@
 // squid, api-proxy, cli-proxy) so the rewrite is symmetric across services
 // that share daemon-side directories.
 
-export function normalizeDockerHostPathPrefix(prefix: string): string {
+function normalizeDockerHostPathPrefix(prefix: string): string {
   const trimmed = prefix.trim();
   if (!trimmed) return '';
   const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;


### PR DESCRIPTION
Remove the `export` keyword from `normalizeDockerHostPathPrefix` in `src/services/host-path-prefix.ts`. The function is only used internally within the same file — no other module imports it.

Fixes #3762