### PR TITLE
feat: persist budget fields in token-usage.jsonl and align maxTurns/docs reporting

### DIFF
--- a/containers/api-proxy/guards/ai-credits-guard.js
+++ b/containers/api-proxy/guards/ai-credits-guard.js
@@ -24,17 +24,37 @@ let aiCreditsState = createAiCreditsState();
 
 const aiCreditsConfigCache = {
   rawMax: undefined,
-  parsed: { max: null },
+  rawDefault: undefined,
+  parsed: { max: null, defaultPricing: null },
 };
 
 function getAiCreditsConfig() {
   const rawMax = process.env.AWF_MAX_AI_CREDITS;
-  if (aiCreditsConfigCache.rawMax === rawMax) {
+  const rawDefault = process.env.AWF_DEFAULT_AI_CREDITS_PRICING;
+  if (aiCreditsConfigCache.rawMax === rawMax && aiCreditsConfigCache.rawDefault === rawDefault) {
     return aiCreditsConfigCache.parsed;
   }
   aiCreditsConfigCache.rawMax = rawMax;
+  aiCreditsConfigCache.rawDefault = rawDefault;
+
+  let defaultPricing = null;
+  if (rawDefault) {
+    try {
+      const parsed = JSON.parse(rawDefault);
+      if (parsed && typeof parsed.input === 'number' && typeof parsed.output === 'number') {
+        defaultPricing = {
+          input: parsed.input,
+          cachedInput: parsed.cachedInput ?? parsed.input * 0.1,
+          cacheWrite: parsed.cacheWrite ?? null,
+          output: parsed.output,
+        };
+      }
+    } catch { /* invalid JSON — leave null */ }
+  }
+
   aiCreditsConfigCache.parsed = {
     max: parsePositiveNumber(rawMax),
+    defaultPricing,
   };
   return aiCreditsConfigCache.parsed;
 }
@@ -79,7 +99,41 @@ function resolveModelPricing(model, state = aiCreditsState) {
     });
     state.warnedUnknownModels.add(model);
   }
+
+  // Fall back to configured default pricing if available
+  const config = getAiCreditsConfig();
+  if (config.defaultPricing) return config.defaultPricing;
+
   return null;
