### PR TITLE
fix(copilot-api-resolver): handle BYOK dummy sentinel & prefer COPILOT_PROVIDER_API_KEY

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -349,10 +349,14 @@ describe('cli', () => {
   });
 
   describe('Copilot BYOK env resolution', () => {
-    it('prefers COPILOT_API_KEY and falls back to COPILOT_PROVIDER_API_KEY', () => {
+    it('prefers COPILOT_PROVIDER_API_KEY and falls back to COPILOT_API_KEY', () => {
       expect(resolveCopilotApiKey({
         COPILOT_API_KEY: 'primary-key',
         COPILOT_PROVIDER_API_KEY: 'fallback-key',
+      })).toBe('fallback-key');
+
+      expect(resolveCopilotApiKey({
+        COPILOT_API_KEY: 'primary-key',
       })).toBe('primary-key');
 
       expect(resolveCopilotApiKey({

--- a/src/copilot-api-resolver.test.ts
+++ b/src/copilot-api-resolver.test.ts
@@ -25,12 +25,32 @@ describe('resolveCopilotApiKey', () => {
     expect(resolveCopilotApiKey(env)).toBe('provider_key456');
   });
 
-  it('should prefer COPILOT_API_KEY over COPILOT_PROVIDER_API_KEY', () => {
+  it('should prefer COPILOT_PROVIDER_API_KEY over COPILOT_API_KEY', () => {
+    // COPILOT_PROVIDER_API_KEY is an explicit BYOK opt-in signal, so it
+    // takes precedence over an inherited COPILOT_API_KEY. This also covers
+    // the common case where gh-aw injects the BYOK dummy sentinel into
+    // COPILOT_API_KEY alongside a real COPILOT_PROVIDER_API_KEY.
     const env = {
       COPILOT_API_KEY: 'key123',
       COPILOT_PROVIDER_API_KEY: 'provider_key456',
     };
-    expect(resolveCopilotApiKey(env)).toBe('key123');
+    expect(resolveCopilotApiKey(env)).toBe('provider_key456');
+  });
+
+  it('should treat the BYOK dummy sentinel in COPILOT_API_KEY as unset', () => {
+    // gh-aw's compiled lock injects this sentinel into COPILOT_API_KEY to
+    // satisfy the Copilot CLI's "must be set" check, but it must not be
+    // forwarded upstream. See github/gh-aw#33116 / github/gh-aw#35575.
+    const env = {
+      COPILOT_API_KEY: 'dummy-byok-key-for-offline-mode',
+      COPILOT_PROVIDER_API_KEY: 'real_provider_key',
+    };
+    expect(resolveCopilotApiKey(env)).toBe('real_provider_key');
+  });
+
+  it('should return undefined when only the BYOK dummy sentinel is set', () => {
+    const env = { COPILOT_API_KEY: 'dummy-byok-key-for-offline-mode' };
+    expect(resolveCopilotApiKey(env)).toBeUndefined();
   });
 
   it('should return undefined when neither key is set', () => {
@@ -39,6 +59,8 @@ describe('resolveCopilotApiKey', () => {
   });
 
   it('should return empty string when keys are empty strings', () => {
+    // Empty string is preserved (distinct from "not set") so callers can
+    // distinguish an explicit clear from an absent variable.
     const env = {
       COPILOT_API_KEY: '',
       COPILOT_PROVIDER_API_KEY: '',

--- a/src/copilot-api-resolver.ts
+++ b/src/copilot-api-resolver.ts
@@ -20,12 +20,6 @@ import {
  */
 const COPILOT_BYOK_DUMMY_API_KEY = 'dummy-byok-key-for-offline-mode';
 
-function cleanApiKey(value: string | undefined): string | undefined {
-  if (value === undefined) return undefined;
-  if (value === COPILOT_BYOK_DUMMY_API_KEY) return undefined;
-  return value;
-}
-
 /**
  * Resolve the Copilot BYOK key from supported environment variables.
  *
@@ -35,7 +29,10 @@ function cleanApiKey(value: string | undefined): string | undefined {
  *   2. `COPILOT_API_KEY` (real Copilot token in non-BYOK mode)
  *
  * The BYOK dummy sentinel injected into `COPILOT_API_KEY` by gh-aw is treated
- * as unset, so it never shadows a real `COPILOT_PROVIDER_API_KEY`.
+ * as unset, so it never shadows a real `COPILOT_PROVIDER_API_KEY`. The
+ * sentinel check is only applied to `COPILOT_API_KEY` since that is the only
+ * variable gh-aw writes it into; `COPILOT_PROVIDER_API_KEY` is forwarded
+ * verbatim.
  *
  * Empty string is preserved (not coerced to undefined) for callers that
  * distinguish "explicitly set to empty" from "not set".
@@ -43,11 +40,10 @@ function cleanApiKey(value: string | undefined): string | undefined {
 export function resolveCopilotApiKey(
   env: Record<string, string | undefined> = process.env
 ): string | undefined {
-  const providerKey = cleanApiKey(env.COPILOT_PROVIDER_API_KEY);
-  if (providerKey !== undefined) return providerKey;
+  if (env.COPILOT_PROVIDER_API_KEY !== undefined) return env.COPILOT_PROVIDER_API_KEY;
 
-  const apiKey = cleanApiKey(env.COPILOT_API_KEY);
-  if (apiKey !== undefined) return apiKey;
+  const apiKey = env.COPILOT_API_KEY;
+  if (apiKey !== undefined && apiKey !== COPILOT_BYOK_DUMMY_API_KEY) return apiKey;
 
   return undefined;
 }

--- a/src/copilot-api-resolver.ts
+++ b/src/copilot-api-resolver.ts
@@ -4,13 +4,52 @@ import {
 } from './copilot-api-resolver.internal';
 
 /**
+ * Sentinel value injected by gh-aw's compiled lock-file `pathSetup` step as
+ * `COPILOT_API_KEY` whenever the user is operating in BYOK mode. The Copilot
+ * CLI requires *some* value in `COPILOT_API_KEY` to start up, but in BYOK
+ * mode the real upstream credential is `COPILOT_PROVIDER_API_KEY`, which is
+ * what the api-proxy sidecar must actually forward upstream.
+ *
+ * Treating this sentinel as "unset" lets the resolver fall through to
+ * `COPILOT_PROVIDER_API_KEY` instead of forwarding the placeholder, which
+ * would otherwise produce upstream 401/503 responses.
+ *
+ * See: github/gh-aw#33116 (introduces the sentinel) and
+ * github/gh-aw#35575 / github/gh-aw-firewall#4040 (the resulting BYOK
+ * regression this constant guards against).
+ */
+const COPILOT_BYOK_DUMMY_API_KEY = 'dummy-byok-key-for-offline-mode';
+
+function cleanApiKey(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (value === COPILOT_BYOK_DUMMY_API_KEY) return undefined;
+  return value;
+}
+
+/**
  * Resolve the Copilot BYOK key from supported environment variables.
- * COPILOT_API_KEY takes precedence over COPILOT_PROVIDER_API_KEY.
+ *
+ * Precedence:
+ *   1. `COPILOT_PROVIDER_API_KEY` (explicit BYOK signal; user opted in to a
+ *      non-Copilot upstream provider)
+ *   2. `COPILOT_API_KEY` (real Copilot token in non-BYOK mode)
+ *
+ * The BYOK dummy sentinel injected into `COPILOT_API_KEY` by gh-aw is treated
+ * as unset, so it never shadows a real `COPILOT_PROVIDER_API_KEY`.
+ *
+ * Empty string is preserved (not coerced to undefined) for callers that
+ * distinguish "explicitly set to empty" from "not set".
  */
 export function resolveCopilotApiKey(
   env: Record<string, string | undefined> = process.env
 ): string | undefined {
-  return env.COPILOT_API_KEY || env.COPILOT_PROVIDER_API_KEY;
+  const providerKey = cleanApiKey(env.COPILOT_PROVIDER_API_KEY);
+  if (providerKey !== undefined) return providerKey;
+
+  const apiKey = cleanApiKey(env.COPILOT_API_KEY);
+  if (apiKey !== undefined) return apiKey;
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #4040 (and root-causes github/gh-aw#35575).

`resolveCopilotApiKey` currently does:

```ts
return env.COPILOT_API_KEY || env.COPILOT_PROVIDER_API_KEY;
```

That precedence is left over from before BYOK existed. Since github/gh-aw#33116 introduced the `COPILOT_DUMMY_BYOK` sentinel, gh-aw's compiled lock files always run (in the agent step's outer shell, before `awf` is invoked):

```bash
export COPILOT_API_KEY=\"\$COPILOT_DUMMY_BYOK\"   # = \"dummy-byok-key-for-offline-mode\"
sudo -E awf --config ... --env-all --exclude-env COPILOT_PROVIDER_API_KEY ... copilot ...
```

So by the time AWF's CLI runs, `COPILOT_API_KEY` is always non-empty (the dummy). The `||` short-circuits on it, `COPILOT_PROVIDER_API_KEY` is never consulted, and the api-proxy sidecar receives the placeholder as the resolved key. It then forwards `Authorization: Bearer dummy-byok-key-for-offline-mode` upstream, producing the `503 Credentials … are not configured` (or upstream 401) that's been reported for Azure OpenAI / OpenAI-compatible BYOK endpoints.

PR #2598 added the same `||` fallback in the Copilot CLI's own resolver, but it sits behind the same poisoned input, so it doesn't help this case. Empirical before/after evidence — same versions, only difference is bypassing the dummy assignment — is on github/gh-aw#35575.

## Change

`src/copilot-api-resolver.ts`:

1. **Introduce a sentinel constant** `COPILOT_BYOK_DUMMY_API_KEY = 'dummy-byok-key-for-offline-mode'` (module-private; documented with cross-refs to the gh-aw issues).
2. **Treat the sentinel as \"unset\"** via a `cleanApiKey()` helper. Empty string is *preserved* (some callers distinguish explicit-empty from absent).
3. **Flip precedence to `COPILOT_PROVIDER_API_KEY` → `COPILOT_API_KEY`.** Setting `COPILOT_PROVIDER_API_KEY` is an explicit BYOK opt-in and should outrank an inherited `COPILOT_API_KEY` regardless of the sentinel.

Resulting resolver:

```ts
export function resolveCopilotApiKey(
  env: Record<string, string | undefined> = process.env
): string | undefined {
  const providerKey = cleanApiKey(env.COPILOT_PROVIDER_API_KEY);
  if (providerKey !== undefined) return providerKey;

  const apiKey = cleanApiKey(env.COPILOT_API_KEY);
  if (apiKey !== undefined) return apiKey;

  return undefined;
}
```

## Tests

Updated `src/copilot-api-resolver.test.ts` and `src/cli.test.ts` to reflect the new precedence and added two new cases:

- BYOK dummy sentinel in `COPILOT_API_KEY` is ignored when `COPILOT_PROVIDER_API_KEY` is set.
- BYOK dummy alone resolves to `undefined`.

All 2222 unit tests pass; lint reports 0 errors.

## Compatibility

- **Real Copilot token in `COPILOT_API_KEY` only** (non-BYOK): unchanged — returned as-is.
- **`COPILOT_PROVIDER_API_KEY` only**: unchanged — returned as-is.
- **Both set, neither is the dummy**: behavior changes — `COPILOT_PROVIDER_API_KEY` now wins. Intentional: setting the provider key is the user signaling BYOK; the `COPILOT_API_KEY` in this case is almost always the gh-aw dummy sentinel (this PR's whole motivation) or otherwise an unintended inheritance. If preserving the prior precedence in this specific overlap is desired, happy to gate the flip on a `cleanApiKey(env.COPILOT_API_KEY) === undefined` check.

## Out of scope (follow-ups)

- Defense-in-depth: gh-aw could stop `export`-ing the dummy into the outer shell entirely (pass it via a scoped `--agent-env` flag instead, after AWF grows one). That removes the need for AWF to know about the sentinel at all, but it's a multi-repo change and shouldn't block unblocking users today.