### PR TITLE
fix(api-proxy): use api-key header for Azure OpenAI BYOK requests

### DIFF
--- a/containers/api-proxy/oidc-token-provider.test.js
+++ b/containers/api-proxy/oidc-token-provider.test.js
@@ -330,6 +330,27 @@ describe('OpenAI adapter with OIDC', () => {
     expect(adapter.getAuthHeaders()).toEqual({ 'X-Custom-Auth': 'azure-byok-key' });
   });
 
+  it('should not default to api-key header in OIDC mode when COPILOT_PROVIDER_TYPE=azure', () => {
+    const adapter = createOpenAIAdapter({
+      COPILOT_PROVIDER_TYPE: 'azure',
+      AWF_AUTH_TYPE: 'github-oidc',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test-token',
+      AWF_AUTH_AZURE_TENANT_ID: 'test-tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'test-client',
+    });
+
+    const provider = adapter.getOidcProvider();
+    provider._cachedToken = 'azure-ad-token';
+    provider._expiresAt = Math.floor(Date.now() / 1000) + 600;
+
+    const headers = adapter.getAuthHeaders({});
+    expect(headers).toEqual({ Authorization: 'Bearer azure-ad-token' });
+    expect(headers['api-key']).toBeUndefined();
+
+    provider.shutdown();
+  });
+
   it('should not create OIDC provider when required vars are missing', () => {
     const adapter = createOpenAIAdapter({
       AWF_AUTH_TYPE: 'github-oidc',

--- a/containers/api-proxy/oidc-token-provider.test.js
+++ b/containers/api-proxy/oidc-token-provider.test.js
@@ -297,7 +297,7 @@ describe('OpenAI adapter with OIDC', () => {
     expect(adapter.isEnabled()).toBe(true);
     expect(adapter.getTargetHost()).toBe('my-resource.openai.azure.com');
     expect(adapter.getBasePath()).toBe('/openai/deployments/gpt-5');
-    expect(adapter.getAuthHeaders()).toEqual({ Authorization: 'Bearer azure-byok-key' });
+    expect(adapter.getAuthHeaders()).toEqual({ 'api-key': 'azure-byok-key' });
     expect(adapter.getReflectionInfo().auth_type).toBe('static-key');
   });
 
@@ -314,7 +314,20 @@ describe('OpenAI adapter with OIDC', () => {
     expect(adapter.isEnabled()).toBe(true);
     expect(adapter.getTargetHost()).toBe('gateway.example.com');
     expect(adapter.getBasePath()).toBe('/v2');
-    expect(adapter.getAuthHeaders()).toEqual({ Authorization: 'Bearer sk-openai' });
+    // Explicit OPENAI_API_KEY still uses api-key header because COPILOT_PROVIDER_TYPE=azure
+    expect(adapter.getAuthHeaders()).toEqual({ 'api-key': 'sk-openai' });
+  });
+
+  it('should allow AWF_OPENAI_AUTH_HEADER to override Azure api-key default', () => {
+    const adapter = createOpenAIAdapter({
+      COPILOT_PROVIDER_TYPE: 'azure',
+      COPILOT_PROVIDER_BASE_URL: 'https://my-resource.openai.azure.com/openai/deployments/gpt-5',
+      COPILOT_PROVIDER_API_KEY: 'azure-byok-key',
+      AWF_OPENAI_AUTH_HEADER: 'X-Custom-Auth',
+    });
+
+    expect(adapter.isEnabled()).toBe(true);
+    expect(adapter.getAuthHeaders()).toEqual({ 'X-Custom-Auth': 'azure-byok-key' });
   });
 
   it('should not create OIDC provider when required vars are missing', () => {

--- a/containers/api-proxy/providers/openai.js
+++ b/containers/api-proxy/providers/openai.js
@@ -50,18 +50,22 @@ function createOpenAIAdapter(env, deps = {}) {
     basePathEnvVar: 'OPENAI_API_BASE_PATH',
     defaultTarget: 'api.openai.com',
   });
-  const customAuthHeader = (() => {
-    const header = (env.AWF_OPENAI_AUTH_HEADER || '').trim();
-    if (!header) return '';
-    try {
-      require('http').validateHeaderName(header);
-    } catch {
-      throw new Error('Invalid AWF_OPENAI_AUTH_HEADER value: expected a valid HTTP header name');
-    }
-    return header;
-  })();
   const providerType = (env.COPILOT_PROVIDER_TYPE || '').trim().toLowerCase();
   const copilotAzureByokEnabled = providerType === 'azure';
+  const customAuthHeader = (() => {
+    const header = (env.AWF_OPENAI_AUTH_HEADER || '').trim();
+    if (header) {
+      try {
+        require('http').validateHeaderName(header);
+      } catch {
+        throw new Error('Invalid AWF_OPENAI_AUTH_HEADER value: expected a valid HTTP header name');
+      }
+      return header;
+    }
+    // Azure OpenAI uses `api-key` header instead of `Authorization: Bearer`
+    if (copilotAzureByokEnabled) return 'api-key';
+    return '';
+  })();
   const copilotByokApiKey = (env.COPILOT_PROVIDER_API_KEY || '').trim() || undefined;
   const { target: copilotByokTarget, basePath: copilotByokBasePath } = parseByokBaseUrl(env.COPILOT_PROVIDER_BASE_URL);
 

--- a/containers/api-proxy/providers/openai.js
+++ b/containers/api-proxy/providers/openai.js
@@ -62,8 +62,9 @@ function createOpenAIAdapter(env, deps = {}) {
       }
       return header;
     }
-    // Azure OpenAI uses `api-key` header instead of `Authorization: Bearer`
-    if (copilotAzureByokEnabled) return 'api-key';
+    // Azure OpenAI BYOK uses `api-key` header instead of `Authorization: Bearer`
+    // (but OIDC auth still requires `Authorization: Bearer` unless explicitly overridden)
+    if (copilotAzureByokEnabled && (env.AWF_AUTH_TYPE || '').trim().toLowerCase() !== 'github-oidc') return 'api-key';
     return '';
   })();
   const copilotByokApiKey = (env.COPILOT_PROVIDER_API_KEY || '').trim() || undefined;


### PR DESCRIPTION
## Problem

When `COPILOT_PROVIDER_TYPE=azure`, Azure OpenAI requires credentials in the `api-key` header. The api-proxy was sending `Authorization: Bearer <key>` instead, causing all Azure BYOK requests to fail with 401 Unauthorized.

## Fix

The OpenAI adapter now auto-selects `api-key` as the auth header name when Azure BYOK is detected (`COPILOT_PROVIDER_TYPE=azure`). The existing `AWF_OPENAI_AUTH_HEADER` env var still takes precedence if explicitly set, allowing custom gateways to override.

## Changes

- `containers/api-proxy/providers/openai.js`: Moved `providerType` / `copilotAzureByokEnabled` detection before the `customAuthHeader` IIFE so it can default to `api-key` for Azure
- `containers/api-proxy/oidc-token-provider.test.js`: Updated assertions to expect `api-key` header; added test for `AWF_OPENAI_AUTH_HEADER` override

## Testing

All 861 api-proxy tests pass.

Fixes #4018
Closes #4220
Closes #4269