### PR TITLE
fix: make DinD staging test platform-agnostic for identity synthesis

### DIFF
--- a/src/services/agent-volumes-mounts.test.ts
+++ b/src/services/agent-volumes-mounts.test.ts
@@ -145,19 +145,27 @@ describe('agent service', () => {
         const result = generateDockerCompose(configWithTmpPrefix, mockNetworkConfig);
         const volumes = result.services.agent.volumes as string[];
         const stageRoot = path.join(sharedTmpPrefix, 'awf-docker-host-stage');
-        const stagedPasswdPath = path.join(stageRoot, 'etc/passwd');
-        const stagedGroupPath = path.join(stageRoot, 'etc/group');
         const stagedBinaryPath = path.join(stageRoot, 'bin/copilot');
         const hostsVolume = volumes.find((v: string) => v.endsWith(':/host/etc/hosts:ro'));
+        const passwdVolume = volumes.find((v: string) => v.endsWith(':/host/etc/passwd:ro'));
+        const groupVolume = volumes.find((v: string) => v.endsWith(':/host/etc/group:ro'));
 
-        expect(volumes).toContain(`${stagedPasswdPath}:/host/etc/passwd:ro`);
-        expect(volumes).toContain(`${stagedGroupPath}:/host/etc/group:ro`);
+        // passwd and group are staged under stageRoot — either at etc/passwd (direct copy)
+        // or identity-XXXXX/passwd (synthesized when host UID not found in staged file)
+        expect(passwdVolume).toBeDefined();
+        expect(passwdVolume?.startsWith(stageRoot)).toBe(true);
+        expect(groupVolume).toBeDefined();
+        expect(groupVolume?.startsWith(stageRoot)).toBe(true);
         expect(volumes).toContain(`${stagedBinaryPath}:/tmp/awf-runner-bin/copilot:ro`);
         expect(hostsVolume).toBeDefined();
         expect(hostsVolume?.startsWith(`${stageRoot}/chroot-`)).toBe(true);
 
-        expect(fs.readFileSync(stagedPasswdPath, 'utf8')).toBe(fs.readFileSync('/etc/passwd', 'utf8'));
-        expect(fs.readFileSync(stagedGroupPath, 'utf8')).toBe(fs.readFileSync('/etc/group', 'utf8'));
+        const stagedPasswdPath = passwdVolume!.split(':')[0];
+        const stagedGroupPath = groupVolume!.split(':')[0];
+        // Staged passwd must contain the host UID (either copied or synthesized)
+        const uid = String(process.getuid?.() ?? 1000);
+        expect(fs.readFileSync(stagedPasswdPath, 'utf8')).toMatch(new RegExp(`^[^:]*:[^:]*:${uid}:`, 'm'));
+        expect(fs.existsSync(stagedGroupPath)).toBe(true);
         expect(fs.readFileSync(stagedBinaryPath, 'utf8')).toContain('echo copilot');
         expect(fs.statSync(stagedBinaryPath).mode & 0o111).not.toBe(0);
 

--- a/src/services/agent-volumes-mounts.test.ts
+++ b/src/services/agent-volumes-mounts.test.ts
@@ -163,7 +163,8 @@ describe('agent service', () => {
         const stagedPasswdPath = passwdVolume!.split(':')[0];
         const stagedGroupPath = groupVolume!.split(':')[0];
         // Staged passwd must contain the host UID (either copied or synthesized)
-        const uid = String(process.getuid?.() ?? 1000);
+        const { getSafeHostUid } = jest.requireActual('../host-identity') as typeof import('../host-identity');
+        const uid = getSafeHostUid();
         expect(fs.readFileSync(stagedPasswdPath, 'utf8')).toMatch(new RegExp(`^[^:]*:[^:]*:${uid}:`, 'm'));
         expect(fs.existsSync(stagedGroupPath)).toBe(true);
         expect(fs.readFileSync(stagedBinaryPath, 'utf8')).toContain('echo copilot');


### PR DESCRIPTION
## Problem

`npm test` fails on macOS (and would fail on minimal ARC containers) with:

```
FAIL src/services/agent-volumes-mounts.test.ts
  ● agent service › should auto-stage the ARC/DinD manual bootstrap files under a shared /tmp docker-host-path-prefix

    Expected value: "/tmp/gh-aw-.../awf-docker-host-stage/etc/passwd:/host/etc/passwd:ro"
    Received array: [...] (missing)
```

## Root Cause

PR #4026 introduced identity synthesis for DinD environments. When the host UID is not found in the staged `/etc/passwd` (always on macOS — comments-only format; and on minimal ARC containers), the code synthesizes a new file at `identity-XXXXXX/passwd` instead of the predictable `etc/passwd` path.

The test asserted the exact path `stageRoot/etc/passwd`, which only works on Linux hosts that have the running UID in their `/etc/passwd`.

## Fix

Update the test to be platform-agnostic:
- Find passwd/group volumes by mount target suffix (`:/host/etc/passwd:ro`) instead of exact source path
- Verify the staged file is within the stageRoot (not at a specific subpath)
- Assert the staged passwd contains the host UID (the synthesis guarantee)
- Remove assertion that staged content must equal the raw host file verbatim

## Verification

- All 2289 tests pass (`npm test`)
- Tested on macOS where UID 1000 is not in `/etc/passwd`