### PR TITLE
refactor!: only consult COPILOT_PROVIDER_API_KEY for Copilot BYOK

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -349,15 +349,20 @@ describe('cli', () => {
   });
 
   describe('Copilot BYOK env resolution', () => {
-    it('prefers COPILOT_API_KEY and falls back to COPILOT_PROVIDER_API_KEY', () => {
+    it('resolves only COPILOT_PROVIDER_API_KEY; ignores legacy COPILOT_API_KEY', () => {
       expect(resolveCopilotApiKey({
-        COPILOT_API_KEY: 'primary-key',
-        COPILOT_PROVIDER_API_KEY: 'fallback-key',
-      })).toBe('primary-key');
+        COPILOT_API_KEY: 'legacy-key',
+        COPILOT_PROVIDER_API_KEY: 'provider-key',
+      })).toBe('provider-key');
 
       expect(resolveCopilotApiKey({
-        COPILOT_PROVIDER_API_KEY: 'fallback-key',
-      })).toBe('fallback-key');
+        COPILOT_PROVIDER_API_KEY: 'provider-key',
+      })).toBe('provider-key');
+
+      // Legacy COPILOT_API_KEY alone is no longer a BYOK credential.
+      expect(resolveCopilotApiKey({
+        COPILOT_API_KEY: 'legacy-key',
+      })).toBeUndefined();
     });
 
     it('derives copilot target hostname from COPILOT_PROVIDER_BASE_URL', () => {

--- a/src/copilot-api-resolver.test.ts
+++ b/src/copilot-api-resolver.test.ts
@@ -2,8 +2,10 @@ import * as copilotApiResolverModule from './copilot-api-resolver';
 import {
   resolveCopilotApiKey,
   resolveCopilotApiRouting,
+  __resetCopilotApiKeyDeprecationLatchForTesting,
 } from './copilot-api-resolver';
 import { copilotApiResolverTestHelpers } from './copilot-api-resolver.test-utils';
+import { logger } from './logger';
 
 const {
   deriveCopilotApiTargetFromProviderBaseUrl,
@@ -11,38 +13,59 @@ const {
 } = copilotApiResolverTestHelpers;
 
 describe('resolveCopilotApiKey', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __resetCopilotApiKeyDeprecationLatchForTesting();
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it('should not expose test helpers from the production module API', () => {
     expect(copilotApiResolverModule).not.toHaveProperty('copilotApiResolverTestHelpers');
   });
 
-  it('should return COPILOT_API_KEY when set', () => {
-    const env = { COPILOT_API_KEY: 'key123' };
-    expect(resolveCopilotApiKey(env)).toBe('key123');
-  });
-
-  it('should return COPILOT_PROVIDER_API_KEY when COPILOT_API_KEY is not set', () => {
+  it('should return COPILOT_PROVIDER_API_KEY when set', () => {
     const env = { COPILOT_PROVIDER_API_KEY: 'provider_key456' };
     expect(resolveCopilotApiKey(env)).toBe('provider_key456');
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('should prefer COPILOT_API_KEY over COPILOT_PROVIDER_API_KEY', () => {
+  it('should prefer COPILOT_PROVIDER_API_KEY when both are set and not warn', () => {
     const env = {
-      COPILOT_API_KEY: 'key123',
+      COPILOT_API_KEY: 'legacy_key123',
       COPILOT_PROVIDER_API_KEY: 'provider_key456',
     };
-    expect(resolveCopilotApiKey(env)).toBe('key123');
+    expect(resolveCopilotApiKey(env)).toBe('provider_key456');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should ignore COPILOT_API_KEY (legacy) and log a one-time deprecation warning', () => {
+    // COPILOT_API_KEY is the Copilot CLI's session-token slot and in BYOK mode
+    // contains gh-aw's placeholder sentinel; it must not be forwarded upstream.
+    const env = { COPILOT_API_KEY: 'legacy_key123' };
+    expect(resolveCopilotApiKey(env)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/COPILOT_API_KEY is set/);
+
+    // Latched: a second invocation does not re-warn.
+    resolveCopilotApiKey(env);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should return undefined when neither key is set', () => {
     const env = {};
     expect(resolveCopilotApiKey(env)).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('should return empty string when keys are empty strings', () => {
-    const env = {
-      COPILOT_API_KEY: '',
-      COPILOT_PROVIDER_API_KEY: '',
-    };
+  it('should return empty string when COPILOT_PROVIDER_API_KEY is empty', () => {
+    // Empty string is preserved (distinct from "not set") so callers can
+    // distinguish an explicit clear from an absent variable.
+    const env = { COPILOT_PROVIDER_API_KEY: '' };
     expect(resolveCopilotApiKey(env)).toBe('');
   });
 
@@ -56,7 +79,7 @@ describe('resolveCopilotApiKey', () => {
       delete process.env.COPILOT_PROVIDER_API_KEY;
       expect(resolveCopilotApiKey()).toBeUndefined();
 
-      process.env.COPILOT_API_KEY = 'test_key';
+      process.env.COPILOT_PROVIDER_API_KEY = 'test_key';
       expect(resolveCopilotApiKey()).toBe('test_key');
     } finally {
       // Restore original env

--- a/src/copilot-api-resolver.ts
+++ b/src/copilot-api-resolver.ts
@@ -2,15 +2,63 @@ import {
   deriveCopilotApiBasePathFromProviderBaseUrl,
   deriveCopilotApiTargetFromProviderBaseUrl,
 } from './copilot-api-resolver.internal';
+import { logger } from './logger';
 
 /**
- * Resolve the Copilot BYOK key from supported environment variables.
- * COPILOT_API_KEY takes precedence over COPILOT_PROVIDER_API_KEY.
+ * Tracks whether we've already logged the COPILOT_API_KEY deprecation warning
+ * in this process so we don't spam users with repeats per invocation of the
+ * resolver (which is called from multiple sites in build-config and CLI tests).
+ */
+let copilotApiKeyDeprecationWarned = false;
+
+/**
+ * Reset the deprecation-warning latch. Intended for tests; not exported from
+ * the production module surface (see `copilot-api-resolver.test-utils.ts`).
+ */
+export function __resetCopilotApiKeyDeprecationLatchForTesting(): void {
+  copilotApiKeyDeprecationWarned = false;
+}
+
+/**
+ * Resolve the upstream Copilot BYOK key from supported environment variables.
+ *
+ * Only `COPILOT_PROVIDER_API_KEY` is consulted. The legacy `COPILOT_API_KEY`
+ * input is intentionally ignored here:
+ *
+ *   - The Copilot CLI itself reads `COPILOT_API_KEY` as its session token.
+ *     In BYOK mode that value is gh-aw's placeholder sentinel
+ *     (`dummy-byok-key-for-offline-mode`), not a real upstream credential.
+ *     Forwarding it produced github/gh-aw#35575 / github/gh-aw-firewall#4040.
+ *   - The real, documented BYOK entry point is `COPILOT_PROVIDER_API_KEY`,
+ *     paired with `COPILOT_PROVIDER_BASE_URL` (see
+ *     https://github.blog/changelog/2026-04-07-copilot-cli-now-supports-byok-and-local-models/).
+ *   - Non-BYOK Copilot auth has its own field on the resolved config
+ *     (`copilotGithubToken`, sourced from `COPILOT_GITHUB_TOKEN`) and does not
+ *     flow through this resolver.
+ *
+ * For backwards compatibility, if a caller still has `COPILOT_API_KEY` set
+ * but no `COPILOT_PROVIDER_API_KEY`, we log a one-time deprecation warning so
+ * operators can migrate. The legacy value is *not* forwarded.
  */
 export function resolveCopilotApiKey(
   env: Record<string, string | undefined> = process.env
 ): string | undefined {
-  return env.COPILOT_API_KEY || env.COPILOT_PROVIDER_API_KEY;
+  if (env.COPILOT_PROVIDER_API_KEY !== undefined) {
+    return env.COPILOT_PROVIDER_API_KEY;
+  }
+
+  if (env.COPILOT_API_KEY !== undefined && !copilotApiKeyDeprecationWarned) {
+    copilotApiKeyDeprecationWarned = true;
+    logger.warn(
+      'COPILOT_API_KEY is set but COPILOT_PROVIDER_API_KEY is not. ' +
+        'AWF no longer treats COPILOT_API_KEY as a BYOK upstream credential ' +
+        '(it is owned by the Copilot CLI). Set COPILOT_PROVIDER_API_KEY ' +
+        '(and COPILOT_PROVIDER_BASE_URL) to enable BYOK, or COPILOT_GITHUB_TOKEN ' +
+        'for standard Copilot auth.',
+    );
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Alternative, more comprehensive fix to #4040 (root-causes github/gh-aw#35575). Compared to #4139 (which adds a sentinel-aware check for the gh-aw dummy `dummy-byok-key-for-offline-mode`), this PR eliminates the bug class by removing `COPILOT_API_KEY` from \`resolveCopilotApiKey\` entirely. **Only one of #4139 or this PR needs to land.**

## The problem with the current contract

`COPILOT_API_KEY` is structurally the wrong place to look for a BYOK upstream credential:

- **The Copilot CLI itself owns that env var** as its session-token slot. In BYOK mode gh-aw injects a placeholder sentinel into it (\`dummy-byok-key-for-offline-mode\`, github/gh-aw#33116) precisely because the CLI refuses to start without something there. That value is never a real credential the sidecar should forward.
- **The documented BYOK entry point is `COPILOT_PROVIDER_API_KEY`**, paired with `COPILOT_PROVIDER_BASE_URL`. See the [BYOK changelog](https://github.blog/changelog/2026-04-07-copilot-cli-now-supports-byok-and-local-models/).
- **Non-BYOK Copilot auth already has its own field** on the resolved config — `copilotGithubToken`, sourced from `COPILOT_GITHUB_TOKEN`. It does not flow through `resolveCopilotApiKey` and is unaffected by this PR. The Copilot proxy gate `if (config.copilotGithubToken || config.copilotApiKey)` continues to fire correctly for that path.

So `COPILOT_API_KEY` in this resolver is purely a legacy alias from before either of those existed, and it's the alias that produced the regression.

## Change

`src/copilot-api-resolver.ts`:

1. `resolveCopilotApiKey` only consults `COPILOT_PROVIDER_API_KEY`.
2. If a caller still has `COPILOT_API_KEY` set (without `COPILOT_PROVIDER_API_KEY`), log a **one-time deprecation warning** pointing them at the two supported paths (`COPILOT_PROVIDER_API_KEY` for BYOK; `COPILOT_GITHUB_TOKEN` for standard Copilot auth). The legacy value is *not* forwarded.
3. The gh-aw BYOK dummy sentinel is no longer reachable through this resolver, so the sentinel constant and helper from #4139 are unnecessary.

## Tests

- `src/copilot-api-resolver.test.ts`: replaced precedence cases; added "legacy `COPILOT_API_KEY` alone resolves to undefined and warns once" and "both set → provider wins, no warn."
- `src/cli.test.ts`: BYOK env-resolution case rewritten for the new contract.
- All 2220 unit tests pass; ESLint clean on changed files.

## Compatibility

| User config | Before | After |
|---|---|---|
| `COPILOT_GITHUB_TOKEN` only (the common case, auto-injected by gh-aw) | works | works (unchanged) |
| `COPILOT_PROVIDER_API_KEY` + `COPILOT_PROVIDER_BASE_URL` | works | works (unchanged) |
| Both `COPILOT_API_KEY` (real token) + `COPILOT_PROVIDER_API_KEY` | provider key ignored, real token forwarded as upstream → broken for BYOK | provider key forwarded, real token treated as CLI session token where it belongs |
| `COPILOT_API_KEY` only (with no provider key, no GitHub token) | resolver returns it as if it were a BYOK key | returns undefined + one-time deprecation warning |

The fourth row is the **only** breaking change. It's almost certainly empty in practice: real Copilot auth via gh-aw always uses `COPILOT_GITHUB_TOKEN`, and BYOK always uses `COPILOT_PROVIDER_API_KEY`. The deprecation warning gives operators a runtime breadcrumb if they're in that fourth row.

## Why I prefer this over #4139

- **Removes the bug class**, not just one instance. The current resolver is structurally unsafe: it conflates the CLI's session-token slot with the sidecar's upstream-credential slot. #4139 patches one symptom (the gh-aw dummy literal) but leaves the conflation in place; any future sentinel value (changed by gh-aw, leaked from somewhere else) would re-introduce it.
- **No knowledge of upstream sentinel literals.** AWF doesn't have to know what magic string gh-aw is using this week.
- **Simpler resolver.** The "Empty string preserved" caveat from #4139 disappears; there's nothing to preserve from a slot we don't read.

## Out of scope (future)

- Rename the config field `copilotApiKey` → `copilotProviderApiKey` (and the sidecar env injection from `COPILOT_API_KEY` to `COPILOT_PROVIDER_API_KEY`) so the type system reflects the contract. Larger blast radius (~8 files); deferred.
- gh-aw side: stop emitting `export COPILOT_API_KEY=\"\$COPILOT_DUMMY_BYOK\"` into the outer shell; pass the dummy via a scoped per-container env flag once AWF grows one. Multi-repo change; deferred.

## Alignment with gh-aw ADR-26544

This change brings AWF into conformance with the [BYOK-Copilot composition ADR](https://github.com/github/gh-aw/blob/5a74ace77c46a191eaca2e500de8d4f2cc2d8510/docs/adr/26544-byok-copilot-feature-flag-composition.md), which states normatively (§Dummy Key Constant):

> The dummy key **MUST NOT** be treated as a real credential; the real AWF API proxy credential **SHALL** remain isolated in the sidecar and **MUST NOT** be injected into the workflow container environment.

The pre-existing resolver violated this requirement: it read `COPILOT_API_KEY` (which in BYOK mode contains gh-aw's dummy sentinel) and forwarded that value to the sidecar as the upstream credential. This PR makes AWF actually behave the way the ADR's Consequences section already claimed it did: *"the real credential path is entirely in the AWF API proxy sidecar."*

#4139 also achieves §Dummy Key Constant.3 conformance, but by embedding the sentinel string literal in AWF's source — which violates the spirit of §Dummy Key Constant.2 ("Implementations **MUST NOT** embed the dummy key value as a string literal outside of the constants package"). That rule is technically gh-aw-scoped, but its intent (centralize the sentinel so it can change in one place) is broken across the repo boundary: if gh-aw ever rotates the literal, AWF silently regresses. This PR avoids the cross-repo coupling entirely — AWF never needs to know what magic string gh-aw is using.

It also tightens the BYOK detection signal in the spirit of the ADR. The ADR's §Feature Flag Behavior.2 leaves "AWF's runtime BYOK-detection path" unspecified, but its narrative treats the dummy as "well-known" and "opaque to the AWF container" — implying the *real* signal that BYOK is in use is the presence of `COPILOT_PROVIDER_API_KEY` (the actual credential), not the dummy (which is just there to keep the Copilot CLI happy). After this PR, that's exactly how AWF treats it.