+}
+
+/**
+ * Check if a model is unresolvable and should be rejected.
+ * Only rejects when maxAiCredits is active and no default pricing is configured.
+ *
+ * @param {string} model
+ * @returns {{ rejected: boolean, model: string, error: object } | null}
+ */
+function checkUnknownModelRejection(model) {
+  const config = getAiCreditsConfig();
+  if (!config.max) return null; // guard not active, don't reject
+  if (!model) return null; // no model in request body, can't check
+  if (config.defaultPricing) return null; // has fallback, don't reject
+
+  const pricing = resolveModelPricing(model);
+  if (pricing) return null; // model resolved, don't reject
+
+  return {
+    rejected: true,
+    model,
+    error: {
+      type: 'unknown_model_ai_credits',
+      message: `Model "${model}" has no AI credits pricing and no default pricing is configured. ` +
+        'Set apiProxy.defaultAiCreditsPricing in the AWF config (e.g. {"input": 3.0, "output": 15.0}) ' +
+        'to provide a fallback rate, or add the model to the pricing table.',
+      model,
+    },
+  };
 }
 
 function calculateAiCredits(normalizedUsage, model, state = aiCreditsState) {
@@ -181,7 +235,8 @@ function buildAiCreditsLimitError(aiCreditsBlockState) {
 function resetAiCreditsGuardForTests() {
   aiCreditsState = createAiCreditsState();
   aiCreditsConfigCache.rawMax = undefined;
-  aiCreditsConfigCache.parsed = { max: null };
+  aiCreditsConfigCache.rawDefault = undefined;
+  aiCreditsConfigCache.parsed = { max: null, defaultPricing: null };
   delete process.env.AWF_AI_CREDITS_USED;
 }
 
@@ -190,5 +245,7 @@ module.exports = {
   getAiCreditsReflectState,
   getAiCreditsBlockState,
   buildAiCreditsLimitError,
+  checkUnknownModelRejection,
+  canonicalizeModel,
   resetAiCreditsGuardForTests,
 };

--- a/containers/api-proxy/guards/ai-credits-guard.js
+++ b/containers/api-proxy/guards/ai-credits-guard.js
@@ -39,14 +39,35 @@ function getAiCreditsConfig() {
   return aiCreditsConfigCache.parsed;
 }
 
+/**
+ * Canonicalize a model name by stripping provider prefix and normalizing
+ * separators (dash, dot, underscore are all treated as equivalent).
+ * E.g. "copilot/claude-sonnet-4.6" → "claude-sonnet-4-6"
+ *      "claude_sonnet_4_6"          → "claude-sonnet-4-6"
+ */
+function canonicalizeModel(model) {
+  const bare = model.includes('/') ? model.slice(model.indexOf('/') + 1) : model;
+  return bare.replace(/[._]/g, '-');
+}
+
 function resolveModelPricing(model, state = aiCreditsState) {
   if (Object.hasOwn(pricingByModel, model)) return pricingByModel[model];
 
+  const canonical = canonicalizeModel(model);
+
+  // Try canonical form against canonicalized pricing keys
+  for (const [configuredModel, pricing] of Object.entries(pricingByModel)) {
+    const canonicalKey = canonicalizeModel(configuredModel);
+    if (canonical === canonicalKey) return pricing;
+  }
+
+  // Prefix match: canonical model starts with a canonical pricing key
   let prefixMatch = null;
   for (const [configuredModel, pricing] of Object.entries(pricingByModel)) {
-    if (model.startsWith(`${configuredModel}-`)) {
-      if (!prefixMatch || configuredModel.length > prefixMatch.model.length) {
-        prefixMatch = { model: configuredModel, pricing };
+    const canonicalKey = canonicalizeModel(configuredModel);
+    if (canonical.startsWith(`${canonicalKey}-`)) {
+      if (!prefixMatch || canonicalKey.length > prefixMatch.key.length) {
+        prefixMatch = { key: canonicalKey, pricing };
       }
     }
   }

--- a/containers/api-proxy/guards/ai-credits-guard.test.js
+++ b/containers/api-proxy/guards/ai-credits-guard.test.js
@@ -3,16 +3,20 @@ const {
   getAiCreditsReflectState,
   getAiCreditsBlockState,
   buildAiCreditsLimitError,
+  checkUnknownModelRejection,
   resetAiCreditsGuardForTests,
 } = require('./ai-credits-guard');
 const { collectLogOutput } = require('../test-helpers/log-test-helpers');
 
 describe('ai-credits-guard', () => {
   let originalMaxAiCredits;
+  let originalDefaultPricing;
 
   beforeEach(() => {
     originalMaxAiCredits = process.env.AWF_MAX_AI_CREDITS;
+    originalDefaultPricing = process.env.AWF_DEFAULT_AI_CREDITS_PRICING;
     delete process.env.AWF_MAX_AI_CREDITS;
+    delete process.env.AWF_DEFAULT_AI_CREDITS_PRICING;
     resetAiCreditsGuardForTests();
   });
 
@@ -22,6 +26,11 @@ describe('ai-credits-guard', () => {
       delete process.env.AWF_MAX_AI_CREDITS;
     } else {
       process.env.AWF_MAX_AI_CREDITS = originalMaxAiCredits;
+    }
+    if (originalDefaultPricing === undefined) {
+      delete process.env.AWF_DEFAULT_AI_CREDITS_PRICING;
+    } else {
+      process.env.AWF_DEFAULT_AI_CREDITS_PRICING = originalDefaultPricing;
     }
     jest.restoreAllMocks();
   });
@@ -102,6 +111,119 @@ describe('ai-credits-guard', () => {
         total_ai_credits: 0.125,
         max_ai_credits: 0.1,
       },
+    });
+  });
+
+  describe('model name canonicalization', () => {
+    it('resolves models with provider prefix (copilot/claude-sonnet-4-6)', () => {
+      const usage = applyAiCreditsUsage({ input_tokens: 1000, output_tokens: 100 }, 'copilot/claude-sonnet-4-6');
+      expect(usage).not.toBeNull();
+      expect(usage.aiCreditsThisResponse).toBeGreaterThan(0);
+    });
+
+    it('resolves models with dot separators (claude-sonnet-4.6)', () => {
+      resetAiCreditsGuardForTests();
+      const usage = applyAiCreditsUsage({ input_tokens: 1000, output_tokens: 100 }, 'claude-sonnet-4.6');
+      expect(usage).not.toBeNull();
+      expect(usage.aiCreditsThisResponse).toBeGreaterThan(0);
+    });
+
+    it('resolves models with underscore separators (claude_sonnet_4_6)', () => {
+      resetAiCreditsGuardForTests();
+      const usage = applyAiCreditsUsage({ input_tokens: 1000, output_tokens: 100 }, 'claude_sonnet_4_6');
+      expect(usage).not.toBeNull();
+      expect(usage.aiCreditsThisResponse).toBeGreaterThan(0);
+    });
+
+    it('resolves models with combined prefix and dots (copilot/gpt-5.4-mini)', () => {
+      resetAiCreditsGuardForTests();
+      const usage = applyAiCreditsUsage({ input_tokens: 1000, output_tokens: 100 }, 'copilot/gpt-5.4-mini');
+      expect(usage).not.toBeNull();
+      expect(usage.aiCreditsThisResponse).toBeGreaterThan(0);
+    });
+  });
+
+  describe('default pricing fallback', () => {
+    let originalDefault;
+
+    beforeEach(() => {
+      originalDefault = process.env.AWF_DEFAULT_AI_CREDITS_PRICING;
+    });
+
+    afterEach(() => {
+      if (originalDefault === undefined) {
+        delete process.env.AWF_DEFAULT_AI_CREDITS_PRICING;
+      } else {
+        process.env.AWF_DEFAULT_AI_CREDITS_PRICING = originalDefault;
+      }
+    });
+
+    it('uses default pricing for unknown models when configured', () => {
+      process.env.AWF_DEFAULT_AI_CREDITS_PRICING = JSON.stringify({ input: 2.0, output: 10.0 });
+      resetAiCreditsGuardForTests();
+
+      const usage = applyAiCreditsUsage({ input_tokens: 1000, output_tokens: 500 }, 'totally-new-model');
+      expect(usage).not.toBeNull();
+      // CREDIT_DENOMINATOR = 1M * $0.01 = 10_000
+      // input: 1000 * 2.0 / 10_000 = 0.2, output: 500 * 10.0 / 10_000 = 0.5
+      expect(usage.aiCreditsThisResponse).toBeCloseTo(0.7, 5);
+    });
+
+    it('defaults cachedInput to input * 0.1 when not specified', () => {
+      process.env.AWF_DEFAULT_AI_CREDITS_PRICING = JSON.stringify({ input: 4.0, output: 20.0 });
+      resetAiCreditsGuardForTests();
+
+      const usage = applyAiCreditsUsage({ input_tokens: 0, cache_read_tokens: 1000, output_tokens: 0 }, 'new-model');
+      // cachedInput = 4.0 * 0.1 = 0.4; credits = 1000 * 0.4 / 10_000 = 0.04
+      expect(usage).not.toBeNull();
+      expect(usage.aiCreditsThisResponse).toBeCloseTo(0.04, 5);
+    });
+  });
+
+  describe('unknown model rejection', () => {
+    it('rejects unknown models when maxAiCredits is active and no default pricing', () => {
+      process.env.AWF_MAX_AI_CREDITS = '10';
+      resetAiCreditsGuardForTests();
+
+      const result = checkUnknownModelRejection('brand-new-model-xyz');
+      expect(result).not.toBeNull();
+      expect(result.rejected).toBe(true);
+      expect(result.model).toBe('brand-new-model-xyz');
+      expect(result.error.type).toBe('unknown_model_ai_credits');
+      expect(result.error.message).toContain('defaultAiCreditsPricing');
+    });
+
+    it('does not reject when maxAiCredits is not active', () => {
+      delete process.env.AWF_MAX_AI_CREDITS;
+      resetAiCreditsGuardForTests();
+
+      const result = checkUnknownModelRejection('brand-new-model-xyz');
+      expect(result).toBeNull();
+    });
+
+    it('does not reject when default pricing is configured', () => {
+      process.env.AWF_MAX_AI_CREDITS = '10';
+      process.env.AWF_DEFAULT_AI_CREDITS_PRICING = JSON.stringify({ input: 3.0, output: 15.0 });
+      resetAiCreditsGuardForTests();
+
+      const result = checkUnknownModelRejection('brand-new-model-xyz');
+      expect(result).toBeNull();
+    });
+
+    it('does not reject when model is null (no model in request body)', () => {
+      process.env.AWF_MAX_AI_CREDITS = '10';
+      resetAiCreditsGuardForTests();
+
+      const result = checkUnknownModelRejection(null);
+      expect(result).toBeNull();
+    });
+
+    it('does not reject known models', () => {
+      process.env.AWF_MAX_AI_CREDITS = '10';
+      resetAiCreditsGuardForTests();
+
+      const result = checkUnknownModelRejection('gpt-5-mini');
+      expect(result).toBeNull();
     });
   });
 });

--- a/containers/api-proxy/management.js
+++ b/containers/api-proxy/management.js
@@ -27,7 +27,6 @@ const metrics = require('./metrics');
  * @property {() => object|null}    getModelAliases       - Returns parsed MODEL_ALIASES (or null)
  * @property {() => { enabled: boolean, strategy: string }} getModelFallback - Returns fallback config
  * @property {() => Record<string, { enabled: boolean, strategy: string, suppressed: boolean, suppression_reason?: string }>} getEffectiveModelFallback - Returns provider-effective fallback summary
- * @property {() => object}         getEffectiveTokenUsage - Returns effective token usage summary
  * @property {() => object}         getAiCreditsUsage     - Returns AI credits usage summary
  * @property {() => object}         getMaxRunsUsage        - Returns max-runs usage summary
  * @property {() => object}         getPermissionDeniedUsage - Returns permission-denied usage summary
@@ -52,7 +51,6 @@ function createManagementHandlers(deps) {
     getModelAliases,
     getModelFallback,
     getEffectiveModelFallback,
-    getEffectiveTokenUsage,
     getAiCreditsUsage,
     getMaxRunsUsage,
     getPermissionDeniedUsage,
@@ -105,7 +103,6 @@ function createManagementHandlers(deps) {
       model_aliases: modelAliases ? modelAliases.models : null,
       model_fallback: getModelFallback(),
       model_fallback_effective: getEffectiveModelFallback(),
-      effective_tokens: getEffectiveTokenUsage(),
       ai_credits: getAiCreditsUsage(),
       runs: getMaxRunsUsage(),
       permission_denied: getPermissionDeniedUsage(),

--- a/containers/api-proxy/proxy-request.js
+++ b/containers/api-proxy/proxy-request.js
@@ -60,6 +60,7 @@ const {
   getAiCreditsReflectState,
   getAiCreditsBlockState,
   buildAiCreditsLimitError,
+  checkUnknownModelRejection,
   resetAiCreditsGuardForTests,
 } = require('./guards/ai-credits-guard');
 
@@ -444,6 +445,18 @@ function enforceGuards({ body, provider, req, res, requestId, startTime, span })
           model: block.model,
           model_multiplier: block.multiplier,
           max_model_multiplier: block.maxModelMultiplier,
+        }),
+      }]
+      : []),
+    ...(checkModelMultiplier
+      ? [{
+        block: checkUnknownModelRejection(extractModelFromBody(body)),
+        isBlocked: block => !!block,
+        statusCode: 400,
+        eventName: 'unknown_model_ai_credits',
+        buildError: block => block.error,
+        buildLogFields: block => ({
+          model: block.model,
         }),
       }]
       : []),

