### PR TITLE
feat: support custom API auth headers for internal AI gateways

### DIFF
--- a/containers/api-proxy/providers/anthropic.js
+++ b/containers/api-proxy/providers/anthropic.js
@@ -47,6 +47,7 @@ function createAnthropicAdapter(env, deps = {}) {
     basePathEnvVar: 'ANTHROPIC_API_BASE_PATH',
     defaultTarget: 'api.anthropic.com',
   });
+  const authHeaderName = (env.AWF_ANTHROPIC_AUTH_HEADER || '').trim() || 'x-api-key';
   const authType = (env.AWF_AUTH_TYPE || '').trim().toLowerCase();
   const authProvider = (env.AWF_AUTH_PROVIDER || '').trim().toLowerCase();
   const oidcRequested = authType === 'github-oidc' && authProvider === 'anthropic';
@@ -105,7 +106,7 @@ function createAnthropicAdapter(env, deps = {}) {
     validationMethod: 'POST',
     validationBody: '{}',
     validationHeaders: () => ({
-      'x-api-key': apiKey,
+      [authHeaderName]: apiKey,
       'anthropic-version': '2023-06-01',
       'content-type': 'application/json',
     }),
@@ -114,7 +115,7 @@ function createAnthropicAdapter(env, deps = {}) {
       : null),
     skipModelsFetch: () => oidcConfigured,
     modelsPath: '/v1/models',
-    modelsFetchHeaders: () => ({ 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' }),
+    modelsFetchHeaders: () => ({ [authHeaderName]: apiKey, 'anthropic-version': '2023-06-01' }),
     reflectionConfigured: !!apiKey || oidcRequested,
     reflectionExtra: () => ({
       auth_type: oidcRequested ? 'github-oidc/anthropic' : 'static-key',
@@ -155,7 +156,7 @@ function createAnthropicAdapter(env, deps = {}) {
         }
         headers['Authorization'] = 'Bearer ' + token;
       } else {
-        headers['x-api-key'] = apiKey;
+        headers[authHeaderName] = apiKey;
       }
 
       if (!req.headers['anthropic-version']) {

--- a/containers/api-proxy/providers/anthropic.js
+++ b/containers/api-proxy/providers/anthropic.js
@@ -47,7 +47,15 @@ function createAnthropicAdapter(env, deps = {}) {
     basePathEnvVar: 'ANTHROPIC_API_BASE_PATH',
     defaultTarget: 'api.anthropic.com',
   });
-  const authHeaderName = (env.AWF_ANTHROPIC_AUTH_HEADER || '').trim() || 'x-api-key';
+  const authHeaderName = (() => {
+    const header = (env.AWF_ANTHROPIC_AUTH_HEADER || '').trim() || 'x-api-key';
+    try {
+      require('http').validateHeaderName(header);
+    } catch {
+      throw new Error('Invalid AWF_ANTHROPIC_AUTH_HEADER value: expected a valid HTTP header name');
+    }
+    return header;
+  })();
   const authType = (env.AWF_AUTH_TYPE || '').trim().toLowerCase();
   const authProvider = (env.AWF_AUTH_PROVIDER || '').trim().toLowerCase();
   const oidcRequested = authType === 'github-oidc' && authProvider === 'anthropic';

--- a/containers/api-proxy/providers/openai.js
+++ b/containers/api-proxy/providers/openai.js
@@ -50,6 +50,7 @@ function createOpenAIAdapter(env, deps = {}) {
     basePathEnvVar: 'OPENAI_API_BASE_PATH',
     defaultTarget: 'api.openai.com',
   });
+  const customAuthHeader = (env.AWF_OPENAI_AUTH_HEADER || '').trim() || '';
   const providerType = (env.COPILOT_PROVIDER_TYPE || '').trim().toLowerCase();
   const copilotAzureByokEnabled = providerType === 'azure';
   const copilotByokApiKey = (env.COPILOT_PROVIDER_API_KEY || '').trim() || undefined;
@@ -122,6 +123,18 @@ function createOpenAIAdapter(env, deps = {}) {
       }
     }
   }
+  /**
+   * Build a static-key auth header object.
+   * When AWF_OPENAI_AUTH_HEADER is set, uses that header name with the raw key.
+   * Otherwise uses the standard `Authorization: Bearer <key>` format.
+   */
+  function buildStaticAuthHeaders(key) {
+    if (customAuthHeader) {
+      return { [customAuthHeader]: key };
+    }
+    return { 'Authorization': `Bearer ${key}` };
+  }
+
   const oidcConfigured = !!(oidcProvider || awsOidcProvider);
   const adapterMethods = createAdapterMethods({
     apiKey,
@@ -131,13 +144,13 @@ function createOpenAIAdapter(env, deps = {}) {
     port: 10000,
     defaultTarget: 'api.openai.com',
     validationPath: '/v1/models',
-    validationHeaders: () => ({ 'Authorization': `Bearer ${apiKey}` }),
+    validationHeaders: () => buildStaticAuthHeaders(apiKey),
     validationSkip: () => (oidcConfigured
       ? { skip: true, reason: 'OIDC auth; validation via token acquisition' }
       : null),
     skipModelsFetch: () => oidcConfigured, // Models fetched after OIDC init
     modelsPath: '/v1/models',
-    modelsFetchHeaders: () => ({ 'Authorization': `Bearer ${apiKey}` }),
+    modelsFetchHeaders: () => buildStaticAuthHeaders(apiKey),
     reflectionConfigured: !!apiKey || oidcConfigured,
     reflectionModelsPath: '/v1/models',
     reflectionExtra: () => ({
@@ -179,7 +192,9 @@ function createOpenAIAdapter(env, deps = {}) {
       if (oidcProvider) {
         const token = oidcProvider.getToken();
         if (token) {
-          return { 'Authorization': `Bearer ${token}` };
+          return customAuthHeader
+            ? { [customAuthHeader]: token }
+            : { 'Authorization': `Bearer ${token}` };
         }
         return {};
       }
@@ -188,7 +203,7 @@ function createOpenAIAdapter(env, deps = {}) {
       if (awsOidcProvider) {
         return {};
       }
-      return { 'Authorization': `Bearer ${apiKey}` };
+      return buildStaticAuthHeaders(apiKey);
     },
 
     getBodyTransform() { return bodyTransform; },

--- a/containers/api-proxy/providers/openai.js
+++ b/containers/api-proxy/providers/openai.js
@@ -50,7 +50,16 @@ function createOpenAIAdapter(env, deps = {}) {
     basePathEnvVar: 'OPENAI_API_BASE_PATH',
     defaultTarget: 'api.openai.com',
   });
-  const customAuthHeader = (env.AWF_OPENAI_AUTH_HEADER || '').trim() || '';
+  const customAuthHeader = (() => {
+    const header = (env.AWF_OPENAI_AUTH_HEADER || '').trim();
+    if (!header) return '';
+    try {
+      require('http').validateHeaderName(header);
+    } catch {
+      throw new Error('Invalid AWF_OPENAI_AUTH_HEADER value: expected a valid HTTP header name');
+    }
+    return header;
+  })();
   const providerType = (env.COPILOT_PROVIDER_TYPE || '').trim().toLowerCase();
   const copilotAzureByokEnabled = providerType === 'azure';
   const copilotByokApiKey = (env.COPILOT_PROVIDER_API_KEY || '').trim() || undefined;

--- a/containers/api-proxy/server.custom-auth-header.test.js
+++ b/containers/api-proxy/server.custom-auth-header.test.js
@@ -1,0 +1,179 @@
+/**
+ * Tests for custom API auth header support (AWF_OPENAI_AUTH_HEADER, AWF_ANTHROPIC_AUTH_HEADER).
+ *
+ * These env vars allow internal AI gateways (e.g. Azure OpenAI) to use custom
+ * auth header names instead of the provider defaults.
+ */
+
+const { createAnthropicAdapter } = require('./providers/anthropic');
+const { createOpenAIAdapter } = require('./providers/openai');
+
+// ─── Anthropic ───
+
+describe('createAnthropicAdapter — custom auth header', () => {
+  const fakeReq = { url: '/v1/messages', method: 'POST', headers: {} };
+
+  it('uses x-api-key by default', () => {
+    const adapter = createAnthropicAdapter({
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      'x-api-key': 'sk-ant-test',
+      'anthropic-version': '2023-06-01',
+    });
+  });
+
+  it('uses custom header name from AWF_ANTHROPIC_AUTH_HEADER', () => {
+    const adapter = createAnthropicAdapter({
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      AWF_ANTHROPIC_AUTH_HEADER: 'api-key',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      'api-key': 'sk-ant-test',
+      'anthropic-version': '2023-06-01',
+    });
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('custom header is used in validation probe', () => {
+    const adapter = createAnthropicAdapter({
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      AWF_ANTHROPIC_AUTH_HEADER: 'api-key',
+    });
+    const probe = adapter.getValidationProbe();
+    expect(probe.opts.headers['api-key']).toBe('sk-ant-test');
+    expect(probe.opts.headers['x-api-key']).toBeUndefined();
+  });
+
+  it('custom header is used in models fetch config', () => {
+    const adapter = createAnthropicAdapter({
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      AWF_ANTHROPIC_AUTH_HEADER: 'api-key',
+    });
+    const config = adapter.getModelsFetchConfig();
+    expect(config.opts.headers['api-key']).toBe('sk-ant-test');
+    expect(config.opts.headers['x-api-key']).toBeUndefined();
+  });
+
+  it('OIDC mode ignores custom header (always uses Authorization Bearer)', () => {
+    const adapter = createAnthropicAdapter({
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      AWF_ANTHROPIC_AUTH_HEADER: 'api-key',
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'anthropic',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test-token',
+    });
+
+    const provider = adapter.getOidcProvider();
+    provider._cachedToken = 'oidc-token';
+    provider._expiresAt = Math.floor(Date.now() / 1000) + 600;
+
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      Authorization: 'Bearer oidc-token',
+      'anthropic-version': '2023-06-01',
+    });
+    expect(headers['api-key']).toBeUndefined();
+
+    provider.shutdown();
+  });
+});
+
+// ─── OpenAI ───
+
+describe('createOpenAIAdapter — custom auth header', () => {
+  const fakeReq = { url: '/v1/chat/completions', method: 'POST', headers: {} };
+
+  it('uses Authorization Bearer by default', () => {
+    const adapter = createOpenAIAdapter({
+      OPENAI_API_KEY: 'sk-openai-test',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      Authorization: 'Bearer sk-openai-test',
+    });
+  });
+
+  it('uses custom header name from AWF_OPENAI_AUTH_HEADER with raw key', () => {
+    const adapter = createOpenAIAdapter({
+      OPENAI_API_KEY: 'sk-openai-test',
+      AWF_OPENAI_AUTH_HEADER: 'api-key',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      'api-key': 'sk-openai-test',
+    });
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('custom header is used in validation probe', () => {
+    const adapter = createOpenAIAdapter({
+      OPENAI_API_KEY: 'sk-openai-test',
+      AWF_OPENAI_AUTH_HEADER: 'api-key',
+    });
+    const probe = adapter.getValidationProbe();
+    expect(probe.opts.headers['api-key']).toBe('sk-openai-test');
+    expect(probe.opts.headers.Authorization).toBeUndefined();
+  });
+
+  it('custom header is used in models fetch config', () => {
+    const adapter = createOpenAIAdapter({
+      OPENAI_API_KEY: 'sk-openai-test',
+      AWF_OPENAI_AUTH_HEADER: 'api-key',
+    });
+    const config = adapter.getModelsFetchConfig();
+    expect(config.opts.headers['api-key']).toBe('sk-openai-test');
+    expect(config.opts.headers.Authorization).toBeUndefined();
+  });
+
+  it('OIDC mode (Azure) uses custom header with token', () => {
+    const adapter = createOpenAIAdapter({
+      OPENAI_API_KEY: 'sk-openai-test',
+      AWF_OPENAI_AUTH_HEADER: 'api-key',
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'openai',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test-token',
+      AWF_AUTH_AZURE_TENANT_ID: 'test-tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'test-client',
+    });
+
+    const provider = adapter.getOidcProvider();
+    provider._cachedToken = 'oidc-token';
+    provider._expiresAt = Math.floor(Date.now() / 1000) + 600;
+
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      'api-key': 'oidc-token',
+    });
+    expect(headers.Authorization).toBeUndefined();
+
+    provider.shutdown();
+  });
+
+  it('OIDC mode (Azure) without custom header uses Authorization Bearer', () => {
+    const adapter = createOpenAIAdapter({
+      OPENAI_API_KEY: 'sk-openai-test',
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'openai',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test-token',
+      AWF_AUTH_AZURE_TENANT_ID: 'test-tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'test-client',
+    });
+
+    const provider = adapter.getOidcProvider();
+    provider._cachedToken = 'oidc-token';
+    provider._expiresAt = Math.floor(Date.now() / 1000) + 600;
+
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers).toEqual({
+      Authorization: 'Bearer oidc-token',
+    });
+
+    provider.shutdown();
+  });
+});

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -121,7 +121,9 @@ the corresponding CLI flag.
 - `apiProxy.targets.<provider>.host` → `--<provider>-api-target` *(except `antigravity.host`, which maps to the Gemini flag below)*
 - `apiProxy.targets.antigravity.host` → `--gemini-api-target`
 - `apiProxy.targets.openai.basePath` → `--openai-api-base-path`
+- `apiProxy.targets.openai.authHeader` → `--openai-api-auth-header`
 - `apiProxy.targets.anthropic.basePath` → `--anthropic-api-base-path`
+- `apiProxy.targets.anthropic.authHeader` → `--anthropic-api-auth-header`
 - `apiProxy.targets.gemini.basePath` → `--gemini-api-base-path`
 - `apiProxy.targets.antigravity.basePath` → `--gemini-api-base-path`
 - When both `apiProxy.targets.antigravity` and `apiProxy.targets.gemini` are set, `antigravity` takes precedence per field.

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -510,6 +510,10 @@
         "basePath": {
           "type": "string",
           "description": "Override the provider API base path."
+        },
+        "authHeader": {
+          "type": "string",
+          "description": "Override the auth header name used for API requests. For OpenAI, replaces 'Authorization: Bearer <key>' with '<authHeader>: <key>' (raw key, no Bearer prefix). For Anthropic, replaces 'x-api-key'. Not applicable to Copilot or Gemini."
         }
       }
     },

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -510,6 +510,10 @@
         "basePath": {
           "type": "string",
           "description": "Override the provider API base path."
+        },
+        "authHeader": {
+          "type": "string",
+          "description": "Override the auth header name used for API requests. For OpenAI, replaces 'Authorization: Bearer <key>' with '<authHeader>: <key>' (raw key, no Bearer prefix). For Anthropic, replaces 'x-api-key'. Not applicable to Copilot or Gemini."
         }
       }
     },

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -287,6 +287,14 @@ program
     'Base path prefix for Anthropic API requests (e.g. /anthropic)',
   )
   .option(
+    '--openai-api-auth-header <name>',
+    'Custom auth header name for OpenAI requests (default: Authorization with Bearer prefix)',
+  )
+  .option(
+    '--anthropic-api-auth-header <name>',
+    'Custom auth header name for Anthropic requests (default: x-api-key)',
+  )
+  .option(
     '--gemini-api-target <host>',
     'Target hostname for Gemini API requests (default: generativelanguage.googleapis.com)',
   )

