### PR TITLE
Add hard cap on AI credits (10000) and restore agentic-workflows integration ID

### DIFF
--- a/containers/api-proxy/guards/ai-credits-guard.js
+++ b/containers/api-proxy/guards/ai-credits-guard.js
@@ -57,8 +57,9 @@ function getAiCreditsConfig() {
     } catch { /* invalid JSON — leave null */ }
   }
 
+  const parsedMax = parsePositiveNumber(rawMax);
   aiCreditsConfigCache.parsed = {
-    max: parsePositiveNumber(rawMax) ? Math.min(parsePositiveNumber(rawMax), HARD_CAP_AI_CREDITS) : null,
+    max: parsedMax ? Math.min(parsedMax, HARD_CAP_AI_CREDITS) : null,
     defaultPricing,
   };
   return aiCreditsConfigCache.parsed;

--- a/containers/api-proxy/guards/ai-credits-guard.js
+++ b/containers/api-proxy/guards/ai-credits-guard.js
@@ -8,6 +8,11 @@ const TOKENS_PER_MILLION = 1_000_000;
 const DOLLARS_PER_CREDIT = 0.01;
 const CREDIT_DENOMINATOR = TOKENS_PER_MILLION * DOLLARS_PER_CREDIT;
 
+// Absolute hard cap on AI credits that cannot be overridden by configuration.
+// This is a safety limit to prevent runaway spending regardless of what
+// maxAiCredits is set to via CLI flags or config files.
+const HARD_CAP_AI_CREDITS = 10_000;
+
 function roundCredits(value) {
   return Math.round((value + Number.EPSILON) * 1_000_000) / 1_000_000;
 }
@@ -53,7 +58,7 @@ function getAiCreditsConfig() {
   }
 
   aiCreditsConfigCache.parsed = {
-    max: parsePositiveNumber(rawMax),
+    max: parsePositiveNumber(rawMax) ? Math.min(parsePositiveNumber(rawMax), HARD_CAP_AI_CREDITS) : null,
     defaultPricing,
   };
   return aiCreditsConfigCache.parsed;
