### PR TITLE
feat(api-proxy): Azure OpenAI BYOK routing support

### DIFF
--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -12,6 +12,10 @@
  * Special routing: GET /models (and /models/*) always uses COPILOT_GITHUB_TOKEN
  * regardless of which auth mode is active, because the /models endpoint only
  * accepts OAuth tokens, not API keys.
+ *
+ * Azure OpenAI BYOK: when the target is *.openai.azure.com, the adapter uses
+ * `api-key:` header (instead of `Authorization: Bearer`) and appends
+ * `api-version` query parameter if not present.
  */
 
 const {
@@ -124,6 +128,24 @@ function deriveCopilotApiTarget(env = process.env) {
   }
   return 'api.githubcopilot.com';
 }
+
+/**
+ * Returns true when the target hostname is an Azure OpenAI endpoint.
+ * Azure OpenAI uses a distinct auth header (`api-key:`) and may need
+ * `api-version` query parameters.
+ *
+ * @param {string} target - Normalized hostname
+ * @returns {boolean}
+ */
+function isAzureOpenAITarget(target) {
+  return (
+    target === 'openai.azure.com' || target.endsWith('.openai.azure.com') ||
+    target === 'cognitiveservices.azure.com' || target.endsWith('.cognitiveservices.azure.com')
+  );
+}
+
+/** Default Azure OpenAI API version used when none is specified */
+const AZURE_DEFAULT_API_VERSION = '2024-10-21';
 
 /**
  * Derive the GitHub REST API target hostname (used for GHES/GHEC endpoints).
@@ -241,6 +263,8 @@ function createCopilotAdapter(env, deps = {}) {
   const integrationId = env.COPILOT_INTEGRATION_ID || 'copilot-developer-cli';
   const rawTarget = deriveCopilotApiTarget(env);
   const basePath = normalizeBasePath(env.COPILOT_API_BASE_PATH);
+  const isAzure = isAzureOpenAITarget(rawTarget);
+  const azureApiVersion = env.COPILOT_AZURE_API_VERSION || AZURE_DEFAULT_API_VERSION;
 
   const bodyTransform = composeBodyTransforms(
     deps.bodyTransform || null,
@@ -373,6 +397,11 @@ function createCopilotAdapter(env, deps = {}) {
         };
       }
 
+      // Azure OpenAI uses `api-key:` header instead of `Authorization: Bearer`
+      if (isAzure) {
+        return { 'api-key': authToken };
+      }
+
       return {
         'Authorization': `Bearer ${authToken}`,
         'Copilot-Integration-Id': integrationId,
@@ -380,6 +409,25 @@ function createCopilotAdapter(env, deps = {}) {
     },
 
     getBodyTransform() { return bodyTransform; },
+
+    /**
+     * For Azure OpenAI targets, inject `api-version` query param if absent.
+     * @param {string} url
+     * @returns {string}
+     */
+    transformRequestUrl(url) {
+      if (!isAzure) return url;
+      try {
+        const parsed = new URL(url, 'http://localhost');
+        if (!parsed.searchParams.has('api-version')) {
+          parsed.searchParams.set('api-version', azureApiVersion);
+        }
+        return parsed.pathname + parsed.search;
+      } catch {
+        return url;
+      }
+    },
+
     ...adapterMethods,
 
     /** Response returned for all requests when no Copilot credentials are configured. */
@@ -420,7 +468,9 @@ module.exports = {
     deriveGitHubApiTarget,
     deriveGitHubApiBasePath,
     isGithubCopilotCatalogTarget,
+    isAzureOpenAITarget,
     COPILOT_PLACEHOLDER_TOKEN,
     COPILOT_DUMMY_BYOK_KEY,
+    AZURE_DEFAULT_API_VERSION,
   },
 };

