### PR TITLE
fix(squid): increase healthcheck tolerance to prevent intermittent startup failures

### DIFF
--- a/src/services/squid-service.test.ts
+++ b/src/services/squid-service.test.ts
@@ -26,6 +26,13 @@ describe('squid service', () => {
       expect(squid.volumes).not.toContainEqual(expect.stringContaining('squid.conf'));
       expect(squid.volumes).toContain(`${mockConfig.workDir}/squid-logs:/var/log/squid:rw`);
       expect(squid.healthcheck).toBeDefined();
+      expect(squid.healthcheck).toEqual({
+        test: ['CMD', 'nc', '-z', 'localhost', '3128'],
+        interval: '2s',
+        timeout: '2s',
+        retries: 10,
+        start_period: '5s',
+      });
       expect(squid.ports).toContain('3128:3128');
     });
 

--- a/src/services/squid-service.ts
+++ b/src/services/squid-service.ts
@@ -73,10 +73,10 @@ export function buildSquidService(params: SquidServiceParams): any {
     volumes: translatedSquidVolumes,
     healthcheck: {
       test: ['CMD', 'nc', '-z', 'localhost', '3128'],
-      interval: '1s',
-      timeout: '1s',
-      retries: 5,
-      start_period: '2s',
+      interval: '2s',
+      timeout: '2s',
+      retries: 10,
+      start_period: '5s',
     },
     ports: [`${SQUID_PORT}:${SQUID_PORT}`],
     // Security hardening: Drop unnecessary capabilities


### PR DESCRIPTION
## Summary

Increases the Squid container healthcheck tolerance to prevent intermittent "container is unhealthy" failures on loaded runners.

## Problem

The Squid healthcheck was configured with tight timing:
- `start_period: 2s`, `retries: 5`, `interval: 1s`, `timeout: 1s`
- Total window: ~7 seconds

On loaded ubuntu-24.04 runners, Squid initialization (chown preflight → base64 config decode → IPv6 check → Squid startup) can exceed this window, causing dependent containers to fail with `dependency failed to start: container awf-squid is unhealthy`.

## Fix

Relaxed healthcheck parameters:
- `start_period: 5s` (was 2s)
- `retries: 10` (was 5)
- `interval: 2s` (was 1s)
- `timeout: 2s` (was 1s)

Total window: ~25s. Happy-path startup still detected within 5-7s (first successful probe during start_period or first retry).

Fixes #3934