### PR TITLE
fix: add api-proxy hostname to NO_PROXY for Node.js undici compatibility

### DIFF
--- a/src/services/agent-environment/proxy-environment.ts
+++ b/src/services/agent-environment/proxy-environment.ts
@@ -22,7 +22,9 @@ export function buildProxyEnvironment(params: ProxyEnvironmentParams): void {
   }
 
   if (config.enableApiProxy && networkConfig.proxyIp) {
-    environment.NO_PROXY += `,${networkConfig.proxyIp}`;
+    // Include both IP and Docker service hostname — Node.js undici matches
+    // NO_PROXY against the request hostname string, not the resolved IP.
+    environment.NO_PROXY += `,${networkConfig.proxyIp},api-proxy`;
     environment.no_proxy = environment.NO_PROXY;
   }
 }

--- a/src/services/api-proxy-service-config.test.ts
+++ b/src/services/api-proxy-service-config.test.ts
@@ -210,13 +210,15 @@ describe('API proxy sidecar: service configuration', () => {
         expect(env.AWF_API_PROXY_IP).toBe('172.30.0.30');
       });
 
-      it('should set NO_PROXY to include api-proxy IP', () => {
+      it('should set NO_PROXY to include api-proxy IP and hostname', () => {
         const configWithProxy = { ...mockConfig, enableApiProxy: true, anthropicApiKey: 'sk-ant-test-key' };
         const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
         const agent = result.services.agent;
         const env = agent.environment as Record<string, string>;
         expect(env.NO_PROXY).toContain('172.30.0.30');
+        expect(env.NO_PROXY).toContain('api-proxy');
         expect(env.no_proxy).toContain('172.30.0.30');
+        expect(env.no_proxy).toContain('api-proxy');
       });
 
       it('should set CLAUDE_CODE_API_KEY_HELPER when Anthropic key is provided', () => {


### PR DESCRIPTION
## Problem

Node.js undici matches `NO_PROXY` entries against the request **hostname string**, not the resolved IP. When code fetches `http://api-proxy:10000/reflect`, undici checks for `api-proxy` in `NO_PROXY` — the existing IP entry (`172.30.0.30`) doesn't match.

This caused internal api-proxy traffic to be tunneled through Squid via `CONNECT api-proxy:10000`, which Squid rejects (403) since `api-proxy` isn't in the domain allowlist.

Affected: Pi provider and any Node.js runtime that fetches internal api-proxy endpoints by hostname.

## Fix

Include both the IP and the Docker service hostname `api-proxy` in `NO_PROXY`:

```typescript
environment.NO_PROXY += `,${networkConfig.proxyIp},api-proxy`;
```

## Evidence

From UNDICI debug trace in [gh-aw#35381](https://github.com/github/gh-aw/pull/35381):
```
UNDICI: connecting to api-proxy:10000 → routed to 172.30.0.10:3128 (Squid) → CONNECT rejected
```

`curl` to the same URL succeeds because it resolves hostname to IP before matching `NO_PROXY`.

Closes #4001