### PR TITLE
refactor: extract assignImageSource to deduplicate service builders

### DIFF
--- a/src/image-tag.test.ts
+++ b/src/image-tag.test.ts
@@ -1,4 +1,5 @@
-import { parseImageTag, buildRuntimeImageRef } from './image-tag';
+import path from 'path';
+import { parseImageTag, buildRuntimeImageRef, assignImageSource } from './image-tag';
 
 const IMAGE_DIGEST_KEYS = ['squid', 'agent', 'agent-act', 'api-proxy', 'cli-proxy'] as const;
 
@@ -133,6 +134,45 @@ describe('buildRuntimeImageRef', () => {
       const parsed = parseImageTag(`0.25.18,squid=${VALID_DIGEST}`);
       const ref = buildRuntimeImageRef('ghcr.io/github/gh-aw-firewall', 'agent', parsed);
       expect(ref).toBe('ghcr.io/github/gh-aw-firewall/agent:0.25.18');
+    });
+  });
+
+  describe('assignImageSource', () => {
+    it('should assign image when useGHCR is true', () => {
+      const service: Record<string, unknown> = {};
+      const parsedTag = parseImageTag(`0.25.18,squid=${VALID_DIGEST}`);
+
+      assignImageSource(service, {
+        useGHCR: true,
+        registry: 'ghcr.io/github/gh-aw-firewall',
+        imageName: 'squid',
+        parsedTag,
+        projectRoot: '/repo',
+        containerDir: 'squid',
+      });
+
+      expect(service.image).toBe(`ghcr.io/github/gh-aw-firewall/squid:0.25.18@${VALID_DIGEST}`);
+      expect(service.build).toBeUndefined();
+    });
+
+    it('should assign build config when useGHCR is false', () => {
+      const service: Record<string, unknown> = {};
+      const parsedTag = parseImageTag('0.25.18');
+
+      assignImageSource(service, {
+        useGHCR: false,
+        registry: 'ghcr.io/github/gh-aw-firewall',
+        imageName: 'squid',
+        parsedTag,
+        projectRoot: '/repo',
+        containerDir: 'squid',
+      });
+
+      expect(service.image).toBeUndefined();
+      expect(service.build).toEqual({
+        context: path.join('/repo', 'containers', 'squid'),
+        dockerfile: 'Dockerfile',
+      });
     });
   });
 

--- a/src/image-tag.ts
+++ b/src/image-tag.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 const IMAGE_DIGEST_KEYS = ['squid', 'agent', 'agent-act', 'api-proxy', 'cli-proxy'] as const;
 
 type ImageDigestKey = typeof IMAGE_DIGEST_KEYS[number];
@@ -97,7 +99,7 @@ export function assignImageSource(
     service.image = buildRuntimeImageRef(opts.registry, opts.imageName, opts.parsedTag);
   } else {
     service.build = {
-      context: `${opts.projectRoot}/containers/${opts.containerDir}`,
+      context: path.join(opts.projectRoot, 'containers', opts.containerDir),
       dockerfile: 'Dockerfile',
     };
   }

--- a/src/image-tag.ts
+++ b/src/image-tag.ts
@@ -75,3 +75,30 @@ export function buildRuntimeImageRef(
   const digest = parsedTag.digests[imageName as ImageDigestKey];
   return `${imageRegistry}/${imageName}:${parsedTag.tag}${digest ? `@${digest}` : ''}`;
 }
+
+/**
+ * Assigns either an `image` reference (GHCR pull) or a `build` config (local build)
+ * to a Docker Compose service object based on the `useGHCR` flag.
+ *
+ * Consolidates the repeated image/build assignment pattern used across service builders.
+ */
+export function assignImageSource(
+  service: Record<string, unknown>,
+  opts: {
+    useGHCR: boolean;
+    registry: string;
+    imageName: string;
+    parsedTag: ParsedImageTag;
+    projectRoot: string;
+    containerDir: string;
+  }
+): void {
+  if (opts.useGHCR) {
+    service.image = buildRuntimeImageRef(opts.registry, opts.imageName, opts.parsedTag);
+  } else {
+    service.build = {
+      context: `${opts.projectRoot}/containers/${opts.containerDir}`,
+      dockerfile: 'Dockerfile',
+    };
+  }
+}

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -1,10 +1,9 @@
-import * as path from 'path';
 import {
   API_PROXY_CONTAINER_NAME,
   SQUID_PORT,
 } from '../constants';
 import { stripScheme } from '../host-env';