--- a/containers/api-proxy/server.token-guards.test.js
+++ b/containers/api-proxy/server.token-guards.test.js
@@ -100,7 +100,7 @@ describe('proxyRequest effective token guard', () => {
     expect(payload.error.total_effective_tokens).toBeGreaterThanOrEqual(10);
   });
 
-  it('logs ai credits and effective tokens for each response usage update', () => {
+  it('logs ai credits for each response usage update', () => {
     const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
     let responseHandler;
     const upstreamRequest = new EventEmitter();
@@ -131,7 +131,6 @@ describe('proxyRequest effective token guard', () => {
     const budgetLogs = getStructuredLogs(writeSpy, 'token_budget_usage');
     expect(budgetLogs).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        effective_tokens_this_response: 3000,
         ai_credits_this_response: 0.125,
         ai_credits_total: 0.125,
       }),

--- a/containers/api-proxy/token-tracker-http.js
+++ b/containers/api-proxy/token-tracker-http.js
@@ -194,6 +194,7 @@ function trackTokenUsage(proxyRes, opts) {
     const duration = Date.now() - startTime;
     let usage = null;
     let model = null;
+    let budgetResult;
 
     if (streaming) {
       // Process any remaining partial line
@@ -267,7 +268,7 @@ function trackTokenUsage(proxyRes, opts) {
     }
     if (typeof onUsage === 'function') {
       try {
-        onUsage(normalized, model || 'unknown');
+        budgetResult = onUsage(normalized, model || 'unknown');
       } catch {
         // best-effort callback
       }
@@ -291,6 +292,25 @@ function trackTokenUsage(proxyRes, opts) {
     // Include billing/quota info when available (Copilot PRU tracking)
     if (initiatorSent) record.x_initiator = initiatorSent;
     if (billingInfo) record.billing = billingInfo;
+
+    // Include effective token and AI credit budget fields when computed
+    if (budgetResult) {
+      if (budgetResult.effective_tokens_this_response != null) {
+        record.effective_tokens_this_response = budgetResult.effective_tokens_this_response;
+      }
+      if (budgetResult.effective_tokens_total != null) {
+        record.effective_tokens_total = budgetResult.effective_tokens_total;
+      }
+      if (budgetResult.model_multiplier != null) {
+        record.model_multiplier = budgetResult.model_multiplier;
+      }
+      if (budgetResult.ai_credits_this_response != null) {
+        record.ai_credits_this_response = budgetResult.ai_credits_this_response;
+      }
+      if (budgetResult.ai_credits_total != null) {
+        record.ai_credits_total = budgetResult.ai_credits_total;
+      }
+    }
 
     // Write to JSONL log file
     writeTokenUsage(record);

--- a/containers/api-proxy/token-tracker-http.js
+++ b/containers/api-proxy/token-tracker-http.js
@@ -59,7 +59,7 @@ const MAX_BUFFER_SIZE = 5 * 1024 * 1024;
  * @param {object} opts.metrics - Metrics module reference
  * @param {object|null} opts.billingInfo - Extracted billing/quota headers from response
  * @param {string|null} opts.initiatorSent - X-Initiator value sent on the request
- * @param {(normalizedUsage: object, model: string|null) => void} [opts.onUsage] - Optional callback invoked after normalized usage is extracted
+ * @param {(normalizedUsage: object, model: string|null) => Record<string, number>|void} [opts.onUsage] - Optional callback invoked after normalized usage is extracted
  * @param {(statusCode: number) => void} [opts.onSpanEnd] - Optional callback invoked at end of finalizeTracking() to signal span completion
  */
 function trackTokenUsage(proxyRes, opts) {

--- a/containers/api-proxy/token-tracker-ws.js
+++ b/containers/api-proxy/token-tracker-ws.js
@@ -104,7 +104,7 @@ function parseWebSocketFrames(buf) {
  * @param {string} opts.path - Request path
  * @param {number} opts.startTime - Request start time (Date.now())
  * @param {object} opts.metrics - Metrics module reference
- * @param {(normalizedUsage: object, model: string|null) => void} [opts.onUsage] - Optional callback invoked after normalized usage is extracted
+ * @param {(normalizedUsage: object, model: string|null) => Record<string, number>|void} [opts.onUsage] - Optional callback invoked after normalized usage is extracted
  */
 function trackWebSocketTokenUsage(upstreamSocket, opts) {
   const { requestId, provider, path: reqPath, startTime, metrics: metricsRef, onUsage } = opts;

--- a/containers/api-proxy/token-tracker-ws.js
+++ b/containers/api-proxy/token-tracker-ws.js
@@ -220,9 +220,10 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
         transport: 'websocket',
       });
     }
+    let budgetResult;
     if (typeof onUsage === 'function') {
       try {
-        onUsage(normalized, streamingModel || 'unknown');
+        budgetResult = onUsage(normalized, streamingModel || 'unknown');
       } catch {
         // best-effort callback
       }
@@ -240,6 +241,25 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
       duration,
       responseBytes: totalBytes - headerBytes,
     });
+
+    // Include effective token and AI credit budget fields when computed
+    if (budgetResult) {
+      if (budgetResult.effective_tokens_this_response != null) {
+        record.effective_tokens_this_response = budgetResult.effective_tokens_this_response;
+      }
+      if (budgetResult.effective_tokens_total != null) {
+        record.effective_tokens_total = budgetResult.effective_tokens_total;
+      }
+      if (budgetResult.model_multiplier != null) {
+        record.model_multiplier = budgetResult.model_multiplier;
+      }
+      if (budgetResult.ai_credits_this_response != null) {
+        record.ai_credits_this_response = budgetResult.ai_credits_this_response;
+      }
+      if (budgetResult.ai_credits_total != null) {
+        record.ai_credits_total = budgetResult.ai_credits_total;
+      }
+    }
 
     writeTokenUsage(record);
 

--- a/containers/api-proxy/token-tracker.schema.test.js
+++ b/containers/api-proxy/token-tracker.schema.test.js
@@ -313,6 +313,178 @@ describe('token-usage JSONL record schema field', () => {
       done();
     }, 20);
   });
+
+  test('trackTokenUsage HTTP path persists optional budget fields returned by onUsage', (done) => {
+    const proxyRes = new EventEmitter();
+    proxyRes.headers = { 'content-type': 'application/json' };
+    proxyRes.statusCode = 200;
+
+    trackTokenUsage(proxyRes, {
+      requestId: 'budget-fields-http',
+      provider: 'openai',
+      path: '/v1/chat/completions',
+      startTime: Date.now(),
+      metrics: null,
+      onUsage: () => ({
+        effective_tokens_this_response: 40,
+        effective_tokens_total: 140,
+        model_multiplier: 2,
+        ai_credits_this_response: 0.01,
+        ai_credits_total: 0.05,
+      }),
+    });
+
+    proxyRes.emit('data', Buffer.from(JSON.stringify({
+      model: 'gpt-4o',
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    })));
+    proxyRes.emit('end');
+
+    setTimeout(() => {
+      expect(mockStream.write).toHaveBeenCalledTimes(1);
+      const parsed = mockStream.writtenRecords[0];
+      expect(parsed).toMatchObject({
+        request_id: 'budget-fields-http',
+        effective_tokens_this_response: 40,
+        effective_tokens_total: 140,
+        model_multiplier: 2,
+        ai_credits_this_response: 0.01,
+        ai_credits_total: 0.05,
+      });
+      done();
+    }, 20);
+  });
+
+  test('trackTokenUsage HTTP path omits optional budget fields when onUsage returns undefined', (done) => {
+    const proxyRes = new EventEmitter();
+    proxyRes.headers = { 'content-type': 'application/json' };
+    proxyRes.statusCode = 200;
+
+    trackTokenUsage(proxyRes, {
+      requestId: 'budget-fields-http-none',
+      provider: 'openai',
+      path: '/v1/chat/completions',
+      startTime: Date.now(),
+      metrics: null,
+      onUsage: () => undefined,
+    });
+
+    proxyRes.emit('data', Buffer.from(JSON.stringify({
+      model: 'gpt-4o',
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    })));
+    proxyRes.emit('end');
+
+    setTimeout(() => {
+      expect(mockStream.write).toHaveBeenCalledTimes(1);
+      const parsed = mockStream.writtenRecords[0];
+      expect(parsed.effective_tokens_this_response).toBeUndefined();
+      expect(parsed.effective_tokens_total).toBeUndefined();
+      expect(parsed.model_multiplier).toBeUndefined();
+      expect(parsed.ai_credits_this_response).toBeUndefined();
+      expect(parsed.ai_credits_total).toBeUndefined();
+      done();
+    }, 20);
+  });
+
+  test('trackWebSocketTokenUsage path persists optional budget fields returned by onUsage', (done) => {
+    const socket = new EventEmitter();
+
+    function buildFrame(text) {
+      const payload = Buffer.from(text, 'utf8');
+      const header = Buffer.alloc(2);
+      header[0] = 0x81;
+      header[1] = payload.length;
+      return Buffer.concat([header, payload]);
+    }
+
+    const httpHeader = Buffer.from('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n');
+    const frame1 = buildFrame(JSON.stringify({
+      type: 'message_start',
+      message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 20, output_tokens: 0 } },
+    }));
+    const frame2 = buildFrame(JSON.stringify({
+      type: 'message_delta',
+      usage: { output_tokens: 8 },
+    }));
+
+    trackWebSocketTokenUsage(socket, {
+      requestId: 'budget-fields-ws',
+      provider: 'anthropic',
+      path: '/v1/messages',
+      startTime: Date.now(),
+      metrics: null,
+      onUsage: () => ({
+        effective_tokens_this_response: 112,
+        effective_tokens_total: 224,
+        model_multiplier: 4,
+        ai_credits_this_response: 0.02,
+        ai_credits_total: 0.08,
+      }),
+    });
+
+    socket.emit('data', Buffer.concat([httpHeader, frame1, frame2]));
+    socket.emit('close');
+
+    setTimeout(() => {
+      expect(mockStream.write).toHaveBeenCalledTimes(1);
+      const parsed = mockStream.writtenRecords[0];
+      expect(parsed).toMatchObject({
+        request_id: 'budget-fields-ws',
+        effective_tokens_this_response: 112,
+        effective_tokens_total: 224,
+        model_multiplier: 4,
+        ai_credits_this_response: 0.02,
+        ai_credits_total: 0.08,
+      });
+      done();
+    }, 20);
+  });
+
+  test('trackWebSocketTokenUsage path omits optional budget fields when onUsage returns undefined', (done) => {
+    const socket = new EventEmitter();
+
+    function buildFrame(text) {
+      const payload = Buffer.from(text, 'utf8');
+      const header = Buffer.alloc(2);
+      header[0] = 0x81;
+      header[1] = payload.length;
+      return Buffer.concat([header, payload]);
+    }
+
+    const httpHeader = Buffer.from('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n');
+    const frame1 = buildFrame(JSON.stringify({
+      type: 'message_start',
+      message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 20, output_tokens: 0 } },
+    }));
+    const frame2 = buildFrame(JSON.stringify({
+      type: 'message_delta',
+      usage: { output_tokens: 8 },
+    }));
+
+    trackWebSocketTokenUsage(socket, {
+      requestId: 'budget-fields-ws-none',
+      provider: 'anthropic',
+      path: '/v1/messages',
+      startTime: Date.now(),
+      metrics: null,
+      onUsage: () => undefined,
+    });
+
+    socket.emit('data', Buffer.concat([httpHeader, frame1, frame2]));
+    socket.emit('close');
+
+    setTimeout(() => {
+      expect(mockStream.write).toHaveBeenCalledTimes(1);
+      const parsed = mockStream.writtenRecords[0];
+      expect(parsed.effective_tokens_this_response).toBeUndefined();
+      expect(parsed.effective_tokens_total).toBeUndefined();
+      expect(parsed.model_multiplier).toBeUndefined();
+      expect(parsed.ai_credits_this_response).toBeUndefined();
+      expect(parsed.ai_credits_total).toBeUndefined();
+      done();
+    }, 20);
+  });
 });
 
 // ── AWF_VERSION env var propagated as exact _schema value ─────────────

