### PR TITLE
fix: correct acl-generator test assertions to match formatDomainForSquid output

### DIFF
--- a/src/squid/acl-generator.test.ts
+++ b/src/squid/acl-generator.test.ts
@@ -164,7 +164,8 @@ describe('generateAclSections', () => {
       expect(
         blockedDomainConfig.aclLines.some(l => {
           if (!l.startsWith('acl blocked_domains dstdomain')) return false;
-          return l.includes('.evil.com');
+          const tokens = l.trim().split(/\s+/);
+          return tokens.includes('.evil.com');
         })
       ).toBe(true);
       expect(blockedDomainConfig.accessRules).toContain('http_access deny blocked_domains');
@@ -174,7 +175,7 @@ describe('generateAclSections', () => {
       const { domainsByProto, patternsByProto } = parseDomainConfig(['github.com']);
       const { blockedDomainConfig } = generateAclSections(domainsByProto, patternsByProto, ['https://evil.com']);
 
-      const aclLine = blockedDomainConfig.aclLines.find(l => l.includes('.evil.com'));
+      const aclLine = blockedDomainConfig.aclLines.find(l => l.trim().split(/\s+/).includes('.evil.com'));
       expect(aclLine).toBeDefined();
       expect(aclLine).not.toContain('https://');
     });
@@ -183,7 +184,7 @@ describe('generateAclSections', () => {
       const { domainsByProto, patternsByProto } = parseDomainConfig(['github.com']);
       const { blockedDomainConfig } = generateAclSections(domainsByProto, patternsByProto, ['http://evil.com']);
 
-      const aclLine = blockedDomainConfig.aclLines.find(l => l.includes('.evil.com'));
+      const aclLine = blockedDomainConfig.aclLines.find(l => l.trim().split(/\s+/).includes('.evil.com'));
       expect(aclLine).toBeDefined();
       expect(aclLine).not.toContain('http://');
     });
@@ -192,7 +193,7 @@ describe('generateAclSections', () => {
       const { domainsByProto, patternsByProto } = parseDomainConfig(['github.com']);
       const { blockedDomainConfig } = generateAclSections(domainsByProto, patternsByProto, ['evil.com/']);
 
-      const aclLine = blockedDomainConfig.aclLines.find(l => l.includes('.evil.com'));
+      const aclLine = blockedDomainConfig.aclLines.find(l => l.trim().split(/\s+/).includes('.evil.com'));
       expect(aclLine).toBeDefined();
       expect(aclLine).not.toContain('evil.com/');
     });

--- a/src/squid/acl-generator.test.ts
+++ b/src/squid/acl-generator.test.ts
@@ -88,11 +88,11 @@ describe('generateAclSections', () => {
 
       expect(aclLines).toContain('# ACL definitions for HTTP-only domains');
       expect(
-        aclLines.some(
-          l =>
-            l.startsWith('acl allowed_http_only dstdomain') &&
-            l.includes('.metrics.example.com')
-        )
+        aclLines.some(l => {
+          if (!l.startsWith('acl allowed_http_only dstdomain')) return false;
+          const tokens = l.trim().split(/\s+/);
+          return tokens.includes('.metrics.example.com');
+        })
       ).toBe(true);
     });
 

--- a/src/squid/acl-generator.test.ts
+++ b/src/squid/acl-generator.test.ts
@@ -91,7 +91,7 @@ describe('generateAclSections', () => {
         aclLines.some(
           l =>
             l.startsWith('acl allowed_http_only dstdomain') &&
-            /\b\.metrics\.example\.com\b/.test(l)
+            l.includes('.metrics.example.com')
         )
       ).toBe(true);
     });
@@ -164,8 +164,7 @@ describe('generateAclSections', () => {
       expect(
         blockedDomainConfig.aclLines.some(l => {
           if (!l.startsWith('acl blocked_domains dstdomain')) return false;
-          const tokens = l.trim().split(/\s+/);
-          return tokens.includes('evil.com');
+          return l.includes('.evil.com');
         })
       ).toBe(true);
       expect(blockedDomainConfig.accessRules).toContain('http_access deny blocked_domains');
@@ -175,7 +174,7 @@ describe('generateAclSections', () => {
       const { domainsByProto, patternsByProto } = parseDomainConfig(['github.com']);
       const { blockedDomainConfig } = generateAclSections(domainsByProto, patternsByProto, ['https://evil.com']);
 
-      const aclLine = blockedDomainConfig.aclLines.find(l => l.split(/\s+/).includes('evil.com'));
+      const aclLine = blockedDomainConfig.aclLines.find(l => l.includes('.evil.com'));
       expect(aclLine).toBeDefined();
       expect(aclLine).not.toContain('https://');
     });
@@ -184,7 +183,7 @@ describe('generateAclSections', () => {
       const { domainsByProto, patternsByProto } = parseDomainConfig(['github.com']);
       const { blockedDomainConfig } = generateAclSections(domainsByProto, patternsByProto, ['http://evil.com']);
 
-      const aclLine = blockedDomainConfig.aclLines.find(l => l.split(/\s+/).includes('evil.com'));
+      const aclLine = blockedDomainConfig.aclLines.find(l => l.includes('.evil.com'));
       expect(aclLine).toBeDefined();
       expect(aclLine).not.toContain('http://');
     });
@@ -193,9 +192,9 @@ describe('generateAclSections', () => {
       const { domainsByProto, patternsByProto } = parseDomainConfig(['github.com']);
       const { blockedDomainConfig } = generateAclSections(domainsByProto, patternsByProto, ['evil.com/']);
 
-      const aclLine = blockedDomainConfig.aclLines.find(l => l.split(/\s+/).includes('evil.com'));
+      const aclLine = blockedDomainConfig.aclLines.find(l => l.includes('.evil.com'));
       expect(aclLine).toBeDefined();
-      expect(aclLine).not.toContain('/');
+      expect(aclLine).not.toContain('evil.com/');
     });
 
     it('works on a stand-alone allowlist (no allowed domains)', () => {

--- a/src/squid/acl-generator.test.ts
+++ b/src/squid/acl-generator.test.ts
@@ -195,7 +195,7 @@ describe('generateAclSections', () => {
 
       const aclLine = blockedDomainConfig.aclLines.find(l => l.trim().split(/\s+/).includes('.evil.com'));
       expect(aclLine).toBeDefined();
-      expect(aclLine).not.toContain('evil.com/');
+      expect(aclLine).not.toContain('/');
     });
 
     it('works on a stand-alone allowlist (no allowed domains)', () => {


### PR DESCRIPTION
## Problem

5 tests in `src/squid/acl-generator.test.ts` are failing on main because they search for bare domain names (e.g. `evil.com`) as exact whitespace-delimited tokens, but `formatDomainForSquid()` prepends a dot (producing `.evil.com`).

Similarly, the HTTP-only test used a regex with \\b word boundaries before a dot which doesn't work.

## Fix

- Use `.includes('.evil.com')` instead of `.split(/\\s+/).includes('evil.com')`
- Use `.includes('.metrics.example.com')` instead of broken regex
- Update trailing-slash test assertion

All 21 tests now pass.