### PR TITLE
fix(api-proxy): suppress model fallback for Copilot, add excludeEngines

### DIFF
--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -196,14 +196,29 @@ function getCopilotModelFallbackPolicy(modelFallback, env = process.env) {
     || (env.COPILOT_PROVIDER_API_KEY || '').trim()
     || (env.COPILOT_API_KEY || '').trim()
   );
+
+  // Standard Copilot (no BYOK hints): suppress fallback because Copilot is
+  // authoritative for its own model catalogue. Rewriting a retired/restricted
+  // model to a middle-power fallback obscures the real error.
   if (!hasByokHints) {
-    return { effective: modelFallback, suppressed: false };
+    return {
+      effective: { ...modelFallback, enabled: false },
+      suppressed: true,
+      suppression_reason: 'copilot_standard_authoritative',
+    };
   }
 
+  // BYOK pointing at a GitHub Copilot catalog target — still suppress because
+  // the catalog is authoritative.
   if (isGithubCopilotCatalogTarget(env.COPILOT_API_TARGET)) {
-    return { effective: modelFallback, suppressed: false };
+    return {
+      effective: { ...modelFallback, enabled: false },
+      suppressed: true,
+      suppression_reason: 'copilot_catalog_target_authoritative',
+    };
   }
 
+  // BYOK pointing at a non-GitHub target (Azure, custom OpenAI, etc.)
   return {
     effective: { ...modelFallback, enabled: false },
     suppressed: true,

--- a/containers/api-proxy/server.js
+++ b/containers/api-proxy/server.js
@@ -101,7 +101,10 @@ function parseModelFallbackConfig(rawConfig) {
     const strategy = typeof parsed.strategy === 'string' && parsed.strategy.trim()
       ? parsed.strategy.trim()
       : DEFAULT_MODEL_FALLBACK.strategy;
-    return { enabled, strategy };
+    const excludeEngines = Array.isArray(parsed.excludeEngines)
+      ? parsed.excludeEngines.filter(e => typeof e === 'string').map(e => e.toLowerCase())
+      : [];
+    return { enabled, strategy, excludeEngines };
   } catch {
     return { ...DEFAULT_MODEL_FALLBACK };
   }
@@ -126,6 +129,14 @@ logRequest('info', 'startup', {
 });
 
 function getModelFallbackPolicyForProvider(provider) {
+  // Check excludeEngines first — applies to all providers
+  if (MODEL_FALLBACK.excludeEngines && MODEL_FALLBACK.excludeEngines.includes(provider.toLowerCase())) {
+    return {
+      effective: { ...MODEL_FALLBACK, enabled: false },
+      suppressed: true,
+      suppression_reason: 'excluded_by_config',
+    };
+  }
   if (provider !== 'copilot') {
     return { effective: MODEL_FALLBACK, suppressed: false };
   }

--- a/containers/api-proxy/server.js
+++ b/containers/api-proxy/server.js
@@ -90,23 +90,33 @@ if (!HTTPS_PROXY) {
 // and rewritten to a concrete model name before forwarding to upstream.
 const MODEL_ALIASES_RAW = (process.env.AWF_MODEL_ALIASES || '').trim() || undefined;
 const MODEL_ALIASES = parseModelAliases(MODEL_ALIASES_RAW);
-const DEFAULT_MODEL_FALLBACK = Object.freeze({ enabled: true, strategy: 'middle_power' });
+const DEFAULT_MODEL_FALLBACK = Object.freeze({ enabled: true, strategy: 'middle_power', excludeEngines: Object.freeze([]) });
+
+function parseExcludeEngines(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(
+    value
+      .filter(engine => typeof engine === 'string')
+      .map(engine => engine.trim().toLowerCase())
+      .filter(Boolean),
+  )];
+}
 
 function parseModelFallbackConfig(rawConfig) {
-  if (!rawConfig) return { ...DEFAULT_MODEL_FALLBACK };
+  if (!rawConfig) return { ...DEFAULT_MODEL_FALLBACK, excludeEngines: [] };
   try {
     const parsed = JSON.parse(rawConfig);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return { ...DEFAULT_MODEL_FALLBACK };
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ...DEFAULT_MODEL_FALLBACK, excludeEngines: [] };
+    }
     const enabled = parsed.enabled === undefined ? true : Boolean(parsed.enabled);
     const strategy = typeof parsed.strategy === 'string' && parsed.strategy.trim()
       ? parsed.strategy.trim()
       : DEFAULT_MODEL_FALLBACK.strategy;
-    const excludeEngines = Array.isArray(parsed.excludeEngines)
-      ? parsed.excludeEngines.filter(e => typeof e === 'string').map(e => e.toLowerCase())
-      : [];
+    const excludeEngines = parseExcludeEngines(parsed.excludeEngines);
     return { enabled, strategy, excludeEngines };
   } catch {
-    return { ...DEFAULT_MODEL_FALLBACK };
+    return { ...DEFAULT_MODEL_FALLBACK, excludeEngines: [] };
   }
 }
 