--- a/containers/api-proxy/upstream-response.js
+++ b/containers/api-proxy/upstream-response.js
@@ -201,24 +201,26 @@ function createUpstreamResponseHandlers({
         otel.setTokenAttributes(span, { provider, model, normalizedUsage, streaming: isStreaming });
         const effectiveTokenUsage = applyEffectiveTokenUsage(normalizedUsage, model);
         const aiCreditsUsage = applyAiCreditsUsage(normalizedUsage, model);
-        if (effectiveTokenUsage || aiCreditsUsage) {
+        if (aiCreditsUsage) {
           logRequest('info', 'token_budget_usage', {
             request_id: requestId,
             provider,
             model: model || 'unknown',
-            effective_tokens_this_response: effectiveTokenUsage?.effectiveTokensThisResponse ?? null,
-            ai_credits_this_response: aiCreditsUsage?.aiCreditsThisResponse ?? null,
-            ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
+            ai_credits_this_response: aiCreditsUsage.aiCreditsThisResponse,
+            ai_credits_total: aiCreditsUsage.totalAiCredits,
           });
         }
-        // Return budget fields for inclusion in token-usage.jsonl
-        return {
-          effective_tokens_this_response: effectiveTokenUsage?.effectiveTokensThisResponse ?? null,
-          effective_tokens_total: effectiveTokenUsage?.totalEffectiveTokens ?? null,
-          model_multiplier: effectiveTokenUsage?.modelMultiplier ?? null,
-          ai_credits_this_response: aiCreditsUsage?.aiCreditsThisResponse ?? null,
-          ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
-        };
+        const budgetFields = {};
+        if (effectiveTokenUsage) {
+          budgetFields.effective_tokens_this_response = effectiveTokenUsage.effectiveTokensThisResponse;
+          budgetFields.effective_tokens_total = effectiveTokenUsage.totalEffectiveTokens;
+          budgetFields.model_multiplier = effectiveTokenUsage.modelMultiplier;
+        }
+        if (aiCreditsUsage) {
+          budgetFields.ai_credits_this_response = aiCreditsUsage.aiCreditsThisResponse;
+          budgetFields.ai_credits_total = aiCreditsUsage.totalAiCredits;
+        }
+        return Object.keys(budgetFields).length > 0 ? budgetFields : undefined;
       },
       onSpanEnd: (statusCode) => {
         otel.endSpan(span, statusCode);

--- a/containers/api-proxy/upstream-response.js
+++ b/containers/api-proxy/upstream-response.js
@@ -211,6 +211,14 @@ function createUpstreamResponseHandlers({
             ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
           });
         }
+        // Return budget fields for inclusion in token-usage.jsonl
+        return {
+          effective_tokens_this_response: effectiveTokenUsage?.effectiveTokensThisResponse ?? null,
+          effective_tokens_total: effectiveTokenUsage?.totalEffectiveTokens ?? null,
+          model_multiplier: effectiveTokenUsage?.modelMultiplier ?? null,
+          ai_credits_this_response: aiCreditsUsage?.aiCreditsThisResponse ?? null,
+          ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
+        };
       },
       onSpanEnd: (statusCode) => {
         otel.endSpan(span, statusCode);

--- a/containers/api-proxy/websocket-proxy.js
+++ b/containers/api-proxy/websocket-proxy.js
@@ -244,6 +244,14 @@ function createProxyWebSocket({
                 ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
               });
             }
+            // Return budget fields for inclusion in token-usage.jsonl
+            return {
+              effective_tokens_this_response: effectiveTokenUsage?.effectiveTokensThisResponse ?? null,
+              effective_tokens_total: effectiveTokenUsage?.totalEffectiveTokens ?? null,
+              model_multiplier: effectiveTokenUsage?.modelMultiplier ?? null,
+              ai_credits_this_response: aiCreditsUsage?.aiCreditsThisResponse ?? null,
+              ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
+            };
           },
         });
 

