### PR TITLE
fix(test): use unlinkSync for symlink cleanup in tool-cache mount test

### DIFF
--- a/src/services/agent-volumes-mounts.test.ts
+++ b/src/services/agent-volumes-mounts.test.ts
@@ -557,7 +557,7 @@ describe('agent service', () => {
         expect(volumes).not.toContain(`${symlinkPath}:/host${symlinkPath}:ro`);
       });
     } finally {
-      fs.rmSync(symlinkPath, { force: true });
+      try { fs.unlinkSync(symlinkPath); } catch { /* already removed */ }
       fs.rmSync(symlinkTarget, { recursive: true, force: true });
     }
   });

--- a/src/services/agent-volumes-mounts.test.ts
+++ b/src/services/agent-volumes-mounts.test.ts
@@ -557,10 +557,8 @@ describe('agent service', () => {
         expect(volumes).not.toContain(`${symlinkPath}:/host${symlinkPath}:ro`);
       });
     } finally {
-      try {
+      if (fs.existsSync(symlinkPath)) {
         fs.unlinkSync(symlinkPath);
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
       }
       fs.rmSync(symlinkTarget, { recursive: true, force: true });
     }

--- a/src/services/agent-volumes-mounts.test.ts
+++ b/src/services/agent-volumes-mounts.test.ts
@@ -557,7 +557,11 @@ describe('agent service', () => {
         expect(volumes).not.toContain(`${symlinkPath}:/host${symlinkPath}:ro`);
       });
     } finally {
-      try { fs.unlinkSync(symlinkPath); } catch { /* already removed */ }
+      try {
+        fs.unlinkSync(symlinkPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
       fs.rmSync(symlinkTarget, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Problem

The test `should not mount container.runnerToolCachePath when it is a symlink` fails on macOS because `fs.rmSync(symlinkPath, { force: true })` without `recursive: true` throws when the symlink points to a directory.

## Fix

Use `fs.unlinkSync()` which correctly removes the symlink itself (not the target directory).

## Testing
All 35 tests in `agent-volumes-mounts.test.ts` pass.