### PR TITLE
refactor: extract shared token-tracker budget helpers

### DIFF
--- a/containers/api-proxy/token-tracker-http.js
+++ b/containers/api-proxy/token-tracker-http.js
@@ -34,6 +34,7 @@ const {
   incrementTokenMetrics,
   diag,
 } = require('./token-persistence');
+const { warnCacheReadRollupMismatch, mergeBudgetFields } = require('./token-tracker-shared');
 
 // Max response body to buffer for non-streaming usage extraction (5 MB).
 // Responses larger than this are still forwarded but usage is not extracted.
@@ -249,22 +250,7 @@ function trackTokenUsage(proxyRes, opts) {
       return;
     }
     if (observedCacheReadTokens > 0 && normalized.cache_read_tokens === 0) {
-      logRequest('warn', 'token_cache_read_rollup_mismatch', {
-        request_id: requestId,
-        provider,
-        model: model || 'unknown',
-        observed_cache_read_tokens: observedCacheReadTokens,
-        rolled_up_cache_read_tokens: normalized.cache_read_tokens,
-        streaming,
-      });
-      diag('CACHE_READ_ROLLUP_MISMATCH', {
-        request_id: requestId,
-        provider,
-        model: model || 'unknown',
-        observed_cache_read_tokens: observedCacheReadTokens,
-        rolled_up_cache_read_tokens: normalized.cache_read_tokens,
-        streaming,
-      });
+      warnCacheReadRollupMismatch({ logRequest, diag, requestId, provider, model, observedCacheReadTokens, normalizedCacheReadTokens: normalized.cache_read_tokens, streaming });
     }
     if (typeof onUsage === 'function') {
       try {
@@ -294,23 +280,7 @@ function trackTokenUsage(proxyRes, opts) {
     if (billingInfo) record.billing = billingInfo;
 
     // Include effective token and AI credit budget fields when computed
-    if (budgetResult) {
-      if (budgetResult.effective_tokens_this_response != null) {
-        record.effective_tokens_this_response = budgetResult.effective_tokens_this_response;
-      }
-      if (budgetResult.effective_tokens_total != null) {
-        record.effective_tokens_total = budgetResult.effective_tokens_total;
-      }
-      if (budgetResult.model_multiplier != null) {
-        record.model_multiplier = budgetResult.model_multiplier;
-      }
-      if (budgetResult.ai_credits_this_response != null) {
-        record.ai_credits_this_response = budgetResult.ai_credits_this_response;
-      }
-      if (budgetResult.ai_credits_total != null) {
-        record.ai_credits_total = budgetResult.ai_credits_total;
-      }
-    }
+    mergeBudgetFields(record, budgetResult);
 
     // Write to JSONL log file
     writeTokenUsage(record);

--- a/containers/api-proxy/token-tracker-shared.js
+++ b/containers/api-proxy/token-tracker-shared.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Warn when observed streaming cache-read tokens don't match the final rollup.
+ * This indicates the provider's final usage object dropped cache_read_tokens
+ * that were present in incremental streaming deltas.
+ */
+function warnCacheReadRollupMismatch({ logRequest, diag, requestId, provider, model, observedCacheReadTokens, normalizedCacheReadTokens, streaming, transport }) {
+  if (observedCacheReadTokens > 0 && normalizedCacheReadTokens === 0) {
+    const context = {
+      request_id: requestId,
+      provider,
+      model: model || 'unknown',
+      observed_cache_read_tokens: observedCacheReadTokens,
+      rolled_up_cache_read_tokens: normalizedCacheReadTokens,
+      streaming,
+      ...(transport ? { transport } : {}),
+    };
+    logRequest('warn', 'token_cache_read_rollup_mismatch', context);
+    diag('CACHE_READ_ROLLUP_MISMATCH', context);
+  }
+}
+
+/**
+ * Merge budget result fields (effective tokens, AI credits, model multiplier)
+ * onto a token usage log record.
+ */
+function mergeBudgetFields(record, budgetResult) {
+  if (!budgetResult) return;
+  if (budgetResult.effective_tokens_this_response != null) {
+    record.effective_tokens_this_response = budgetResult.effective_tokens_this_response;
+  }
+  if (budgetResult.effective_tokens_total != null) {
+    record.effective_tokens_total = budgetResult.effective_tokens_total;
+  }
+  if (budgetResult.model_multiplier != null) {
+    record.model_multiplier = budgetResult.model_multiplier;
+  }
+  if (budgetResult.ai_credits_this_response != null) {
+    record.ai_credits_this_response = budgetResult.ai_credits_this_response;
+  }
+  if (budgetResult.ai_credits_total != null) {
+    record.ai_credits_total = budgetResult.ai_credits_total;
+  }
+}
+
+module.exports = {
+  warnCacheReadRollupMismatch,
+  mergeBudgetFields,
+};

--- a/containers/api-proxy/token-tracker-ws.js
+++ b/containers/api-proxy/token-tracker-ws.js
@@ -17,6 +17,7 @@ const {
   incrementTokenMetrics,
   diag,
 } = require('./token-persistence');
+const { warnCacheReadRollupMismatch, mergeBudgetFields } = require('./token-tracker-shared');
 
 /**
  * Parse WebSocket frames from a buffer (server→client direction, unmasked).
@@ -201,24 +202,7 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
     const normalized = normalizeUsage(streamingUsage);
     if (!normalized) return;
     if (observedCacheReadTokens > 0 && normalized.cache_read_tokens === 0) {
-      logRequest('warn', 'token_cache_read_rollup_mismatch', {
-        request_id: requestId,
-        provider,
-        model: streamingModel || 'unknown',
-        observed_cache_read_tokens: observedCacheReadTokens,
-        rolled_up_cache_read_tokens: normalized.cache_read_tokens,
-        streaming: true,
-        transport: 'websocket',
-      });
-      diag('CACHE_READ_ROLLUP_MISMATCH', {
-        request_id: requestId,
-        provider,
-        model: streamingModel || 'unknown',
-        observed_cache_read_tokens: observedCacheReadTokens,
-        rolled_up_cache_read_tokens: normalized.cache_read_tokens,
-        streaming: true,
-        transport: 'websocket',
-      });
+      warnCacheReadRollupMismatch({ logRequest, diag, requestId, provider, model: streamingModel, observedCacheReadTokens, normalizedCacheReadTokens: normalized.cache_read_tokens, streaming: true, transport: 'websocket' });
     }
     let budgetResult;
     if (typeof onUsage === 'function') {
@@ -243,23 +227,7 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
     });
 
     // Include effective token and AI credit budget fields when computed
-    if (budgetResult) {
-      if (budgetResult.effective_tokens_this_response != null) {
-        record.effective_tokens_this_response = budgetResult.effective_tokens_this_response;
-      }
-      if (budgetResult.effective_tokens_total != null) {
-        record.effective_tokens_total = budgetResult.effective_tokens_total;
-      }
-      if (budgetResult.model_multiplier != null) {
-        record.model_multiplier = budgetResult.model_multiplier;
-      }
-      if (budgetResult.ai_credits_this_response != null) {
-        record.ai_credits_this_response = budgetResult.ai_credits_this_response;
-      }
-      if (budgetResult.ai_credits_total != null) {
-        record.ai_credits_total = budgetResult.ai_credits_total;
-      }
-    }
+    mergeBudgetFields(record, budgetResult);
 
     writeTokenUsage(record);
 


### PR DESCRIPTION
## Summary

Extracts two duplicated code blocks from `token-tracker-http.js` and `token-tracker-ws.js` into a shared `token-tracker-shared.js` module:

1. **`warnCacheReadRollupMismatch()`** — logs warning + diag when observed cache-read tokens don't match normalized rollup
2. **`mergeBudgetFields()`** — copies effective token/AI credit budget fields from budgetResult onto the usage record

This eliminates ~30 lines of duplicated logic while preserving identical behavior (including the WS-specific `transport: 'websocket'` field passed via the extra fields parameter).

Fixes #4711