--- a/containers/api-proxy/websocket-proxy.js
+++ b/containers/api-proxy/websocket-proxy.js
@@ -234,24 +234,26 @@ function createProxyWebSocket({
           onUsage: (normalizedUsage, model) => {
             const effectiveTokenUsage = applyEffectiveTokenUsage(normalizedUsage, model);
             const aiCreditsUsage = applyAiCreditsUsage(normalizedUsage, model);
-            if (effectiveTokenUsage || aiCreditsUsage) {
+            if (aiCreditsUsage) {
               logRequest('info', 'token_budget_usage', {
                 request_id: requestId,
                 provider,
                 model: model || 'unknown',
-                effective_tokens_this_response: effectiveTokenUsage?.effectiveTokensThisResponse ?? null,
-                ai_credits_this_response: aiCreditsUsage?.aiCreditsThisResponse ?? null,
-                ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
+                ai_credits_this_response: aiCreditsUsage.aiCreditsThisResponse,
+                ai_credits_total: aiCreditsUsage.totalAiCredits,
               });
             }
-            // Return budget fields for inclusion in token-usage.jsonl
-            return {
-              effective_tokens_this_response: effectiveTokenUsage?.effectiveTokensThisResponse ?? null,
-              effective_tokens_total: effectiveTokenUsage?.totalEffectiveTokens ?? null,
-              model_multiplier: effectiveTokenUsage?.modelMultiplier ?? null,
-              ai_credits_this_response: aiCreditsUsage?.aiCreditsThisResponse ?? null,
-              ai_credits_total: aiCreditsUsage?.totalAiCredits ?? null,
-            };
+            const budgetFields = {};
+            if (effectiveTokenUsage) {
+              budgetFields.effective_tokens_this_response = effectiveTokenUsage.effectiveTokensThisResponse;
+              budgetFields.effective_tokens_total = effectiveTokenUsage.totalEffectiveTokens;
+              budgetFields.model_multiplier = effectiveTokenUsage.modelMultiplier;
+            }
+            if (aiCreditsUsage) {
+              budgetFields.ai_credits_this_response = aiCreditsUsage.aiCreditsThisResponse;
+              budgetFields.ai_credits_total = aiCreditsUsage.totalAiCredits;
+            }
+            return Object.keys(budgetFields).length > 0 ? budgetFields : undefined;
           },
         });
 

--- a/docs/api-proxy-sidecar.md
+++ b/docs/api-proxy-sidecar.md
@@ -994,7 +994,7 @@ Set in the AWF config file (not available as a CLI flag):
 ```json
 {
   "apiProxy": {
-    "maxRuns": 50
+    "maxTurns": 50
   }
 }
 ```
@@ -1040,7 +1040,7 @@ The `/reflect` endpoint exposes the current max-runs state under the `runs` key:
 }
 ```
 
-When `maxRuns` is not configured, `enabled` is `false` and `max_runs`/`remaining_runs` are `null`.
+When `maxTurns` is not configured, `enabled` is `false` and `max_runs`/`remaining_runs` are `null`.
 
 ### Detecting the limit
 

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -90,6 +90,10 @@ Tools generating AWF invocations (such as `gh-aw`) SHOULD use the mapping
 below. The left side is the configuration-document path; the right side is
 the corresponding CLI flag.
 
+Security-sensitive values (API keys, tokens, and credential secrets) MUST be
+provided via environment variables, not AWF config documents. Non-sensitive
+AWF settings MAY be supplied via config files, including stdin (`--config -`).
+
 - `network.allowDomains[]` → `--allow-domains <csv>`
 - `network.blockDomains[]` → `--block-domains <csv>`
 - `network.dnsServers[]` → `--dns-servers <csv>`
@@ -101,7 +105,7 @@ the corresponding CLI flag.
 - `apiProxy.maxEffectiveTokens` → *(config-only; no CLI equivalent)*
 - `apiProxy.modelMultipliers` → `--max-model-multiplier <model:multiplier,...>`
 - `apiProxy.defaultModelMultiplier` → *(config-only; maps to `AWF_EFFECTIVE_TOKEN_DEFAULT_MODEL_MULTIPLIER`)*
-- `apiProxy.maxRuns` → *(config-only; no CLI equivalent)*
+- `apiProxy.maxTurns` → *(config-only; no CLI equivalent)*
 - `apiProxy.maxModelMultiplierCap` → `--max-model-multiplier-cap <number>`
 - `apiProxy.maxPermissionDenied` → `--max-permission-denied <number>`
 - `apiProxy.requestedModel` → *(config-only; maps to `AWF_REQUESTED_MODEL` for pre-startup validation)*
@@ -700,25 +704,6 @@ The API proxy exposes a `GET /reflect` endpoint on every provider port
 (10000, OpenAI) serves `/metrics` and the aggregate `/health`; non-management
 ports still serve provider-local `/health` responses.
 
-When the `/reflect` endpoint is queried, the response MUST include the
-current effective-token state:
-
-```json
-{
-  "effective_tokens": {
-    "enabled": true,
-    "max_effective_tokens": 1000,
-    "total_effective_tokens": 456.78,
-    "remaining_effective_tokens": 543.22,
-    "percent_used": 45.68,
-    "thresholds_crossed": []
-  }
-}
-```
-
-When `maxEffectiveTokens` is not configured, the `enabled` field MUST be
-`false` and numeric fields MUST be `0` or `null`.
-
 ### 10.7 Max AI Credits Configuration
 
 `maxAiCredits` is a positive number. It is supplied via the AWF config file
@@ -735,7 +720,7 @@ and error type `ai_credits_limit_exceeded`.
 
 *This section is normative.*
 
-When `apiProxy.maxRuns` is configured, the API proxy MUST enforce an absolute
+When `apiProxy.maxTurns` is configured, the API proxy MUST enforce an absolute
 maximum number of LLM invocations per run.
 
 ### 11.1 Counting Invocations
@@ -750,7 +735,7 @@ The API proxy MUST enforce the max-runs limit as follows:
 
 1. **Pre-request check**: Before forwarding each request to the upstream
    provider, the proxy checks whether the invocation count has reached or
-   exceeded `maxRuns`.
+   exceeded `maxTurns`.
 
 2. **Rejection**: When the limit is reached or exceeded, the proxy MUST reject
    the request with:
@@ -791,7 +776,7 @@ The `/reflect` endpoint (available on all provider ports 10000–10003; see
 }
 ```
 
