### PR TITLE
fix(workflow): prevent multiline GITHUB_OUTPUT in red-team benchmark

### DIFF
--- a/.github/workflows/red-team-benchmark.lock.yml
+++ b/.github/workflows/red-team-benchmark.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"aca51598f5eab3f854e7a12930412772f35836173d94aed018584fea710ff7de","compiler_version":"v0.76.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8eb21b6b8f8caf6c6fbfa5a5f763f55b9a8fa795762a6ec46bc1d72c322a6493","compiler_version":"v0.76.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"46d564922b082d0db93244972e8005ea6904ee5f","version":"v0.76.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.55"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.19"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -179,20 +179,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0d3e3a03cac831c4_EOF'
+          cat << 'GH_AW_PROMPT_b49de899c9164139_EOF'
           <system>
-          GH_AW_PROMPT_0d3e3a03cac831c4_EOF
+          GH_AW_PROMPT_b49de899c9164139_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0d3e3a03cac831c4_EOF'
+          cat << 'GH_AW_PROMPT_b49de899c9164139_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_0d3e3a03cac831c4_EOF
+          GH_AW_PROMPT_b49de899c9164139_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0d3e3a03cac831c4_EOF'
+          cat << 'GH_AW_PROMPT_b49de899c9164139_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -221,12 +221,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0d3e3a03cac831c4_EOF
+          GH_AW_PROMPT_b49de899c9164139_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0d3e3a03cac831c4_EOF'
+          cat << 'GH_AW_PROMPT_b49de899c9164139_EOF'
           </system>
           {{#runtime-import .github/workflows/red-team-benchmark.md}}
-          GH_AW_PROMPT_0d3e3a03cac831c4_EOF
+          GH_AW_PROMPT_b49de899c9164139_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -397,7 +397,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         id: awf_run
         name: Run AWF-protected benchmark (victim inside AWF sandbox)
-        run: "mkdir -p /tmp/gh-aw/agent/awf\nmkdir -p /tmp/gh-aw/agent/awf/firewall-logs\nAWF_LEAKS=\"n/a\"\nAWF_BLOCKED=\"n/a\"\nif [ -z \"$ANTHROPIC_API_KEY\" ] || [ -z \"$OPENAI_API_KEY\" ]; then\n  echo \"::warning::Missing API keys — AWF-protected run skipped\"\n  echo '{\"skipped\":true,\"reason\":\"missing API keys\"}' > /tmp/gh-aw/agent/awf/summary.json\nelif ! command -v claude >/dev/null 2>&1; then\n  echo \"::error::Claude CLI is missing on runner\"\n  echo '{\"skipped\":false,\"reason\":\"missing claude binary\"}' > /tmp/gh-aw/agent/awf/summary.json\n  exit 1\nelse\n  cd /tmp/adversarial_dojo\n  # Run the benchmark inside AWF sandbox — benchmark traffic is restricted\n  # to api.anthropic.com and api.openai.com, blocking other egress attempts.\n  sudo awf \\\n    --allow-domains api.anthropic.com,api.openai.com \\\n    --proxy-logs-dir /tmp/gh-aw/agent/awf/firewall-logs \\\n    --log-level info \\\n    -- \"$HOME/.local/bin/uv\" run adversarial-dojo search-attacks \\\n    /tmp/awf-benchmark.toml \\\n    --out /tmp/gh-aw/agent/awf \\\n    2>/tmp/gh-aw/agent/awf/stderr.log || true\n  if [ -f /tmp/gh-aw/agent/awf/summary.json ]; then\n    AWF_LEAKS=$(jq -r '.leak_events | length' /tmp/gh-aw/agent/awf/summary.json 2>/dev/null || echo \"unknown\")\n  fi\n  # Count DENIED entries in Squid access log produced by AWF\n  SQUID_LOG=/tmp/gh-aw/agent/awf/firewall-logs/access.log\n  if [ ! -f \"$SQUID_LOG\" ]; then\n    SQUID_LOG=$(find /tmp -name 'access.log' -path '*awf*' 2>/dev/null | head -1)\n  fi\n  if [ -n \"$SQUID_LOG\" ]; then\n    AWF_BLOCKED=$(grep -c \"DENIED\" \"$SQUID_LOG\" 2>/dev/null || echo \"0\")\n    cp \"$SQUID_LOG\" /tmp/gh-aw/agent/squid-access.log\n  else\n    echo \"No Squid access log found\" > /tmp/gh-aw/agent/squid-access.log\n    AWF_BLOCKED=\"0\"\n  fi\n  echo \"AWF-protected — leaks: $AWF_LEAKS, blocked requests: $AWF_BLOCKED\"\nfi\necho \"AWF_LEAKS=$AWF_LEAKS\" >> \"$GITHUB_OUTPUT\"\necho \"AWF_BLOCKED=$AWF_BLOCKED\" >> \"$GITHUB_OUTPUT\"\n"
+        run: "mkdir -p /tmp/gh-aw/agent/awf\nmkdir -p /tmp/gh-aw/agent/awf/firewall-logs\nAWF_LEAKS=\"n/a\"\nAWF_BLOCKED=\"n/a\"\nif [ -z \"$ANTHROPIC_API_KEY\" ] || [ -z \"$OPENAI_API_KEY\" ]; then\n  echo \"::warning::Missing API keys — AWF-protected run skipped\"\n  echo '{\"skipped\":true,\"reason\":\"missing API keys\"}' > /tmp/gh-aw/agent/awf/summary.json\nelif ! command -v claude >/dev/null 2>&1; then\n  echo \"::error::Claude CLI is missing on runner\"\n  echo '{\"skipped\":false,\"reason\":\"missing claude binary\"}' > /tmp/gh-aw/agent/awf/summary.json\n  exit 1\nelse\n  cd /tmp/adversarial_dojo\n  # Run the benchmark inside AWF sandbox — benchmark traffic is restricted\n  # to api.anthropic.com and api.openai.com, blocking other egress attempts.\n  sudo awf \\\n    --allow-domains api.anthropic.com,api.openai.com \\\n    --proxy-logs-dir /tmp/gh-aw/agent/awf/firewall-logs \\\n    --log-level info \\\n    -- \"$HOME/.local/bin/uv\" run adversarial-dojo search-attacks \\\n    /tmp/awf-benchmark.toml \\\n    --out /tmp/gh-aw/agent/awf \\\n    2>/tmp/gh-aw/agent/awf/stderr.log || true\n  if [ -f /tmp/gh-aw/agent/awf/summary.json ]; then\n    AWF_LEAKS=$(jq -r '.leak_events | length' /tmp/gh-aw/agent/awf/summary.json 2>/dev/null || echo \"unknown\")\n  fi\n  # Count DENIED entries in Squid access log produced by AWF\n  SQUID_LOG=/tmp/gh-aw/agent/awf/firewall-logs/access.log\n  if [ ! -f \"$SQUID_LOG\" ]; then\n    SQUID_LOG=$(find /tmp -name 'access.log' -path '*awf*' 2>/dev/null | head -1)\n  fi\n  if [ -n \"$SQUID_LOG\" ]; then\n    AWF_BLOCKED=$(grep -c \"DENIED\" \"$SQUID_LOG\" 2>/dev/null || true)\n    cp \"$SQUID_LOG\" /tmp/gh-aw/agent/squid-access.log\n  else\n    echo \"No Squid access log found\" > /tmp/gh-aw/agent/squid-access.log\n    AWF_BLOCKED=\"0\"\n  fi\n  echo \"AWF-protected — leaks: $AWF_LEAKS, blocked requests: $AWF_BLOCKED\"\nfi\necho \"AWF_LEAKS=$AWF_LEAKS\" >> \"$GITHUB_OUTPUT\"\necho \"AWF_BLOCKED=$AWF_BLOCKED\" >> \"$GITHUB_OUTPUT\"\n"
       - env:
           EXPR_AWF_BLOCKED: ${{ steps.awf_run.outputs.AWF_BLOCKED }}
           EXPR_AWF_LEAKS: ${{ steps.awf_run.outputs.AWF_LEAKS }}
@@ -502,9 +502,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6ceef4c85a48899b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_108c484ff873e020_EOF'
           {"create_issue":{"expires":168,"labels":["security"],"max":1,"title_prefix":"[Red-Team Benchmark] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6ceef4c85a48899b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_108c484ff873e020_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -711,7 +711,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.19'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3bee1585703686e6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4d4103e8586e2eab_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -751,7 +751,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3bee1585703686e6_EOF
+          GH_AW_MCP_CONFIG_4d4103e8586e2eab_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/red-team-benchmark.md
+++ b/.github/workflows/red-team-benchmark.md
@@ -196,7 +196,7 @@ steps:
           SQUID_LOG=$(find /tmp -name 'access.log' -path '*awf*' 2>/dev/null | head -1)
         fi
         if [ -n "$SQUID_LOG" ]; then
-          AWF_BLOCKED=$(grep -c "DENIED" "$SQUID_LOG" 2>/dev/null || echo "0")
+          AWF_BLOCKED=$(grep -c "DENIED" "$SQUID_LOG" 2>/dev/null || true)
           cp "$SQUID_LOG" /tmp/gh-aw/agent/squid-access.log
         else
           echo "No Squid access log found" > /tmp/gh-aw/agent/squid-access.log


### PR DESCRIPTION
## Problem

The red-team benchmark workflow fails at step 15 ("Run AWF-protected benchmark") with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '0'
```

**Root cause:** `grep -c "DENIED"` outputs `0` to stdout even when it exits with code 1 (no matches). The `|| echo "0"` fallback then appends a *second* `0`, making `AWF_BLOCKED` a multiline value (`0\n0`). When written to `$GITHUB_OUTPUT`, the bare `0` on the second line has no `key=` prefix — invalid format.

## Fix

Replace `|| echo "0"` with `|| true`. Since `grep -c` already outputs `0` on no-match, the variable captures the correct single-line value.

## Failing run

https://github.com/github/gh-aw-firewall/actions/runs/26790836372/job/78976724535#step:15:1