--- a/containers/api-proxy/server.models.test.js
+++ b/containers/api-proxy/server.models.test.js
@@ -242,9 +242,9 @@ describe('makeModelBodyTransform', () => {
 
       stdoutSpy.mockClear();
       isolatedServer.resetModelCacheState();
-      isolatedServer.cachedModels.copilot = ['gpt-5.2', 'gpt-4.1', 'gpt-3.5-turbo'];
+      isolatedServer.cachedModels.openai = ['gpt-5.2', 'gpt-4.1', 'gpt-3.5-turbo'];
 
-      const transform = isolatedServer.makeModelBodyTransform('copilot');
+      const transform = isolatedServer.makeModelBodyTransform('openai');
       const transformed = await transform(Buffer.from(JSON.stringify({ model: 'sonnet', messages: [] })));
       expect(transformed).toBeInstanceOf(Buffer);
 
@@ -267,7 +267,7 @@ describe('makeModelBodyTransform', () => {
   it('emits model_fallback_skipped log when normal resolution succeeds', async () => {
     const prevAliases = process.env.AWF_MODEL_ALIASES;
     const prevFallback = process.env.AWF_MODEL_FALLBACK;
-    process.env.AWF_MODEL_ALIASES = JSON.stringify({ models: { sonnet: ['copilot/*sonnet*'] } });
+    process.env.AWF_MODEL_ALIASES = JSON.stringify({ models: { sonnet: ['openai/*sonnet*'] } });
     process.env.AWF_MODEL_FALLBACK = JSON.stringify({ enabled: true, strategy: 'middle_power' });
 
     const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -280,9 +280,9 @@ describe('makeModelBodyTransform', () => {
 
       stdoutSpy.mockClear();
       isolatedServer.resetModelCacheState();
-      isolatedServer.cachedModels.copilot = ['claude-sonnet-4.6', 'claude-haiku-4.5'];
+      isolatedServer.cachedModels.openai = ['claude-sonnet-4.6', 'claude-haiku-4.5'];
 
-      const transform = isolatedServer.makeModelBodyTransform('copilot');
+      const transform = isolatedServer.makeModelBodyTransform('openai');
       const transformed = await transform(Buffer.from(JSON.stringify({ model: 'sonnet', messages: [] })));
       expect(transformed).toBeInstanceOf(Buffer);
 

--- a/containers/api-proxy/server.network.test.js
+++ b/containers/api-proxy/server.network.test.js
@@ -401,7 +401,7 @@ describe('reflectEndpoints', () => {
     expect(result.model_fallback_effective).toEqual({
       openai: { enabled: true, strategy: 'middle_power', suppressed: false },
       anthropic: { enabled: true, strategy: 'middle_power', suppressed: false },
-      copilot: { enabled: true, strategy: 'middle_power', suppressed: false },
+      copilot: { enabled: false, strategy: 'middle_power', suppressed: true, suppression_reason: 'copilot_standard_authoritative' },
       gemini: { enabled: true, strategy: 'middle_power', suppressed: false },
     });
   });
@@ -440,6 +440,59 @@ describe('reflectEndpoints', () => {
       else process.env.COPILOT_PROVIDER_BASE_URL = prevProviderBase;
       if (prevApiKey === undefined) delete process.env.COPILOT_API_KEY;
       else process.env.COPILOT_API_KEY = prevApiKey;
+    }
+  });
+
+  it('should suppress fallback for standard Copilot (no BYOK hints)', () => {
+    // Default test environment has no BYOK env vars set — standard Copilot
+    const result = reflectEndpoints();
+    expect(result.model_fallback_effective.copilot).toEqual({
+      enabled: false,
+      strategy: 'middle_power',
+      suppressed: true,
+      suppression_reason: 'copilot_standard_authoritative',
+    });
+  });
+
+  it('should suppress fallback for engines in excludeEngines config', () => {
+    const prevFallback = process.env.AWF_MODEL_FALLBACK;
+    process.env.AWF_MODEL_FALLBACK = JSON.stringify({
+      enabled: true,
+      strategy: 'middle_power',
+      excludeEngines: ['openai', 'anthropic'],
+    });
+
+    try {
+      let isolatedServer;
+      jest.isolateModules(() => {
+        isolatedServer = require('./server');
+      });
+
+      const reflect = isolatedServer.reflectEndpoints();
+      expect(reflect.model_fallback_effective.openai).toEqual({
+        enabled: false,
+        strategy: 'middle_power',
+        excludeEngines: ['openai', 'anthropic'],
+        suppressed: true,
+        suppression_reason: 'excluded_by_config',
+      });
+      expect(reflect.model_fallback_effective.anthropic).toEqual({
+        enabled: false,
+        strategy: 'middle_power',
+        excludeEngines: ['openai', 'anthropic'],
+        suppressed: true,
+        suppression_reason: 'excluded_by_config',
+      });
+      // Gemini not in excludeEngines — should NOT be suppressed
+      expect(reflect.model_fallback_effective.gemini).toEqual({
+        enabled: true,
+        strategy: 'middle_power',
+        excludeEngines: ['openai', 'anthropic'],
+        suppressed: false,
+      });
+    } finally {
+      if (prevFallback === undefined) delete process.env.AWF_MODEL_FALLBACK;
+      else process.env.AWF_MODEL_FALLBACK = prevFallback;
     }
   });
 

--- a/containers/api-proxy/server.network.test.js
+++ b/containers/api-proxy/server.network.test.js
@@ -397,12 +397,13 @@ describe('reflectEndpoints', () => {
     expect(result.model_fallback).toEqual({
       enabled: true,
       strategy: 'middle_power',
+      excludeEngines: [],
     });
     expect(result.model_fallback_effective).toEqual({
-      openai: { enabled: true, strategy: 'middle_power', suppressed: false },
-      anthropic: { enabled: true, strategy: 'middle_power', suppressed: false },
-      copilot: { enabled: false, strategy: 'middle_power', suppressed: true, suppression_reason: 'copilot_standard_authoritative' },
-      gemini: { enabled: true, strategy: 'middle_power', suppressed: false },
+      openai: { enabled: true, strategy: 'middle_power', excludeEngines: [], suppressed: false },
+      anthropic: { enabled: true, strategy: 'middle_power', excludeEngines: [], suppressed: false },
+      copilot: { enabled: false, strategy: 'middle_power', excludeEngines: [], suppressed: true, suppression_reason: 'copilot_standard_authoritative' },
+      gemini: { enabled: true, strategy: 'middle_power', excludeEngines: [], suppressed: false },
     });
   });
 
@@ -424,10 +425,11 @@ describe('reflectEndpoints', () => {
       });
 
       const reflect = isolatedServer.reflectEndpoints();
-      expect(reflect.model_fallback).toEqual({ enabled: true, strategy: 'middle_power' });
+      expect(reflect.model_fallback).toEqual({ enabled: true, strategy: 'middle_power', excludeEngines: [] });
       expect(reflect.model_fallback_effective.copilot).toEqual({
         enabled: false,
         strategy: 'middle_power',
+        excludeEngines: [],
         suppressed: true,
         suppression_reason: 'copilot_byok_non_githubcopilot_target',
       });
@@ -444,14 +446,36 @@ describe('reflectEndpoints', () => {
   });
 
   it('should suppress fallback for standard Copilot (no BYOK hints)', () => {
-    // Default test environment has no BYOK env vars set — standard Copilot
-    const result = reflectEndpoints();
-    expect(result.model_fallback_effective.copilot).toEqual({
-      enabled: false,
-      strategy: 'middle_power',
-      suppressed: true,
-      suppression_reason: 'copilot_standard_authoritative',
-    });
+    const hintVars = [
+      'COPILOT_PROVIDER_TYPE',
+      'COPILOT_PROVIDER_BASE_URL',
+      'COPILOT_PROVIDER_API_KEY',
+      'COPILOT_API_KEY',
+      'COPILOT_API_TARGET',
+    ];
+    const prevValues = Object.fromEntries(hintVars.map(name => [name, process.env[name]]));
+    for (const name of hintVars) delete process.env[name];
+
+    try {
+      let isolatedServer;
+      jest.isolateModules(() => {
+        isolatedServer = require('./server');
+      });
+
+      const result = isolatedServer.reflectEndpoints();
+      expect(result.model_fallback_effective.copilot).toEqual({
+        enabled: false,
+        strategy: 'middle_power',
+        excludeEngines: [],
+        suppressed: true,
+        suppression_reason: 'copilot_standard_authoritative',
+      });
+    } finally {
+      for (const [name, value] of Object.entries(prevValues)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
   });
 
   it('should suppress fallback for engines in excludeEngines config', () => {
@@ -459,7 +483,7 @@ describe('reflectEndpoints', () => {
     process.env.AWF_MODEL_FALLBACK = JSON.stringify({
       enabled: true,
       strategy: 'middle_power',
-      excludeEngines: ['openai', 'anthropic'],
+      excludeEngines: [' OpenAI ', 'anthropic', 'OPENAI', '   '],
     });
 
     try {

--- a/containers/api-proxy/upstream-response.js
+++ b/containers/api-proxy/upstream-response.js
@@ -57,8 +57,17 @@ function createUpstreamResponseHandlers({
     logRequest('info', 'request_complete', logFields);
   }
 
-  function logUpstreamAuthError(statusCode, { requestId, provider, targetHost, req }) {
-    if (statusCode === 400 || statusCode === 401 || statusCode === 403) {
+  function logUpstreamAuthError(statusCode, { requestId, provider, targetHost, req, responseBody }) {
+    if (statusCode === 401 || statusCode === 403) {
+      logRequest('warn', 'upstream_auth_error', {
+        request_id: requestId, provider, status: statusCode,
+        upstream_host: targetHost, path: sanitizeForLog(req.url),
+        message: `Upstream returned ${statusCode} — check that the API key is valid and correctly formatted`,
+      });
+    } else if (statusCode === 400) {
+      // Suppress generic auth-error message when the 400 is a model-not-supported
+      // error — that case is handled by the model_unavailable diagnostic.
+      if (responseBody && parseModelNotSupportedFromBody(responseBody)) return;
       logRequest('warn', 'upstream_auth_error', {
         request_id: requestId, provider, status: statusCode,
         upstream_host: targetHost, path: sanitizeForLog(req.url),
@@ -142,8 +151,22 @@ function createUpstreamResponseHandlers({
           return;
         }
 
+        // ── (c) Model-unavailable diagnostic (retries exhausted or non-retryable) ───
+        if (proxyRes.statusCode === 400 && parseModelNotSupportedFromBody(responseBody)) {
+          logRequest('error', 'model_unavailable', {
+            request_id: requestId,
+            provider,
+            status: proxyRes.statusCode,
+            path: sanitizeForLog(req.url),
+            retries_attempted: modelNotSupportedRetryCount,
+            message: `Model is unavailable or retired — the requested model is not supported by ${provider}. ` +
+              'Check that the model name is correct and not deprecated. ' +
+              'If using model aliases, verify the alias resolves to an available model.',
+          });
+        }
+
         logRequestCompletion(proxyRes.statusCode, responseBytes, initiatorSent, billingInfo, completionCtx);
-        logUpstreamAuthError(proxyRes.statusCode, authErrCtx);
+        logUpstreamAuthError(proxyRes.statusCode, { ...authErrCtx, responseBody });
 
         const resHeaders = {
           ...proxyRes.headers,

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -818,6 +818,9 @@ The fallback is **NOT** activated when:
   authoritative for its own model catalogue, so retired/restricted model names
   should fail fast with a clear upstream error rather than being silently
   rewritten to a middle-power fallback
+- Copilot BYOK that still targets a GitHub Copilot catalog host (for example
+  `api.githubcopilot.com`): the catalog remains authoritative, so fallback is
+  still suppressed
 - Copilot is configured for a BYOK non-`githubcopilot` target (for example Azure
   OpenAI deployment endpoints), where deployment names are provider-local and
   must not be rewritten to catalog model IDs

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -769,6 +769,7 @@ Model fallback is controlled via `apiProxy.modelFallback`:
 |-------|------|---------|-------------|
 | `enabled` | boolean | `true` | Enable/disable the fallback mechanism |
 | `strategy` | string | `middle_power` | Selection strategy (`middle_power` is currently the only strategy) |
+| `excludeEngines` | string[] | `[]` | Engines for which middle-power fallback is suppressed (e.g. `["openai"]`). Excluded engines receive native model-unavailable errors instead of silent rewrites. |
 
 ### 12.2 Middle-Power Strategy
 
@@ -812,6 +813,11 @@ The fallback is **NOT** activated when:
 - A family version fallback is available (for `gpt-5.*` only)
 - The fallback is disabled (`enabled: false`)
 - An alias has `fallback: false` (see §12.4)
+- The provider is in the `excludeEngines` list
+- Copilot engine in standard mode (no BYOK env vars): the Copilot CLI is
+  authoritative for its own model catalogue, so retired/restricted model names
+  should fail fast with a clear upstream error rather than being silently
+  rewritten to a middle-power fallback
 - Copilot is configured for a BYOK non-`githubcopilot` target (for example Azure
   OpenAI deployment endpoints), where deployment names are provider-local and
   must not be rewritten to catalog model IDs

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -100,6 +100,13 @@
                 "middle_power"
               ],
               "description": "Fallback selection strategy. Currently only 'middle_power' is supported."
+            },
+            "excludeEngines": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of engine/provider names for which middle-power fallback is suppressed. Use this to let specific providers handle model-unavailable errors natively instead of rewriting to a fallback model."
             }
           }
         },

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -100,6 +100,13 @@
                 "middle_power"
               ],
               "description": "Fallback selection strategy. Currently only 'middle_power' is supported."
+            },
+            "excludeEngines": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of engine/provider names for which middle-power fallback is suppressed. Use this to let specific providers handle model-unavailable errors natively instead of rewriting to a fallback model."
             }
           }
         },


### PR DESCRIPTION
## Summary

Addresses #3987 — `modelFallback` was silently rewriting retired/restricted Copilot model names to middle-power fallback models, obscuring the real upstream error with generic auth-failure diagnostics.

## Changes

### 1. Suppress middle-power fallback for standard Copilot
When no BYOK env vars are set, the Copilot CLI is authoritative for its own model catalogue. Retired or restricted models should fail fast with a clear upstream error instead of being silently rewritten to a random middle-tier model.

Previously: standard Copilot → fallback enabled → model rewritten → confusing error or wrong model
Now: standard Copilot → fallback suppressed → request goes through with original model → clear `400 model not supported` error

### 2. Suppress for BYOK Copilot targeting GitHub catalog
When BYOK hints are present but the target is still a GitHub Copilot catalog host (`api.githubcopilot.com`, etc.), the same logic applies — catalog is authoritative.

### 3. Add `modelFallback.excludeEngines` config option
New config field: array of engine/provider names for which middle-power fallback is suppressed. This gives gh-aw authors explicit control to disable fallback per-engine without disabling it globally.

```json
{
  "apiProxy": {
    "modelFallback": {
      "enabled": true,
      "strategy": "middle_power",
      "excludeEngines": ["copilot", "anthropic"]
    }
  }
}
```

### 4. Improved error messaging
- **New `model_unavailable` diagnostic log**: Emitted when Copilot returns `400 model not supported` after retries are exhausted. Provides actionable guidance instead of generic auth-error message.
- **Suppressed misleading auth-error log**: The generic `upstream_auth_error` warning ("check that the API key is valid") is no longer emitted for 400 responses that are actually model-not-supported errors.

## Files Changed

- `containers/api-proxy/providers/copilot.js` — Suppress fallback for standard Copilot + BYOK catalog targets
- `containers/api-proxy/server.js` — Parse `excludeEngines`, apply per-provider policy
- `containers/api-proxy/upstream-response.js` — Add `model_unavailable` diagnostic, suppress auth-error for model errors
- `src/awf-config-schema.json` + `docs/awf-config.schema.json` — Add `excludeEngines` field to schema
- `docs/awf-config-spec.md` — Document new field and suppression conditions
- `containers/api-proxy/server.network.test.js` — Tests for suppression policies
- `containers/api-proxy/server.models.test.js` — Updated model transform tests to use non-copilot provider

## Testing

- All 2193 AWF tests pass
- All 777 api-proxy tests pass (excluding 1 pre-existing failure in `server.custom-auth-header.test.js` on main)
- New tests added for `excludeEngines` config and standard-Copilot suppression