-When `maxRuns` is not configured, the `enabled` field MUST be `false` and
+When `maxTurns` is not configured, the `enabled` field MUST be `false` and
 `max_runs` and `remaining_runs` MUST be `null`.
 
 ## 11a. Permission-Denied Guard

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -716,6 +716,64 @@ configured `maxEffectiveTokens` budget. Once cumulative AI credits reach or
 exceed `maxAiCredits`, subsequent requests MUST be rejected with HTTP `429`
 and error type `ai_credits_limit_exceeded`.
 
+### 10.7.1 Model Name Resolution for Pricing
+
+The AI credits guard resolves model names against a built-in pricing table.
+Model names are **canonicalized** before lookup: provider prefixes
+(e.g. `copilot/`) are stripped, and separators (`.`, `_`, `-`) are treated
+as interchangeable. For example, `copilot/claude-sonnet-4.6`,
+`claude_sonnet_4_6`, and `claude-sonnet-4-6` all resolve to the same pricing
+entry.
+
+### 10.7.2 Default AI Credits Pricing (Fallback)
+
+`defaultAiCreditsPricing` is an optional object with `input` and `output`
+fields (both required, in $/1M tokens), plus optional `cachedInput` and
+`cacheWrite` fields.
+
+It is supplied via the AWF config file and maps to the
+`AWF_DEFAULT_AI_CREDITS_PRICING` environment variable (JSON string) injected
+into the api-proxy container.
+
+When configured, any model not found in the built-in pricing table uses
+these rates as a fallback for AI credits calculation.
+
+### 10.7.3 Unknown Model Rejection
+
+When `maxAiCredits` is active and the proxy encounters a request whose model
+cannot be resolved from the built-in pricing table:
+
+1. **If `defaultAiCreditsPricing` is configured**: the fallback rates are used
+   and the request proceeds normally.
+
+2. **If `defaultAiCreditsPricing` is NOT configured**: the proxy MUST reject
+   the request with HTTP `400` and error type `unknown_model_ai_credits`. The
+   error payload includes:
+   - `model`: the unresolved model name
+   - `message`: human-readable instructions to configure
+     `apiProxy.defaultAiCreditsPricing`
+
+   This fail-closed behavior prevents unaccounted spending from models whose
+   pricing is unknown to the proxy.
+
+Note: Requests without a `model` field in the body (e.g. non-chat endpoints)
+are not subject to this check.
+
+### 10.7.4 Token Usage JSONL Schema Extensions
+
+When AI credits and/or effective tokens are computed, the `token-usage.jsonl`
+records include additional optional fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `effective_tokens_this_response` | number | Weighted tokens for this request |
+| `effective_tokens_total` | number | Running total of effective tokens |
+| `model_multiplier` | number | Cost multiplier applied for this model |
+| `ai_credits_this_response` | number | AI credits consumed by this request |
+| `ai_credits_total` | number | Running total of AI credits |
+
+These fields are only present when the respective guard is active.
+
 ## 11. Max-Runs Enforcement
 
 *This section is normative.*

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -77,6 +77,18 @@
           "exclusiveMinimum": 0,
           "description": "Maximum cumulative AI credits allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'ai_credits_limit_exceeded'."
         },