--- a/containers/api-proxy/server.copilot-azure.test.js
+++ b/containers/api-proxy/server.copilot-azure.test.js
@@ -1,0 +1,124 @@
+/**
+ * Tests for Copilot Azure OpenAI BYOK routing.
+ *
+ * Covers: isAzureOpenAITarget detection, api-key header injection,
+ * and api-version query parameter injection via transformRequestUrl.
+ */
+
+const {
+  createCopilotAdapter,
+  _testing: {
+    isAzureOpenAITarget,
+    AZURE_DEFAULT_API_VERSION,
+  },
+} = require('./providers/copilot');
+
+describe('isAzureOpenAITarget', () => {
+  it('detects *.openai.azure.com', () => {
+    expect(isAzureOpenAITarget('my-resource.openai.azure.com')).toBe(true);
+  });
+
+  it('detects *.cognitiveservices.azure.com', () => {
+    expect(isAzureOpenAITarget('my-resource.cognitiveservices.azure.com')).toBe(true);
+  });
+
+  it('does not match standard Copilot target', () => {
+    expect(isAzureOpenAITarget('api.githubcopilot.com')).toBe(false);
+  });
+
+  it('does not match partial hostname match', () => {
+    expect(isAzureOpenAITarget('evil.openai.azure.com.attacker.com')).toBe(false);
+    expect(isAzureOpenAITarget('openai.azure.com')).toBe(true);
+  });
+
+  it('does not match GitHub catalog targets', () => {
+    expect(isAzureOpenAITarget('models.inference.ai.azure.com')).toBe(false);
+  });
+});
+
+describe('Azure OpenAI BYOK adapter', () => {
+  const azureEnv = {
+    COPILOT_API_KEY: 'my-azure-api-key',
+    COPILOT_API_TARGET: 'https://my-resource.openai.azure.com',
+    COPILOT_API_BASE_PATH: '/openai/deployments/gpt-4o',
+  };
+
+  describe('getAuthHeaders', () => {
+    it('uses api-key header for Azure targets', () => {
+      const adapter = createCopilotAdapter(azureEnv);
+      const req = { url: '/chat/completions', method: 'POST', headers: {} };
+      const headers = adapter.getAuthHeaders(req);
+      expect(headers).toEqual({ 'api-key': 'my-azure-api-key' });
+    });
+
+    it('does not include Copilot-Integration-Id for Azure targets', () => {
+      const adapter = createCopilotAdapter(azureEnv);
+      const req = { url: '/chat/completions', method: 'POST', headers: {} };
+      const headers = adapter.getAuthHeaders(req);
+      expect(headers['Copilot-Integration-Id']).toBeUndefined();
+      expect(headers['Authorization']).toBeUndefined();
+    });
+
+    it('still uses Bearer auth for non-Azure targets', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_API_KEY: 'my-key',
+        COPILOT_API_TARGET: 'https://api.githubcopilot.com',
+      });
+      const req = { url: '/chat/completions', method: 'POST', headers: {} };
+      const headers = adapter.getAuthHeaders(req);
+      expect(headers['Authorization']).toBe('Bearer my-key');
+    });
+  });
+
+  describe('transformRequestUrl', () => {
+    it('appends api-version when absent for Azure targets', () => {
+      const adapter = createCopilotAdapter(azureEnv);
+      const result = adapter.transformRequestUrl('/chat/completions');
+      expect(result).toBe(`/chat/completions?api-version=${AZURE_DEFAULT_API_VERSION}`);
+    });
+
+    it('preserves existing api-version parameter', () => {
+      const adapter = createCopilotAdapter(azureEnv);
+      const result = adapter.transformRequestUrl('/chat/completions?api-version=2025-01-01');
+      expect(result).toBe('/chat/completions?api-version=2025-01-01');
+    });
+
+    it('preserves other query parameters', () => {
+      const adapter = createCopilotAdapter(azureEnv);
+      const result = adapter.transformRequestUrl('/chat/completions?stream=true');
+      expect(result).toContain('stream=true');
+      expect(result).toContain(`api-version=${AZURE_DEFAULT_API_VERSION}`);
+    });
+
+    it('respects COPILOT_AZURE_API_VERSION override', () => {
+      const adapter = createCopilotAdapter({
+        ...azureEnv,
+        COPILOT_AZURE_API_VERSION: '2025-03-01',
+      });
+      const result = adapter.transformRequestUrl('/chat/completions');
+      expect(result).toBe('/chat/completions?api-version=2025-03-01');
+    });
+
+    it('is a no-op for non-Azure targets', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_API_KEY: 'my-key',
+        COPILOT_API_TARGET: 'https://api.githubcopilot.com',
+      });
+      const result = adapter.transformRequestUrl('/v1/chat/completions');
+      expect(result).toBe('/v1/chat/completions');
+    });
+  });
+
+  describe('cognitiveservices.azure.com target', () => {
+    it('also uses api-key header', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_API_KEY: 'cog-key',
+        COPILOT_API_TARGET: 'https://my-resource.cognitiveservices.azure.com',
+        COPILOT_API_BASE_PATH: '/openai/deployments/gpt-4o',
+      });
+      const req = { url: '/chat/completions', method: 'POST', headers: {} };
+      const headers = adapter.getAuthHeaders(req);
+      expect(headers).toEqual({ 'api-key': 'cog-key' });
+    });
+  });
+});

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -128,6 +128,8 @@ the corresponding CLI flag.
 - `apiProxy.targets.openai.authHeader` → `--openai-api-auth-header`
 - `apiProxy.targets.anthropic.basePath` → `--anthropic-api-base-path`
 - `apiProxy.targets.anthropic.authHeader` → `--anthropic-api-auth-header`
