### PR TITLE
refactor: move test helper imports to .test-utils.ts files

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -21,8 +21,8 @@ import * as cliModule from './cli';
 import {
   resolveCopilotApiKey,
   resolveCopilotApiRouting,
-  copilotApiResolverTestHelpers,
 } from './copilot-api-resolver';
+import { copilotApiResolverTestHelpers } from './copilot-api-resolver.test-utils';
 import { redactSecrets } from './redact-secrets';
 
 const { deriveCopilotApiTargetFromProviderBaseUrl, deriveCopilotApiBasePathFromProviderBaseUrl } =

--- a/src/container-lifecycle.test-utils.ts
+++ b/src/container-lifecycle.test-utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Test-only re-export of internal state helpers from container-lifecycle.
+ * Tests should import from this file, not directly from the production module.
+ */
+export { containerLifecycleTestHelpers } from './container-lifecycle';

--- a/src/copilot-api-resolver.test-utils.ts
+++ b/src/copilot-api-resolver.test-utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Test-only re-export of internal helpers from copilot-api-resolver.
+ * Tests should import from this file, not directly from the production module.
+ */
+export { copilotApiResolverTestHelpers } from './copilot-api-resolver';

--- a/src/copilot-api-resolver.test.ts
+++ b/src/copilot-api-resolver.test.ts
@@ -1,8 +1,8 @@
 import {
   resolveCopilotApiKey,
   resolveCopilotApiRouting,
-  copilotApiResolverTestHelpers,
 } from './copilot-api-resolver';