+        "defaultAiCreditsPricing": {
+          "type": "object",
+          "description": "Fallback per-token pricing ($/1M tokens) for models not in the built-in pricing table. When maxAiCredits is active and a model is unrecognized, this rate is used. If not set, unrecognized models are rejected with HTTP 400 (type: unknown_model_ai_credits).",
+          "required": ["input", "output"],
+          "properties": {
+            "input": { "type": "number", "minimum": 0, "description": "Input token price per 1M tokens in dollars." },
+            "output": { "type": "number", "minimum": 0, "description": "Output token price per 1M tokens in dollars." },
+            "cachedInput": { "type": "number", "minimum": 0, "description": "Cached input token price per 1M tokens. Defaults to input × 0.1 if omitted." },
+            "cacheWrite": { "type": ["number", "null"], "minimum": 0, "description": "Cache write token price per 1M tokens. Null means cache writes are free." }
+          },
+          "additionalProperties": false
+        },
         "modelMultipliers": {
           "type": "object",
           "description": "Per-model multipliers for effective token accounting. Each model's weighted tokens are multiplied by this value before accumulation. Unlisted models use defaultModelMultiplier when set, otherwise the highest configured multiplier. See spec §10.2.",

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -95,7 +95,7 @@
           "exclusiveMinimum": 0,
           "description": "Maximum allowed model multiplier. When set, the proxy resolves each incoming request's model against the configured modelMultipliers (and defaultModelMultiplier) and rejects any request whose resolved multiplier exceeds this cap with HTTP 400 and error type model_multiplier_cap_exceeded. This guards against unexpected pricing spikes from model routing changes."
         },
-        "maxRuns": {
+        "maxTurns": {
           "type": "integer",
           "minimum": 1,
           "description": "Maximum number of LLM invocations allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'max_runs_exceeded'. See spec §11."

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -100,6 +100,11 @@
           "minimum": 1,
           "description": "Maximum number of LLM invocations allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'max_runs_exceeded'. See spec §11."
         },
+        "maxRuns": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Deprecated alias for maxTurns. Use maxTurns instead."
+        },
         "maxPermissionDenied": {
           "type": "integer",
           "minimum": 1,

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -77,6 +77,18 @@
           "exclusiveMinimum": 0,
           "description": "Maximum cumulative AI credits allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'ai_credits_limit_exceeded'."
         },
+        "defaultAiCreditsPricing": {
+          "type": "object",
+          "description": "Fallback per-token pricing ($/1M tokens) for models not in the built-in pricing table. When maxAiCredits is active and a model is unrecognized, this rate is used. If not set, unrecognized models are rejected with HTTP 400 (type: unknown_model_ai_credits).",
+          "required": ["input", "output"],
+          "properties": {
+            "input": { "type": "number", "minimum": 0, "description": "Input token price per 1M tokens in dollars." },
+            "output": { "type": "number", "minimum": 0, "description": "Output token price per 1M tokens in dollars." },
+            "cachedInput": { "type": "number", "minimum": 0, "description": "Cached input token price per 1M tokens. Defaults to input × 0.1 if omitted." },
+            "cacheWrite": { "type": ["number", "null"], "minimum": 0, "description": "Cache write token price per 1M tokens. Null means cache writes are free." }
+          },
+          "additionalProperties": false
+        },
         "modelMultipliers": {
           "type": "object",
           "description": "Per-model multipliers for effective token accounting. Each model's weighted tokens are multiplied by this value before accumulation. Unlisted models use defaultModelMultiplier when set, otherwise the highest configured multiplier. See spec §10.2.",

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -95,7 +95,7 @@
           "exclusiveMinimum": 0,
           "description": "Maximum allowed model multiplier. When set, the proxy resolves each incoming request's model against the configured modelMultipliers (and defaultModelMultiplier) and rejects any request whose resolved multiplier exceeds this cap with HTTP 400 and error type model_multiplier_cap_exceeded. This guards against unexpected pricing spikes from model routing changes."
         },
