### PR TITLE
fix: skip symlink assertion for pre-existing path segments

### DIFF
--- a/src/config-writer.test.ts
+++ b/src/config-writer.test.ts
@@ -21,6 +21,9 @@ jest.mock('fs', () => {
     existsSync: jest.fn((...args: Parameters<typeof actual.existsSync>) =>
       actual.existsSync(...args)
     ),
+    lstatSync: jest.fn((...args: Parameters<typeof actual.lstatSync>) =>
+      actual.lstatSync(...args)
+    ) as typeof actual.lstatSync,
   };
 });
 
@@ -254,6 +257,48 @@ describe('writeConfigs', () => {
       expect(fs.chmodSync).toHaveBeenCalledWith(runnerToolCacheParent, 0o755);
       expect(fs.chownSync).toHaveBeenCalledWith(runnerToolCachePath, 1000, 1000);
       expect(fs.chmodSync).toHaveBeenCalledWith(runnerToolCachePath, 0o755);
+    });
+
+    it('throws when runnerToolCachePath contains a pre-existing non-root-owned intermediate symlink', async () => {
+      const realDir = path.join(tempDir, 'real-dir');
+      const symlinkDir = path.join(tempDir, 'link-to-real');
+      fs.mkdirSync(realDir, { recursive: true });
+      fs.symlinkSync(realDir, symlinkDir);
+      const runnerToolCachePath = path.join(symlinkDir, 'child');
+      (getRealUserHome as jest.Mock).mockReturnValue(tempDir);
+
+      await expect(
+        writeConfigs(buildWriteConfig({ runnerToolCachePath }))
+      ).rejects.toThrow(`Refusing to use symlink as directory: ${symlinkDir}`);
+    });
+
+    it('allows pre-existing root-owned intermediate symlinks in runnerToolCachePath', async () => {
+      const actualDir = path.join(tempDir, 'real-dir');
+      const symlinkDir = path.join(tempDir, 'root-symlink');
+      fs.mkdirSync(actualDir, { recursive: true });
+      fs.symlinkSync(actualDir, symlinkDir);
+
+      const lstatSyncMock = fs.lstatSync as jest.MockedFunction<typeof fs.lstatSync>;
+      const actualLstatSync = jest.requireActual<typeof import('fs')>('fs').lstatSync;
+      lstatSyncMock.mockImplementation((...args) => {
+        const p = typeof args[0] === 'string' ? args[0] : args[0].toString();
+        if (p === symlinkDir) {
+          // Simulate a root-owned symlink (e.g. /var → /private/var on macOS)
+          return { isSymbolicLink: () => true, uid: 0 } as unknown as fs.Stats;
+        }
+        return actualLstatSync(...args);
+      });
+
+      const runnerToolCachePath = path.join(symlinkDir, 'child');
+      (getRealUserHome as jest.Mock).mockReturnValue(tempDir);
+
+      try {
+        await expect(
+          writeConfigs(buildWriteConfig({ runnerToolCachePath }))
+        ).resolves.toBeUndefined();
+      } finally {
+        lstatSyncMock.mockImplementation(actualLstatSync);
+      }
     });
 
     it('prepares chroot mountpoint for fallback runner tool cache under home', async () => {

--- a/src/config-writer.ts
+++ b/src/config-writer.ts
@@ -74,10 +74,18 @@ function createMissingOwnedDirectorySegments(dirPath: string, uid: number, gid: 
       created = true;
     }
 
-    // Only validate directories we created — pre-existing system paths (e.g.
-    // /var on macOS which is a symlink to /private/var) are trusted.
+    // Validate the current segment is a directory. Allow root-owned system symlinks
+    // (e.g. /var on macOS) but refuse user-controlled symlinks.
+    const lstat = fs.lstatSync(currentPath);
+    if (lstat.isSymbolicLink() && (created || lstat.uid !== 0)) {
+      throw new Error(`Refusing to use symlink as directory: ${currentPath}`);
+    }
+    const stat = fs.statSync(currentPath);
+    if (!stat.isDirectory()) {
+      throw new Error(`Expected directory but found non-directory path: ${currentPath}`);
+    }
+
     if (created) {
-      assertRealDirectory(currentPath);
       fs.chownSync(currentPath, uid, gid);
       fs.chmodSync(currentPath, 0o755);
     }

--- a/src/config-writer.ts
+++ b/src/config-writer.ts
@@ -74,9 +74,10 @@ function createMissingOwnedDirectorySegments(dirPath: string, uid: number, gid: 
       created = true;
     }
 
-    assertRealDirectory(currentPath);
-
+    // Only validate directories we created — pre-existing system paths (e.g.
+    // /var on macOS which is a symlink to /private/var) are trusted.
     if (created) {
+      assertRealDirectory(currentPath);
       fs.chownSync(currentPath, uid, gid);
       fs.chmodSync(currentPath, 0o755);
     }


### PR DESCRIPTION
## Problem

`createMissingOwnedDirectorySegments` in `config-writer.ts` called `assertRealDirectory()` on **every** path segment, including pre-existing system directories. On macOS, `/var` is a symlink to `/private/var`, so any `runnerToolCachePath` under `/var/...` (including temp dirs from `os.tmpdir()`) would throw:

```
Refusing to use symlink as directory: /var
```

This caused the `npm test` suite to fail with 1 test failure.

## Fix

Only call `assertRealDirectory()` on segments we **created** — pre-existing system paths are trusted and don't need the symlink security check. The check still protects against symlink attacks on newly-created directories.