+- `apiProxy.targets.copilot.basePath` → `COPILOT_API_BASE_PATH` *(config-only; used for Azure OpenAI deployment path)*
+- `apiProxy.targets.copilot.azureApiVersion` → `COPILOT_AZURE_API_VERSION` *(config-only; default `2024-10-21`)*
 - `apiProxy.targets.gemini.basePath` → `--gemini-api-base-path`
 - `apiProxy.targets.antigravity.basePath` → `--gemini-api-base-path`
 - When both `apiProxy.targets.antigravity` and `apiProxy.targets.gemini` are set, `antigravity` takes precedence per field.
@@ -518,6 +520,39 @@ Default OIDC audience: `https://api.anthropic.com`
 When `security.difcProxy.host` is set, `GITHUB_TOKEN` and `GH_TOKEN` MUST
 be excluded from the agent environment. These tokens SHALL be held
 exclusively by the external DIFC proxy.
+
+### 9.7 Azure OpenAI BYOK Routing
+
+When the Copilot target host is an Azure OpenAI endpoint (`*.openai.azure.com`
+or `*.cognitiveservices.azure.com`), the API proxy adapter applies Azure-specific
+routing:
+
+1. **Auth header**: Uses `api-key: <token>` instead of `Authorization: Bearer <token>`
+2. **API version**: Appends `?api-version=<version>` to upstream requests when absent
+3. **Deployment path**: The `basePath` specifies the Azure deployment path
+   (e.g., `/openai/deployments/gpt-4o`)
+
+**Configuration example:**
+
+```json
+{
+  "apiProxy": {
+    "targets": {
+      "copilot": {
+        "host": "my-resource.openai.azure.com",
+        "basePath": "/openai/deployments/gpt-4o",
+        "azureApiVersion": "2024-10-21"
+      }
+    }
+  }
+}
+```
+
+**Environment variable equivalents:**
+- `COPILOT_API_TARGET=https://my-resource.openai.azure.com`
+- `COPILOT_API_BASE_PATH=/openai/deployments/gpt-4o`
+- `COPILOT_API_KEY=<azure-api-key>` (security-sensitive; use env var, not config)
+- `COPILOT_AZURE_API_VERSION=2024-10-21` (optional; defaults to `2024-10-21`)
 
 ## 10. Effective Token Budget Enforcement
 

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -124,8 +124,8 @@
               "description": "Anthropic API target override."
             },
             "copilot": {
-              "$ref": "#/$defs/providerHostOnlyTarget",
-              "description": "GitHub Copilot API target override (basePath not supported)."
+              "$ref": "#/$defs/copilotProviderTarget",
+              "description": "GitHub Copilot API target override. Supports Azure OpenAI BYOK via basePath and azureApiVersion."
             },
             "gemini": {
               "$ref": "#/$defs/providerTarget",
@@ -543,6 +543,25 @@
         "authHeader": {
           "type": "string",
           "description": "Override the auth header name used for API requests. For OpenAI, replaces 'Authorization: Bearer <key>' with '<authHeader>: <key>' (raw key, no Bearer prefix). For Anthropic, replaces 'x-api-key'. Not applicable to Copilot or Gemini."
+        }
+      }
+    },
+    "copilotProviderTarget": {
+      "type": "object",
+      "description": "Copilot API provider target override with Azure OpenAI support.",
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Override the Copilot API host (e.g., 'my-resource.openai.azure.com' for Azure BYOK)."
+        },
+        "basePath": {
+          "type": "string",
+          "description": "Override the API base path (e.g., '/openai/deployments/gpt-4o' for Azure deployments)."
+        },
+        "azureApiVersion": {
+          "type": "string",
+          "description": "Azure OpenAI API version. Only used when host is an Azure endpoint. Default: '2024-10-21'."
         }
       }
     },

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -124,8 +124,8 @@
               "description": "Anthropic API target override."
             },
             "copilot": {
-              "$ref": "#/$defs/providerHostOnlyTarget",
-              "description": "GitHub Copilot API target override (basePath not supported)."
+              "$ref": "#/$defs/copilotProviderTarget",
+              "description": "GitHub Copilot API target override. Supports Azure OpenAI BYOK via basePath and azureApiVersion."
             },
             "gemini": {
               "$ref": "#/$defs/providerTarget",
@@ -543,6 +543,25 @@
         "authHeader": {
           "type": "string",
           "description": "Override the auth header name used for API requests. For OpenAI, replaces 'Authorization: Bearer <key>' with '<authHeader>: <key>' (raw key, no Bearer prefix). For Anthropic, replaces 'x-api-key'. Not applicable to Copilot or Gemini."
+        }
+      }
+    },
+    "copilotProviderTarget": {
+      "type": "object",
+      "description": "Copilot API provider target override with Azure OpenAI support.",
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Override the Copilot API host (e.g., 'my-resource.openai.azure.com' for Azure BYOK)."
+        },
+        "basePath": {
+          "type": "string",
+          "description": "Override the API base path (e.g., '/openai/deployments/gpt-4o' for Azure deployments)."
+        },
+        "azureApiVersion": {
+          "type": "string",
+          "description": "Azure OpenAI API version. Only used when host is an Azure endpoint. Default: '2024-10-21'."
         }
       }
     },