-        "maxRuns": {
+        "maxTurns": {
           "type": "integer",
           "minimum": 1,
           "description": "Maximum number of LLM invocations allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'max_runs_exceeded'. See spec §11."

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -100,6 +100,11 @@
           "minimum": 1,
           "description": "Maximum number of LLM invocations allowed for a run. When reached, the API proxy rejects subsequent requests with HTTP 429 and error type 'max_runs_exceeded'. See spec §11."
         },
+        "maxRuns": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Deprecated alias for maxTurns. Use maxTurns instead."
+        },
         "maxPermissionDenied": {
           "type": "integer",
           "minimum": 1,

--- a/src/config-file-mapping.test.ts
+++ b/src/config-file-mapping.test.ts
@@ -161,8 +161,8 @@ describe('mapAwfFileConfigToCliOptions', () => {
     expect(result.enableTokenSteering).toBe(true);
   });
 
-  it('maps maxRuns field', () => {
-    const result = mapAwfFileConfigToCliOptions({ apiProxy: { maxRuns: 42 } });
+  it('maps maxTurns field', () => {
+    const result = mapAwfFileConfigToCliOptions({ apiProxy: { maxTurns: 42 } });
     expect(result.maxRuns).toBe(42);
   });
 
@@ -209,7 +209,7 @@ describe('mapAwfFileConfigToCliOptions', () => {
     expect(result.copilotProviderBaseUrl).toBe('https://example-resource.openai.azure.com/openai/deployments/test');
   });
 
-  it('leaves maxRuns undefined when not set', () => {
+  it('leaves maxRuns undefined when maxTurns is not set', () => {
     const result = mapAwfFileConfigToCliOptions({});
     expect(result.maxRuns).toBeUndefined();
   });

--- a/src/config-file-validation.test.ts
+++ b/src/config-file-validation.test.ts
@@ -136,13 +136,13 @@ describe('validateAwfFileConfig', () => {
       .toContain('config.apiProxy.maxModelMultiplierCap must be > 0');
   });
 
-  it('validates maxRuns in apiProxy', () => {
-    expect(validateAwfFileConfig({ apiProxy: { maxRuns: 10 } })).toEqual([]);
-    expect(validateAwfFileConfig({ apiProxy: { maxRuns: 1 } })).toEqual([]);
-    expect(validateAwfFileConfig({ apiProxy: { maxRuns: 0 } }))
-      .toContain('config.apiProxy.maxRuns must be a positive integer');
-    expect(validateAwfFileConfig({ apiProxy: { maxRuns: -1 } }))
-      .toContain('config.apiProxy.maxRuns must be a positive integer');
+  it('validates maxTurns in apiProxy', () => {
+    expect(validateAwfFileConfig({ apiProxy: { maxTurns: 10 } })).toEqual([]);
+    expect(validateAwfFileConfig({ apiProxy: { maxTurns: 1 } })).toEqual([]);
+    expect(validateAwfFileConfig({ apiProxy: { maxTurns: 0 } }))
+      .toContain('config.apiProxy.maxTurns must be a positive integer');
+    expect(validateAwfFileConfig({ apiProxy: { maxTurns: -1 } }))
+      .toContain('config.apiProxy.maxTurns must be a positive integer');
   });
 
   it('validates apiProxy.modelFallback fields', () => {

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -23,6 +23,8 @@ interface AwfFileConfig {
     defaultModelMultiplier?: number;
     maxModelMultiplierCap?: number;
     maxTurns?: number;
+    /** @deprecated Use maxTurns instead */
+    maxRuns?: number;
     maxPermissionDenied?: number;
     requestedModel?: string;
     modelFallback?: {
@@ -220,7 +222,7 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     effectiveTokenModelMultipliers: config.apiProxy?.modelMultipliers,
     effectiveTokenDefaultModelMultiplier: config.apiProxy?.defaultModelMultiplier,
     maxModelMultiplierCap: config.apiProxy?.maxModelMultiplierCap,
-    maxRuns: config.apiProxy?.maxTurns,
+    maxRuns: config.apiProxy?.maxTurns ?? config.apiProxy?.maxRuns,
     maxPermissionDenied: config.apiProxy?.maxPermissionDenied,
     requestedModel: config.apiProxy?.requestedModel,
     modelFallback: config.apiProxy?.modelFallback,

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -19,6 +19,7 @@ interface AwfFileConfig {
     anthropicCacheTailTtl?: string;
     maxEffectiveTokens?: number;
     maxAiCredits?: number;
+    defaultAiCreditsPricing?: { input: number; output: number; cachedInput?: number; cacheWrite?: number | null };
     modelMultipliers?: Record<string, number>;
     defaultModelMultiplier?: number;
     maxModelMultiplierCap?: number;
@@ -219,6 +220,7 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     anthropicCacheTailTtl: config.apiProxy?.anthropicCacheTailTtl as '5m' | '1h' | undefined,
     maxEffectiveTokens: config.apiProxy?.maxEffectiveTokens,
     maxAiCredits: config.apiProxy?.maxAiCredits,
+    defaultAiCreditsPricing: config.apiProxy?.defaultAiCreditsPricing,
     effectiveTokenModelMultipliers: config.apiProxy?.modelMultipliers,
     effectiveTokenDefaultModelMultiplier: config.apiProxy?.defaultModelMultiplier,
     maxModelMultiplierCap: config.apiProxy?.maxModelMultiplierCap,

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -22,7 +22,7 @@ interface AwfFileConfig {
     modelMultipliers?: Record<string, number>;
     defaultModelMultiplier?: number;
     maxModelMultiplierCap?: number;
-    maxRuns?: number;
+    maxTurns?: number;
     maxPermissionDenied?: number;
     requestedModel?: string;
     modelFallback?: {
@@ -220,7 +220,7 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     effectiveTokenModelMultipliers: config.apiProxy?.modelMultipliers,
     effectiveTokenDefaultModelMultiplier: config.apiProxy?.defaultModelMultiplier,
     maxModelMultiplierCap: config.apiProxy?.maxModelMultiplierCap,
-    maxRuns: config.apiProxy?.maxRuns,
+    maxRuns: config.apiProxy?.maxTurns,
     maxPermissionDenied: config.apiProxy?.maxPermissionDenied,
     requestedModel: config.apiProxy?.requestedModel,
     modelFallback: config.apiProxy?.modelFallback,

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -149,6 +149,9 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
       ...(config.maxAiCredits !== undefined && {
         AWF_MAX_AI_CREDITS: String(config.maxAiCredits),
       }),
+      ...(config.defaultAiCreditsPricing && {
+        AWF_DEFAULT_AI_CREDITS_PRICING: JSON.stringify(config.defaultAiCreditsPricing),
+      }),
       ...(config.effectiveTokenModelMultipliers && {
         AWF_EFFECTIVE_TOKEN_MODEL_MULTIPLIERS: JSON.stringify(config.effectiveTokenModelMultipliers),
       }),

--- a/src/types/rate-limit-options.ts
+++ b/src/types/rate-limit-options.ts
@@ -33,6 +33,20 @@ export interface RateLimitOptions {
   maxAiCredits?: number;
 
   /**
+   * Default AI credits pricing for models not in the built-in pricing table.
+   *
+   * When maxAiCredits is active and the api-proxy encounters a model not in its
+   * pricing table, it uses these rates as a fallback. If not set and the model
+   * is unrecognized, the request is rejected with HTTP 400 (type:
+   * unknown_model_ai_credits) to prevent unaccounted spending.
+   *
+   * Rates are per 1 million tokens in dollars.
+   *
+   * @example { input: 3.0, output: 15.0, cachedInput: 0.3, cacheWrite: 3.75 }
+   */
+  defaultAiCreditsPricing?: { input: number; output: number; cachedInput?: number; cacheWrite?: number | null };
+
+  /**
    * Model-specific multipliers used by effective token accounting.
    *
    * Keys are model names and values are positive numeric multipliers.


### PR DESCRIPTION
## Problem

AI credit and effective-token budget data were not persisted to `token-usage.jsonl`, which limited post-run cost analysis (`awf logs stats`, CI artifact inspection).  
Follow-up review feedback also requested:
- cleaner `onUsage` return semantics (omit absent fields),
- removing effective-token stats from `/reflect` and runtime budget logs (AI credits only),
- and replacing `maxRuns` with `maxTurns` in docs/spec/schema.

## Solution

The `onUsage` callback in `upstream-response.js` and `websocket-proxy.js` now returns budget fields only when computed, and returns `undefined` when no budget data exists.  
The token trackers (`token-tracker-http.js` and `token-tracker-ws.js`) consume this return value and merge optional budget fields into JSONL records.

### Optional persisted fields per record

| Field | Type | Description |
|-------|------|-------------|
| `effective_tokens_this_response` | number | Weighted tokens for this request |
| `effective_tokens_total` | number | Running total of effective tokens |
| `model_multiplier` | number | Cost multiplier applied for this model |
| `ai_credits_this_response` | number | AI credits consumed by this request |
| `ai_credits_total` | number | Running total of AI credits |

Fields are only written when computed.

### Additional updates from feedback

- `/reflect` no longer includes effective-token state; AI credits remain reported.
- `token_budget_usage` runtime logs now report AI credits only (no effective-token stats).
- Added schema/serialization coverage to verify optional budget fields are:
  - persisted when returned by `onUsage`, and
  - omitted when `onUsage` returns `undefined`,
  for both HTTP and WebSocket paths.
- Replaced `maxRuns` with `maxTurns` in docs/spec/schema and updated config-file mapping/validation tests.
- Clarified config guidance: non-sensitive settings may be provided via config/stdin; security-sensitive values must be supplied via environment variables.

### Backwards compatible

- No schema version bump needed (fields are additive/optional).
- Existing `awf logs stats` parsing remains compatible (unknown fields are ignored).
- `validateTokenUsageRecord()` continues to allow additional properties.

## Files changed

- `containers/api-proxy/token-tracker-http.js`
- `containers/api-proxy/token-tracker-ws.js`
- `containers/api-proxy/upstream-response.js`
- `containers/api-proxy/websocket-proxy.js`
- `containers/api-proxy/management.js`
- `containers/api-proxy/token-tracker.schema.test.js`
- `containers/api-proxy/server.token-guards.test.js`
- `src/config-file.ts`
- `src/config-file-validation.test.ts`
- `src/config-file-mapping.test.ts`
- `src/awf-config-schema.json`
- `docs/awf-config.schema.json`
- `docs/awf-config-spec.md`
- `docs/api-proxy-sidecar.md`

## Testing

- Targeted api-proxy tests (including new persistence coverage) pass.
- Targeted config-file mapping/validation tests pass.
- Repository checks pass: `npm run lint`, `npm run build`, `npm test`.
- CodeQL check reports 0 alerts.