### PR TITLE
fix(ci-gate): tag PR owner with instructions

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -76,22 +76,10 @@ jobs:
               const reviewLogins = reviews.map(r => r.user?.login);
               core.info(`Found ${reviews.length} review(s): ${reviewLogins.join(', ')}`);
               copilotReviewed = reviews.some(r => isCopilotReviewer(r.user?.login));
-
-              if (copilotReviewed) {
-                // Check for outstanding inline comments even on synchronize events,
-                // so we don't prematurely post the "passed" message when Copilot
-                // still has unresolved inline review comments.
-                const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-                  owner, repo, pull_number: pr_number
-                });
-                const copilotComments = reviewComments.filter(c =>
-                  isCopilotReviewer(c.user?.login) && !c.in_reply_to_id
-                );
-                hasInlineComments = copilotComments.length > 0;
-                if (hasInlineComments) {
-                  core.info(`Copilot left ${copilotComments.length} inline comment(s), waiting for fixes`);
-                }
-              }
+              // On synchronize (push), skip the inline comment check.
+              // Old review comments persist even after fixes, so checking them
+              // would permanently block the gate. The push itself signals that
+              // the author has addressed the feedback.
             }
 
             if (context.eventName === 'pull_request_review') {

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -76,6 +76,22 @@ jobs:
               const reviewLogins = reviews.map(r => r.user?.login);
               core.info(`Found ${reviews.length} review(s): ${reviewLogins.join(', ')}`);
               copilotReviewed = reviews.some(r => isCopilotReviewer(r.user?.login));
+
+              if (copilotReviewed) {
+                // Check for outstanding inline comments even on synchronize events,
+                // so we don't prematurely post the "passed" message when Copilot
+                // still has unresolved inline review comments.
+                const { data: reviewComments } = await github.rest.pulls.listReviewComments({
+                  owner, repo, pull_number: pr_number
+                });
+                const copilotComments = reviewComments.filter(c =>
+                  isCopilotReviewer(c.user?.login) && !c.in_reply_to_id
+                );
+                hasInlineComments = copilotComments.length > 0;
+                if (hasInlineComments) {
+                  core.info(`Copilot left ${copilotComments.length} inline comment(s), waiting for fixes`);
+                }
+              }
             }
 
             if (context.eventName === 'pull_request_review') {

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -106,14 +106,18 @@ jobs:
             }
 
             if (hasInlineComments) {
+              const prAuthor = context.payload.pull_request?.user?.login
+                || context.payload.review?.pull_request?.user?.login;
               await postGateComment(
-                '⏳ Copilot review has inline comments.\n\n@copilot Please address the review feedback from the Copilot pull request reviewer above. Fix the issues raised in the inline comments and push your changes.'
+                `⏳ Copilot review left inline comments.\n\n@${prAuthor} To proceed:\n1. Ask \`@copilot\` to address the review feedback (reply to this comment or the review thread)\n2. Once the fix is pushed, add the \`ready-for-aw\` label to trigger agentic CI smoke tests`
               );
               return;
             }
 
-            // Copilot reviewed with no inline comments — ask CCA to add the label
+            // Copilot reviewed with no inline comments — tell owner to add label
+            const prAuthor = context.payload.pull_request?.user?.login
+              || context.payload.review?.pull_request?.user?.login;
             await postGateComment(
-              '✅ Copilot review passed.\n\n@copilot Please add the `ready-for-aw` label to this PR to trigger agentic CI smoke tests. Use: `gh pr edit ' + pr_number + ' --add-label ready-for-aw`'
+              `✅ Copilot review passed with no inline comments.\n\n@${prAuthor} Add the \`ready-for-aw\` label to this PR to trigger agentic CI smoke tests.`
             );
-            core.info('Posted comment asking CCA to add ready-for-aw label');
+            core.info('Posted comment directing PR owner to add ready-for-aw label');


### PR DESCRIPTION
## Problem

The previous ci-gate approach of @-mentioning `@copilot` in comments didn't reliably trigger Copilot Coding Agent (CCA).

## Fix

Tag the PR author directly with clear instructions:

**When Copilot review has inline comments:**
> ⏳ Copilot review left inline comments.
>
> @author To proceed:
> 1. Ask `@copilot` to address the review feedback
> 2. Once the fix is pushed, add the `ready-for-aw` label to trigger agentic CI smoke tests

**When Copilot review passes (no inline comments):**
> ✅ Copilot review passed with no inline comments.
>
> @author Add the `ready-for-aw` label to this PR to trigger agentic CI smoke tests.

## Re-triggering

ci-gate automatically re-runs on `pull_request: [synchronize]` — when CCA pushes a fix, ci-gate checks the existing review again. If the review has no inline comments, the comment updates to the 'passed' state directing the owner to add the label.