@@ -215,8 +220,19 @@ function getAiCreditsReflectState() {
 
 function getAiCreditsBlockState() {
   const config = getAiCreditsConfig();
-  if (!config.max) return null;
   const roundedTotalAiCredits = roundCredits(aiCreditsState.totalAiCredits);
+
+  // Hard cap always applies, regardless of config
+  if (roundedTotalAiCredits >= HARD_CAP_AI_CREDITS) {
+    return {
+      maxAiCredits: HARD_CAP_AI_CREDITS,
+      totalAiCredits: roundedTotalAiCredits,
+      maxExceeded: true,
+      hardCap: true,
+    };
+  }
+
+  if (!config.max) return null;
   return {
     maxAiCredits: config.max,
     totalAiCredits: roundedTotalAiCredits,
@@ -225,12 +241,16 @@ function getAiCreditsBlockState() {
 }
 
 function buildAiCreditsLimitError(aiCreditsBlockState) {
+  const isHardCap = aiCreditsBlockState.hardCap === true;
   return {
     error: {
       type: 'ai_credits_limit_exceeded',
-      message: `Maximum AI credits exceeded (${aiCreditsBlockState.totalAiCredits.toFixed(6)} / ${aiCreditsBlockState.maxAiCredits}).`,
+      message: isHardCap
+        ? `Hard cap on AI credits reached (${aiCreditsBlockState.totalAiCredits.toFixed(6)} / ${aiCreditsBlockState.maxAiCredits}). This limit cannot be overridden.`
+        : `Maximum AI credits exceeded (${aiCreditsBlockState.totalAiCredits.toFixed(6)} / ${aiCreditsBlockState.maxAiCredits}).`,
       total_ai_credits: aiCreditsBlockState.totalAiCredits,
       max_ai_credits: aiCreditsBlockState.maxAiCredits,
+      hard_cap: isHardCap,
     },
   };
 }
@@ -244,6 +264,7 @@ function resetAiCreditsGuardForTests() {
 }
 
 module.exports = {
+  HARD_CAP_AI_CREDITS,
   applyAiCreditsUsage,
   getAiCreditsReflectState,
   getAiCreditsBlockState,

--- a/containers/api-proxy/guards/ai-credits-guard.test.js
+++ b/containers/api-proxy/guards/ai-credits-guard.test.js
@@ -103,8 +103,14 @@ describe('ai-credits-guard', () => {
   });
 
   it('enforces hard cap even when no max is configured', () => {
-    // No AWF_MAX_AI_CREDITS set — hard cap still applies
-    expect(HARD_CAP_AI_CREDITS).toBe(10_000);
+    expect(process.env.AWF_MAX_AI_CREDITS).toBeUndefined();
+    applyAiCreditsUsage({ input_tokens: 400_000_000, output_tokens: 0 }, 'gpt-5-mini');
+    expect(getAiCreditsBlockState()).toEqual({
+      maxAiCredits: HARD_CAP_AI_CREDITS,
+      totalAiCredits: HARD_CAP_AI_CREDITS,
+      maxExceeded: true,
+      hardCap: true,
+    });
   });
 
   it('clamps configured max to hard cap', () => {

--- a/containers/api-proxy/guards/ai-credits-guard.test.js
+++ b/containers/api-proxy/guards/ai-credits-guard.test.js
@@ -1,4 +1,5 @@
 const {
+  HARD_CAP_AI_CREDITS,
   applyAiCreditsUsage,
   getAiCreditsReflectState,
   getAiCreditsBlockState,
@@ -101,6 +102,18 @@ describe('ai-credits-guard', () => {
     });
   });
 
+  it('enforces hard cap even when no max is configured', () => {
+    // No AWF_MAX_AI_CREDITS set — hard cap still applies
+    expect(HARD_CAP_AI_CREDITS).toBe(10_000);
+  });
+
+  it('clamps configured max to hard cap', () => {
+    process.env.AWF_MAX_AI_CREDITS = '99999';
+    applyAiCreditsUsage({ input_tokens: 100, output_tokens: 0 }, 'gpt-5-mini');
+    const state = getAiCreditsBlockState();
+    expect(state.maxAiCredits).toBe(HARD_CAP_AI_CREDITS);
+  });
+
   it('builds a structured max ai credits limit error payload', () => {
     expect(buildAiCreditsLimitError({
       totalAiCredits: 0.125,
@@ -111,6 +124,23 @@ describe('ai-credits-guard', () => {
         message: 'Maximum AI credits exceeded (0.125000 / 0.1).',
         total_ai_credits: 0.125,
         max_ai_credits: 0.1,
+        hard_cap: false,
+      },
+    });
+  });
+
+  it('builds a hard cap error payload when hardCap is true', () => {
+    expect(buildAiCreditsLimitError({
+      totalAiCredits: 10000.5,
+      maxAiCredits: 10000,
+      hardCap: true,
+    })).toEqual({
+      error: {
+        type: 'ai_credits_limit_exceeded',
+        message: 'Hard cap on AI credits reached (10000.500000 / 10000). This limit cannot be overridden.',
+        total_ai_credits: 10000.5,
+        max_ai_credits: 10000,
+        hard_cap: true,
       },
     });
   });

--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -50,7 +50,7 @@ function createCopilotAdapter(env, deps = {}) {
   // resolveApiKey filters out the AWF placeholder so it is never used as a real BYOK credential.
   const apiKey = resolveApiKey(env);
   const staticAuthToken = resolveCopilotAuthToken(env);
-  const integrationId = env.COPILOT_INTEGRATION_ID || 'copilot-developer-cli';
+  const integrationId = env.COPILOT_INTEGRATION_ID || 'agentic-workflows';
   const rawTarget = deriveCopilotApiTarget(env);
   const basePath = normalizeBasePath(env.COPILOT_API_BASE_PATH);
 

--- a/containers/api-proxy/proxy-request.js
+++ b/containers/api-proxy/proxy-request.js
@@ -426,6 +426,7 @@ function enforceGuards({ body, provider, req, res, requestId, startTime, span })
       buildLogFields: block => ({
         total_ai_credits: block.totalAiCredits,
         max_ai_credits: block.maxAiCredits,
+        hard_cap: block.hardCap || false,
       }),
     },
     ...(checkModelMultiplier

--- a/containers/api-proxy/server.auth.test.js
+++ b/containers/api-proxy/server.auth.test.js
@@ -254,7 +254,7 @@ describe('createCopilotAdapter — BYOK getAuthHeaders', () => {
   it('injects Copilot-Integration-Id header for BYOK inference request', () => {
     const adapter = createCopilotAdapter({ COPILOT_PROVIDER_API_KEY: 'sk-or-v1-abc123' });
     const headers = adapter.getAuthHeaders(fakeReq);
-    expect(headers['Copilot-Integration-Id']).toBe('copilot-developer-cli');
+    expect(headers['Copilot-Integration-Id']).toBe('agentic-workflows');
   });
 
   it('prevents double "Bearer " prefix when API key already contains "Bearer " prefix (BYOK bug fix)', () => {
@@ -489,7 +489,7 @@ describe('createCopilotAdapter — AWF_BYOK_EXTRA_HEADERS injection', () => {
     });
     const headers = adapter.getAuthHeaders(fakeReq);
     expect(headers['Authorization']).toBe('Bearer sk-or-v1-abc123');
-    expect(headers['Copilot-Integration-Id']).toBe('copilot-developer-cli');
+    expect(headers['Copilot-Integration-Id']).toBe('agentic-workflows');
     expect(headers['x-session-id']).toBe('sess-1');
     warnSpy.mockRestore();
   });
@@ -711,7 +711,7 @@ describe('createCopilotAdapter — Azure OIDC (Entra) getAuthHeaders', () => {
 
     const headers = adapter.getAuthHeaders(fakeReq);
     expect(headers['Authorization']).toBe(['Bearer', 'aad-access-token'].join(' '));
-    expect(headers['Copilot-Integration-Id']).toBe('copilot-developer-cli');
+    expect(headers['Copilot-Integration-Id']).toBe('agentic-workflows');
 
     provider.shutdown();
   });

--- a/containers/api-proxy/websocket-proxy.js
+++ b/containers/api-proxy/websocket-proxy.js
@@ -114,6 +114,7 @@ function createProxyWebSocket({
         provider,
         total_ai_credits: aiCreditsBlock.totalAiCredits,
         max_ai_credits: aiCreditsBlock.maxAiCredits,
+        hard_cap: aiCreditsBlock.hardCap || false,
       });
       socket.write('HTTP/1.1 429 Too Many Requests\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n');
       socket.write(JSON.stringify(buildAiCreditsLimitError(aiCreditsBlock)));

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -113,8 +113,8 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
       // Forward GITHUB_API_URL so api-proxy can route /models to the correct GitHub REST API
       // target on GHES/GHEC (e.g. api.mycompany.ghe.com instead of api.github.com)
       ...(process.env.GITHUB_API_URL && { GITHUB_API_URL: process.env.GITHUB_API_URL }),
-      // Do not forward GITHUB_COPILOT_INTEGRATION_ID for now. api-proxy defaults to
-      // 'copilot-developer-cli', which remains required for PAT compatibility.
+      // Do not forward GITHUB_COPILOT_INTEGRATION_ID — api-proxy defaults to
+      // 'agentic-workflows' which is the correct integration ID for AWF.
       // Note: AWF_VERSION is intentionally NOT forwarded here. It is baked into the api-proxy
       // container image at release build time (via --build-arg AWF_VERSION=...), so the
       // token-usage.jsonl _schema field reflects the api-proxy image version rather than


### PR DESCRIPTION
## Changes

### 1. Hard cap on AI credits (10,000)

Introduces an absolute safety limit (`HARD_CAP_AI_CREDITS = 10_000`) that cannot be overridden by any configuration:

- If `maxAiCredits` is set higher than 10,000, it's clamped to 10,000
- Even if no `maxAiCredits` is configured at all, the hard cap still triggers at 10,000
- When hit, the error response includes `hard_cap: true` and a distinct message
- Token usage logs include `hard_cap: true` field for observability

The constant lives in `containers/api-proxy/guards/ai-credits-guard.js` for easy discoverability.

### 2. Restore `agentic-workflows` integration ID

Changes the default Copilot integration ID from `copilot-developer-cli` back to `agentic-workflows` in the api-proxy's Copilot adapter.

## Files changed

- `containers/api-proxy/guards/ai-credits-guard.js` — hard cap constant + enforcement logic
- `containers/api-proxy/guards/ai-credits-guard.test.js` — tests for hard cap
- `containers/api-proxy/proxy-request.js` — log `hard_cap` field
- `containers/api-proxy/websocket-proxy.js` — log `hard_cap` field
- `containers/api-proxy/providers/copilot.js` — integration ID default
- `containers/api-proxy/server.auth.test.js` — updated assertions
- `src/services/api-proxy-service-config.ts` — updated comment

## Testing

- All api-proxy tests pass (946 tests)
- All main repo tests pass (2458 tests)