### PR TITLE
fix(copilot-byok): prefer COPILOT_PROVIDER_API_KEY over COPILOT_API_KEY

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -349,14 +349,14 @@ describe('cli', () => {
   });
 
   describe('Copilot BYOK env resolution', () => {
-    it('prefers COPILOT_API_KEY and falls back to COPILOT_PROVIDER_API_KEY', () => {
+    it('prefers COPILOT_PROVIDER_API_KEY and falls back to COPILOT_API_KEY', () => {
       expect(resolveCopilotApiKey({
-        COPILOT_API_KEY: 'primary-key',
-        COPILOT_PROVIDER_API_KEY: 'fallback-key',
+        COPILOT_API_KEY: 'fallback-key',
+        COPILOT_PROVIDER_API_KEY: 'primary-key',
       })).toBe('primary-key');
 
       expect(resolveCopilotApiKey({
-        COPILOT_PROVIDER_API_KEY: 'fallback-key',
+        COPILOT_API_KEY: 'fallback-key',
       })).toBe('fallback-key');
     });
 

--- a/src/copilot-api-resolver.test.ts
+++ b/src/copilot-api-resolver.test.ts
@@ -15,22 +15,22 @@ describe('resolveCopilotApiKey', () => {
     expect(copilotApiResolverModule).not.toHaveProperty('copilotApiResolverTestHelpers');
   });
 
-  it('should return COPILOT_API_KEY when set', () => {
+  it('should return COPILOT_API_KEY when only it is set', () => {
     const env = { COPILOT_API_KEY: 'key123' };
     expect(resolveCopilotApiKey(env)).toBe('key123');
   });
 
-  it('should return COPILOT_PROVIDER_API_KEY when COPILOT_API_KEY is not set', () => {
+  it('should return COPILOT_PROVIDER_API_KEY when only it is set', () => {
     const env = { COPILOT_PROVIDER_API_KEY: 'provider_key456' };
     expect(resolveCopilotApiKey(env)).toBe('provider_key456');
   });
 
-  it('should prefer COPILOT_API_KEY over COPILOT_PROVIDER_API_KEY', () => {
+  it('should prefer COPILOT_PROVIDER_API_KEY over COPILOT_API_KEY', () => {
     const env = {
       COPILOT_API_KEY: 'key123',
       COPILOT_PROVIDER_API_KEY: 'provider_key456',
     };
-    expect(resolveCopilotApiKey(env)).toBe('key123');
+    expect(resolveCopilotApiKey(env)).toBe('provider_key456');
   });
 
   it('should return undefined when neither key is set', () => {

--- a/src/copilot-api-resolver.ts
+++ b/src/copilot-api-resolver.ts
@@ -5,12 +5,25 @@ import {
 
 /**
  * Resolve the Copilot BYOK key from supported environment variables.
- * COPILOT_API_KEY takes precedence over COPILOT_PROVIDER_API_KEY.
+ *
+ * `COPILOT_PROVIDER_API_KEY` takes precedence over `COPILOT_API_KEY`.
+ *
+ * Rationale: `COPILOT_API_KEY` is the Copilot CLI's *session token* env var,
+ * not a BYOK upstream credential. In integrations such as gh-aw's
+ * `byok-copilot: true` flow, `COPILOT_API_KEY` is intentionally set to a
+ * placeholder sentinel (e.g. `dummy-byok-key-for-offline-mode`) to satisfy
+ * the CLI's startup check, while the real upstream BYOK credential is passed
+ * via `COPILOT_PROVIDER_API_KEY` (paired with `COPILOT_PROVIDER_BASE_URL`).
+ * Preferring `COPILOT_PROVIDER_API_KEY` here prevents AWF from forwarding the
+ * sentinel to the sidecar (github/gh-aw#35575, github/gh-aw-firewall#4040).
+ *
+ * `COPILOT_API_KEY` is still honored as a fallback for callers that have
+ * only ever set that variable.
  */
 export function resolveCopilotApiKey(
   env: Record<string, string | undefined> = process.env
 ): string | undefined {
-  return env.COPILOT_API_KEY || env.COPILOT_PROVIDER_API_KEY;
+  return env.COPILOT_PROVIDER_API_KEY || env.COPILOT_API_KEY;
 }
 
 /**


### PR DESCRIPTION
## Summary

Minimal alternative fix for github/gh-aw#35575 / github/gh-aw-firewall#4040: flip the precedence in `resolveCopilotApiKey` so `COPILOT_PROVIDER_API_KEY` is preferred over `COPILOT_API_KEY`. The legacy variable is still honored as a fallback.

This PR is offered as a smaller, more conservative alternative to #4143 (which removes `COPILOT_API_KEY` from the resolver entirely). Reviewers should pick one approach; the two PRs are mutually exclusive.

## The bug

When a gh-aw workflow uses `engine: copilot` with `byok-copilot: true`, gh-aw's generated runner script does (per [`pkg/workflow/copilot_engine_execution.go`](https://github.com/github/gh-aw/blob/main/pkg/workflow/copilot_engine_execution.go#L481-L491)):

```bash
export COPILOT_API_KEY="$COPILOT_DUMMY_BYOK"   # dummy-byok-key-for-offline-mode
export COPILOT_PROVIDER_API_KEY="<real BYOK key>"
sudo -E awf --enable-api-proxy -- copilot ...
```

AWF inherits both. The old resolver returned `env.COPILOT_API_KEY || env.COPILOT_PROVIDER_API_KEY`, so `config.copilotApiKey` ended up holding the dummy sentinel. The sidecar then injected the sentinel into upstream BYOK requests → 503/401 at the BYOK endpoint.

## Why `COPILOT_PROVIDER_API_KEY` is the correct precedence winner

`COPILOT_API_KEY` is the Copilot CLI's **session-token** env var — it's what the CLI reads to identify itself locally — not a BYOK upstream credential. The documented BYOK entry point (per the [Copilot CLI BYOK changelog](https://github.blog/changelog/2026-04-07-copilot-cli-now-supports-byok-and-local-models/)) is `COPILOT_PROVIDER_API_KEY` paired with `COPILOT_PROVIDER_BASE_URL`. When both are set, the provider-key value is the one that represents an upstream credential.

## What this PR changes

```ts
// before
return env.COPILOT_API_KEY || env.COPILOT_PROVIDER_API_KEY;

// after
return env.COPILOT_PROVIDER_API_KEY || env.COPILOT_API_KEY;
```

Plus updated docstring and the matching unit tests (`copilot-api-resolver.test.ts`, `cli.test.ts`).

## Comparison vs. alternatives

| Option | What it does | Trade-off |
|---|---|---|
| **This PR** | Flip precedence only | Smallest possible diff; no literal-string coupling; fixes the gh-aw flow today. Doesn't *eliminate* the bug class — a user setting only `COPILOT_API_KEY=<sentinel>` would still poison the sidecar. |
| #4143 | Drop `COPILOT_API_KEY` from the resolver entirely | Eliminates the bug class structurally and removes the dual-source ambiguity; honors ADR-26544 §Dummy Key Constant.2 spirit (no sentinel literal embedded in AWF). Breaking change (`refactor!:`), though no documented user scenario relies on the removed behavior. |
| gh-aw-side fix | Stop exporting `COPILOT_API_KEY=<dummy>` in the outer shell; inject it only inside the agent container where the Copilot CLI needs it | Root-cause fix; requires upstream change in gh-aw. Should be filed regardless of which AWF-side option lands. |

## Compatibility

- **gh-aw `byok-copilot: true`**: now reads `COPILOT_PROVIDER_API_KEY` (the real key). Fixed.
- **User sets only `COPILOT_PROVIDER_API_KEY`**: unchanged (still returns it).
- **User sets only `COPILOT_API_KEY`**: unchanged (still falls back to it).
- **User sets both with different values**: previously returned `COPILOT_API_KEY`, now returns `COPILOT_PROVIDER_API_KEY`. This is the intended behavior change. No documented configuration sets both to different real upstream values.

## Testing

- `npx jest src/copilot-api-resolver.test.ts src/cli.test.ts` — 73/73 pass.
- ESLint clean for changed files.

## Out of scope

- ADR-26544 §2 sentinel-literal cleanup (would require either dropping `COPILOT_API_KEY` from the resolver — see #4143 — or moving the constant into a shared package).
- Documentation updates that present `COPILOT_API_KEY` as the user-facing BYOK input (handled in #4143's larger doc sweep).
- gh-aw-side fix to stop exporting the dummy sentinel in the outer shell.

Refs: github/gh-aw#35575, github/gh-aw-firewall#4040
Related: #4143 (resolver-removal alternative)