--- a/src/config-file-mapping.test.ts
+++ b/src/config-file-mapping.test.ts
@@ -37,7 +37,7 @@ describe('mapAwfFileConfigToCliOptions', () => {
       apiProxy: {
         targets: {
           openai: { host: 'api.openai.com', basePath: '/v1' },
-          copilot: { host: 'api.githubcopilot.com' },
+          copilot: { host: 'my-resource.openai.azure.com', basePath: '/openai/deployments/gpt-4o', azureApiVersion: '2025-03-01' },
           gemini: { host: 'generativelanguage.googleapis.com', basePath: '/v1beta' },
         },
       },
@@ -45,7 +45,9 @@ describe('mapAwfFileConfigToCliOptions', () => {
 
     expect(result.openaiApiTarget).toBe('api.openai.com');
     expect(result.openaiApiBasePath).toBe('/v1');
-    expect(result.copilotApiTarget).toBe('api.githubcopilot.com');
+    expect(result.copilotApiTarget).toBe('my-resource.openai.azure.com');
+    expect(result.copilotApiBasePath).toBe('/openai/deployments/gpt-4o');
+    expect(result.copilotAzureApiVersion).toBe('2025-03-01');
     expect(result.geminiApiTarget).toBe('generativelanguage.googleapis.com');
     expect(result.geminiApiBasePath).toBe('/v1beta');
   });

--- a/src/config-file-validation.test.ts
+++ b/src/config-file-validation.test.ts
@@ -21,12 +21,12 @@ describe('validateAwfFileConfig', () => {
     expect(errors).toContain('config.network.allowDomains must be an array of strings');
   });
 
-  it('rejects unsupported copilot basePath', () => {
+  it('accepts copilot basePath and azureApiVersion for Azure BYOK', () => {
     const errors = validateAwfFileConfig({
-      apiProxy: { targets: { copilot: { host: 'api.githubcopilot.com', basePath: '/v1' } } },
+      apiProxy: { targets: { copilot: { host: 'my-resource.openai.azure.com', basePath: '/openai/deployments/gpt-4o', azureApiVersion: '2025-03-01' } } },
     });
 
-    expect(errors).toContain('config.apiProxy.targets.copilot.basePath is not supported');
+    expect(errors).toHaveLength(0);
   });
 
   it('rejects non-object config root', () => {

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -27,7 +27,7 @@ interface AwfFileConfig {
     targets?: {
       openai?: { host?: string; basePath?: string; authHeader?: string };
       anthropic?: { host?: string; basePath?: string; authHeader?: string };
-      copilot?: { host?: string; basePath?: string };
+      copilot?: { host?: string; basePath?: string; azureApiVersion?: string };
       gemini?: { host?: string; basePath?: string };
       antigravity?: { host?: string; basePath?: string };
     };
@@ -187,6 +187,8 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     anthropicApiBasePath: config.apiProxy?.targets?.anthropic?.basePath,
     anthropicApiAuthHeader: config.apiProxy?.targets?.anthropic?.authHeader,
     copilotApiTarget: config.apiProxy?.targets?.copilot?.host,
+    copilotApiBasePath: config.apiProxy?.targets?.copilot?.basePath,
+    copilotAzureApiVersion: config.apiProxy?.targets?.copilot?.azureApiVersion,
     geminiApiTarget: antigravityTargetConfig?.host ?? geminiTargetConfig?.host,
     geminiApiBasePath: antigravityTargetConfig?.basePath ?? geminiTargetConfig?.basePath,
     modelAliases: config.apiProxy?.models,

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -172,8 +172,13 @@ describe('awf-config.schema.json', () => {
     expect(validate({ rateLimiting: { bytesPerMinute: -5 } })).toBe(false);
   });
 
-  it('rejects copilot basePath (not supported)', () => {
-    expect(validate({ apiProxy: { targets: { copilot: { host: 'api.githubcopilot.com', basePath: '/v1' } } } })).toBe(false);
+  it('accepts copilot basePath and azureApiVersion', () => {
+    expect(validate({ apiProxy: { targets: { copilot: { host: 'my-resource.openai.azure.com', basePath: '/openai/deployments/gpt-4o' } } } })).toBe(true);
+    expect(validate({ apiProxy: { targets: { copilot: { host: 'my-resource.openai.azure.com', basePath: '/openai/deployments/gpt-4o', azureApiVersion: '2025-03-01' } } } })).toBe(true);
+  });
+
+  it('rejects copilot unknown properties', () => {
+    expect(validate({ apiProxy: { targets: { copilot: { host: 'api.githubcopilot.com', unknownProp: true } } } })).toBe(false);
   });
 
   it('accepts allowHostPorts as string or array of strings', () => {

--- a/src/services/api-proxy-service.ts
+++ b/src/services/api-proxy-service.ts
@@ -60,6 +60,9 @@ function buildProviderTargetEnv(config: WrapperConfig): Record<string, string> {
   if (copilotProviderBaseUrl) env.COPILOT_PROVIDER_BASE_URL = copilotProviderBaseUrl;
   if (copilotProviderApiKey) env.COPILOT_PROVIDER_API_KEY = copilotProviderApiKey;
 
+  // Azure OpenAI API version (non-sensitive config)
+  if (config.copilotAzureApiVersion) env.COPILOT_AZURE_API_VERSION = config.copilotAzureApiVersion;
+
   return env;
 }
 

--- a/src/types/api-proxy-options.ts
+++ b/src/types/api-proxy-options.ts
@@ -164,6 +164,19 @@ export interface ApiProxyOptions {
   copilotApiBasePath?: string;
 
   /**
+   * Azure OpenAI API version for Copilot BYOK Azure deployments.
+   *
+   * When the Copilot target is an Azure OpenAI endpoint, this version is appended
+   * as a `?api-version=` query parameter to upstream requests.
+   *
+   * - Config: `apiProxy.targets.copilot.azureApiVersion`
+   * - Environment variable: `COPILOT_AZURE_API_VERSION`
+   *
+   * @default '2024-10-21'
+   */
+  copilotAzureApiVersion?: string;
+
+  /**
    * Target hostname for OpenAI API requests (used by API proxy sidecar)
    *
    * When enableApiProxy is true, this hostname is passed to the Node.js sidecar


### PR DESCRIPTION
## Summary

Add Azure OpenAI detection and proper auth/URL handling to the Copilot adapter for BYOK configurations targeting Azure endpoints.

## Changes

- **`isAzureOpenAITarget()`**: Detects `*.openai.azure.com` and `*.cognitiveservices.azure.com` hostnames
- **`api-key:` header**: Azure uses this instead of `Authorization: Bearer`; adapter now sends the correct auth format
- **`transformRequestUrl()` hook**: Injects `api-version` query parameter when absent (default: `2024-10-21`)
- **`COPILOT_AZURE_API_VERSION`**: Env var to override the default API version

## Usage

```bash
COPILOT_API_TARGET=https://my-resource.openai.azure.com
COPILOT_API_BASE_PATH=/openai/deployments/gpt-4o
COPILOT_API_KEY=<azure-api-key>
# Optional: COPILOT_AZURE_API_VERSION=2025-03-01
```

## Test Coverage

14 new tests covering:
- Azure hostname detection (positive/negative cases)
- `api-key:` header injection for Azure targets
- `api-version` query parameter injection and override
- Non-Azure targets remain unaffected

All 802 api-proxy tests pass.

Closes #4018