### PR TITLE
fix: update workflow test SHA assertions after recompile

### DIFF
--- a/scripts/ci/security-guard-workflow.test.ts
+++ b/scripts/ci/security-guard-workflow.test.ts
@@ -38,7 +38,7 @@ describe('security guard workflow optimization config', () => {
     expect(lock).toContain('--max-turns 6');
     expect(lock).toContain('ANTHROPIC_MODEL: claude-sonnet-4-5');
     expect(lock).toContain('GH_AW_MAX_TURNS: 6');
-    expect(lock).toContain('github/gh-aw-actions/setup@9b1d730701c16b15673633e5696d01677fad9844 # v0.79.2');
+    expect(lock).toContain('github/gh-aw-actions/setup@d059700c6a8ec3b5fd798b9ea60f5d048447b918 # v0.79.4');
     expect(lock).not.toContain('github/gh-aw-actions/setup@v0.79.2');
     expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.1.2');
   });

--- a/scripts/ci/test-coverage-improver-workflow.test.ts
+++ b/scripts/ci/test-coverage-improver-workflow.test.ts
@@ -75,7 +75,7 @@ describe('test coverage improver workflow token optimization config', () => {
     expect(lock).not.toContain("shell(cat:src/*.test.ts)");
     expect(lock).not.toContain("shell(npm run lint)");
     expect(lock).not.toContain("shell(npm run test)");
-    expect(lock).toContain('github/gh-aw-actions/setup@9b1d730701c16b15673633e5696d01677fad9844 # v0.79.2');
+    expect(lock).toContain('github/gh-aw-actions/setup@d059700c6a8ec3b5fd798b9ea60f5d048447b918 # v0.79.4');
     expect(lock).not.toContain('github/gh-aw-actions/setup@v0.79.2');
     expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.1.2');
 


### PR DESCRIPTION
PR #4714 recompiled all workflows, bumping `github/gh-aw-actions/setup` from v0.79.2 (`9b1d7307`) to v0.79.4 (`d059700c`), but the test assertions in `security-guard-workflow.test.ts` and `test-coverage-improver-workflow.test.ts` weren't updated — causing `npm test` to fail on main.

This fixes both tests to match the current lock file content.