### PR TITLE
Fix ghs_ DLP pattern to support new token format

### DIFF
--- a/src/dlp.test.ts
+++ b/src/dlp.test.ts
@@ -52,7 +52,14 @@ describe('DLP Patterns', () => {
       const matchingRegexes = findMatchingDlpRegexes(
         'https://api.example.com/?key=ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij'
       );
-      expect(matchingRegexes).toContain('ghs_[a-zA-Z0-9]{36}');
+      expect(matchingRegexes).toContain('ghs_[A-Za-z0-9._]{36,}');
+    });
+
+    it('should detect new-format GitHub App installation token (ghs_) with dots', () => {
+      const matchingRegexes = findMatchingDlpRegexes(
+        'https://api.example.com/?key=ghs_ABC.DEF.GHIJKLMNOPQRSTUVWXYZabcdefghij'
+      );
+      expect(matchingRegexes).toContain('ghs_[A-Za-z0-9._]{36,}');
     });
 
     it('should detect GitHub App user-to-server token (ghu_)', () => {

--- a/src/dlp.ts
+++ b/src/dlp.ts
@@ -52,7 +52,7 @@ const DLP_PATTERNS: DlpPattern[] = [
   {
     name: 'GitHub App Installation Token',
     description: 'GitHub App installation access token (ghs_)',
-    regex: 'ghs_[a-zA-Z0-9]{36}',
+    regex: 'ghs_[A-Za-z0-9._]{36,}',
   },
   {
     name: 'GitHub App User-to-Server Token',


### PR DESCRIPTION
Updates the `ghs_` token regex to support the new token format which allows dots and underscores (`[A-Za-z0-9._]`) and variable length (no longer fixed at 36 chars).

See the changelog: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/
Tracking in Slack: https://github-grid.enterprise.slack.com/archives/C0AH8M0MVUK