+import { copilotApiResolverTestHelpers } from './copilot-api-resolver.test-utils';
 
 const {
   deriveCopilotApiTargetFromProviderBaseUrl,

--- a/src/docker-manager-lifecycle.test.ts
+++ b/src/docker-manager-lifecycle.test.ts
@@ -2,8 +2,8 @@ import {
   startContainers,
   runAgentCommand,
   fastKillAgentContainer,
-  containerLifecycleTestHelpers,
 } from './container-lifecycle';
+import { containerLifecycleTestHelpers } from './container-lifecycle.test-utils';
 import { setAwfDockerHost, getLocalDockerEnv } from './docker-host';
 import { stopContainers } from './container-cleanup';
 import { AGENT_CONTAINER_NAME } from './constants';

--- a/src/docker-manager-utils.test.ts
+++ b/src/docker-manager-utils.test.ts
@@ -1,11 +1,11 @@
 import {
-  hostEnvTestHelpers,
   getSafeHostUid,
   getSafeHostGid,
   getRealUserHome,
   stripScheme,
   parseDifcProxyHost,
 } from './host-env';
+import { hostEnvTestHelpers } from './host-env.test-utils';
 import {
   validateIdNotInSystemRange,
   MIN_REGULAR_UID,

--- a/src/host-env.test-utils.ts
+++ b/src/host-env.test-utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Test-only re-export of internal helpers from host-env.
+ * Tests should import from this file, not directly from the production module.
+ */
+export { hostEnvTestHelpers } from './host-env';

--- a/src/host-iptables-cleanup.test.ts
+++ b/src/host-iptables-cleanup.test.ts
@@ -1,6 +1,6 @@
 import { execaResult, mockedExeca, setupHostIptablesTestSuite } from './test-helpers/host-iptables-test-setup';
 import { cleanupHostIptables, setupHostIptables } from './host-iptables';
-import { iptablesSharedTestHelpers } from './host-iptables-shared';
+import { iptablesSharedTestHelpers } from './host-iptables-shared.test-utils';
 
 describe('host-iptables (cleanup)', () => {
   setupHostIptablesTestSuite(iptablesSharedTestHelpers.resetIpv6State);

--- a/src/host-iptables-doh.test.ts
+++ b/src/host-iptables-doh.test.ts
@@ -1,6 +1,6 @@
 import { execaResult, mockedExeca, setupHostIptablesTestSuite } from './test-helpers/host-iptables-test-setup';
 import { setupHostIptables } from './host-iptables';
-import { iptablesSharedTestHelpers } from './host-iptables-shared';
+import { iptablesSharedTestHelpers } from './host-iptables-shared.test-utils';
 
 describe('host-iptables (doh)', () => {
   setupHostIptablesTestSuite(iptablesSharedTestHelpers.resetIpv6State);

--- a/src/host-iptables-host-access.test.ts
+++ b/src/host-iptables-host-access.test.ts
@@ -1,6 +1,6 @@
 import { mockedExeca, setupDefaultIptablesMocks, setupHostIptablesTestSuite } from './test-helpers/host-iptables-test-setup';
 import { HostAccessConfig, setupHostIptables } from './host-iptables';
-import { iptablesSharedTestHelpers } from './host-iptables-shared';
+import { iptablesSharedTestHelpers } from './host-iptables-shared.test-utils';
 
 describe('host-iptables (host access)', () => {
   setupHostIptablesTestSuite(iptablesSharedTestHelpers.resetIpv6State);

--- a/src/host-iptables-network.test.ts
+++ b/src/host-iptables-network.test.ts
@@ -1,6 +1,6 @@
 import { execaResult, mockedExeca, setupHostIptablesTestSuite } from './test-helpers/host-iptables-test-setup';
 import { ensureFirewallNetwork } from './host-iptables';
-import { iptablesSharedTestHelpers } from './host-iptables-shared';
+import { iptablesSharedTestHelpers } from './host-iptables-shared.test-utils';
 
 describe('host-iptables (network)', () => {
   setupHostIptablesTestSuite(iptablesSharedTestHelpers.resetIpv6State);

--- a/src/host-iptables-setup.test.ts
+++ b/src/host-iptables-setup.test.ts
@@ -2,7 +2,7 @@ import { API_PROXY_PORTS } from './types';
 import { execaError, execaResult, mockedExeca, setupDefaultIptablesMocks, setupHostIptablesTestSuite } from './test-helpers/host-iptables-test-setup';
 import { isValidPortSpec } from './host-iptables-rules';
 import { setupHostIptables } from './host-iptables';
-import { iptablesSharedTestHelpers } from './host-iptables-shared';
+import { iptablesSharedTestHelpers } from './host-iptables-shared.test-utils';
 
 // setupHostIptables intentionally allows the inclusive min:max API proxy port window.
 const apiProxyPortRange = `${Math.min(...Object.values(API_PROXY_PORTS))}:${Math.max(...Object.values(API_PROXY_PORTS))}`;

--- a/src/host-iptables-shared.test-utils.ts
+++ b/src/host-iptables-shared.test-utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Test-only re-export of internal state-reset helpers from host-iptables-shared.
+ * Tests should import from this file, not directly from the production module.
+ */
+export { iptablesSharedTestHelpers } from './host-iptables-shared';

--- a/src/host-iptables-shared.test.ts
+++ b/src/host-iptables-shared.test.ts
@@ -7,8 +7,8 @@ import {
   getDockerBridgeGateway,
   getNetworkBridgeName,
   isIp6tablesAvailable,
-  iptablesSharedTestHelpers,
 } from './host-iptables-shared';
+import { iptablesSharedTestHelpers } from './host-iptables-shared.test-utils';
 import { logger } from './logger';
 
 describe('host-iptables-shared', () => {

--- a/src/logs/log-discovery.test-utils.ts
+++ b/src/logs/log-discovery.test-utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Test-only re-export of internal helpers from log-discovery.
+ * Tests should import from this file, not directly from the production module.
+ */
+export { logDiscoveryTestHelpers } from './log-discovery';

--- a/src/logs/log-discovery.test.ts
+++ b/src/logs/log-discovery.test.ts
@@ -8,10 +8,10 @@ import * as os from 'os';
 import {
   discoverLogSources,
   selectMostRecent,
-  logDiscoveryTestHelpers,
   validateSource,
   listLogSources,
 } from './log-discovery';
+import { logDiscoveryTestHelpers } from './log-discovery.test-utils';
 import execa from 'execa';
 import { glob } from 'glob';
 import { LogSource } from '../types';


### PR DESCRIPTION
## Summary

Moves test-only helper imports out of production module paths into co-located `.test-utils.ts` re-export files. This cleans up the production API surface by ensuring tests import from dedicated test-utils modules.

### Changes

- Created 5 new `.test-utils.ts` files for each affected module
- Updated 11 test files to import from the new test-utils paths instead of directly from production modules

### Why re-export instead of fully relocating?

The test helpers (`resetIpv6State`, `resetAgentExternallyKilled`, etc.) mutate module-scoped `let` variables that cannot be accessed from external files. The production exports are physically required, but by routing all test imports through `.test-utils.ts` files, we establish a clear convention that can be enforced via lint rules in the future.

### Verification

- TypeScript compiles cleanly
- All 101 test suites pass (2266 tests)

Fixes #3968
Fixes #3969