--- a/src/commands/build-config.ts
+++ b/src/commands/build-config.ts
@@ -125,6 +125,10 @@ export function buildConfig(inputs: BuildConfigInputs): WrapperConfig {
       (options.anthropicApiTarget as string | undefined) || process.env.ANTHROPIC_API_TARGET,
     anthropicApiBasePath:
       (options.anthropicApiBasePath as string | undefined) || process.env.ANTHROPIC_API_BASE_PATH,
+    openaiApiAuthHeader:
+      (options.openaiApiAuthHeader as string | undefined) || process.env.AWF_OPENAI_AUTH_HEADER,
+    anthropicApiAuthHeader:
+      (options.anthropicApiAuthHeader as string | undefined) || process.env.AWF_ANTHROPIC_AUTH_HEADER,
     geminiApiTarget:
       (options.geminiApiTarget as string | undefined) || process.env.GEMINI_API_TARGET,
     geminiApiBasePath:

--- a/src/config-file-mapping.test.ts
+++ b/src/config-file-mapping.test.ts
@@ -50,6 +50,34 @@ describe('mapAwfFileConfigToCliOptions', () => {
     expect(result.geminiApiBasePath).toBe('/v1beta');
   });
 
+  it('maps authHeader fields for openai and anthropic targets', () => {
+    const result = mapAwfFileConfigToCliOptions({
+      apiProxy: {
+        targets: {
+          openai: { host: 'azure-openai.internal', authHeader: 'api-key' },
+          anthropic: { host: 'anthropic-gw.internal', authHeader: 'api-key' },
+        },
+      },
+    });
+
+    expect(result.openaiApiAuthHeader).toBe('api-key');
+    expect(result.anthropicApiAuthHeader).toBe('api-key');
+  });
+
+  it('leaves authHeader undefined when not set', () => {
+    const result = mapAwfFileConfigToCliOptions({
+      apiProxy: {
+        targets: {
+          openai: { host: 'api.openai.com' },
+          anthropic: { host: 'api.anthropic.com' },
+        },
+      },
+    });
+
+    expect(result.openaiApiAuthHeader).toBeUndefined();
+    expect(result.anthropicApiAuthHeader).toBeUndefined();
+  });
+
   it('maps antigravity target fields to existing gemini runtime options', () => {
     const result = mapAwfFileConfigToCliOptions({
       apiProxy: {

--- a/src/config-file-validation.test.ts
+++ b/src/config-file-validation.test.ts
@@ -171,6 +171,23 @@ describe('validateAwfFileConfig', () => {
     expect(errors).toEqual([]);
   });
 
+  it('accepts authHeader on openai and anthropic targets', () => {
+    const errors = validateAwfFileConfig({
+      apiProxy: { targets: {
+        openai: { host: 'azure-openai.internal', authHeader: 'api-key' },
+        anthropic: { host: 'anthropic-gw.internal', authHeader: 'api-key' },
+      } },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects non-string authHeader', () => {
+    const errors = validateAwfFileConfig({
+      apiProxy: { targets: { openai: { authHeader: 123 } } },
+    });
+    expect(errors).toContain('config.apiProxy.targets.openai.authHeader must be a string');
+  });
+
   it('rejects non-object security', () => {
     const errors = validateAwfFileConfig({ security: 'invalid' });
     expect(errors).toContain('config.security must be an object');

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -25,8 +25,8 @@ interface AwfFileConfig {
       strategy?: 'middle_power';
     };
     targets?: {
-      openai?: { host?: string; basePath?: string };
-      anthropic?: { host?: string; basePath?: string };
+      openai?: { host?: string; basePath?: string; authHeader?: string };
+      anthropic?: { host?: string; basePath?: string; authHeader?: string };
       copilot?: { host?: string; basePath?: string };
       gemini?: { host?: string; basePath?: string };
       antigravity?: { host?: string; basePath?: string };
@@ -182,8 +182,10 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     modelFallback: config.apiProxy?.modelFallback,
     openaiApiTarget: config.apiProxy?.targets?.openai?.host,
     openaiApiBasePath: config.apiProxy?.targets?.openai?.basePath,
+    openaiApiAuthHeader: config.apiProxy?.targets?.openai?.authHeader,
     anthropicApiTarget: config.apiProxy?.targets?.anthropic?.host,
     anthropicApiBasePath: config.apiProxy?.targets?.anthropic?.basePath,
+    anthropicApiAuthHeader: config.apiProxy?.targets?.anthropic?.authHeader,
     copilotApiTarget: config.apiProxy?.targets?.copilot?.host,
     geminiApiTarget: antigravityTargetConfig?.host ?? geminiTargetConfig?.host,
     geminiApiBasePath: antigravityTargetConfig?.basePath ?? geminiTargetConfig?.basePath,

--- a/src/services/api-proxy-service-env-forwarding.test.ts
+++ b/src/services/api-proxy-service-env-forwarding.test.ts
@@ -683,4 +683,38 @@ describe('API proxy sidecar: env var forwarding', () => {
         const env = proxy.environment as Record<string, string>;
         expect(env.GEMINI_API_BASE_PATH).toBeUndefined();
       });
+
+      // ─── Custom auth headers ───
+
+      it('should set AWF_OPENAI_AUTH_HEADER when openaiApiAuthHeader is provided', () => {
+        const configWithProxy = { ...mockConfig, enableApiProxy: true, openaiApiKey: 'sk-test-key', openaiApiAuthHeader: 'api-key' };
+        const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+        const proxy = result.services['api-proxy'];
+        const env = proxy.environment as Record<string, string>;
+        expect(env.AWF_OPENAI_AUTH_HEADER).toBe('api-key');
+      });
+
+      it('should not set AWF_OPENAI_AUTH_HEADER when openaiApiAuthHeader is not provided', () => {
+        const configWithProxy = { ...mockConfig, enableApiProxy: true, openaiApiKey: 'sk-test-key' };
+        const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+        const proxy = result.services['api-proxy'];
+        const env = proxy.environment as Record<string, string>;
+        expect(env.AWF_OPENAI_AUTH_HEADER).toBeUndefined();
+      });
+
+      it('should set AWF_ANTHROPIC_AUTH_HEADER when anthropicApiAuthHeader is provided', () => {
+        const configWithProxy = { ...mockConfig, enableApiProxy: true, anthropicApiKey: 'sk-ant-test', anthropicApiAuthHeader: 'api-key' };
+        const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+        const proxy = result.services['api-proxy'];
+        const env = proxy.environment as Record<string, string>;
+        expect(env.AWF_ANTHROPIC_AUTH_HEADER).toBe('api-key');
+      });
+
+      it('should not set AWF_ANTHROPIC_AUTH_HEADER when anthropicApiAuthHeader is not provided', () => {
+        const configWithProxy = { ...mockConfig, enableApiProxy: true, anthropicApiKey: 'sk-ant-test' };
+        const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+        const proxy = result.services['api-proxy'];
+        const env = proxy.environment as Record<string, string>;
+        expect(env.AWF_ANTHROPIC_AUTH_HEADER).toBeUndefined();
+      });
 });

--- a/src/services/api-proxy-service.ts
+++ b/src/services/api-proxy-service.ts
@@ -217,6 +217,9 @@ export function buildApiProxyService(params: ApiProxyServiceParams): ApiProxyBui
         'AWF_ANTHROPIC_DROP_TOOLS',
         'AWF_ANTHROPIC_STRIP_ANSI',
       ),
+      // Custom auth header names for internal AI gateways
+      ...(config.openaiApiAuthHeader && { AWF_OPENAI_AUTH_HEADER: config.openaiApiAuthHeader }),
+      ...(config.anthropicApiAuthHeader && { AWF_ANTHROPIC_AUTH_HEADER: config.anthropicApiAuthHeader }),
       // NOTE: AWF_ANTHROPIC_TRANSFORM_FILE is intentionally NOT forwarded from the host.
       // The api-proxy container holds live API credentials; loading arbitrary host-side JS
       // files into it would create an arbitrary-code-execution risk.  If you need a custom

--- a/src/types/api-proxy-options.ts
+++ b/src/types/api-proxy-options.ts
@@ -240,6 +240,41 @@ export interface ApiProxyOptions {
   anthropicApiBasePath?: string;
 
   /**
+   * Custom auth header name for OpenAI API requests (used by API proxy sidecar)
+   *
+   * When set, the proxy uses this header name instead of the default
+   * `Authorization: Bearer <key>` format. The key is sent as the raw header
+   * value without a "Bearer" prefix.
+   *
+   * Useful for internal AI gateways (e.g. Azure OpenAI) that require a
+   * different header name such as `api-key`.
+   *
+   * Can be set via:
+   * - CLI flag: `--openai-api-auth-header <name>`
+   * - Environment variable: `AWF_OPENAI_AUTH_HEADER`
+   *
+   * @default undefined (uses `Authorization: Bearer <key>`)
+   * @example 'api-key'
+   */
+  openaiApiAuthHeader?: string;
+
+  /**
+   * Custom auth header name for Anthropic API requests (used by API proxy sidecar)
+   *
+   * When set, the proxy uses this header name instead of the default `x-api-key`.
+   *
+   * Useful for internal AI gateways that require a different header name.
+   *
+   * Can be set via:
+   * - CLI flag: `--anthropic-api-auth-header <name>`
+   * - Environment variable: `AWF_ANTHROPIC_AUTH_HEADER`
+   *
+   * @default 'x-api-key'
+   * @example 'api-key'
+   */
+  anthropicApiAuthHeader?: string;
+
+  /**
    * Target hostname for Google Gemini API requests (used by API proxy sidecar)
    *
    * When enableApiProxy is true, this hostname is passed to the Node.js sidecar


### PR DESCRIPTION
## Summary

Adds support for custom API auth header names via `AWF_OPENAI_AUTH_HEADER` and `AWF_ANTHROPIC_AUTH_HEADER` env vars (or equivalent CLI flags). This unblocks internal AI gateways (e.g. Azure OpenAI) that require headers like `api-key:` instead of the standard `Authorization: Bearer` or `x-api-key`.

## Changes

### API Proxy (containers/api-proxy/)
- **Anthropic adapter**: reads `AWF_ANTHROPIC_AUTH_HEADER` to override the default `x-api-key` header name. Applied consistently to `getAuthHeaders()`, validation probe, and models fetch.
- **OpenAI adapter**: reads `AWF_OPENAI_AUTH_HEADER` to override the default `Authorization: Bearer <key>` pattern. When a custom header is set, the raw key is sent without the `Bearer` prefix (matching Azure's `api-key: <rawkey>` convention).
- OIDC paths: Anthropic OIDC always uses `Authorization: Bearer` (no override). OpenAI OIDC respects the custom header if set.

### AWF CLI (src/)
- New CLI flags: `--openai-api-auth-header <name>`, `--anthropic-api-auth-header <name>`
- New `WrapperConfig` fields with JSDoc
- Env vars forwarded to api-proxy container when set

### Tests
- 11 new api-proxy tests covering default behavior, custom headers, validation probes, models fetch, and OIDC interactions
- 4 new AWF env-forwarding tests

## Usage

```bash
# Azure OpenAI gateway (uses api-key header)
awf --enable-api-proxy \
    --openai-api-auth-header api-key \
    --openai-api-target my-azure-gateway.internal \
    -- copilot

# Internal Anthropic gateway with custom auth
awf --enable-api-proxy \
    --anthropic-api-auth-header api-key \
    --anthropic-api-target my-anthropic-gateway.internal \
    -- claude
```

Closes #3986