### PR TITLE
refactor: extract createCounterGuard factory for guard modules

### DIFF
--- a/containers/api-proxy/guards/counter-guard.js
+++ b/containers/api-proxy/guards/counter-guard.js
@@ -12,7 +12,7 @@ const { parsePositiveInteger } = require('./guard-utils');
  * @param {object} opts
  * @param {string} opts.envVar - Environment variable name (e.g. 'AWF_MAX_RUNS')
  * @param {string} opts.countField - Name of the counter field in state (e.g. 'invocationCount')
- * @returns {{ getConfig, getState, applyIncrement, getBlockState, getReflectState, resetForTests }}
+ * @returns {{ getConfig, getState, applyIncrement, getBlockState, resetForTests }}
  */
 function createCounterGuard({ envVar, countField }) {
   let guardState = { configKey: null, [countField]: 0 };

--- a/containers/api-proxy/guards/counter-guard.js
+++ b/containers/api-proxy/guards/counter-guard.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { parsePositiveInteger } = require('./guard-utils');
+
+/**
+ * Factory for creating counter-based guard modules.
+ *
+ * Both max-runs-guard and max-permission-denied-guard follow identical patterns:
+ * config cache → state tracking → increment → block check → reflect → reset.
+ * This factory eliminates that duplication.
+ *
+ * @param {object} opts
+ * @param {string} opts.envVar - Environment variable name (e.g. 'AWF_MAX_RUNS')
+ * @param {string} opts.countField - Name of the counter field in state (e.g. 'invocationCount')
+ * @returns {{ getConfig, getState, applyIncrement, getBlockState, getReflectState, resetForTests }}
+ */
+function createCounterGuard({ envVar, countField }) {
+  let guardState = { configKey: null, [countField]: 0 };
+  const configCache = { rawMax: undefined, parsed: null };
+
+  function getConfig() {
+    const rawMax = process.env[envVar];
+    if (configCache.rawMax === rawMax) return configCache.parsed;
+    configCache.rawMax = rawMax;
+    configCache.parsed = parsePositiveInteger(rawMax);
+    return configCache.parsed;
+  }
+
+  function getState(max) {
+    if (!max) return null;
+    const configKey = String(max);
+    if (guardState.configKey !== configKey) {
+      guardState = { configKey, [countField]: 0 };
+    }
+    return guardState;
+  }
+
+  function applyIncrement() {
+    const max = getConfig();
+    const state = getState(max);
+    if (!state) return;
+    state[countField] += 1;
+  }
+
+  function getBlockState(maxField) {
+    const max = getConfig();
+    const state = getState(max);
+    if (!state) return null;
+    return {
+      [maxField]: max,
+      [countField]: state[countField],
+      maxExceeded: state[countField] >= max,
+    };
+  }
+
+  function resetForTests() {
+    guardState = { configKey: null, [countField]: 0 };
+    configCache.rawMax = undefined;
+    configCache.parsed = null;
+  }
+
+  return { getConfig, getState, applyIncrement, getBlockState, resetForTests };
+}
+
+module.exports = { createCounterGuard };

--- a/containers/api-proxy/guards/counter-guard.test.js
+++ b/containers/api-proxy/guards/counter-guard.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const { createCounterGuard } = require('./counter-guard');
+
+describe('createCounterGuard', () => {
+  const ENV_VAR = 'AWF_TEST_COUNTER_GUARD';
+  const COUNT_FIELD = 'testCount';
+  const MAX_FIELD = 'maxTest';
+
+  let guard;
+
+  beforeEach(() => {
+    delete process.env[ENV_VAR];
+    guard = createCounterGuard({ envVar: ENV_VAR, countField: COUNT_FIELD });
+  });
+
+  afterEach(() => {
+    delete process.env[ENV_VAR];
+  });
+
+  describe('getConfig', () => {
+    it('returns null when env var is not set', () => {
+      expect(guard.getConfig()).toBeNull();
+    });
+
+    it('returns null for zero', () => {
+      process.env[ENV_VAR] = '0';
+      expect(guard.getConfig()).toBeNull();
+    });
+
+    it('returns null for negative values', () => {
+      process.env[ENV_VAR] = '-1';
+      expect(guard.getConfig()).toBeNull();
+    });
+
+    it('returns null for non-numeric values', () => {
+      process.env[ENV_VAR] = 'abc';
+      expect(guard.getConfig()).toBeNull();
+    });
+
+    it('returns parsed integer for a valid positive value', () => {
+      process.env[ENV_VAR] = '5';
+      expect(guard.getConfig()).toBe(5);
+    });
+
+    it('memoizes the parsed config when the env var does not change', () => {
+      process.env[ENV_VAR] = '3';
+      const first = guard.getConfig();
+      const second = guard.getConfig();
+      expect(first).toBe(second);
+    });
+
+    it('re-parses when the env var changes at runtime', () => {
+      process.env[ENV_VAR] = '3';
+      expect(guard.getConfig()).toBe(3);
+      process.env[ENV_VAR] = '7';
+      expect(guard.getConfig()).toBe(7);
+    });
+  });
+
+  describe('getState', () => {
+    it('returns null when max is falsy', () => {
+      expect(guard.getState(null)).toBeNull();
+      expect(guard.getState(0)).toBeNull();
+    });
+
+    it('returns state with zero count for a new max', () => {
+      const state = guard.getState(5);
+      expect(state).toEqual({ configKey: '5', [COUNT_FIELD]: 0 });
+    });
+
+    it('resets state when the max (configKey) changes', () => {
+      const state1 = guard.getState(3);
+      state1[COUNT_FIELD] = 2;
+
+      const state2 = guard.getState(5);
+      expect(state2[COUNT_FIELD]).toBe(0);
+    });
+
+    it('returns the same state object when the max is unchanged', () => {
+      const state1 = guard.getState(5);
+      state1[COUNT_FIELD] = 2;
+      const state2 = guard.getState(5);
+      expect(state2[COUNT_FIELD]).toBe(2);
+    });
+  });
+
+  describe('applyIncrement', () => {
+    it('does nothing when env var is not configured', () => {
+      guard.applyIncrement();
+      expect(guard.getBlockState(MAX_FIELD)).toBeNull();
+    });
+
+    it('increments the counter on each call', () => {
+      process.env[ENV_VAR] = '5';
+      guard.applyIncrement();
+      guard.applyIncrement();
+      const state = guard.getBlockState(MAX_FIELD);
+      expect(state[COUNT_FIELD]).toBe(2);
+    });
+  });
+
+  describe('getBlockState', () => {
+    it('returns null when env var is not configured', () => {
+      expect(guard.getBlockState(MAX_FIELD)).toBeNull();
+    });
+
+    it('returns initial state with maxExceeded false', () => {
+      process.env[ENV_VAR] = '3';
+      expect(guard.getBlockState(MAX_FIELD)).toEqual({
+        [MAX_FIELD]: 3,
+        [COUNT_FIELD]: 0,
+        maxExceeded: false,
+      });
+    });
+
+    it('sets maxExceeded true when count reaches the max', () => {
+      process.env[ENV_VAR] = '2';
+      guard.applyIncrement();
+      guard.applyIncrement();
+      const state = guard.getBlockState(MAX_FIELD);
+      expect(state[COUNT_FIELD]).toBe(2);
+      expect(state.maxExceeded).toBe(true);
+    });
+
+    it('remains exceeded after count exceeds the max', () => {
+      process.env[ENV_VAR] = '2';
+      for (let i = 0; i < 4; i++) guard.applyIncrement();
+      const state = guard.getBlockState(MAX_FIELD);
+      expect(state[COUNT_FIELD]).toBe(4);
+      expect(state.maxExceeded).toBe(true);
+    });
+  });
+
+  describe('resetForTests', () => {
+    it('resets counter and config cache', () => {
+      process.env[ENV_VAR] = '3';
+      guard.applyIncrement();
+      guard.applyIncrement();
+
+      guard.resetForTests();
+
+      const state = guard.getBlockState(MAX_FIELD);
+      expect(state[COUNT_FIELD]).toBe(0);
+      expect(state.maxExceeded).toBe(false);
+    });
+
+    it('allows picking up a changed env var after reset', () => {
+      process.env[ENV_VAR] = '3';
+      guard.applyIncrement();
+
+      process.env[ENV_VAR] = '10';
+      guard.resetForTests();
+
+      const state = guard.getBlockState(MAX_FIELD);
+      expect(state[MAX_FIELD]).toBe(10);
+      expect(state[COUNT_FIELD]).toBe(0);
+    });
+  });
+
+  describe('config cache invalidation', () => {
+    it('resets state when max changes due to env var update', () => {
+      process.env[ENV_VAR] = '2';
+      guard.applyIncrement();
+      guard.applyIncrement();
+      expect(guard.getBlockState(MAX_FIELD).maxExceeded).toBe(true);
+
+      process.env[ENV_VAR] = '5';
+      const state = guard.getBlockState(MAX_FIELD);
+      expect(state[COUNT_FIELD]).toBe(0);
+      expect(state[MAX_FIELD]).toBe(5);
+      expect(state.maxExceeded).toBe(false);
+    });
+  });
+
+  describe('each factory call returns an independent instance', () => {
+    it('two guards with the same env var do not share state', () => {
+      process.env[ENV_VAR] = '5';
+      const guard2 = createCounterGuard({ envVar: ENV_VAR, countField: COUNT_FIELD });
+
+      guard.applyIncrement();
+      guard.applyIncrement();
+
+      expect(guard.getBlockState(MAX_FIELD)[COUNT_FIELD]).toBe(2);
+      expect(guard2.getBlockState(MAX_FIELD)[COUNT_FIELD]).toBe(0);
+    });
+  });
+});

--- a/containers/api-proxy/guards/max-permission-denied-guard.js
+++ b/containers/api-proxy/guards/max-permission-denied-guard.js
@@ -1,57 +1,23 @@
 'use strict';
 
-const { parsePositiveInteger } = require('./guard-utils');
+const { createCounterGuard } = require('./counter-guard');
 
-let permDeniedGuardState = {
-  configKey: null,
-  deniedCount: 0,
-};
-
-const permDeniedConfigCache = {
-  rawMax: undefined,
-  parsed: null,
-};
-
-function getPermDeniedConfig() {
-  const rawMax = process.env.AWF_MAX_PERMISSION_DENIED;
-  if (permDeniedConfigCache.rawMax === rawMax) {
-    return permDeniedConfigCache.parsed;
-  }
-  permDeniedConfigCache.rawMax = rawMax;
-  permDeniedConfigCache.parsed = parsePositiveInteger(rawMax);
-  return permDeniedConfigCache.parsed;
-}
-
-function getPermDeniedState(max) {
-  if (!max) return null;
-  const configKey = String(max);
-  if (permDeniedGuardState.configKey !== configKey) {
-    permDeniedGuardState = { configKey, deniedCount: 0 };
-  }
-  return permDeniedGuardState;
-}
+const guard = createCounterGuard({
+  envVar: 'AWF_MAX_PERMISSION_DENIED',
+  countField: 'deniedCount',
+});
 
 function applyPermissionDenied() {
-  const max = getPermDeniedConfig();
-  const state = getPermDeniedState(max);
-  if (!state) return;
-  state.deniedCount += 1;
+  guard.applyIncrement();
 }
 
 function getPermissionDeniedBlockState() {
-  const max = getPermDeniedConfig();
-  const state = getPermDeniedState(max);
-  if (!state) return null;
-  return {
-    maxPermissionDenied: max,
-    deniedCount: state.deniedCount,
-    maxExceeded: state.deniedCount >= max,
-  };
+  return guard.getBlockState('maxPermissionDenied');
 }
 
 function getPermissionDeniedReflectState() {
-  const max = getPermDeniedConfig();
-  const state = getPermDeniedState(max);
+  const max = guard.getConfig();
+  const state = guard.getState(max);
   if (!state) {
     return {
       enabled: false,
@@ -67,9 +33,7 @@ function getPermissionDeniedReflectState() {
 }
 
 function resetPermissionDeniedGuardForTests() {
-  permDeniedGuardState = { configKey: null, deniedCount: 0 };
-  permDeniedConfigCache.rawMax = undefined;
-  permDeniedConfigCache.parsed = null;
+  guard.resetForTests();
 }
 
 function buildPermissionDeniedLimitError(state) {

--- a/containers/api-proxy/guards/max-runs-guard.js
+++ b/containers/api-proxy/guards/max-runs-guard.js
@@ -1,57 +1,23 @@
 'use strict';
 
-const { parsePositiveInteger } = require('./guard-utils');
+const { createCounterGuard } = require('./counter-guard');
 
-let maxRunsGuardState = {
-  configKey: null,
-  invocationCount: 0,
-};
-
-const maxRunsConfigCache = {
-  rawMax: undefined,
-  parsed: null,
-};
-
-function getMaxRunsConfig() {
-  const rawMax = process.env.AWF_MAX_RUNS;
-  if (maxRunsConfigCache.rawMax === rawMax) {
-    return maxRunsConfigCache.parsed;
-  }
-  maxRunsConfigCache.rawMax = rawMax;
-  maxRunsConfigCache.parsed = parsePositiveInteger(rawMax);
-  return maxRunsConfigCache.parsed;
-}
-
-function getMaxRunsState(max) {
-  if (!max) return null;
-  const configKey = String(max);
-  if (maxRunsGuardState.configKey !== configKey) {
-    maxRunsGuardState = { configKey, invocationCount: 0 };
-  }
-  return maxRunsGuardState;
-}
+const guard = createCounterGuard({
+  envVar: 'AWF_MAX_RUNS',
+  countField: 'invocationCount',
+});
 
 function applyMaxRunsInvocation() {
-  const max = getMaxRunsConfig();
-  const state = getMaxRunsState(max);
-  if (!state) return;
-  state.invocationCount += 1;
+  guard.applyIncrement();
 }
 
 function getMaxRunsBlockState() {
-  const max = getMaxRunsConfig();
-  const state = getMaxRunsState(max);
-  if (!state) return null;
-  return {
-    maxRuns: max,
-    invocationCount: state.invocationCount,
-    maxExceeded: state.invocationCount >= max,
-  };
+  return guard.getBlockState('maxRuns');
 }
 
 function getMaxRunsReflectState() {
-  const max = getMaxRunsConfig();
-  const state = getMaxRunsState(max);
+  const max = guard.getConfig();
+  const state = guard.getState(max);
   if (!state) {
     return {
       enabled: false,
@@ -69,9 +35,7 @@ function getMaxRunsReflectState() {
 }
 
 function resetMaxRunsGuardForTests() {
-  maxRunsGuardState = { configKey: null, invocationCount: 0 };
-  maxRunsConfigCache.rawMax = undefined;
-  maxRunsConfigCache.parsed = null;
+  guard.resetForTests();
 }
 
 function buildMaxRunsExceededError(state) {


### PR DESCRIPTION
## Summary

Extracts a `createCounterGuard({ envVar, countField })` factory into `guards/counter-guard.js` that encapsulates the shared counter-guard pattern:
- Config cache with env var memoization
- State tracking with configKey-based reset
- Increment, block-state, and reset operations

Both `max-runs-guard.js` and `max-permission-denied-guard.js` now delegate their core mechanics to this factory, keeping only their unique API exports and error builders. This makes it trivial to add future counter guards (e.g., max-timeout-errors) without duplicating the boilerplate.

Fixes #4710