### PR TITLE
feat(api-proxy): forward COPILOT_INTEGRATION_ID from host env

### DIFF
--- a/src/services/api-proxy-service-api-targets.test.ts
+++ b/src/services/api-proxy-service-api-targets.test.ts
@@ -540,5 +540,41 @@ describe('API proxy sidecar: API targets and auth forwarding', () => {
             }
           }
         });
+
+        it('should forward COPILOT_INTEGRATION_ID from host env to api-proxy when explicitly set', () => {
+          const orig = process.env.COPILOT_INTEGRATION_ID;
+          process.env.COPILOT_INTEGRATION_ID = 'my-custom-integration';
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
+          } finally {
+            if (orig !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = orig;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
+
+        it('should not set COPILOT_INTEGRATION_ID when host env var is empty', () => {
+          const orig = process.env.COPILOT_INTEGRATION_ID;
+          process.env.COPILOT_INTEGRATION_ID = '';
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
+          } finally {
+            if (orig !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = orig;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
       });
 });

--- a/src/services/api-proxy-service-api-targets.test.ts
+++ b/src/services/api-proxy-service-api-targets.test.ts
@@ -505,76 +505,64 @@ describe('API proxy sidecar: API targets and auth forwarding', () => {
       });
 
       describe('COPILOT_INTEGRATION_ID forwarding', () => {
-        it('should not forward GITHUB_COPILOT_INTEGRATION_ID as COPILOT_INTEGRATION_ID to api-proxy', () => {
-          const orig = process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          process.env.GITHUB_COPILOT_INTEGRATION_ID = 'agentic-workflows';
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (orig !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = orig;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
+        // Snapshot both env vars once per test so we never leak state between
+        // tests in the suite or pick up host-set values from CI runners.
+        let savedGhCopilot: string | undefined;
+        let savedCopilot: string | undefined;
+
+        beforeEach(() => {
+          savedGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          savedCopilot = process.env.COPILOT_INTEGRATION_ID;
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          delete process.env.COPILOT_INTEGRATION_ID;
+        });
+
+        afterEach(() => {
+          if (savedGhCopilot !== undefined) {
+            process.env.GITHUB_COPILOT_INTEGRATION_ID = savedGhCopilot;
+          } else {
+            delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
           }
+          if (savedCopilot !== undefined) {
+            process.env.COPILOT_INTEGRATION_ID = savedCopilot;
+          } else {
+            delete process.env.COPILOT_INTEGRATION_ID;
+          }
+        });
+
+        function proxyEnv(): Record<string, string> {
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          return result.services['api-proxy'].environment as Record<string, string>;
+        }
+
+        it('should not forward GITHUB_COPILOT_INTEGRATION_ID as COPILOT_INTEGRATION_ID to api-proxy', () => {
+          process.env.GITHUB_COPILOT_INTEGRATION_ID = 'agentic-workflows';
+          expect(proxyEnv().COPILOT_INTEGRATION_ID).toBeUndefined();
         });
 
         it('should not set COPILOT_INTEGRATION_ID when GITHUB_COPILOT_INTEGRATION_ID is not set', () => {
-          const orig = process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (orig !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = orig;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          expect(proxyEnv().COPILOT_INTEGRATION_ID).toBeUndefined();
         });
 
         it('should forward COPILOT_INTEGRATION_ID from host env to api-proxy when explicitly set', () => {
-          const orig = process.env.COPILOT_INTEGRATION_ID;
           process.env.COPILOT_INTEGRATION_ID = 'my-custom-integration';
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
-          } finally {
-            if (orig !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = orig;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-          }
+          expect(proxyEnv().COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
         });
 
         it('should not set COPILOT_INTEGRATION_ID when host env var is empty', () => {
-          const orig = process.env.COPILOT_INTEGRATION_ID;
           process.env.COPILOT_INTEGRATION_ID = '';
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (orig !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = orig;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-          }
+          expect(proxyEnv().COPILOT_INTEGRATION_ID).toBeUndefined();
+        });
+
+        it('should not set COPILOT_INTEGRATION_ID when host env var is whitespace only', () => {
+          process.env.COPILOT_INTEGRATION_ID = '   ';
+          expect(proxyEnv().COPILOT_INTEGRATION_ID).toBeUndefined();
+        });
+
+        it('should trim surrounding whitespace before forwarding', () => {
+          process.env.COPILOT_INTEGRATION_ID = '  my-custom-integration  ';
+          expect(proxyEnv().COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
         });
       });
 });

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -115,8 +115,18 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
       // Forward GITHUB_API_URL so api-proxy can route /models to the correct GitHub REST API
       // target on GHES/GHEC (e.g. api.mycompany.ghe.com instead of api.github.com)
       ...(process.env.GITHUB_API_URL && { GITHUB_API_URL: process.env.GITHUB_API_URL }),
-      // Do not forward GITHUB_COPILOT_INTEGRATION_ID — api-proxy defaults to
-      // 'agentic-workflows' which is the correct integration ID for AWF.
+      // Forward COPILOT_INTEGRATION_ID if explicitly set on the host so callers
+      // (e.g. external agents using AWF as their network firewall + auth proxy)
+      // can identify themselves to the Copilot API with their own integration ID
+      // instead of being attributed to AWF's default 'agentic-workflows'.
+      // Default behaviour is unchanged: when the env var is unset, api-proxy
+      // falls back to its built-in default.
+      ...(process.env.COPILOT_INTEGRATION_ID && {
+        COPILOT_INTEGRATION_ID: process.env.COPILOT_INTEGRATION_ID,
+      }),
+      // Note: GITHUB_COPILOT_INTEGRATION_ID (the gh-aw-prefixed variant) is
+      // intentionally NOT forwarded -- api-proxy's default 'agentic-workflows'
+      // is the correct integration ID for AWF's own internal use.
       // Note: AWF_VERSION is intentionally NOT forwarded here. It is baked into the api-proxy
       // container image at release build time (via --build-arg AWF_VERSION=...), so the
       // token-usage.jsonl _schema field reflects the api-proxy image version rather than

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -119,10 +119,12 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
       // (e.g. external agents using AWF as their network firewall + auth proxy)
       // can identify themselves to the Copilot API with their own integration ID
       // instead of being attributed to AWF's default 'agentic-workflows'.
-      // Default behaviour is unchanged: when the env var is unset, api-proxy
-      // falls back to its built-in default.
-      ...(process.env.COPILOT_INTEGRATION_ID && {
-        COPILOT_INTEGRATION_ID: process.env.COPILOT_INTEGRATION_ID,
+      // Whitespace-only values are treated as unset to avoid accidentally
+      // shipping a meaningless integration ID. Default behaviour is unchanged:
+      // when the env var is unset or whitespace, api-proxy falls back to its
+      // built-in default.
+      ...(process.env.COPILOT_INTEGRATION_ID?.trim() && {
+        COPILOT_INTEGRATION_ID: process.env.COPILOT_INTEGRATION_ID.trim(),
       }),
       // Note: GITHUB_COPILOT_INTEGRATION_ID (the gh-aw-prefixed variant) is
       // intentionally NOT forwarded -- api-proxy's default 'agentic-workflows'


### PR DESCRIPTION
## Summary

Allow external callers using AWF as a network firewall + auth proxy to set their own `Copilot-Integration-Id` on outbound Copilot API requests by forwarding the `COPILOT_INTEGRATION_ID` env var from the host process to the api-proxy container.

## Problem

The api-proxy unconditionally rewrites the `Copilot-Integration-Id` header from `env.COPILOT_INTEGRATION_ID` (defaulting to the api-proxy built-in, currently `agentic-workflows`). The CLI wrapper deliberately does not forward `COPILOT_INTEGRATION_ID` to the api-proxy container, so external callers have no way to opt out:

- Whatever `Copilot-Integration-Id` the caller sends to the api-proxy is discarded.
- All requests are attributed to AWF on the upstream provider's side, even when the underlying caller is a distinct product with its own identity.
- Some upstream models (e.g. internal preview models) are scoped to specific integration IDs. A caller whose integration ID is not on the allowlist silently loses access when routed through AWF -- and crucially, a caller whose integration ID *is* on the allowlist gets that access by accident, depending on whatever value the api-proxy happens to default to in the pinned AWF version.

In our pipeline this surfaced as: every audit our taskflow agent runs is silently tagged as the api-proxy default integration ID, regardless of what our agent code requests. We discovered this while investigating dashboard attribution, and only afterwards realised the v0.25.46 -> v0.25.47 flip of the api-proxy default would have silently removed model access for any caller depending on the old default.

## Change

Mirror the existing `GITHUB_API_URL` / `GITHUB_SERVER_URL` forwarding pattern in `api-proxy-service-config.ts`: forward `COPILOT_INTEGRATION_ID` from the host env to the api-proxy container when (and only when) it is explicitly set.

Default behaviour is unchanged: unset on the host -> not set on api-proxy -> falls back to whatever default the api-proxy ships with.

The gh-aw-prefixed variant (`GITHUB_COPILOT_INTEGRATION_ID`) is intentionally still stripped, because that one is set by gh-aw for AWF's own bookkeeping. Existing tests covering that strip-behaviour continue to pass.

## Tests

Two new tests under the existing `describe('COPILOT_INTEGRATION_ID forwarding')` block in `api-proxy-service-api-targets.test.ts`:
- forwards `COPILOT_INTEGRATION_ID` to api-proxy when explicitly set on the host
- does not set it on api-proxy when the host env var is empty string

```
PASS src/services/api-proxy-service-api-targets.test.ts
Tests:       56 passed, 56 total
```

Full `src/services/` suite: 392 pass, 1 pre-existing unrelated failure on main (`agent-volumes-mounts.test.ts` -- reproduced before applying this change).

`tsc --noEmit`: clean. `eslint`: no new warnings introduced.