### PR TITLE
fix(api-proxy): use 'token' auth prefix for GHES enterprise Copilot API

### DIFF
--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -241,10 +241,15 @@ function createCopilotAdapter(env, deps = {}) {
         reqPathname = req.url || '';
       }
 
+      // Enterprise Copilot API (GHES) requires 'token <value>' format;
+      // standard api.githubcopilot.com and GHEC (*.ghe.com) use 'Bearer <value>'.
+      const isEnterprise = rawTarget === 'api.enterprise.githubcopilot.com';
+      const authPrefix = (isEnterprise && !apiKey) ? 'token' : 'Bearer';
+
       const isModelsPath = reqPathname === '/models' || reqPathname.startsWith('/models/');
       if (isModelsPath && req.method === 'GET' && githubToken) {
         return {
-          'Authorization': ['Bearer', githubToken].join(' '),
+          'Authorization': [authPrefix, githubToken].join(' '),
           'Copilot-Integration-Id': integrationId,
         };
       }
@@ -269,7 +274,7 @@ function createCopilotAdapter(env, deps = {}) {
 
       return {
         ...(apiKey ? byokExtraHeaders : {}),
-        'Authorization': ['Bearer', authToken].join(' '),
+        'Authorization': [authPrefix, authToken].join(' '),
         'Copilot-Integration-Id': integrationId,
       };
     },

--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -241,15 +241,17 @@ function createCopilotAdapter(env, deps = {}) {
         reqPathname = req.url || '';
       }
 
-      // Enterprise Copilot API (GHES) requires 'token <value>' format;
-      // standard api.githubcopilot.com and GHEC (*.ghe.com) use 'Bearer <value>'.
+      // Enterprise Copilot API (GHES) requires 'token <value>' for GitHub OAuth tokens;
+      // BYOK API keys always use 'Bearer <value>' regardless of target.
+      // Standard api.githubcopilot.com and GHEC (*.ghe.com) use 'Bearer' for all credentials.
       const isEnterprise = rawTarget === 'api.enterprise.githubcopilot.com';
-      const authPrefix = (isEnterprise && !apiKey) ? 'token' : 'Bearer';
 
       const isModelsPath = reqPathname === '/models' || reqPathname.startsWith('/models/');
       if (isModelsPath && req.method === 'GET' && githubToken) {
+        // /models always uses the GitHub OAuth token (not BYOK key)
+        const prefix = isEnterprise ? 'token' : 'Bearer';
         return {
-          'Authorization': [authPrefix, githubToken].join(' '),
+          'Authorization': [prefix, githubToken].join(' '),
           'Copilot-Integration-Id': integrationId,
         };
       }
@@ -272,6 +274,8 @@ function createCopilotAdapter(env, deps = {}) {
         return {};
       }
 
