### PR TITLE
refactor: extract validateAuthHeaderEnv and isValidHeaderName helpers

### DIFF
--- a/containers/api-proxy/providers/anthropic.js
+++ b/containers/api-proxy/providers/anthropic.js
@@ -15,6 +15,7 @@
 const {
   composeBodyTransforms,
   makeProviderNotConfiguredResponse,
+  validateAuthHeaderEnv,
   createBaseAdapterConfig,
   createAdapterMethods,
 } = require('../proxy-utils');
@@ -47,15 +48,7 @@ function createAnthropicAdapter(env, deps = {}) {
     basePathEnvVar: 'ANTHROPIC_API_BASE_PATH',
     defaultTarget: 'api.anthropic.com',
   });
-  const authHeaderName = (() => {
-    const header = (env.AWF_ANTHROPIC_AUTH_HEADER || '').trim() || 'x-api-key';
-    try {
-      require('http').validateHeaderName(header);
-    } catch {
-      throw new Error('Invalid AWF_ANTHROPIC_AUTH_HEADER value: expected a valid HTTP header name');
-    }
-    return header;
-  })();
+  const authHeaderName = validateAuthHeaderEnv('AWF_ANTHROPIC_AUTH_HEADER', env.AWF_ANTHROPIC_AUTH_HEADER, 'x-api-key');
   const authType = (env.AWF_AUTH_TYPE || '').trim().toLowerCase();
   const authProvider = (env.AWF_AUTH_PROVIDER || '').trim().toLowerCase();
   const oidcRequested = authType === 'github-oidc' && authProvider === 'anthropic';

--- a/containers/api-proxy/providers/copilot-byok.js
+++ b/containers/api-proxy/providers/copilot-byok.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { parseBodyAsObject } = require('../body-utils');
+const { isValidHeaderName } = require('../proxy-utils');
 
 /**
  * Header names that must never be overridden by caller-supplied extra headers.
@@ -43,7 +44,6 @@ function parseByokExtraHeaders(raw) {
   }
 
   const result = {};
-  const http = require('http');
   for (const [name, value] of Object.entries(parsed)) {
     const lowerName = name.toLowerCase();
 
@@ -57,9 +57,7 @@ function parseByokExtraHeaders(raw) {
       console.warn(`AWF_BYOK_EXTRA_HEADERS: "${name}" is an auth-critical header and cannot be overridden; skipping`);
       continue;
     }
-    try {
-      http.validateHeaderName(name);
-    } catch {
+    if (!isValidHeaderName(name)) {
       console.warn(`AWF_BYOK_EXTRA_HEADERS: "${name}" is not a valid HTTP header name; skipping`);
       continue;
     }

--- a/containers/api-proxy/providers/openai.js
+++ b/containers/api-proxy/providers/openai.js
@@ -14,6 +14,7 @@ const {
   createBaseAdapterConfig,
   createAdapterMethods,
   normalizeBasePath,
+  validateAuthHeaderEnv,
 } = require('../proxy-utils');
 const { resolveCloudOidcProviders } = require('./cloud-oidc-init');
 
@@ -53,15 +54,8 @@ function createOpenAIAdapter(env, deps = {}) {
   const providerType = (env.COPILOT_PROVIDER_TYPE || '').trim().toLowerCase();
   const copilotAzureByokEnabled = providerType === 'azure';
   const customAuthHeader = (() => {
-    const header = (env.AWF_OPENAI_AUTH_HEADER || '').trim();
-    if (header) {
-      try {
-        require('http').validateHeaderName(header);
-      } catch {
-        throw new Error('Invalid AWF_OPENAI_AUTH_HEADER value: expected a valid HTTP header name');
-      }
-      return header;
-    }
+    const header = validateAuthHeaderEnv('AWF_OPENAI_AUTH_HEADER', env.AWF_OPENAI_AUTH_HEADER);
+    if (header) return header;
     // Azure OpenAI BYOK uses `api-key` header instead of `Authorization: Bearer`
     // (but OIDC auth still requires `Authorization: Bearer` unless explicitly overridden)
     if (copilotAzureByokEnabled && (env.AWF_AUTH_TYPE || '').trim().toLowerCase() !== 'github-oidc') return 'api-key';

--- a/containers/api-proxy/proxy-utils.js
+++ b/containers/api-proxy/proxy-utils.js
@@ -217,7 +217,37 @@ function makeProviderNotConfiguredResponse(provider, port, message) {
 }
 
 /**
- * Extract common adapter configuration from environment variables.
+ * Validate that a string is a legal HTTP header name.
+ * @param {string} name - The header name to validate
+ * @returns {boolean} true if valid
+ */
+function isValidHeaderName(name) {
+  try {
+    require('http').validateHeaderName(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read and validate a custom auth header from an env var.
+ * @param {string} envVarName - The environment variable name (for error messages)
+ * @param {string|undefined} rawValue - The raw env var value
+ * @param {string} [defaultHeader] - Fallback if value is empty
+ * @returns {string} The validated header name (or empty string if no value and no default)
+ * @throws {Error} If the value is not a valid HTTP header name
+ */
+function validateAuthHeaderEnv(envVarName, rawValue, defaultHeader) {
+  const header = (rawValue || '').trim() || defaultHeader || '';
+  if (!header) return '';
+  if (!isValidHeaderName(header)) {
+    throw new Error(`Invalid ${envVarName} value: expected a valid HTTP header name`);
+  }
+  return header;
+}
+
+/**
  *
  * Every non-Copilot adapter repeats the same three-line pattern to read
  * an API key, normalize a target hostname, and normalize a base path.
@@ -362,6 +392,8 @@ module.exports = {
   shouldStripHeader,
   composeBodyTransforms,
   makeProviderNotConfiguredResponse,
+  isValidHeaderName,
+  validateAuthHeaderEnv,
   createBaseAdapterConfig,
   createAdapterMethods,
 };


### PR DESCRIPTION
## Summary

Centralizes the repeated HTTP header name validation pattern into two helpers in `proxy-utils.js`:

1. **`validateAuthHeaderEnv(envVarName, rawValue, defaultHeader)`** — reads/trims/validates an env var as an HTTP header name, throwing with a descriptive error on failure. Replaces the throw-on-invalid IIFEs in anthropic.js and openai.js.

2. **`isValidHeaderName(name)`** — boolean predicate wrapping `http.validateHeaderName()`. Replaces the try/catch in copilot-byok.js's header loop.

Fixes #4709