-import { buildRuntimeImageRef } from '../image-tag';
+import { assignImageSource } from '../image-tag';
 import { WrapperConfig, API_PROXY_HEALTH_PORT } from '../types';
 import { getConfigEnvValue, getLowerCaseProcessEnvValue, pickEnvVars } from '../env-utils';
 import { NetworkConfig, ImageBuildConfig } from './squid-service';
@@ -252,14 +251,9 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
   };
 
   // Use GHCR image or build locally
-  if (useGHCR) {
-    proxyService.image = buildRuntimeImageRef(registry, 'api-proxy', parsedTag);
-  } else {
-    proxyService.build = {
-      context: path.join(projectRoot, 'containers/api-proxy'),
-      dockerfile: 'Dockerfile',
-    };
-  }
+  assignImageSource(proxyService, {
+    useGHCR, registry, imageName: 'api-proxy', parsedTag, projectRoot, containerDir: 'api-proxy',
+  });
 
   return proxyService;
 }

--- a/src/services/cli-proxy-service.ts
+++ b/src/services/cli-proxy-service.ts
@@ -1,7 +1,6 @@
-import * as path from 'path';
 import { CLI_PROXY_CONTAINER_NAME } from '../constants';
 import { parseDifcProxyHost } from '../host-env';
-import { buildRuntimeImageRef } from '../image-tag';
+import { assignImageSource } from '../image-tag';
 import { logger } from '../logger';
 import { WrapperConfig, CLI_PROXY_PORT } from '../types';
 import { NetworkConfig, ImageBuildConfig } from './squid-service';
@@ -98,14 +97,9 @@ export function buildCliProxyService(params: CliProxyServiceParams): CliProxyBui
   };
 
   // Use GHCR image or build locally for the Node.js HTTP server container
-  if (useGHCR) {
-    cliProxyService.image = buildRuntimeImageRef(registry, 'cli-proxy', parsedTag);
-  } else {
-    cliProxyService.build = {
-      context: path.join(projectRoot, 'containers/cli-proxy'),
-      dockerfile: 'Dockerfile',
-    };
-  }
+  assignImageSource(cliProxyService, {
+    useGHCR, registry, imageName: 'cli-proxy', parsedTag, projectRoot, containerDir: 'cli-proxy',
+  });
 
   // Tell the agent how to reach the CLI proxy (use cli-proxy's own IP)
   const agentEnvAdditions: Record<string, string> = {

--- a/src/services/squid-service.ts
+++ b/src/services/squid-service.ts
@@ -1,7 +1,6 @@
-import * as path from 'path';
 import { SQUID_PORT, SQUID_CONTAINER_NAME } from '../constants';
 import { SslConfig } from '../host-env';
-import { parseImageTag, buildRuntimeImageRef } from '../image-tag';
+import { parseImageTag, assignImageSource } from '../image-tag';
 import { logger } from '../logger';
 import { WrapperConfig } from '../types';
 import { applyHostPathPrefixToVolumes } from './host-path-prefix';
@@ -167,14 +166,10 @@ export function buildSquidService(params: SquidServiceParams): any {
 
   // Use GHCR image or build locally
   // For SSL Bump, we always build locally to include OpenSSL tools
-  if (useGHCR && !config.sslBump) {
-    squidService.image = buildRuntimeImageRef(registry, 'squid', parsedTag);
-  } else {
-    squidService.build = {
-      context: path.join(projectRoot, 'containers/squid'),
-      dockerfile: 'Dockerfile',
-    };
-  }
+  assignImageSource(squidService, {
+    useGHCR: useGHCR && !config.sslBump,
+    registry, imageName: 'squid', parsedTag, projectRoot, containerDir: 'squid',
+  });
 
   return squidService;
 }


### PR DESCRIPTION
Extracts the repeated `if (useGHCR) { service.image = ... } else { service.build = ... }` pattern into a shared `assignImageSource()` helper in `src/image-tag.ts`.

**Before:** 3 copies of the same 5-line block in squid-service, api-proxy-service-config, and cli-proxy-service.

**After:** Single helper call in each service builder.

Fixes #4634