### PR TITLE
fix: recognize copilot-pull-request-reviewer in ci-gate

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const copilotReviewers = new Set(['copilot', 'copilot[bot]', 'Copilot']);
+            const copilotReviewers = new Set(['copilot', 'copilot[bot]', 'Copilot', 'copilot-pull-request-reviewer']);
             const isCopilotReviewer = login => copilotReviewers.has(login ?? '');
             const { owner, repo } = context.repo;
             const pr_number = context.payload.pull_request?.number

--- a/scripts/ci/ready-for-ci-workflows.test.ts
+++ b/scripts/ci/ready-for-ci-workflows.test.ts
@@ -32,7 +32,7 @@ describe('ready-for-ci workflow gating', () => {
     const gateWorkflow = fs.readFileSync(path.join(workflowsDir, 'ci-gate.yml'), 'utf-8');
 
     expect(gateWorkflow).toContain('issues: write');
-    expect(gateWorkflow).toContain("const copilotReviewers = new Set(['copilot', 'copilot[bot]', 'Copilot']);");
+    expect(gateWorkflow).toContain("const copilotReviewers = new Set(['copilot', 'copilot[bot]', 'Copilot', 'copilot-pull-request-reviewer']);");
     expect(gateWorkflow).toContain('const isCopilotReviewer = login => copilotReviewers.has(login ?? \'\');');
   });
 


### PR DESCRIPTION
The Copilot review bot uses login `copilot-pull-request-reviewer`, which was missing from the ci-gate's reviewer set. This caused the gate to never recognize Copilot's review and never add the `ready-for-ci` label.

One-line fix: add `'copilot-pull-request-reviewer'` to the Set.