+      // For inference: BYOK keys use 'Bearer'; GitHub tokens use 'token' on GHES
+      const authPrefix = (isEnterprise && !apiKey) ? 'token' : 'Bearer';
       return {
         ...(apiKey ? byokExtraHeaders : {}),
         'Authorization': [authPrefix, authToken].join(' '),

--- a/containers/api-proxy/server.auth.test.js
+++ b/containers/api-proxy/server.auth.test.js
@@ -378,6 +378,16 @@ describe('createCopilotAdapter — GHE enterprise auth format', () => {
     expect(headers['Authorization']).toBe('Bearer sk-byok-key');
   });
 
+  it('uses "token" prefix for /models on GHES even when BYOK key is configured', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_enterprise_token_123',
+      COPILOT_PROVIDER_API_KEY: 'sk-byok-key',
+      GITHUB_SERVER_URL: 'https://ghes.example.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeModelsReq);
+    expect(headers['Authorization']).toBe('token ghu_enterprise_token_123');
+  });
+
   it('uses "Bearer" prefix for standard api.githubcopilot.com target', () => {
     const adapter = createCopilotAdapter({
       COPILOT_GITHUB_TOKEN: 'ghu_standard_token_123',

--- a/containers/api-proxy/server.auth.test.js
+++ b/containers/api-proxy/server.auth.test.js
@@ -344,6 +344,68 @@ describe('createCopilotAdapter — BYOK getAuthHeaders', () => {
   });
 });
 
+// ── GHE (Enterprise) auth format ──────────────────────────────────────────────
+
+describe('createCopilotAdapter — GHE enterprise auth format', () => {
+  const fakeReq = { url: '/v1/chat/completions', method: 'POST', headers: {} };
+  const fakeModelsReq = { url: '/models', method: 'GET', headers: {} };
+
+  it('uses "token" prefix for GHES target (api.enterprise.githubcopilot.com)', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_enterprise_token_123',
+      GITHUB_SERVER_URL: 'https://ghes.example.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('token ghu_enterprise_token_123');
+  });
+
+  it('uses "token" prefix for /models on GHES target', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_enterprise_token_123',
+      GITHUB_SERVER_URL: 'https://ghes.example.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeModelsReq);
+    expect(headers['Authorization']).toBe('token ghu_enterprise_token_123');
+  });
+
+  it('uses "Bearer" prefix for BYOK key even on GHES target', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_enterprise_token_123',
+      COPILOT_PROVIDER_API_KEY: 'sk-byok-key',
+      GITHUB_SERVER_URL: 'https://ghes.example.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('Bearer sk-byok-key');
+  });
+
+  it('uses "Bearer" prefix for standard api.githubcopilot.com target', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_standard_token_123',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('Bearer ghu_standard_token_123');
+  });
+
+  it('uses "Bearer" prefix for GHEC tenant (*.ghe.com)', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_ghec_token_123',
+      GITHUB_SERVER_URL: 'https://mycompany.ghe.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('Bearer ghu_ghec_token_123');
+  });
+
+  it('strips "token " prefix from COPILOT_GITHUB_TOKEN before re-prefixing for GHES', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'token ghu_enterprise_token_123',
+      GITHUB_SERVER_URL: 'https://ghes.example.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('token ghu_enterprise_token_123');
+    expect(headers['Authorization']).not.toContain('token token');
+  });
+});
+
 // ── parseByokExtraHeaders ─────────────────────────────────────────────────────
 
 describe('parseByokExtraHeaders', () => {


### PR DESCRIPTION
## Problem

Since v0.27.0, every agentic workflow on GHES fails with:

```
400 bad request: Authorization header is badly formatted
```

The api-proxy sidecar always sends `Authorization: Bearer <token>` to the enterprise Copilot API (`api.enterprise.githubcopilot.com`), which requires `token <value>` format for GitHub tokens.

## Root Cause

**Regression introduced by PR #4235** (`8f6b8942`, merged June 3).

In **v0.25.55** (last working version):
- `COPILOT_OFFLINE=true` was only set when `config.copilotApiKey` (BYOK) was present
- Without a BYOK key, the Copilot CLI inside the agent used its **native auth mechanism** to talk to CAPI directly
- The Copilot CLI natively handles GHES auth format (`token` prefix) internally
- The api-proxy sidecar was never involved for standard GHES GitHub-token auth

In **v0.27.0** (broken):
- PR #4235 universally enables `COPILOT_OFFLINE=true` + `COPILOT_PROVIDER_BASE_URL` whenever `copilotGithubToken` is present
- This forces **all** Copilot CLI traffic through the api-proxy sidecar, including on GHES
- The sidecar's `getAuthHeaders()` always wraps tokens with `Bearer` prefix
- Enterprise CAPI rejects `Bearer` format for GitHub tokens — it requires `token` prefix
- **Result: 400 on every GHES request**

Note: PR #3322 (`4865f82b`, the earlier "fix" for #3313) only added `token ` prefix stripping to `stripBearerPrefix()` — it was irrelevant because at v0.25.55 the sidecar wasn't handling GHES traffic at all.

## Fix

Detect when `rawTarget === 'api.enterprise.githubcopilot.com'` in `getAuthHeaders()` and use `token` prefix for GitHub token auth. BYOK API keys still use `Bearer` regardless of target (those go to third-party providers that expect Bearer format).

| Target | Auth Source | Format |
|--------|------------|--------|
| `api.githubcopilot.com` | GitHub token | `Bearer <token>` |
| `copilot-api.*.ghe.com` (GHEC) | GitHub token | `Bearer <token>` |
| `api.enterprise.githubcopilot.com` (GHES) | GitHub token | `token <token>` |
| Any target | BYOK API key | `Bearer <key>` |

## Testing

6 new tests covering:
- GHES target uses `token` prefix
- GHES /models uses `token` prefix
- BYOK key on GHES still uses `Bearer`
- Standard target uses `Bearer`
- GHEC target uses `Bearer`
- Double-prefix prevention for `token token`

All 94 auth tests pass.

Fixes #3313
Fixes #4744