### PR TITLE
fix(test): update placeholder test to find token in copilot-byok.js

### DIFF
--- a/src/constants/placeholders.test.ts
+++ b/src/constants/placeholders.test.ts
@@ -11,11 +11,13 @@ describe('COPILOT_PLACEHOLDER_TOKEN', () => {
     expect(match?.[1]).toBe(COPILOT_PLACEHOLDER_TOKEN);
   });
 
-  it('matches the api-proxy copilot.js placeholder value', () => {
-    const copilotJsPath = path.resolve(__dirname, '../../containers/api-proxy/providers/copilot.js');
-    const scriptContent = fs.readFileSync(copilotJsPath, 'utf8');
-    const match = scriptContent.match(/COPILOT_PLACEHOLDER_TOKEN\s*=\s*'([^']+)'/);
+  it('matches the api-proxy copilot-byok.js placeholder value', () => {
+    const copilotByokJsPath = path.resolve(__dirname, '../../containers/api-proxy/providers/copilot-byok.js');
+    const scriptContent = fs.readFileSync(copilotByokJsPath, 'utf8');
+    // Value is constructed as: 'ghu_' + 'a'.repeat(36)
+    const match = scriptContent.match(/COPILOT_PLACEHOLDER_TOKEN\s*=\s*'([^']+)'\s*\+\s*'([^']+)'\.repeat\((\d+)\)/);
 
-    expect(match?.[1]).toBe(COPILOT_PLACEHOLDER_TOKEN);
+    const reconstructed = match ? match[1] + match[2].repeat(Number(match[3])) : undefined;
+    expect(reconstructed).toBe(COPILOT_PLACEHOLDER_TOKEN);
   });
 });


### PR DESCRIPTION
## Problem

`COPILOT_PLACEHOLDER_TOKEN` was moved from `providers/copilot.js` to `providers/copilot-byok.js` and is now constructed via string concatenation (`'ghu_' + 'a'.repeat(36)`) rather than a literal string. The placeholder test was looking in the old file with a simple regex, causing the test to fail.

## Fix

- Updated file path: `copilot.js` → `copilot-byok.js`
- Updated regex to parse the concatenation pattern and reconstruct the value for comparison

## Testing
Both placeholder tests pass.