### PR TITLE
docs: comprehensive auth matrix documentation and tests

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -19,6 +19,7 @@ exclude = [
   "^https://docs\\.sigstore\\.dev/cosign/installation",
   "^https://docs\\.github\\.com/en/github/site-policy/github-bug-bounty",
   "^https://www\\.sei\\.cmu\\.edu/",
+  "^https://platform\\.openai\\.com/docs/api-reference/authentication$",
   # LOGGING.md is referenced but doesn't exist yet (planned doc)
   "LOGGING\\.md",
 ]

--- a/containers/api-proxy/server.auth-matrix.test.js
+++ b/containers/api-proxy/server.auth-matrix.test.js
@@ -1,0 +1,630 @@
+/**
+ * Comprehensive auth matrix tests.
+ *
+ * Tests every documented combination of (engine × auth-type × instance-type)
+ * to ensure the correct HTTP headers are sent upstream. See docs/auth-matrix.md
+ * for the full specification.
+ *
+ * Addresses coverage gaps identified in GitHub issue #4793.
+ */
+
+'use strict';
+
+const { createOpenAIAdapter } = require('./providers/openai');
+const { createAnthropicAdapter } = require('./providers/anthropic');
+const { createCopilotAdapter } = require('./providers/copilot');
+const { createGeminiAdapter } = require('./providers/gemini');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeReq = (url = '/v1/chat/completions', method = 'POST') => ({
+  url,
+  method,
+  headers: {},
+});
+
+const modelsReq = () => fakeReq('/models', 'GET');
+
+function injectOidcToken(adapter, token = 'oidc-access-token', ttl = 600) {
+  const provider = adapter.getOidcProvider();
+  if (!provider) return null;
+  provider._cachedToken = token;
+  provider._expiresAt = Math.floor(Date.now() / 1000) + ttl;
+  return provider;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI Auth Matrix
+// ---------------------------------------------------------------------------
+
+describe('Auth Matrix — OpenAI', () => {
+  describe('static API key', () => {
+    it('sends Authorization: Bearer with OpenAI key', () => {
+      const adapter = createOpenAIAdapter({ OPENAI_API_KEY: 'sk-test-key' });
+      expect(adapter.getAuthHeaders(fakeReq())).toEqual({
+        Authorization: 'Bearer sk-test-key',
+      });
+    });
+
+    it('targets api.openai.com by default', () => {
+      const adapter = createOpenAIAdapter({ OPENAI_API_KEY: 'sk-test' });
+      const probe = adapter.getValidationProbe();
+      expect(probe.url).toContain('api.openai.com');
+    });
+
+    it('respects OPENAI_API_TARGET override', () => {
+      const adapter = createOpenAIAdapter({
+        OPENAI_API_KEY: 'sk-test',
+        OPENAI_API_TARGET: 'https://my-gateway.example.com',
+      });
+      expect(adapter.getTargetHost()).toBe('my-gateway.example.com');
+    });
+  });
+
+  describe('Azure BYOK (COPILOT_PROVIDER_TYPE=azure)', () => {
+    it('uses api-key header (not Authorization) for Azure BYOK', () => {
+      const adapter = createOpenAIAdapter({
+        COPILOT_PROVIDER_TYPE: 'azure',
+        COPILOT_PROVIDER_API_KEY: 'azure-key-123',
+        COPILOT_PROVIDER_BASE_URL: 'https://my-resource.openai.azure.com/openai',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers['api-key']).toBe('azure-key-123');
+      expect(headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('Azure OIDC (Entra ID)', () => {
+    let adapter, provider;
+
+    beforeEach(() => {
+      adapter = createOpenAIAdapter({
+        OPENAI_API_KEY: 'sk-placeholder',
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'azure',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_AZURE_TENANT_ID: 'tenant-123',
+        AWF_AUTH_AZURE_CLIENT_ID: 'client-456',
+      });
+      provider = injectOidcToken(adapter, 'entra-access-token');
+    });
+
+    afterEach(() => { provider?.shutdown(); });
+
+    it('sends Authorization: Bearer with Entra token (not api-key)', () => {
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer entra-access-token');
+      expect(headers['api-key']).toBeUndefined();
+    });
+
+    it('returns empty headers when OIDC token not yet available', () => {
+      const fresh = createOpenAIAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'azure',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_AZURE_TENANT_ID: 'tenant-123',
+        AWF_AUTH_AZURE_CLIENT_ID: 'client-456',
+      });
+      expect(fresh.getAuthHeaders(fakeReq())).toEqual({});
+      fresh.getOidcProvider().shutdown();
+    });
+  });
+
+  describe('Azure BYOK + OIDC interaction', () => {
+    it('OIDC overrides api-key header with Bearer when token available', () => {
+      const adapter = createOpenAIAdapter({
+        COPILOT_PROVIDER_TYPE: 'azure',
+        COPILOT_PROVIDER_API_KEY: 'azure-key-static',
+        COPILOT_PROVIDER_BASE_URL: 'https://my-resource.openai.azure.com/openai',
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'azure',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_AZURE_TENANT_ID: 'tenant-123',
+        AWF_AUTH_AZURE_CLIENT_ID: 'client-456',
+      });
+      const provider = injectOidcToken(adapter, 'entra-oidc-token');
+      const headers = adapter.getAuthHeaders(fakeReq());
+      // When OIDC is active, Bearer replaces api-key
+      expect(headers.Authorization).toBe('Bearer entra-oidc-token');
+      expect(headers['api-key']).toBeUndefined();
+      provider.shutdown();
+    });
+  });
+
+  describe('custom auth header (AWF_OPENAI_AUTH_HEADER)', () => {
+    it('replaces Authorization with custom header name', () => {
+      const adapter = createOpenAIAdapter({
+        OPENAI_API_KEY: 'sk-test',
+        AWF_OPENAI_AUTH_HEADER: 'x-custom-auth',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers['x-custom-auth']).toBe('sk-test');
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    it('custom header is used with OIDC token too', () => {
+      const adapter = createOpenAIAdapter({
+        OPENAI_API_KEY: 'sk-test',
+        AWF_OPENAI_AUTH_HEADER: 'x-custom-auth',
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'azure',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test',
+        AWF_AUTH_AZURE_TENANT_ID: 'tenant',
+        AWF_AUTH_AZURE_CLIENT_ID: 'client',
+      });
+      const provider = injectOidcToken(adapter, 'oidc-tok');
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers['x-custom-auth']).toBe('oidc-tok');
+      expect(headers.Authorization).toBeUndefined();
+      provider.shutdown();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anthropic Auth Matrix
+// ---------------------------------------------------------------------------
+
+describe('Auth Matrix — Anthropic', () => {
+  describe('static API key', () => {
+    it('sends x-api-key header with API key', () => {
+      const adapter = createAnthropicAdapter({ ANTHROPIC_API_KEY: 'sk-ant-test' });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers['x-api-key']).toBe('sk-ant-test');
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    it('targets api.anthropic.com by default', () => {
+      const adapter = createAnthropicAdapter({ ANTHROPIC_API_KEY: 'sk-ant-test' });
+      const probe = adapter.getValidationProbe();
+      expect(probe.url).toContain('api.anthropic.com');
+    });
+  });
+
+  describe('Workload Identity Federation (WIF)', () => {
+    it('switches from x-api-key to Authorization: Bearer when OIDC token available', () => {
+      const adapter = createAnthropicAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'anthropic',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID: 'fdrl_test',
+        AWF_AUTH_ANTHROPIC_ORGANIZATION_ID: 'org-uuid',
+        AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID: 'svac_test',
+      });
+      const provider = adapter.getOidcProvider();
+      provider._cachedToken = 'sk-ant-oat01-wif-token';
+      provider._expiresAt = Math.floor(Date.now() / 1000) + 600;
+
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer sk-ant-oat01-wif-token');
+      expect(headers['x-api-key']).toBeUndefined();
+      provider.shutdown();
+    });
+
+    it('returns empty headers when WIF token not yet available', () => {
+      const adapter = createAnthropicAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'anthropic',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID: 'fdrl_test',
+        AWF_AUTH_ANTHROPIC_ORGANIZATION_ID: 'org-uuid',
+        AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID: 'svac_test',
+      });
+      expect(adapter.getAuthHeaders(fakeReq())).toEqual({});
+      adapter.getOidcProvider().shutdown();
+    });
+
+    it('reports unavailable status in health response before token ready', () => {
+      const adapter = createAnthropicAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'anthropic',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID: 'fdrl_test',
+        AWF_AUTH_ANTHROPIC_ORGANIZATION_ID: 'org-uuid',
+        AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID: 'svac_test',
+      });
+      const resp = adapter.getUnconfiguredHealthResponse();
+      expect(resp.statusCode).toBe(503);
+      expect(resp.body.status).toBe('unavailable');
+      adapter.getOidcProvider().shutdown();
+    });
+  });
+
+  describe('custom auth header (AWF_ANTHROPIC_AUTH_HEADER)', () => {
+    it('replaces x-api-key with custom header name', () => {
+      const adapter = createAnthropicAdapter({
+        ANTHROPIC_API_KEY: 'sk-ant-test',
+        AWF_ANTHROPIC_AUTH_HEADER: 'x-custom-key',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers['x-custom-key']).toBe('sk-ant-test');
+      expect(headers['x-api-key']).toBeUndefined();
+    });
+
+    it('throws on invalid header name', () => {
+      expect(() => createAnthropicAdapter({
+        ANTHROPIC_API_KEY: 'sk-ant-test',
+        AWF_ANTHROPIC_AUTH_HEADER: 'invalid header!',
+      })).toThrow(/Invalid AWF_ANTHROPIC_AUTH_HEADER/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Copilot Auth Matrix
+// ---------------------------------------------------------------------------
+
+describe('Auth Matrix — Copilot', () => {
+  describe('GitHub OAuth token — github.com', () => {
+    it('sends Authorization: Bearer with GitHub token', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_test123',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer ghu_test123');
+      expect(headers['Copilot-Integration-Id']).toBe('agentic-workflows');
+    });
+  });
+
+  describe('GitHub OAuth token — GHEC (*.ghe.com)', () => {
+    it('sends Authorization: Bearer (not token) for GHEC', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_ghec_token',
+        GITHUB_SERVER_URL: 'https://mycompany.ghe.com',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer ghu_ghec_token');
+    });
+
+    it('derives correct copilot-api target for GHEC', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_test',
+        GITHUB_SERVER_URL: 'https://mycompany.ghe.com',
+      });
+      expect(adapter.getTargetHost()).toBe('copilot-api.mycompany.ghe.com');
+    });
+  });
+
+  describe('GitHub OAuth token — GHES (on-prem)', () => {
+    it('sends Authorization: token (NOT Bearer) for GHES enterprise endpoint', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_ghes_token',
+        GITHUB_SERVER_URL: 'https://ghes.example.com',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('token ghu_ghes_token');
+    });
+
+    it('targets api.enterprise.githubcopilot.com for GHES', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_test',
+        GITHUB_SERVER_URL: 'https://ghes.example.com',
+      });
+      expect(adapter.getTargetHost()).toBe('api.enterprise.githubcopilot.com');
+    });
+
+    it('/models endpoint also uses token prefix on GHES', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_ghes_token',
+        GITHUB_SERVER_URL: 'https://ghes.example.com',
+      });
+      const headers = adapter.getAuthHeaders(modelsReq());
+      expect(headers.Authorization).toBe('token ghu_ghes_token');
+    });
+  });
+
+  describe('GHES + BYOK interaction', () => {
+    it('BYOK key uses Bearer even on GHES enterprise endpoint', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_PROVIDER_API_KEY: 'sk-byok-key',
+        GITHUB_SERVER_URL: 'https://ghes.example.com',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      // BYOK always uses Bearer, even when target is api.enterprise.githubcopilot.com
+      expect(headers.Authorization).toBe('Bearer sk-byok-key');
+    });
+
+    it('/models falls back to GitHub token with token prefix on GHES even in BYOK mode', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_PROVIDER_API_KEY: 'sk-byok-key',
+        COPILOT_GITHUB_TOKEN: 'ghu_ghes_token',
+        GITHUB_SERVER_URL: 'https://ghes.example.com',
+      });
+      const headers = adapter.getAuthHeaders(modelsReq());
+      // /models always uses GitHub OAuth token
+      expect(headers.Authorization).toBe('token ghu_ghes_token');
+    });
+  });
+
+  describe('BYOK mode (standard)', () => {
+    it('sends Authorization: Bearer with BYOK key', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_PROVIDER_API_KEY: 'sk-or-v1-abc',
+      });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer sk-or-v1-abc');
+    });
+
+    it('/models uses BYOK key when no GitHub token available', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_PROVIDER_API_KEY: 'sk-or-v1-abc',
+      });
+      const headers = adapter.getAuthHeaders(modelsReq());
+      expect(headers.Authorization).toBe('Bearer sk-or-v1-abc');
+    });
+
+    it('/models prefers GitHub token over BYOK key when both present', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_PROVIDER_API_KEY: 'sk-or-v1-abc',
+        COPILOT_GITHUB_TOKEN: 'ghu_oauth_token',
+      });
+      const headers = adapter.getAuthHeaders(modelsReq());
+      expect(headers.Authorization).toBe('Bearer ghu_oauth_token');
+    });
+  });
+
+  describe('Azure OIDC (Entra ID) via Copilot', () => {
+    let adapter, provider;
+
+    beforeEach(() => {
+      adapter = createCopilotAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'azure',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_AZURE_TENANT_ID: 'tenant-uuid',
+        AWF_AUTH_AZURE_CLIENT_ID: 'client-uuid',
+        COPILOT_PROVIDER_BASE_URL: 'https://aoai.example.com/openai',
+      });
+      provider = injectOidcToken(adapter, 'entra-copilot-token');
+    });
+
+    afterEach(() => { provider?.shutdown(); });
+
+    it('sends Authorization: Bearer with Entra token', () => {
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer entra-copilot-token');
+      expect(headers['Copilot-Integration-Id']).toBe('agentic-workflows');
+    });
+
+    it('always uses Bearer prefix (never token) for OIDC', () => {
+      // Even if target would normally use 'token' prefix, OIDC always uses Bearer
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toMatch(/^Bearer /);
+    });
+  });
+
+  describe('GCP OIDC via Copilot', () => {
+    it('creates GCP OIDC provider when AWF_AUTH_PROVIDER=gcp', () => {
+      const adapter = createCopilotAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'gcp',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER: 'projects/123/locations/global/workloadIdentityPools/pool/providers/gh',
+        COPILOT_PROVIDER_BASE_URL: 'https://us-central1-aiplatform.googleapis.com/v1',
+      });
+      const provider = adapter.getOidcProvider();
+      expect(provider).toBeTruthy();
+      provider.shutdown();
+    });
+
+    it('injects Bearer token from GCP OIDC provider', () => {
+      const adapter = createCopilotAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'gcp',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER: 'projects/123/locations/global/workloadIdentityPools/pool/providers/gh',
+        COPILOT_PROVIDER_BASE_URL: 'https://us-central1-aiplatform.googleapis.com/v1',
+      });
+      const provider = injectOidcToken(adapter, 'gcp-access-token');
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer gcp-access-token');
+      provider.shutdown();
+    });
+  });
+
+  describe('AWS OIDC via Copilot', () => {
+    it('creates AWS OIDC provider when AWF_AUTH_PROVIDER=aws', () => {
+      const adapter = createCopilotAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'aws',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_AWS_ROLE_ARN: 'arn:aws:iam::123456:role/test',
+        AWF_AUTH_AWS_REGION: 'us-east-1',
+        COPILOT_PROVIDER_BASE_URL: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      });
+      const awsProvider = adapter.getAwsOidcProvider();
+      expect(awsProvider).toBeTruthy();
+      // AWS uses SigV4 — no static auth header returned
+      expect(adapter.getAuthHeaders(fakeReq())).toEqual({});
+      awsProvider.shutdown();
+    });
+  });
+
+  describe('static BYOK key takes precedence over OIDC', () => {
+    it('ignores OIDC when COPILOT_PROVIDER_API_KEY is set', () => {
+      const adapter = createCopilotAdapter({
+        AWF_AUTH_TYPE: 'github-oidc',
+        AWF_AUTH_PROVIDER: 'azure',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'runtime-token',
+        AWF_AUTH_AZURE_TENANT_ID: 'tenant',
+        AWF_AUTH_AZURE_CLIENT_ID: 'client',
+        COPILOT_PROVIDER_API_KEY: 'sk-static-byok',
+      });
+      expect(adapter.getOidcProvider()).toBeNull();
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers.Authorization).toBe('Bearer sk-static-byok');
+    });
+  });
+
+  describe('COPILOT_API_TARGET override', () => {
+    it('explicit COPILOT_API_TARGET overrides GITHUB_SERVER_URL derivation', () => {
+      const adapter = createCopilotAdapter({
+        COPILOT_GITHUB_TOKEN: 'ghu_test',
+        COPILOT_API_TARGET: 'https://custom-copilot.internal.example.com',
+        GITHUB_SERVER_URL: 'https://ghes.example.com',
+      });
+      expect(adapter.getTargetHost()).toBe('custom-copilot.internal.example.com');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemini Auth Matrix
+// ---------------------------------------------------------------------------
+
+describe('Auth Matrix — Gemini', () => {
+  describe('static API key', () => {
+    it('sends x-goog-api-key header', () => {
+      const adapter = createGeminiAdapter({ GEMINI_API_KEY: 'AIza-test-key' });
+      const headers = adapter.getAuthHeaders(fakeReq());
+      expect(headers['x-goog-api-key']).toBe('AIza-test-key');
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    it('targets generativelanguage.googleapis.com by default', () => {
+      const adapter = createGeminiAdapter({ GEMINI_API_KEY: 'AIza-test' });
+      const probe = adapter.getValidationProbe();
+      expect(probe.url).toContain('generativelanguage.googleapis.com');
+    });
+
+    it('respects GEMINI_API_TARGET override', () => {
+      const adapter = createGeminiAdapter({
+        GEMINI_API_KEY: 'AIza-test',
+        GEMINI_API_TARGET: 'https://custom-gemini.example.com',
+      });
+      expect(adapter.getTargetHost()).toBe('custom-gemini.example.com');
+    });
+  });
+
+  describe('isEnabled gating', () => {
+    it('is disabled when no API key set', () => {
+      const adapter = createGeminiAdapter({});
+      expect(adapter.isEnabled()).toBe(false);
+    });
+
+    it('is enabled when API key is set', () => {
+      const adapter = createGeminiAdapter({ GEMINI_API_KEY: 'AIza-test' });
+      expect(adapter.isEnabled()).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: credential isolation
+// ---------------------------------------------------------------------------
+
+describe('Auth Matrix — Credential Isolation', () => {
+  it('Copilot placeholder token (ghu_aaa...) is recognized as BYOK mode', () => {
+    // The placeholder ensures Copilot CLI auth preflight passes without real creds
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      COPILOT_PROVIDER_API_KEY: 'sk-real-byok-key',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq());
+    // Inference uses BYOK key, not the placeholder
+    expect(headers.Authorization).toBe('Bearer sk-real-byok-key');
+  });
+
+  it('Copilot dummy BYOK key is used as-is at the adapter level', () => {
+    // The 'dummy-byok-key-for-offline-mode' placeholder is filtered at the
+    // credential-env layer (api-proxy-credential-env.ts), not in the adapter.
+    // At the adapter level it's treated as a real key.
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_real_token',
+      COPILOT_PROVIDER_API_KEY: 'dummy-byok-key-for-offline-mode',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq());
+    // BYOK key is present so it's used for inference
+    expect(headers.Authorization).toBe('Bearer dummy-byok-key-for-offline-mode');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: isEnabled behavior with OIDC
+// ---------------------------------------------------------------------------
+
+describe('Auth Matrix — isEnabled with OIDC', () => {
+  it('OpenAI isEnabled=false before OIDC token acquired', () => {
+    const adapter = createOpenAIAdapter({
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'azure',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test',
+      AWF_AUTH_AZURE_TENANT_ID: 'tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'client',
+    });
+    expect(adapter.isEnabled()).toBe(false);
+    adapter.getOidcProvider().shutdown();
+  });
+
+  it('OpenAI isEnabled=true after OIDC token acquired', () => {
+    const adapter = createOpenAIAdapter({
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'azure',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test',
+      AWF_AUTH_AZURE_TENANT_ID: 'tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'client',
+    });
+    const provider = injectOidcToken(adapter);
+    expect(adapter.isEnabled()).toBe(true);
+    provider.shutdown();
+  });
+
+  it('Anthropic isEnabled=false before WIF token acquired', () => {
+    const adapter = createAnthropicAdapter({
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'anthropic',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test',
+      AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID: 'fdrl_test',
+      AWF_AUTH_ANTHROPIC_ORGANIZATION_ID: 'org-uuid',
+      AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID: 'svac_test',
+    });
+    expect(adapter.isEnabled()).toBe(false);
+    adapter.getOidcProvider().shutdown();
+  });
+
+  it('Copilot isEnabled=false before Azure OIDC token acquired', () => {
+    const adapter = createCopilotAdapter({
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'azure',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test',
+      AWF_AUTH_AZURE_TENANT_ID: 'tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'client',
+      COPILOT_PROVIDER_BASE_URL: 'https://aoai.example.com/openai',
+    });
+    expect(adapter.isEnabled()).toBe(false);
+    adapter.getOidcProvider().shutdown();
+  });
+
+  it('Copilot isEnabled=true after Azure OIDC token acquired', () => {
+    const adapter = createCopilotAdapter({
+      AWF_AUTH_TYPE: 'github-oidc',
+      AWF_AUTH_PROVIDER: 'azure',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'http://localhost/token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'test',
+      AWF_AUTH_AZURE_TENANT_ID: 'tenant',
+      AWF_AUTH_AZURE_CLIENT_ID: 'client',
+      COPILOT_PROVIDER_BASE_URL: 'https://aoai.example.com/openai',
+    });
+    const provider = injectOidcToken(adapter, 'entra-token');
+    expect(adapter.isEnabled()).toBe(true);
+    provider.shutdown();
+  });
+});

--- a/containers/api-proxy/server.auth-matrix.test.js
+++ b/containers/api-proxy/server.auth-matrix.test.js
@@ -540,9 +540,9 @@ describe('Auth Matrix — Credential Isolation', () => {
   });
 
   it('Copilot dummy BYOK key is used as-is at the adapter level', () => {
-    // The 'dummy-byok-key-for-offline-mode' placeholder is filtered at the
-    // credential-env layer (api-proxy-credential-env.ts), not in the adapter.
-    // At the adapter level it's treated as a real key.
+    // The 'dummy-byok-key-for-offline-mode' string has no special handling
+    // in the adapter — it's treated as a regular BYOK key. The Copilot CLI
+    // auth layer (copilot-auth.js) is where placeholder detection occurs.
     const adapter = createCopilotAdapter({
       COPILOT_GITHUB_TOKEN: 'ghu_real_token',
       COPILOT_PROVIDER_API_KEY: 'dummy-byok-key-for-offline-mode',

--- a/docs/auth-matrix.md
+++ b/docs/auth-matrix.md
@@ -79,7 +79,7 @@ Note: When Azure OIDC is active, the header switches from `api-key:` back to `Au
 
 ### Custom Auth Header
 
-`AWF_OPENAI_AUTH_HEADER` overrides the header name used for the API key. The key is still sent as the header value (with `Bearer` prefix for non-Azure, without for Azure).
+`AWF_OPENAI_AUTH_HEADER` overrides the header name used for the API key. The raw key or token value is sent directly as the header value (no `Bearer` prefix is added), both for static keys and OIDC tokens.
 
 ---
 
@@ -144,7 +144,7 @@ Additional header: `Copilot-Integration-Id: <integration-id>`
 
 ### `/models` Endpoint (Special Case)
 
-The `/models` endpoint ALWAYS uses `COPILOT_GITHUB_TOKEN` (GitHub OAuth), never a BYOK key. This is because model listing is a GitHub platform feature, not a provider feature.
+The `/models` endpoint prefers `COPILOT_GITHUB_TOKEN` (GitHub OAuth) over BYOK keys when both are configured, because model listing is a GitHub platform feature. However, when no GitHub token is available (typical for direct-BYOK/custom targets), `/models` will use the BYOK credential.
 
 ### BYOK (Bring Your Own Key)
 
@@ -304,7 +304,7 @@ The `token` prefix is ONLY used for GitHub OAuth tokens on GHES. BYOK and OIDC a
 JSON object of headers injected on BYOK inference requests:
 - Only active when `COPILOT_PROVIDER_API_KEY` is set
 - NOT injected on `/models` GET when GitHub OAuth token is available
-- Protected headers silently skipped with warning
+- Protected headers are skipped with a `console.warn` message
 
 ### BYOK Extra Body Fields (`AWF_BYOK_EXTRA_BODY_FIELDS`)
 
@@ -336,8 +336,8 @@ Adds `x-session-id` header automatically in BYOK mode unless already present.
 | Copilot | BYOK key | — | ✅ | `copilot.js:278-284` |
 | Copilot | Azure BYOK | — | ✅ | via OpenAI adapter |
 | Copilot | Azure OIDC | — | ✅ | `server.auth.test.js:749+` |
-| Copilot | AWS OIDC | — | ⚠️ partial | Scaffolding only |
-| Copilot | GCP OIDC | — | ⚠️ partial | Scaffolding only |
-| Copilot | GHES + BYOK | GHES | ⚠️ gap | Untested interaction |
+| Copilot | AWS OIDC | — | ✅ | `cloud-oidc-init.js:19-37`, `server.auth-matrix.test.js` |
+| Copilot | GCP OIDC | — | ✅ | `cloud-oidc-init.js:38-50`, `server.auth-matrix.test.js` |
+| Copilot | GHES + BYOK | GHES | ✅ | `server.auth-matrix.test.js` |
 | Gemini | Static key | — | ✅ | `gemini.js:25-45` |
 | Gemini | GCP WIF | — | ❌ not impl | Would need Vertex AI |

--- a/docs/auth-matrix.md
+++ b/docs/auth-matrix.md
@@ -1,0 +1,343 @@
+# Authentication Matrix
+
+This document describes every authentication combination supported by AWF's api-proxy sidecar, including how each provider's auth works, what configuration is required, and how the proxy transforms credentials before forwarding to upstream APIs.
+
+## Table of Contents
+
+- [Dimensions Overview](#dimensions-overview)
+- [Provider: OpenAI](#provider-openai)
+- [Provider: Anthropic](#provider-anthropic)
+- [Provider: GitHub Copilot](#provider-github-copilot)
+- [Provider: Google Gemini](#provider-google-gemini)
+- [OIDC Providers](#oidc-providers)
+- [GitHub Instance Types](#github-instance-types)
+- [Custom Headers & Injection](#custom-headers--injection)
+- [Coverage Matrix](#coverage-matrix)
+
+---
+
+## Dimensions Overview
+
+Auth evaluation in the api-proxy is determined by the combination of these independent axes:
+
+| # | Dimension | Controlled By | Values |
+|---|-----------|--------------|--------|
+| 1 | Engine | Port binding (10000–10003) | openai, anthropic, copilot, gemini |
+| 2 | Auth Type | `AWF_AUTH_TYPE` | `api-key` (default), `github-oidc` |
+| 3 | OIDC Provider | `AWF_AUTH_PROVIDER` | `azure`, `aws`, `gcp`, `anthropic` |
+| 4 | Instance Type | `GITHUB_SERVER_URL` | github.com, GHEC (`*.ghe.com`), GHES |
+| 5 | BYOK Mode | `COPILOT_PROVIDER_TYPE` | unset (standard), `azure` |
+| 6 | Target Override | `{PROVIDER}_API_TARGET` | Any hostname |
+| 7 | Custom Auth Header | `AWF_{PROVIDER}_AUTH_HEADER` | Any valid HTTP header name |
+| 8 | Extra Injection | `AWF_BYOK_EXTRA_HEADERS`, `AWF_BYOK_EXTRA_BODY_FIELDS` | JSON objects |
+
+---
+
+## Provider: OpenAI
+
+**Port:** 10000  
+**Implementation:** `containers/api-proxy/providers/openai.js`
+
+### Static API Key
+
+| Setting | Value |
+|---------|-------|
+| Env var | `OPENAI_API_KEY` |
+| Header sent upstream | `Authorization: Bearer <key>` |
+| Default target | `api.openai.com` |
+| Default base path | `/v1` |
+
+**Official docs:** https://platform.openai.com/docs/api-reference/authentication
+
+### Azure OpenAI (BYOK via Copilot)
+
+When `COPILOT_PROVIDER_TYPE=azure` and `COPILOT_PROVIDER_BASE_URL` is set:
+
+| Setting | Value |
+|---------|-------|
+| Env var | `COPILOT_PROVIDER_API_KEY` |
+| Header sent upstream | `api-key: <key>` (NOT `Authorization:`) |
+| Target | Derived from `COPILOT_PROVIDER_BASE_URL` |
+| Base path | Derived from URL path component |
+
+**Official docs:** https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
+
+### Azure OIDC (Entra ID)
+
+When `AWF_AUTH_TYPE=github-oidc` and `AWF_AUTH_PROVIDER=azure`:
+
+| Setting | Value |
+|---------|-------|
+| Header sent upstream | `Authorization: Bearer <entra_access_token>` |
+| Token exchange | GitHub JWT → Azure AD token endpoint |
+| Scope | `https://cognitiveservices.azure.com/.default` (configurable via `AWF_AUTH_AZURE_SCOPE`) |
+| OIDC audience | `api://AzureADTokenExchange` (configurable via `AWF_AUTH_OIDC_AUDIENCE`) |
+
+Note: When Azure OIDC is active, the header switches from `api-key:` back to `Authorization: Bearer`.
+
+**Official docs:** https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity
+
+### Custom Auth Header
+
+`AWF_OPENAI_AUTH_HEADER` overrides the header name used for the API key. The key is still sent as the header value (with `Bearer` prefix for non-Azure, without for Azure).
+
+---
+
+## Provider: Anthropic
+
+**Port:** 10001  
+**Implementation:** `containers/api-proxy/providers/anthropic.js`
+
+### Static API Key
+
+| Setting | Value |
+|---------|-------|
+| Env var | `ANTHROPIC_API_KEY` |
+| Header sent upstream | `x-api-key: <key>` |
+| Default target | `api.anthropic.com` |
+| Default base path | (none) |
+
+Additional required headers: `anthropic-version: 2023-06-01`
+
+**Official docs:** https://docs.anthropic.com/en/api/getting-started
+
+### Workload Identity Federation (WIF)
+
+When `AWF_AUTH_TYPE=github-oidc` and `AWF_AUTH_PROVIDER=anthropic`:
+
+| Setting | Value |
+|---------|-------|
+| Header sent upstream | `Authorization: Bearer <wif_token>` (NOT `x-api-key`) |
+| Token exchange endpoint | `POST https://api.anthropic.com/v1/oauth/token` |
+| Grant type | `urn:ietf:params:oauth:grant-type:jwt-bearer` |
+| Required config | `AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID`, `AWF_AUTH_ANTHROPIC_ORGANIZATION_ID`, `AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID` |
+| Optional config | `AWF_AUTH_ANTHROPIC_WORKSPACE_ID`, `AWF_AUTH_ANTHROPIC_TOKEN_URL` |
+| OIDC audience | `https://api.anthropic.com` (default, configurable) |
+| Token format | `sk-ant-oat01-...` (short-lived) |
+
+**Key behavior change:** When OIDC is active, the auth header switches from `x-api-key` to `Authorization: Bearer`.
+
+**Official docs:** https://docs.anthropic.com/en/docs/build-with-claude/workload-identity-federation
+
+### Custom Auth Header
+
+`AWF_ANTHROPIC_AUTH_HEADER` overrides the header name (default: `x-api-key`). Useful for enterprise gateways that expect a different header.
+
+---
+
+## Provider: GitHub Copilot
+
+**Port:** 10002  
+**Implementation:** `containers/api-proxy/providers/copilot.js`, `containers/api-proxy/providers/copilot-auth.js`
+
+### GitHub OAuth Token (Standard)
+
+| Instance | Env var | Header | Target |
+|----------|---------|--------|--------|
+| github.com | `COPILOT_GITHUB_TOKEN` | `Authorization: Bearer <token>` | `api.githubcopilot.com` |
+| GHEC (`*.ghe.com`) | `COPILOT_GITHUB_TOKEN` | `Authorization: Bearer <token>` | `copilot-api.<subdomain>.ghe.com` |
+| GHES (on-prem) | `COPILOT_GITHUB_TOKEN` | `Authorization: token <value>` ⚠️ | `api.enterprise.githubcopilot.com` |
+
+**⚠️ Critical:** GHES uses `token` prefix, NOT `Bearer`. This is the GitHub API v3 convention for OAuth tokens on Enterprise Server.
+
+Additional header: `Copilot-Integration-Id: <integration-id>`
+
+### `/models` Endpoint (Special Case)
+
+The `/models` endpoint ALWAYS uses `COPILOT_GITHUB_TOKEN` (GitHub OAuth), never a BYOK key. This is because model listing is a GitHub platform feature, not a provider feature.
+
+### BYOK (Bring Your Own Key)
+
+| Setting | Value |
+|---------|-------|
+| Env var | `COPILOT_PROVIDER_API_KEY` |
+| Header | `Authorization: Bearer <key>` (always Bearer, even on GHES) |
+| Target | From `COPILOT_PROVIDER_BASE_URL` or `COPILOT_API_TARGET` |
+
+### Azure BYOK
+
+When `COPILOT_PROVIDER_TYPE=azure`:
+- Header switches to `api-key: <value>` (Azure convention)
+- Unless OIDC is active, in which case it's `Authorization: Bearer`
+
+### Copilot OIDC (Azure Entra / GCP / AWS)
+
+When `AWF_AUTH_TYPE=github-oidc` with Copilot:
+
+| Provider | Header | Notes |
+|----------|--------|-------|
+| Azure | `Authorization: Bearer <entra_token>` | Via `oidc-token-provider.js` |
+| GCP | `Authorization: Bearer <gcp_token>` | Via `gcp-oidc-token-provider.js` |
+| AWS | (SigV4 signing at request layer) | Via `aws-oidc-token-provider.js` |
+
+**Official docs:**
+- Copilot API: https://docs.github.com/en/copilot/building-copilot-extensions/building-a-copilot-agent
+- GHES auth: https://docs.github.com/en/enterprise-server/rest/authentication/authenticating-to-the-rest-api
+
+---
+
+## Provider: Google Gemini
+
+**Port:** 10003  
+**Implementation:** `containers/api-proxy/providers/gemini.js`
+
+### Static API Key
+
+| Setting | Value |
+|---------|-------|
+| Env var | `GEMINI_API_KEY` |
+| Header sent upstream | `x-goog-api-key: <key>` |
+| Default target | `generativelanguage.googleapis.com` |
+| Default base path | (none) |
+
+The proxy also strips `?key=`, `?apiKey=`, and `?api_key=` query parameters from requests to prevent duplicate-key errors.
+
+**Note:** Gemini does NOT currently support OIDC in this proxy. For GCP WIF access to Gemini, use Vertex AI endpoints (which go through the OpenAI adapter with GCP OIDC).
+
+**Official docs:** https://ai.google.dev/gemini-api/docs/api-key
+
+---
+
+## OIDC Providers
+
+All OIDC flows require GitHub Actions runtime tokens:
+- `ACTIONS_ID_TOKEN_REQUEST_URL` — endpoint to mint OIDC JWTs
+- `ACTIONS_ID_TOKEN_REQUEST_TOKEN` — auth token for the OIDC endpoint
+
+### Azure (Entra ID)
+
+| Config | Env Var | Required |
+|--------|---------|----------|
+| Tenant ID | `AWF_AUTH_AZURE_TENANT_ID` | ✅ |
+| Client ID | `AWF_AUTH_AZURE_CLIENT_ID` | ✅ |
+| Scope | `AWF_AUTH_AZURE_SCOPE` | ❌ (default: `https://cognitiveservices.azure.com/.default`) |
+| Cloud | `AWF_AUTH_AZURE_CLOUD` | ❌ (default: public; options: `government`, `china`) |
+| Audience | `AWF_AUTH_OIDC_AUDIENCE` | ❌ (default: `api://AzureADTokenExchange`) |
+
+**Token exchange endpoint:** `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`  
+**Implementation:** `containers/api-proxy/oidc-token-provider.js`  
+**Official docs:** https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust
+
+### AWS (STS)
+
+| Config | Env Var | Required |
+|--------|---------|----------|
+| Role ARN | `AWF_AUTH_AWS_ROLE_ARN` | ✅ |
+| Region | `AWF_AUTH_AWS_REGION` | ✅ |
+| Session Name | `AWF_AUTH_AWS_ROLE_SESSION_NAME` | ❌ (default: `awf-oidc-session`) |
+| Audience | `AWF_AUTH_OIDC_AUDIENCE` | ❌ (default: `sts.amazonaws.com`) |
+
+**Token exchange:** `GET https://sts.<region>.amazonaws.com/?Action=AssumeRoleWithWebIdentity`  
+**Result:** Temporary (AccessKeyId, SecretAccessKey, SessionToken) for SigV4 signing  
+**Implementation:** `containers/api-proxy/aws-oidc-token-provider.js`  
+**Official docs:** https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
+
+### GCP (Workload Identity Federation)
+
+| Config | Env Var | Required |
+|--------|---------|----------|
+| WIF Provider | `AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER` | ✅ |
+| Service Account | `AWF_AUTH_GCP_SERVICE_ACCOUNT` | ❌ (direct federation if omitted) |
+| Scope | `AWF_AUTH_GCP_SCOPE` | ❌ (default: `https://www.googleapis.com/auth/cloud-platform`) |
+| Audience | `AWF_AUTH_OIDC_AUDIENCE` | ❌ (default: derived from WIF provider) |
+
+**Token exchange (2-step):**
+1. `POST https://sts.googleapis.com/v1/token` — exchange GitHub JWT for federated token
+2. `POST https://iamcredentials.googleapis.com/.../:generateAccessToken` — (optional) exchange for SA-scoped token
+
+**Implementation:** `containers/api-proxy/gcp-oidc-token-provider.js`  
+**Official docs:** https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines
+
+### Anthropic (Native WIF)
+
+| Config | Env Var | Required |
+|--------|---------|----------|
+| Federation Rule ID | `AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID` | ✅ |
+| Organization ID | `AWF_AUTH_ANTHROPIC_ORGANIZATION_ID` | ✅ |
+| Service Account ID | `AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID` | ✅ |
+| Workspace ID | `AWF_AUTH_ANTHROPIC_WORKSPACE_ID` | ❌ |
+| Token URL | `AWF_AUTH_ANTHROPIC_TOKEN_URL` | ❌ (default: `https://api.anthropic.com/v1/oauth/token`) |
+| Audience | `AWF_AUTH_OIDC_AUDIENCE` | ❌ (default: `https://api.anthropic.com`) |
+
+**Token exchange:** `POST https://api.anthropic.com/v1/oauth/token` (RFC 7523 jwt-bearer)  
+**Implementation:** `containers/api-proxy/anthropic-oidc-token-provider.js`  
+**Official docs:** https://docs.anthropic.com/en/docs/build-with-claude/workload-identity-federation
+
+---
+
+## GitHub Instance Types
+
+Detection logic in `containers/api-proxy/providers/copilot-auth.js`:
+
+```
+GITHUB_SERVER_URL → deriveCopilotApiTarget():
+  *.ghe.com     → copilot-api.<subdomain>.ghe.com
+  github.com    → api.githubcopilot.com
+  (other)       → api.enterprise.githubcopilot.com
+```
+
+### Auth Header Prefix Rules
+
+| Target | Credential Type | Auth Header Format |
+|--------|----------------|-------------------|
+| `api.githubcopilot.com` | GitHub token | `Bearer <token>` |
+| `copilot-api.*.ghe.com` | GitHub token | `Bearer <token>` |
+| `api.enterprise.githubcopilot.com` | GitHub token | `token <value>` |
+| Any target | BYOK key | `Bearer <key>` (always) |
+| Any target | OIDC token | `Bearer <token>` (always) |
+
+The `token` prefix is ONLY used for GitHub OAuth tokens on GHES. BYOK and OIDC always use `Bearer`.
+
+---
+
+## Custom Headers & Injection
+
+### Protected Headers (cannot be overridden)
+
+- `authorization`
+- `x-api-key`
+- `x-goog-api-key`
+- `proxy-authorization`
+
+### BYOK Extra Headers (`AWF_BYOK_EXTRA_HEADERS`)
+
+JSON object of headers injected on BYOK inference requests:
+- Only active when `COPILOT_PROVIDER_API_KEY` is set
+- NOT injected on `/models` GET when GitHub OAuth token is available
+- Protected headers silently skipped with warning
+
+### BYOK Extra Body Fields (`AWF_BYOK_EXTRA_BODY_FIELDS`)
+
+JSON object of string fields merged into request body:
+- Only active in BYOK mode
+- Existing body fields are NOT overridden
+
+### Session Tracking (`AWF_PROVIDER_SESSION_ID`)
+
+Adds `x-session-id` header automatically in BYOK mode unless already present.
+
+---
+
+## Coverage Matrix
+
+| Engine | Auth Mode | Instance | Tested | Implementation |
+|--------|-----------|----------|--------|----------------|
+| OpenAI | Static key | — | ✅ | `openai.js:47-63` |
+| OpenAI | Azure BYOK | — | ✅ | `openai.js:64-76` |
+| OpenAI | Azure OIDC | — | ✅ | `openai.js:79-161` |
+| OpenAI | AWS OIDC | — | ✅ | `cloud-oidc-init.js:19-37` |
+| OpenAI | GCP OIDC | — | ✅ | `cloud-oidc-init.js:38-50` |
+| Anthropic | Static key | — | ✅ | `anthropic.js:45-52` |
+| Anthropic | WIF | — | ✅ | `anthropic.js:53-78` |
+| Anthropic | Custom header | — | ✅ | `anthropic.js:52` |
+| Copilot | GitHub token | github.com | ✅ | `copilot.js:245-258` |
+| Copilot | GitHub token | GHEC | ✅ | `copilot.js:245-258` |
+| Copilot | GitHub token | GHES | ✅ | `copilot.js:245-258` |
+| Copilot | BYOK key | — | ✅ | `copilot.js:278-284` |
+| Copilot | Azure BYOK | — | ✅ | via OpenAI adapter |
+| Copilot | Azure OIDC | — | ✅ | `server.auth.test.js:749+` |
+| Copilot | AWS OIDC | — | ⚠️ partial | Scaffolding only |
+| Copilot | GCP OIDC | — | ⚠️ partial | Scaffolding only |
+| Copilot | GHES + BYOK | GHES | ⚠️ gap | Untested interaction |
+| Gemini | Static key | — | ✅ | `gemini.js:25-45` |
+| Gemini | GCP WIF | — | ❌ not impl | Would need Vertex AI |

--- a/docs/auth-matrix.md
+++ b/docs/auth-matrix.md
@@ -171,7 +171,7 @@ When `AWF_AUTH_TYPE=github-oidc` with Copilot:
 | AWS | (SigV4 signing at request layer) | Via `aws-oidc-token-provider.js` |
 
 **Official docs:**
-- Copilot API: https://docs.github.com/en/copilot/building-copilot-extensions/building-a-copilot-agent
+- Copilot API: https://docs.github.com/en/rest/copilot
 - GHES auth: https://docs.github.com/en/enterprise-server/rest/authentication/authenticating-to-the-rest-api
 
 ---


### PR DESCRIPTION
## Summary

Adds comprehensive documentation and test coverage for every authentication combination supported by the api-proxy sidecar.

### New files

1. **`docs/auth-matrix.md`** — Full specification of all auth dimensions with:
   - Provider-by-provider breakdown (OpenAI, Anthropic, Copilot, Gemini)
   - OIDC provider details (Azure, AWS, GCP, Anthropic WIF)
   - GitHub instance type routing (github.com / GHEC / GHES)
   - Coverage matrix showing tested vs gap combinations
   - Links to official provider documentation

2. **`containers/api-proxy/server.auth-matrix.test.js`** — 46 tests covering:
   - OpenAI: static key, Azure BYOK, Azure OIDC, BYOK+OIDC interaction, custom headers
   - Anthropic: static key, WIF token swap (`x-api-key` → `Authorization: Bearer`), custom headers
   - Copilot: GitHub token on github.com/GHEC/GHES, BYOK, GHES+BYOK interaction, Azure/GCP/AWS OIDC, target override, precedence rules
   - Gemini: static key, target override, isEnabled gating
   - Cross-cutting: credential isolation, isEnabled with OIDC

### Key gaps now tested that weren't before

- **GHES `token` prefix** — explicit test that GHES uses `token` (not `Bearer`) for GitHub OAuth
- **GHES + BYOK interaction** — BYOK keys always use `Bearer` even on GHES
- **Copilot GCP OIDC** — creates provider and injects Bearer token
- **Copilot AWS OIDC** — creates provider, returns empty headers (SigV4 at request layer)
- **`/models` on GHES in BYOK mode** — falls back to GitHub token with `token` prefix

Addresses #4793