### PR TITLE
fix: correctly recover runner tool on PATH (after sudo w/ secure_path). remove incorrect reading from GITHUB_PATH

### DIFF
--- a/containers/agent/entrypoint.sh
+++ b/containers/agent/entrypoint.sh
@@ -892,24 +892,11 @@ AWFEOF
 # Set comprehensive PATH for host binaries
 # Include standard paths plus tool cache locations (GitHub Actions)
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-# Prepend entries from $GITHUB_PATH file (written by setup-* actions) so they
-# take priority over the hostedtoolcache scan below.  This replicates what the
-# Actions runner normally does with GITHUB_PATH, preserving the version chosen
-# by setup-ruby / setup-python / setup-node / etc.
-if [ -n "${GITHUB_PATH}" ] && [ -f "${GITHUB_PATH}" ]; then
-  _github_path_prefix=""
-  while IFS= read -r _gp_entry; do
-    _gp_entry="${_gp_entry%$'\r'}"  # strip trailing CR (Windows-style CRLF files)
-    [ -z "${_gp_entry}" ] && continue
-    _github_path_prefix="${_github_path_prefix}${_gp_entry}:"
-  done < "${GITHUB_PATH}"
-  [ -n "${_github_path_prefix}" ] && export PATH="${_github_path_prefix}${PATH}"
-fi
 # Dynamically scan toolcache roots for all installed tool bin directories.
 # This covers tools installed by setup-* actions on both hosted runners
 # (/opt/hostedtoolcache) and self-hosted runners ($HOME/work/_tool).
-# Append (not prepend) so that $GITHUB_PATH entries and standard paths above
-# retain priority; discovered toolcache dirs serve as fallbacks only.
+# Append (not prepend) so standard paths above retain priority; discovered
+# toolcache dirs serve as fallbacks only.
 append_toolcache_bins() {
   local toolcache_root="$1"
   if [ ! -d "${toolcache_root}" ]; then

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -168,7 +168,7 @@ Tools installed by GitHub Actions `setup-*` actions (e.g., `astral-sh/setup-uv`,
 
 The chroot entrypoint exports `AWF_HOST_PATH` as `PATH` inside the chroot, so tools like `uv`, `node`, `python3`, `ruby`, etc. resolve correctly.
 
-This behavior was introduced in **awf v0.60.0** and is active automatically — no extra flags are required.
+This behavior is active automatically — no extra flags are required.
 
 **Important:** `$GITHUB_PATH` is a per-step command file. The Actions runner consumes each step's file after that step completes and folds those entries into `PATH` for later steps. AWF does not read `$GITHUB_PATH` for path recovery; for previous setup steps, AWF relies on the inherited `PATH` and `RUNNER_TOOL_CACHE` recovery.
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -161,20 +161,25 @@ The following environment variables are set internally by the firewall and used 
 
 ## GitHub Actions `setup-*` Tool Availability
 
-Tools installed by GitHub Actions `setup-*` actions (e.g., `astral-sh/setup-uv`, `actions/setup-node`, `ruby/setup-ruby`, `actions/setup-python`) are **automatically available inside the AWF chroot**. This works by:
+Tools installed by GitHub Actions `setup-*` actions (e.g., `astral-sh/setup-uv`, `actions/setup-node`, `ruby/setup-ruby`, `actions/setup-python`) are **automatically available inside the AWF chroot** when their installation paths can be recovered from the runner environment. AWF builds `AWF_HOST_PATH` from:
 
-1. `setup-*` actions write their tool bin directories to the `$GITHUB_PATH` file.
-2. AWF reads this file at startup and merges its entries (prepended, higher priority) into `AWF_HOST_PATH`.
-3. The chroot entrypoint exports `AWF_HOST_PATH` as `PATH` inside the chroot, so tools like `uv`, `node`, `python3`, `ruby`, etc. resolve correctly.
+1. The `PATH` visible to the `awf` process at startup.
+2. Entries in the current step's `$GITHUB_PATH` command file, if any were written before AWF starts.
+3. Bin directories discovered under `RUNNER_TOOL_CACHE` (for tools installed by setup actions into the Actions tool cache, such as `actions/setup-node`).
+
+The chroot entrypoint exports `AWF_HOST_PATH` as `PATH` inside the chroot, so tools like `uv`, `node`, `python3`, `ruby`, etc. resolve correctly.
 
 This behavior was introduced in **awf v0.60.0** and is active automatically — no extra flags are required.
 
-**Fallback behavior:** If `GITHUB_PATH` is not set (e.g., outside GitHub Actions or on self-hosted runners that don't set it), AWF uses `process.env.PATH` as the chroot PATH. If `sudo` has reset `PATH` before AWF runs and `GITHUB_PATH` is also absent, the tool's directory may be missing from the chroot PATH. In that case, invoke the tool via its absolute path or ensure `GITHUB_PATH` is set.
+**Important:** `$GITHUB_PATH` is a per-step command file. The Actions runner consumes each step's file after that step completes and folds those entries into `PATH` for later steps. AWF can read entries written earlier in the same step before AWF starts, but it cannot read historical `$GITHUB_PATH` entries from previous setup steps. For previous setup steps, AWF relies on the inherited `PATH` and `RUNNER_TOOL_CACHE` recovery.
+
+**Fallback behavior:** If `GITHUB_PATH` and `RUNNER_TOOL_CACHE` are not set (e.g., outside GitHub Actions), AWF uses `process.env.PATH` as the chroot PATH. If `sudo` has reset `PATH` before AWF runs and no tool-cache location is available, the tool's directory may be missing from the chroot PATH. In that case, invoke the tool via its absolute path or preserve the required path when invoking AWF.
 
 **Troubleshooting:** Run AWF with `--log-level debug` to see whether `GITHUB_PATH` is set and how many entries were merged:
 
 ```
 [DEBUG] Merged 3 path(s) from $GITHUB_PATH into AWF_HOST_PATH
+[DEBUG] Merged 1 runner tool cache bin path(s) into AWF_HOST_PATH
 ```
 
 If you see instead:
@@ -183,7 +188,7 @@ If you see instead:
 [DEBUG] GITHUB_PATH env var is not set; skipping $GITHUB_PATH file merge …
 ```
 
-the runner did not set `GITHUB_PATH`, and the tool's bin directory must already be in `$PATH` at AWF launch time.
+the current step did not have any `$GITHUB_PATH` entries for AWF to merge. If the missing tool was installed by a previous setup step, verify that `RUNNER_TOOL_CACHE` is set and points at the Actions tool cache.
 
 ## Debugging Environment Variables
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -164,31 +164,22 @@ The following environment variables are set internally by the firewall and used 
 Tools installed by GitHub Actions `setup-*` actions (e.g., `astral-sh/setup-uv`, `actions/setup-node`, `ruby/setup-ruby`, `actions/setup-python`) are **automatically available inside the AWF chroot** when their installation paths can be recovered from the runner environment. AWF builds `AWF_HOST_PATH` from:
 
 1. The `PATH` visible to the `awf` process at startup.
-2. Entries in the current step's `$GITHUB_PATH` command file, if any were written before AWF starts.
-3. Bin directories discovered under `RUNNER_TOOL_CACHE` (for tools installed by setup actions into the Actions tool cache, such as `actions/setup-node`).
+2. Bin directories discovered under `RUNNER_TOOL_CACHE` (for tools installed by setup actions into the Actions tool cache, such as `actions/setup-node`).
 
 The chroot entrypoint exports `AWF_HOST_PATH` as `PATH` inside the chroot, so tools like `uv`, `node`, `python3`, `ruby`, etc. resolve correctly.
 
 This behavior was introduced in **awf v0.60.0** and is active automatically — no extra flags are required.
 
-**Important:** `$GITHUB_PATH` is a per-step command file. The Actions runner consumes each step's file after that step completes and folds those entries into `PATH` for later steps. AWF can read entries written earlier in the same step before AWF starts, but it cannot read historical `$GITHUB_PATH` entries from previous setup steps. For previous setup steps, AWF relies on the inherited `PATH` and `RUNNER_TOOL_CACHE` recovery.
+**Important:** `$GITHUB_PATH` is a per-step command file. The Actions runner consumes each step's file after that step completes and folds those entries into `PATH` for later steps. AWF does not read `$GITHUB_PATH` for path recovery; for previous setup steps, AWF relies on the inherited `PATH` and `RUNNER_TOOL_CACHE` recovery.
 
-**Fallback behavior:** If `GITHUB_PATH` and `RUNNER_TOOL_CACHE` are not set (e.g., outside GitHub Actions), AWF uses `process.env.PATH` as the chroot PATH. If `sudo` has reset `PATH` before AWF runs and no tool-cache location is available, the tool's directory may be missing from the chroot PATH. In that case, invoke the tool via its absolute path or preserve the required path when invoking AWF.
+**Fallback behavior:** If `RUNNER_TOOL_CACHE` is not set (e.g., outside GitHub Actions), AWF uses `process.env.PATH` as the chroot PATH. If `sudo` has reset `PATH` before AWF runs and no tool-cache location is available, the tool's directory may be missing from the chroot PATH. In that case, invoke the tool via its absolute path or preserve the required path when invoking AWF.
 
-**Troubleshooting:** Run AWF with `--log-level debug` to see whether `GITHUB_PATH` is set and how many entries were merged:
+**Troubleshooting:** Run AWF with `--log-level debug` to see how many runner tool cache entries were merged:
 
 ```
-[DEBUG] Merged 3 path(s) from $GITHUB_PATH into AWF_HOST_PATH
 [DEBUG] Merged 1 runner tool cache bin path(s) into AWF_HOST_PATH
 ```
-
-If you see instead:
-
-```
-[DEBUG] GITHUB_PATH env var is not set; skipping $GITHUB_PATH file merge …
-```
-
-the current step did not have any `$GITHUB_PATH` entries for AWF to merge. If the missing tool was installed by a previous setup step, verify that `RUNNER_TOOL_CACHE` is set and points at the Actions tool cache.
+If the missing tool was installed by a previous setup step, verify that `RUNNER_TOOL_CACHE` is set and points at the Actions tool cache.
 
 ## Debugging Environment Variables
 

--- a/src/docker-manager-utils.test.ts
+++ b/src/docker-manager-utils.test.ts
@@ -11,8 +11,6 @@ import {
 } from './host-identity';
 import {
   extractGhHostFromServerUrl,
-  readGitHubPathEntries,
-  mergeGitHubPathEntries,
   readGitHubEnvEntries,
   readEnvFile,
 } from './github-env';
@@ -376,111 +374,6 @@ describe('docker-manager utilities', () => {
     });
   });
 
-  describe('readGitHubPathEntries', () => {
-    let tmpDir: string;
-
-    beforeEach(() => {
-      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-github-path-'));
-    });
-
-    afterEach(() => {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    });
-
-    it('should return empty array when GITHUB_PATH is not set', () => {
-      const originalGithubPath = process.env.GITHUB_PATH;
-      delete process.env.GITHUB_PATH;
-
-      try {
-        const result = readGitHubPathEntries();
-        expect(result).toEqual([]);
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        }
-      }
-    });
-
-    it('should return empty array when GITHUB_PATH file does not exist', () => {
-      const originalGithubPath = process.env.GITHUB_PATH;
-      process.env.GITHUB_PATH = '/nonexistent/path/to/github_path_file';
-
-      try {
-        const result = readGitHubPathEntries();
-        expect(result).toEqual([]);
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
-      }
-    });
-
-    it('should read path entries from GITHUB_PATH file', () => {
-      const pathFile = path.join(tmpDir, 'add_path');
-      fs.writeFileSync(pathFile, '/opt/hostedtoolcache/Ruby/3.3.10/x64/bin\n/opt/hostedtoolcache/Python/3.12.0/x64/bin\n');
-
-      const originalGithubPath = process.env.GITHUB_PATH;
-      process.env.GITHUB_PATH = pathFile;
-
-      try {
-        const result = readGitHubPathEntries();
-        expect(result).toEqual([
-          '/opt/hostedtoolcache/Ruby/3.3.10/x64/bin',
-          '/opt/hostedtoolcache/Python/3.12.0/x64/bin',
-        ]);
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
-      }
-    });
-
-    it('should handle empty lines and whitespace in GITHUB_PATH file', () => {
-      const pathFile = path.join(tmpDir, 'add_path');
-      fs.writeFileSync(pathFile, '  /opt/hostedtoolcache/Ruby/3.3.10/x64/bin  \n\n  \n/opt/dart-sdk/bin\n');
-
-      const originalGithubPath = process.env.GITHUB_PATH;
-      process.env.GITHUB_PATH = pathFile;
-
-      try {
-        const result = readGitHubPathEntries();
-        expect(result).toEqual([
-          '/opt/hostedtoolcache/Ruby/3.3.10/x64/bin',
-          '/opt/dart-sdk/bin',
-        ]);
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
-      }
-    });
-
-    it('should handle empty GITHUB_PATH file', () => {
-      const pathFile = path.join(tmpDir, 'add_path');
-      fs.writeFileSync(pathFile, '');
-
-      const originalGithubPath = process.env.GITHUB_PATH;
-      process.env.GITHUB_PATH = pathFile;
-
-      try {
-        const result = readGitHubPathEntries();
-        expect(result).toEqual([]);
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
-      }
-    });
-  });
-
   describe('parseGitHubEnvFile (via readGitHubEnvEntries)', () => {
     let tmpDir: string;
     let originalGithubEnv: string | undefined;
@@ -610,53 +503,6 @@ describe('docker-manager utilities', () => {
         if (original !== undefined) process.env.GITHUB_ENV = original;
         else delete process.env.GITHUB_ENV;
       }
-    });
-  });
-
-  describe('mergeGitHubPathEntries', () => {
-    it('should return current PATH when no github path entries', () => {
-      const result = mergeGitHubPathEntries('/usr/bin:/usr/local/bin', []);
-      expect(result).toBe('/usr/bin:/usr/local/bin');
-    });
-
-    it('should prepend github path entries to current PATH', () => {
-      const result = mergeGitHubPathEntries(
-        '/usr/bin:/usr/local/bin',
-        ['/opt/hostedtoolcache/Ruby/3.3.10/x64/bin']
-      );
-      expect(result).toBe('/opt/hostedtoolcache/Ruby/3.3.10/x64/bin:/usr/bin:/usr/local/bin');
-    });
-
-    it('should not duplicate entries already in PATH', () => {
-      const result = mergeGitHubPathEntries(
-        '/opt/hostedtoolcache/Ruby/3.3.10/x64/bin:/usr/bin:/usr/local/bin',
-        ['/opt/hostedtoolcache/Ruby/3.3.10/x64/bin']
-      );
-      expect(result).toBe('/opt/hostedtoolcache/Ruby/3.3.10/x64/bin:/usr/bin:/usr/local/bin');
-    });
-
-    it('should handle multiple new entries', () => {
-      const result = mergeGitHubPathEntries(
-        '/usr/bin',
-        ['/opt/hostedtoolcache/Ruby/3.3.10/x64/bin', '/opt/dart-sdk/bin']
-      );
-      expect(result).toBe('/opt/hostedtoolcache/Ruby/3.3.10/x64/bin:/opt/dart-sdk/bin:/usr/bin');
-    });
-
-    it('should handle mix of new and existing entries', () => {
-      const result = mergeGitHubPathEntries(
-        '/opt/hostedtoolcache/Ruby/3.3.10/x64/bin:/usr/bin',
-        ['/opt/hostedtoolcache/Ruby/3.3.10/x64/bin', '/opt/dart-sdk/bin']
-      );
-      expect(result).toBe('/opt/dart-sdk/bin:/opt/hostedtoolcache/Ruby/3.3.10/x64/bin:/usr/bin');
-    });
-
-    it('should handle empty current PATH', () => {
-      const result = mergeGitHubPathEntries(
-        '',
-        ['/opt/hostedtoolcache/Ruby/3.3.10/x64/bin']
-      );
-      expect(result).toBe('/opt/hostedtoolcache/Ruby/3.3.10/x64/bin');
     });
   });
 

--- a/src/github-env.test.ts
+++ b/src/github-env.test.ts
@@ -3,9 +3,8 @@ import * as path from 'path';
 import * as os from 'os';
 import {
   extractGhHostFromServerUrl,
-  readGitHubPathEntries,
   readGitHubEnvEntries,
-  mergeGitHubPathEntries,
+  prependPathEntries,
   readEnvFile,
   TOOLCHAIN_ENV_VARS,
 } from './github-env';
@@ -47,90 +46,6 @@ describe('extractGhHostFromServerUrl', () => {
 
   it('should handle localhost URLs', () => {
     expect(extractGhHostFromServerUrl('http://localhost:3000')).toBe('localhost');
-  });
-});
-
-describe('readGitHubPathEntries', () => {
-  let testDir: string;
-  let originalGithubPath: string | undefined;
-
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-github-path-test-'));
-    originalGithubPath = process.env.GITHUB_PATH;
-  });
-
-  afterEach(() => {
-    if (originalGithubPath !== undefined) {
-      process.env.GITHUB_PATH = originalGithubPath;
-    } else {
-      delete process.env.GITHUB_PATH;
-    }
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  it('should return empty array when GITHUB_PATH is not set', () => {
-    delete process.env.GITHUB_PATH;
-    expect(readGitHubPathEntries()).toEqual([]);
-  });
-
-  it('should return empty array when file does not exist', () => {
-    process.env.GITHUB_PATH = path.join(testDir, 'nonexistent');
-    expect(readGitHubPathEntries()).toEqual([]);
-  });
-
-  it('should read single path entry', () => {
-    const githubPathFile = path.join(testDir, 'github_path');
-    fs.writeFileSync(githubPathFile, '/usr/local/bin\n');
-    process.env.GITHUB_PATH = githubPathFile;
-    expect(readGitHubPathEntries()).toEqual(['/usr/local/bin']);
-  });
-
-  it('should read multiple path entries', () => {
-    const githubPathFile = path.join(testDir, 'github_path');
-    fs.writeFileSync(githubPathFile, '/usr/local/bin\n/opt/ruby/bin\n/home/runner/.cargo/bin\n');
-    process.env.GITHUB_PATH = githubPathFile;
-    expect(readGitHubPathEntries()).toEqual([
-      '/usr/local/bin',
-      '/opt/ruby/bin',
-      '/home/runner/.cargo/bin',
-    ]);
-  });
-
-  it('should ignore empty lines', () => {
-    const githubPathFile = path.join(testDir, 'github_path');
-    fs.writeFileSync(githubPathFile, '/usr/local/bin\n\n/opt/ruby/bin\n  \n/home/runner/.cargo/bin\n');
-    process.env.GITHUB_PATH = githubPathFile;
-    expect(readGitHubPathEntries()).toEqual([
-      '/usr/local/bin',
-      '/opt/ruby/bin',
-      '/home/runner/.cargo/bin',
-    ]);
-  });
-
-  it('should trim whitespace from entries', () => {
-    const githubPathFile = path.join(testDir, 'github_path');
-    fs.writeFileSync(githubPathFile, '  /usr/local/bin  \n\t/opt/ruby/bin\t\n');
-    process.env.GITHUB_PATH = githubPathFile;
-    expect(readGitHubPathEntries()).toEqual([
-      '/usr/local/bin',
-      '/opt/ruby/bin',
-    ]);
-  });
-
-  it('should handle empty file', () => {
-    const githubPathFile = path.join(testDir, 'github_path');
-    fs.writeFileSync(githubPathFile, '');
-    process.env.GITHUB_PATH = githubPathFile;
-    expect(readGitHubPathEntries()).toEqual([]);
-  });
-
-  it('should handle file with only whitespace', () => {
-    const githubPathFile = path.join(testDir, 'github_path');
-    fs.writeFileSync(githubPathFile, '  \n  \n  \n');
-    process.env.GITHUB_PATH = githubPathFile;
-    expect(readGitHubPathEntries()).toEqual([]);
   });
 });
 
@@ -345,51 +260,51 @@ describe('readGitHubEnvEntries', () => {
   });
 });
 
-describe('mergeGitHubPathEntries', () => {
-  it('should return current path when github path entries are empty', () => {
+describe('prependPathEntries', () => {
+  it('should return current path when path entries are empty', () => {
     const currentPath = '/usr/bin:/usr/local/bin';
-    expect(mergeGitHubPathEntries(currentPath, [])).toBe(currentPath);
+    expect(prependPathEntries(currentPath, [])).toBe(currentPath);
   });
 
   it('should prepend new entries', () => {
     const currentPath = '/usr/bin:/usr/local/bin';
-    const githubEntries = ['/opt/ruby/bin'];
-    expect(mergeGitHubPathEntries(currentPath, githubEntries)).toBe(
+    const entries = ['/opt/ruby/bin'];
+    expect(prependPathEntries(currentPath, entries)).toBe(
       '/opt/ruby/bin:/usr/bin:/usr/local/bin'
     );
   });
 
   it('should prepend multiple new entries in order', () => {
     const currentPath = '/usr/bin';
-    const githubEntries = ['/opt/ruby/bin', '/home/runner/.cargo/bin'];
-    expect(mergeGitHubPathEntries(currentPath, githubEntries)).toBe(
+    const entries = ['/opt/ruby/bin', '/home/runner/.cargo/bin'];
+    expect(prependPathEntries(currentPath, entries)).toBe(
       '/opt/ruby/bin:/home/runner/.cargo/bin:/usr/bin'
     );
   });
 
   it('should skip entries that already exist in current path', () => {
     const currentPath = '/usr/bin:/usr/local/bin:/opt/ruby/bin';
-    const githubEntries = ['/opt/ruby/bin', '/home/runner/.cargo/bin'];
-    expect(mergeGitHubPathEntries(currentPath, githubEntries)).toBe(
+    const entries = ['/opt/ruby/bin', '/home/runner/.cargo/bin'];
+    expect(prependPathEntries(currentPath, entries)).toBe(
       '/home/runner/.cargo/bin:/usr/bin:/usr/local/bin:/opt/ruby/bin'
     );
   });
 
   it('should handle empty current path', () => {
-    const githubEntries = ['/opt/ruby/bin'];
-    expect(mergeGitHubPathEntries('', githubEntries)).toBe('/opt/ruby/bin');
+    const entries = ['/opt/ruby/bin'];
+    expect(prependPathEntries('', entries)).toBe('/opt/ruby/bin');
   });
 
-  it('should return current path when all github entries already exist', () => {
+  it('should return current path when all entries already exist', () => {
     const currentPath = '/usr/bin:/usr/local/bin:/opt/ruby/bin';
-    const githubEntries = ['/opt/ruby/bin', '/usr/bin'];
-    expect(mergeGitHubPathEntries(currentPath, githubEntries)).toBe(currentPath);
+    const entries = ['/opt/ruby/bin', '/usr/bin'];
+    expect(prependPathEntries(currentPath, entries)).toBe(currentPath);
   });
 
   it('should handle multiple colons in path gracefully', () => {
     const currentPath = '/usr/bin::/usr/local/bin'; // Double colon creates empty entry
-    const githubEntries = ['/opt/ruby/bin'];
-    const result = mergeGitHubPathEntries(currentPath, githubEntries);
+    const entries = ['/opt/ruby/bin'];
+    const result = prependPathEntries(currentPath, entries);
     expect(result).toContain('/opt/ruby/bin');
     expect(result).toContain('/usr/bin');
     expect(result).toContain('/usr/local/bin');

--- a/src/github-env.ts
+++ b/src/github-env.ts
@@ -32,15 +32,14 @@ export function extractGhHostFromServerUrl(serverUrl: string | undefined): strin
 }
 
 /**
- * Reads path entries from the $GITHUB_PATH file used by GitHub Actions.
+ * Reads path entries from the current step's $GITHUB_PATH command file.
  *
- * When setup-* actions (e.g., setup-ruby, setup-dart, setup-python) run before AWF,
- * they add tool paths to the $GITHUB_PATH file. The Actions runner prepends these
- * to $PATH for subsequent steps, but if `sudo` resets PATH (depending on sudoers
- * configuration), those entries may be lost by the time AWF reads process.env.PATH.
- *
- * This function reads the $GITHUB_PATH file directly and returns any path entries
- * found, so they can be merged into AWF_HOST_PATH regardless of sudo behavior.
+ * The Actions runner consumes each step's GITHUB_PATH file after that step
+ * completes and folds those entries into PATH for later steps. This only
+ * recovers paths written earlier in the same step before AWF starts; it does
+ * not recover setup-* paths from previous steps after sudo secure_path strips
+ * PATH. Tool-cache paths from previous setup-* steps are recovered separately
+ * from RUNNER_TOOL_CACHE.
  *
  * @returns Array of path entries from the $GITHUB_PATH file, or empty array if unavailable
  * @internal Exported for testing

--- a/src/github-env.ts
+++ b/src/github-env.ts
@@ -32,39 +32,6 @@ export function extractGhHostFromServerUrl(serverUrl: string | undefined): strin
 }
 
 /**
- * Reads path entries from the current step's $GITHUB_PATH command file.
- *
- * The Actions runner consumes each step's GITHUB_PATH file after that step
- * completes and folds those entries into PATH for later steps. This only
- * recovers paths written earlier in the same step before AWF starts; it does
- * not recover setup-* paths from previous steps after sudo secure_path strips
- * PATH. Tool-cache paths from previous setup-* steps are recovered separately
- * from RUNNER_TOOL_CACHE.
- *
- * @returns Array of path entries from the $GITHUB_PATH file, or empty array if unavailable
- * @internal Exported for testing
- */
-export function readGitHubPathEntries(): string[] {
-  const githubPathFile = process.env.GITHUB_PATH;
-  if (!githubPathFile) {
-    logger.debug('GITHUB_PATH env var is not set; skipping $GITHUB_PATH file merge (tools installed by setup-* actions may be missing from PATH if sudo reset it)');
-    return [];
-  }
-
-  try {
-    const content = fs.readFileSync(githubPathFile, 'utf-8');
-    return content
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.length > 0);
-  } catch {
-    // File doesn't exist or isn't readable — expected outside GitHub Actions
-    logger.debug(`GITHUB_PATH file at '${githubPathFile}' could not be read; skipping file merge`);
-    return [];
-  }
-}
-
-/**
  * Reads key-value environment entries from the $GITHUB_ENV file.
  *
  * The Actions runner writes to this file when steps call `core.exportVariable()`.
@@ -161,18 +128,8 @@ export const TOOLCHAIN_ENV_VARS = [
   'BUN_INSTALL',
 ] as const;
 
-/**
- * Merges path entries from the $GITHUB_PATH file into a PATH string.
- * Entries from $GITHUB_PATH are prepended (they have higher priority, matching
- * how the Actions runner processes them). Duplicate entries are removed.
- *
- * @param currentPath - The current PATH string (e.g., from process.env.PATH)
- * @param githubPathEntries - Path entries read from the $GITHUB_PATH file
- * @returns Merged PATH string with $GITHUB_PATH entries prepended
- * @internal Exported for testing
- */
-export function mergeGitHubPathEntries(currentPath: string, githubPathEntries: string[]): string {
-  if (githubPathEntries.length === 0) {
+export function prependPathEntries(currentPath: string, pathEntries: string[]): string {
+  if (pathEntries.length === 0) {
     return currentPath;
   }
 
@@ -180,13 +137,12 @@ export function mergeGitHubPathEntries(currentPath: string, githubPathEntries: s
   const currentSet = new Set(currentEntries);
 
   // Only add entries that aren't already in the current PATH
-  const newEntries = githubPathEntries.filter(entry => !currentSet.has(entry));
+  const newEntries = pathEntries.filter(entry => !currentSet.has(entry));
 
   if (newEntries.length === 0) {
     return currentPath;
   }
 
-  // Prepend new entries (setup-* actions expect their paths to have priority)
   return [...newEntries, ...currentEntries].join(':');
 }
 

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -50,47 +50,34 @@ function discoverRunnerToolCacheBinDirs(
     return [];
   }
 
-  const binDirsByTool = new Map<string, string[]>();
+  // One bin dir per tool (newest version first via reverse sort, first arch alphabetically).
+  const binDirByTool = new Map<string, string>();
   for (const toolName of safeReadDir(runnerToolCache)) {
     const toolDir = path.join(runnerToolCache, toolName);
     if (!isDirectory(toolDir)) continue;
 
-    for (const versionName of safeReadDir(toolDir).sort().reverse()) {
+    const normalizedTool = toolName.toLowerCase();
+    if (binDirByTool.has(normalizedTool)) continue;
+
+    outer: for (const versionName of safeReadDir(toolDir).sort().reverse()) {
       const versionDir = path.join(toolDir, versionName);
       if (!isDirectory(versionDir)) continue;
 
       for (const architectureName of safeReadDir(versionDir).sort()) {
-        const architectureDir = path.join(versionDir, architectureName);
-        const binDir = path.join(architectureDir, 'bin');
+        const binDir = path.join(versionDir, architectureName, 'bin');
         if (isDirectory(binDir)) {
-          const normalizedTool = toolName.toLowerCase();
-          const existing = binDirsByTool.get(normalizedTool) ?? [];
-          existing.push(binDir);
-          binDirsByTool.set(normalizedTool, existing);
+          binDirByTool.set(normalizedTool, binDir);
+          break outer;
         }
       }
     }
   }
 
-  const selectedBinDirs: string[] = [];
-  const sortedToolBinDirs = [...binDirsByTool.entries()]
+  // Sort by tool name for deterministic ordering, then cap total entries.
+  return [...binDirByTool.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([, dirs]) => dirs);
-
-  for (const toolBinDirs of sortedToolBinDirs) {
-    if (selectedBinDirs.length >= MAX_RECOVERED_TOOLCACHE_BINS) {
-      break;
-    }
-
-    // Use the first entry (newest version after reverse-sort).
-    // Deduplication against the current PATH is handled by prependPathEntries.
-    const candidateBinDir = toolBinDirs[0];
-    if (candidateBinDir) {
-      selectedBinDirs.push(candidateBinDir);
-    }
-  }
-
-  return selectedBinDirs;
+    .slice(0, MAX_RECOVERED_TOOLCACHE_BINS)
+    .map(([, dir]) => dir);
 }
 
 function safeReadDir(directory: string): string[] {

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -13,6 +13,7 @@ export function recoverHostPaths(environment: Record<string, string>): void {
   if (process.env.PATH) {
     const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(
       process.env.RUNNER_TOOL_CACHE,
+      process.env.PATH,
     );
     environment.AWF_HOST_PATH = prependPathEntries(process.env.PATH, runnerToolCacheBinDirs);
     if (runnerToolCacheBinDirs.length > 0) {
@@ -37,6 +38,7 @@ export function recoverHostPaths(environment: Record<string, string>): void {
 
 function discoverRunnerToolCacheBinDirs(
   runnerToolCache: string | undefined,
+  currentPath: string,
 ): string[] {
   if (!runnerToolCache) {
     return [];
@@ -66,7 +68,13 @@ function discoverRunnerToolCacheBinDirs(
       for (const architectureName of safeReadDir(versionDir).sort()) {
         const binDir = path.join(versionDir, architectureName, 'bin');
         if (isDirectory(binDir)) {
-          binDirByTool.set(normalizedTool, binDir);
+          // Only inject this bin dir if none of its executables are already
+          // resolvable on the current PATH. This prevents toolcache dirs from
+          // shadowing system tools that are already available (e.g. a toolcache
+          // Ruby shadowing the system Ruby with a different bundler version).
+          if (!anyBinAlreadyOnPath(binDir, currentPath)) {
+            binDirByTool.set(normalizedTool, binDir);
+          }
           break outer;
         }
       }
@@ -94,6 +102,26 @@ function isDirectory(candidate: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Returns true if any executable inside binDir already appears (by name)
+ * somewhere on currentPath. Used to skip toolcache bin dirs whose tools are
+ * already reachable, so we don't shadow system tools with different versions.
+ */
+function anyBinAlreadyOnPath(binDir: string, currentPath: string): boolean {
+  const pathEntries = currentPath.split(path.delimiter).filter(Boolean);
+  for (const name of safeReadDir(binDir)) {
+    for (const pathEntry of pathEntries) {
+      try {
+        fs.accessSync(path.join(pathEntry, name), fs.constants.X_OK);
+        return true;
+      } catch {
+        // not found in this path entry
+      }
+    }
+  }
+  return false;
 }
 
 

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -1,8 +1,7 @@
 import {
   TOOLCHAIN_ENV_VARS,
   readGitHubEnvEntries,
-  readGitHubPathEntries,
-  mergeGitHubPathEntries,
+  prependPathEntries,
 } from '../../github-env';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -10,17 +9,10 @@ import { logger } from '../../logger';
 
 export function recoverHostPaths(environment: Record<string, string>): void {
   if (process.env.PATH) {
-    const githubPathEntries = readGitHubPathEntries();
     const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(process.env.RUNNER_TOOL_CACHE);
-    environment.AWF_HOST_PATH = mergeGitHubPathEntries(process.env.PATH, [
-      ...runnerToolCacheBinDirs,
-      ...githubPathEntries,
-    ]);
+    environment.AWF_HOST_PATH = prependPathEntries(process.env.PATH, runnerToolCacheBinDirs);
     if (runnerToolCacheBinDirs.length > 0) {
       logger.debug(`Merged ${runnerToolCacheBinDirs.length} runner tool cache bin path(s) into AWF_HOST_PATH`);
-    }
-    if (githubPathEntries.length > 0) {
-      logger.debug(`Merged ${githubPathEntries.length} path(s) from $GITHUB_PATH into AWF_HOST_PATH`);
     }
   }
 

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -4,12 +4,21 @@ import {
   readGitHubPathEntries,
   mergeGitHubPathEntries,
 } from '../../github-env';
+import * as fs from 'fs';
+import * as path from 'path';
 import { logger } from '../../logger';
 
 export function recoverHostPaths(environment: Record<string, string>): void {
   if (process.env.PATH) {
     const githubPathEntries = readGitHubPathEntries();
-    environment.AWF_HOST_PATH = mergeGitHubPathEntries(process.env.PATH, githubPathEntries);
+    const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(process.env.RUNNER_TOOL_CACHE);
+    environment.AWF_HOST_PATH = mergeGitHubPathEntries(process.env.PATH, [
+      ...runnerToolCacheBinDirs,
+      ...githubPathEntries,
+    ]);
+    if (runnerToolCacheBinDirs.length > 0) {
+      logger.debug(`Merged ${runnerToolCacheBinDirs.length} runner tool cache bin path(s) into AWF_HOST_PATH`);
+    }
     if (githubPathEntries.length > 0) {
       logger.debug(`Merged ${githubPathEntries.length} path(s) from $GITHUB_PATH into AWF_HOST_PATH`);
     }
@@ -27,5 +36,56 @@ export function recoverHostPaths(environment: Record<string, string>): void {
         logger.debug(`Recovered ${varName} from $GITHUB_ENV (sudo likely stripped it from process.env)`);
       }
     }
+  }
+}
+
+function discoverRunnerToolCacheBinDirs(runnerToolCache: string | undefined): string[] {
+  if (!runnerToolCache) {
+    return [];
+  }
+
+  try {
+    if (!fs.statSync(runnerToolCache).isDirectory()) {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  const binDirs: string[] = [];
+  for (const toolName of safeReadDir(runnerToolCache)) {
+    const toolDir = path.join(runnerToolCache, toolName);
+    if (!isDirectory(toolDir)) continue;
+
+    for (const versionName of safeReadDir(toolDir)) {
+      const versionDir = path.join(toolDir, versionName);
+      if (!isDirectory(versionDir)) continue;
+
+      for (const architectureName of safeReadDir(versionDir)) {
+        const architectureDir = path.join(versionDir, architectureName);
+        const binDir = path.join(architectureDir, 'bin');
+        if (isDirectory(binDir)) {
+          binDirs.push(binDir);
+        }
+      }
+    }
+  }
+
+  return binDirs.sort();
+}
+
+function safeReadDir(directory: string): string[] {
+  try {
+    return fs.readdirSync(directory);
+  } catch {
+    return [];
+  }
+}
+
+function isDirectory(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isDirectory();
+  } catch {
+    return false;
   }
 }

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -7,9 +7,26 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../../logger';
 
+const MAX_RECOVERED_TOOLCACHE_BINS = 12;
+
+// Probe commands used to determine whether a tool is already available on PATH.
+const TOOL_PROBE_BINARIES: Record<string, string> = {
+  node: 'node',
+  python: 'python3',
+  ruby: 'ruby',
+  go: 'go',
+  uv: 'uv',
+  dotnet: 'dotnet',
+  java: 'java',
+  rust: 'rustc',
+};
+
 export function recoverHostPaths(environment: Record<string, string>): void {
   if (process.env.PATH) {
-    const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(process.env.RUNNER_TOOL_CACHE);
+    const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(
+      process.env.RUNNER_TOOL_CACHE,
+      process.env.PATH,
+    );
     environment.AWF_HOST_PATH = prependPathEntries(process.env.PATH, runnerToolCacheBinDirs);
     if (runnerToolCacheBinDirs.length > 0) {
       logger.debug(`Merged ${runnerToolCacheBinDirs.length} runner tool cache bin path(s) into AWF_HOST_PATH`);
@@ -31,7 +48,10 @@ export function recoverHostPaths(environment: Record<string, string>): void {
   }
 }
 
-function discoverRunnerToolCacheBinDirs(runnerToolCache: string | undefined): string[] {
+function discoverRunnerToolCacheBinDirs(
+  runnerToolCache: string | undefined,
+  currentPath: string,
+): string[] {
   if (!runnerToolCache) {
     return [];
   }
@@ -44,26 +64,46 @@ function discoverRunnerToolCacheBinDirs(runnerToolCache: string | undefined): st
     return [];
   }
 
-  const binDirs: string[] = [];
+  const binDirsByTool = new Map<string, string[]>();
   for (const toolName of safeReadDir(runnerToolCache)) {
     const toolDir = path.join(runnerToolCache, toolName);
     if (!isDirectory(toolDir)) continue;
 
-    for (const versionName of safeReadDir(toolDir)) {
+    for (const versionName of safeReadDir(toolDir).sort().reverse()) {
       const versionDir = path.join(toolDir, versionName);
       if (!isDirectory(versionDir)) continue;
 
-      for (const architectureName of safeReadDir(versionDir)) {
+      for (const architectureName of safeReadDir(versionDir).sort()) {
         const architectureDir = path.join(versionDir, architectureName);
         const binDir = path.join(architectureDir, 'bin');
         if (isDirectory(binDir)) {
-          binDirs.push(binDir);
+          const normalizedTool = toolName.toLowerCase();
+          const existing = binDirsByTool.get(normalizedTool) ?? [];
+          existing.push(binDir);
+          binDirsByTool.set(normalizedTool, existing);
         }
       }
     }
   }
 
-  return binDirs.sort();
+  const selectedBinDirs: string[] = [];
+  for (const [toolName, toolBinDirs] of [...binDirsByTool.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    if (selectedBinDirs.length >= MAX_RECOVERED_TOOLCACHE_BINS) {
+      break;
+    }
+
+    const probeBinary = TOOL_PROBE_BINARIES[toolName];
+    if (probeBinary && isExecutableOnPath(probeBinary, currentPath)) {
+      continue;
+    }
+
+    // Use the first discovered entry after reverse version sort (newest-first).
+    if (toolBinDirs[0]) {
+      selectedBinDirs.push(toolBinDirs[0]);
+    }
+  }
+
+  return selectedBinDirs;
 }
 
 function safeReadDir(directory: string): string[] {
@@ -80,4 +120,18 @@ function isDirectory(candidate: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isExecutableOnPath(binaryName: string, currentPath: string): boolean {
+  for (const pathEntry of currentPath.split(path.delimiter)) {
+    if (!pathEntry) continue;
+    const candidate = path.join(pathEntry, binaryName);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return true;
+    } catch {
+      // ignore missing/non-executable entries
+    }
+  }
+  return false;
 }

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -13,7 +13,6 @@ export function recoverHostPaths(environment: Record<string, string>): void {
   if (process.env.PATH) {
     const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(
       process.env.RUNNER_TOOL_CACHE,
-      process.env.PATH,
     );
     environment.AWF_HOST_PATH = prependPathEntries(process.env.PATH, runnerToolCacheBinDirs);
     if (runnerToolCacheBinDirs.length > 0) {
@@ -38,7 +37,6 @@ export function recoverHostPaths(environment: Record<string, string>): void {
 
 function discoverRunnerToolCacheBinDirs(
   runnerToolCache: string | undefined,
-  currentPath: string,
 ): string[] {
   if (!runnerToolCache) {
     return [];
@@ -84,17 +82,12 @@ function discoverRunnerToolCacheBinDirs(
       break;
     }
 
-    // Skip if any executable already present in this bin dir is already on PATH.
-    // This is fully data-driven: no hardcoded tool→binary mapping needed.
+    // Use the first entry (newest version after reverse-sort).
+    // Deduplication against the current PATH is handled by prependPathEntries.
     const candidateBinDir = toolBinDirs[0];
-    if (!candidateBinDir) continue;
-
-    if (anyBinAlreadyOnPath(candidateBinDir, currentPath)) {
-      continue;
+    if (candidateBinDir) {
+      selectedBinDirs.push(candidateBinDir);
     }
-
-    // Use the first discovered entry (newest version after reverse-sort).
-    selectedBinDirs.push(candidateBinDir);
   }
 
   return selectedBinDirs;
@@ -116,23 +109,4 @@ function isDirectory(candidate: string): boolean {
   }
 }
 
-/**
- * Returns true if any executable inside binDir already appears (by name) on
- * currentPath. Used to avoid injecting a toolcache bin dir when the tool is
- * already reachable — no hardcoded tool/binary mapping required.
- */
-function anyBinAlreadyOnPath(binDir: string, currentPath: string): boolean {
-  const entries = safeReadDir(binDir);
-  for (const name of entries) {
-    for (const pathEntry of currentPath.split(path.delimiter)) {
-      if (!pathEntry) continue;
-      try {
-        fs.accessSync(path.join(pathEntry, name), fs.constants.X_OK);
-        return true;
-      } catch {
-        // not found in this path entry
-      }
-    }
-  }
-  return false;
-}
+

--- a/src/services/agent-environment/host-path-recovery.ts
+++ b/src/services/agent-environment/host-path-recovery.ts
@@ -9,18 +9,6 @@ import { logger } from '../../logger';
 
 const MAX_RECOVERED_TOOLCACHE_BINS = 12;
 
-// Probe commands used to determine whether a tool is already available on PATH.
-const TOOL_PROBE_BINARIES: Record<string, string> = {
-  node: 'node',
-  python: 'python3',
-  ruby: 'ruby',
-  go: 'go',
-  uv: 'uv',
-  dotnet: 'dotnet',
-  java: 'java',
-  rust: 'rustc',
-};
-
 export function recoverHostPaths(environment: Record<string, string>): void {
   if (process.env.PATH) {
     const runnerToolCacheBinDirs = discoverRunnerToolCacheBinDirs(
@@ -87,20 +75,26 @@ function discoverRunnerToolCacheBinDirs(
   }
 
   const selectedBinDirs: string[] = [];
-  for (const [toolName, toolBinDirs] of [...binDirsByTool.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+  const sortedToolBinDirs = [...binDirsByTool.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, dirs]) => dirs);
+
+  for (const toolBinDirs of sortedToolBinDirs) {
     if (selectedBinDirs.length >= MAX_RECOVERED_TOOLCACHE_BINS) {
       break;
     }
 
-    const probeBinary = TOOL_PROBE_BINARIES[toolName];
-    if (probeBinary && isExecutableOnPath(probeBinary, currentPath)) {
+    // Skip if any executable already present in this bin dir is already on PATH.
+    // This is fully data-driven: no hardcoded tool→binary mapping needed.
+    const candidateBinDir = toolBinDirs[0];
+    if (!candidateBinDir) continue;
+
+    if (anyBinAlreadyOnPath(candidateBinDir, currentPath)) {
       continue;
     }
 
-    // Use the first discovered entry after reverse version sort (newest-first).
-    if (toolBinDirs[0]) {
-      selectedBinDirs.push(toolBinDirs[0]);
-    }
+    // Use the first discovered entry (newest version after reverse-sort).
+    selectedBinDirs.push(candidateBinDir);
   }
 
   return selectedBinDirs;
@@ -122,15 +116,22 @@ function isDirectory(candidate: string): boolean {
   }
 }
 
-function isExecutableOnPath(binaryName: string, currentPath: string): boolean {
-  for (const pathEntry of currentPath.split(path.delimiter)) {
-    if (!pathEntry) continue;
-    const candidate = path.join(pathEntry, binaryName);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return true;
-    } catch {
-      // ignore missing/non-executable entries
+/**
+ * Returns true if any executable inside binDir already appears (by name) on
+ * currentPath. Used to avoid injecting a toolcache bin dir when the tool is
+ * already reachable — no hardcoded tool/binary mapping required.
+ */
+function anyBinAlreadyOnPath(binDir: string, currentPath: string): boolean {
+  const entries = safeReadDir(binDir);
+  for (const name of entries) {
+    for (const pathEntry of currentPath.split(path.delimiter)) {
+      if (!pathEntry) continue;
+      try {
+        fs.accessSync(path.join(pathEntry, name), fs.constants.X_OK);
+        return true;
+      } catch {
+        // not found in this path entry
+      }
     }
   }
   return false;

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -522,6 +522,37 @@ describe('agent service', () => {
       }
     });
 
+    it('should not add toolcache bin dir when its binary is already executable on PATH via a different dir', () => {
+      // Simulates the case where e.g. a system Ruby is already on PATH and a toolcache
+      // Ruby also exists. The toolcache dir should not be prepended to avoid shadowing.
+      const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
+      const toolcacheBinDir = path.join(toolCacheDir, 'node', '24.16.0', 'x64', 'bin');
+      fs.mkdirSync(toolcacheBinDir, { recursive: true });
+      fs.writeFileSync(path.join(toolcacheBinDir, 'node'), '#!/bin/sh\necho node\n', { mode: 0o755 });
+
+      // A separate system-like dir that also has 'node' — already on PATH.
+      const systemBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-system-bin-'));
+      fs.writeFileSync(path.join(systemBinDir, 'node'), '#!/bin/sh\necho node\n', { mode: 0o755 });
+
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+      process.env.PATH = `${systemBinDir}:/usr/bin`;
+      process.env.RUNNER_TOOL_CACHE = toolCacheDir;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        // toolcacheBinDir should NOT be prepended since 'node' is already on PATH via systemBinDir.
+        expect(env.AWF_HOST_PATH).toBe(`${systemBinDir}:/usr/bin`);
+      } finally {
+        if (originalPath !== undefined) process.env.PATH = originalPath;
+        if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        else delete process.env.RUNNER_TOOL_CACHE;
+        fs.rmSync(systemBinDir, { recursive: true, force: true });
+        fs.rmSync(toolCacheDir, { recursive: true, force: true });
+      }
+    });
+
     it('should ignore RUNNER_TOOL_CACHE when it points to a nonexistent path', () => {
       const originalPath = process.env.PATH;
       const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -470,5 +470,59 @@ describe('agent service', () => {
         }
       }
     });
+
+    it('should ignore RUNNER_TOOL_CACHE when it points to a file', () => {
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+
+      process.env.PATH = '/usr/local/bin:/usr/bin';
+      // create a file instead of a directory
+      const tmpFile = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-file-')) + '.file';
+      fs.writeFileSync(tmpFile, 'not a dir');
+      process.env.RUNNER_TOOL_CACHE = tmpFile;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        expect(env.AWF_HOST_PATH).toBe('/usr/local/bin:/usr/bin');
+      } finally {
+        if (originalPath !== undefined) {
+          process.env.PATH = originalPath;
+        }
+        if (originalRunnerToolCache !== undefined) {
+          process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        } else {
+          delete process.env.RUNNER_TOOL_CACHE;
+        }
+        try { fs.rmSync(tmpFile, { force: true }); } catch {}
+      }
+    });
+
+    it('should skip non-directory entries inside RUNNER_TOOL_CACHE', () => {
+      const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
+      // create a top-level file entry
+      fs.writeFileSync(path.join(toolCacheDir, 'README.txt'), 'info');
+      // create a tool dir with a version that is a file
+      const toolDir = path.join(toolCacheDir, 'oddtool');
+      fs.mkdirSync(toolDir, { recursive: true });
+      fs.writeFileSync(path.join(toolDir, '1.0.0'), 'not-a-dir');
+
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+      process.env.PATH = '/usr/local/bin:/usr/bin';
+      process.env.RUNNER_TOOL_CACHE = toolCacheDir;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        // no bin dirs should have been discovered, so AWF_HOST_PATH equals PATH
+        expect(env.AWF_HOST_PATH).toBe('/usr/local/bin:/usr/bin');
+      } finally {
+        if (originalPath !== undefined) process.env.PATH = originalPath;
+        if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        else delete process.env.RUNNER_TOOL_CACHE;
+        fs.rmSync(toolCacheDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -494,7 +494,10 @@ describe('agent service', () => {
         } else {
           delete process.env.RUNNER_TOOL_CACHE;
         }
-        try { fs.rmSync(tmpFile, { force: true }); } catch {}
+        // eslint-disable-next-line no-empty,@typescript-eslint/no-unused-vars
+        try { fs.rmSync(tmpFile, { force: true }); } catch (_e) {
+          // File may not exist, safe to ignore
+        }
       }
     });
 

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -384,7 +384,7 @@ describe('agent service', () => {
     });
   });
 
-  describe('generateDockerCompose - GITHUB_PATH integration', () => {
+  describe('generateDockerCompose - host PATH recovery', () => {
     let mockConfig: WrapperConfig;
 
     const mockNetworkConfig = {
@@ -408,38 +408,6 @@ describe('agent service', () => {
 
     afterEach(() => {
       fs.rmSync(mockConfig.workDir, { recursive: true, force: true });
-    });
-
-    it('should merge GITHUB_PATH entries into AWF_HOST_PATH', () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-gp-'));
-      const pathFile = path.join(tmpDir, 'add_path');
-      fs.writeFileSync(pathFile, '/opt/hostedtoolcache/Ruby/3.3.10/x64/bin\n');
-
-      const originalGithubPath = process.env.GITHUB_PATH;
-      const originalPath = process.env.PATH;
-      process.env.GITHUB_PATH = pathFile;
-      process.env.PATH = '/usr/local/bin:/usr/bin';
-
-      try {
-        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
-        const env = result.services.agent.environment as Record<string, string>;
-
-        expect(env.AWF_HOST_PATH).toContain('/opt/hostedtoolcache/Ruby/3.3.10/x64/bin');
-        expect(env.AWF_HOST_PATH).toContain('/usr/local/bin');
-        // Ruby path should be prepended
-        expect(env.AWF_HOST_PATH.indexOf('/opt/hostedtoolcache/Ruby/3.3.10/x64/bin'))
-          .toBeLessThan(env.AWF_HOST_PATH.indexOf('/usr/local/bin'));
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
-        if (originalPath !== undefined) {
-          process.env.PATH = originalPath;
-        }
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-      }
     });
 
     it('should merge RUNNER_TOOL_CACHE bin directories into AWF_HOST_PATH', () => {
@@ -480,41 +448,11 @@ describe('agent service', () => {
       }
     });
 
-    it('should not duplicate PATH entries from GITHUB_PATH', () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-gp-'));
-      const pathFile = path.join(tmpDir, 'add_path');
-      fs.writeFileSync(pathFile, '/usr/local/bin\n');
-
-      const originalGithubPath = process.env.GITHUB_PATH;
+    it('should use PATH when RUNNER_TOOL_CACHE is not set', () => {
       const originalPath = process.env.PATH;
-      process.env.GITHUB_PATH = pathFile;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
       process.env.PATH = '/usr/local/bin:/usr/bin';
-
-      try {
-        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
-        const env = result.services.agent.environment as Record<string, string>;
-
-        // /usr/local/bin should appear exactly once
-        const occurrences = env.AWF_HOST_PATH.split(':').filter(p => p === '/usr/local/bin').length;
-        expect(occurrences).toBe(1);
-      } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
-        if (originalPath !== undefined) {
-          process.env.PATH = originalPath;
-        }
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should work when GITHUB_PATH is not set', () => {
-      const originalGithubPath = process.env.GITHUB_PATH;
-      const originalPath = process.env.PATH;
-      delete process.env.GITHUB_PATH;
-      process.env.PATH = '/usr/local/bin:/usr/bin';
+      delete process.env.RUNNER_TOOL_CACHE;
 
       try {
         const result = generateDockerCompose(mockConfig, mockNetworkConfig);
@@ -522,13 +460,13 @@ describe('agent service', () => {
 
         expect(env.AWF_HOST_PATH).toBe('/usr/local/bin:/usr/bin');
       } finally {
-        if (originalGithubPath !== undefined) {
-          process.env.GITHUB_PATH = originalGithubPath;
-        } else {
-          delete process.env.GITHUB_PATH;
-        }
         if (originalPath !== undefined) {
           process.env.PATH = originalPath;
+        }
+        if (originalRunnerToolCache !== undefined) {
+          process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        } else {
+          delete process.env.RUNNER_TOOL_CACHE;
         }
       }
     });

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -477,7 +477,8 @@ describe('agent service', () => {
 
       process.env.PATH = '/usr/local/bin:/usr/bin';
       // create a file instead of a directory
-      const tmpFile = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-file-')) + '.file';
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-file-'));
+      const tmpFile = path.join(tmpDir, 'not-a-dir.file');
       fs.writeFileSync(tmpFile, 'not a dir');
       process.env.RUNNER_TOOL_CACHE = tmpFile;
 
@@ -494,10 +495,33 @@ describe('agent service', () => {
         } else {
           delete process.env.RUNNER_TOOL_CACHE;
         }
-        // eslint-disable-next-line no-empty,@typescript-eslint/no-unused-vars
-        try { fs.rmSync(tmpFile, { force: true }); } catch (_e) {
-          // File may not exist, safe to ignore
-        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should avoid adding toolcache bins for tools already present on PATH', () => {
+      const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
+      const nodeBinDir = path.join(toolCacheDir, 'node', '24.16.0', 'x64', 'bin');
+      fs.mkdirSync(nodeBinDir, { recursive: true });
+      fs.writeFileSync(path.join(nodeBinDir, 'node'), '#!/bin/sh\necho node\n', { mode: 0o755 });
+
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+      const pathDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-path-bin-'));
+      fs.writeFileSync(path.join(pathDir, 'node'), '#!/bin/sh\necho node\n', { mode: 0o755 });
+      process.env.PATH = `${pathDir}:/usr/bin:/bin`;
+      process.env.RUNNER_TOOL_CACHE = toolCacheDir;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        expect(env.AWF_HOST_PATH).toBe(`${pathDir}:/usr/bin:/bin`);
+      } finally {
+        if (originalPath !== undefined) process.env.PATH = originalPath;
+        if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        else delete process.env.RUNNER_TOOL_CACHE;
+        fs.rmSync(pathDir, { recursive: true, force: true });
+        fs.rmSync(toolCacheDir, { recursive: true, force: true });
       }
     });
 

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -442,6 +442,44 @@ describe('agent service', () => {
       }
     });
 
+    it('should merge RUNNER_TOOL_CACHE bin directories into AWF_HOST_PATH', () => {
+      const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
+      const nodeBinDir = path.join(toolCacheDir, 'node', '24.16.0', 'x64', 'bin');
+      fs.mkdirSync(nodeBinDir, { recursive: true });
+
+      const originalGithubPath = process.env.GITHUB_PATH;
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+      delete process.env.GITHUB_PATH;
+      process.env.PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+      process.env.RUNNER_TOOL_CACHE = toolCacheDir;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        expect(env.AWF_HOST_PATH).toContain(nodeBinDir);
+        expect(env.AWF_HOST_PATH).toContain('/usr/local/bin');
+        expect(env.AWF_HOST_PATH.indexOf(nodeBinDir))
+          .toBeLessThan(env.AWF_HOST_PATH.indexOf('/usr/local/bin'));
+      } finally {
+        if (originalGithubPath !== undefined) {
+          process.env.GITHUB_PATH = originalGithubPath;
+        } else {
+          delete process.env.GITHUB_PATH;
+        }
+        if (originalPath !== undefined) {
+          process.env.PATH = originalPath;
+        }
+        if (originalRunnerToolCache !== undefined) {
+          process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        } else {
+          delete process.env.RUNNER_TOOL_CACHE;
+        }
+        fs.rmSync(toolCacheDir, { recursive: true, force: true });
+      }
+    });
+
     it('should not duplicate PATH entries from GITHUB_PATH', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-gp-'));
       const pathFile = path.join(tmpDir, 'add_path');

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -499,28 +499,25 @@ describe('agent service', () => {
       }
     });
 
-    it('should avoid adding toolcache bins for tools already present on PATH', () => {
+    it('should not add toolcache bin dir if it is already present in PATH', () => {
       const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
       const nodeBinDir = path.join(toolCacheDir, 'node', '24.16.0', 'x64', 'bin');
       fs.mkdirSync(nodeBinDir, { recursive: true });
-      fs.writeFileSync(path.join(nodeBinDir, 'node'), '#!/bin/sh\necho node\n', { mode: 0o755 });
 
       const originalPath = process.env.PATH;
       const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
-      const pathDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-path-bin-'));
-      fs.writeFileSync(path.join(pathDir, 'node'), '#!/bin/sh\necho node\n', { mode: 0o755 });
-      process.env.PATH = `${pathDir}:/usr/bin:/bin`;
+      // The toolcache bin dir is already in PATH — prependPathEntries should not add it again.
+      process.env.PATH = `${nodeBinDir}:/usr/bin:/bin`;
       process.env.RUNNER_TOOL_CACHE = toolCacheDir;
 
       try {
         const result = generateDockerCompose(mockConfig, mockNetworkConfig);
         const env = result.services.agent.environment as Record<string, string>;
-        expect(env.AWF_HOST_PATH).toBe(`${pathDir}:/usr/bin:/bin`);
+        expect(env.AWF_HOST_PATH).toBe(`${nodeBinDir}:/usr/bin:/bin`);
       } finally {
         if (originalPath !== undefined) process.env.PATH = originalPath;
         if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
         else delete process.env.RUNNER_TOOL_CACHE;
-        fs.rmSync(pathDir, { recursive: true, force: true });
         fs.rmSync(toolCacheDir, { recursive: true, force: true });
       }
     });

--- a/src/services/agent-service.test.ts
+++ b/src/services/agent-service.test.ts
@@ -522,6 +522,77 @@ describe('agent service', () => {
       }
     });
 
+    it('should ignore RUNNER_TOOL_CACHE when it points to a nonexistent path', () => {
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+
+      process.env.PATH = '/usr/local/bin:/usr/bin';
+      process.env.RUNNER_TOOL_CACHE = '/tmp/awf-nonexistent-path-that-does-not-exist';
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        expect(env.AWF_HOST_PATH).toBe('/usr/local/bin:/usr/bin');
+      } finally {
+        if (originalPath !== undefined) process.env.PATH = originalPath;
+        if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        else delete process.env.RUNNER_TOOL_CACHE;
+      }
+    });
+
+    it('should pick only one bin dir when two tool dirs share the same lowercase name', () => {
+      // Simulates a case-insensitive FS or a toolcache with duplicate-cased tool dirs.
+      const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
+      const bin1 = path.join(toolCacheDir, 'Node', '20.0.0', 'x64', 'bin');
+      const bin2 = path.join(toolCacheDir, 'node', '22.0.0', 'x64', 'bin');
+      fs.mkdirSync(bin1, { recursive: true });
+      fs.mkdirSync(bin2, { recursive: true });
+
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+      process.env.PATH = '/usr/bin';
+      process.env.RUNNER_TOOL_CACHE = toolCacheDir;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        const addedDirs = env.AWF_HOST_PATH.split(':').filter(d => d.startsWith(toolCacheDir));
+        expect(addedDirs).toHaveLength(1);
+      } finally {
+        if (originalPath !== undefined) process.env.PATH = originalPath;
+        if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        else delete process.env.RUNNER_TOOL_CACHE;
+        fs.rmSync(toolCacheDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should pick only the first architecture when a tool version has multiple', () => {
+      const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
+      const binArm = path.join(toolCacheDir, 'node', '20.0.0', 'arm64', 'bin');
+      const binX64 = path.join(toolCacheDir, 'node', '20.0.0', 'x64', 'bin');
+      fs.mkdirSync(binArm, { recursive: true });
+      fs.mkdirSync(binX64, { recursive: true });
+
+      const originalPath = process.env.PATH;
+      const originalRunnerToolCache = process.env.RUNNER_TOOL_CACHE;
+      process.env.PATH = '/usr/bin';
+      process.env.RUNNER_TOOL_CACHE = toolCacheDir;
+
+      try {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+        const addedDirs = env.AWF_HOST_PATH.split(':').filter(d => d.startsWith(toolCacheDir));
+        // Only arm64 (alphabetically first) should be added, not both.
+        expect(addedDirs).toHaveLength(1);
+        expect(addedDirs[0]).toBe(binArm);
+      } finally {
+        if (originalPath !== undefined) process.env.PATH = originalPath;
+        if (originalRunnerToolCache !== undefined) process.env.RUNNER_TOOL_CACHE = originalRunnerToolCache;
+        else delete process.env.RUNNER_TOOL_CACHE;
+        fs.rmSync(toolCacheDir, { recursive: true, force: true });
+      }
+    });
+
     it('should skip non-directory entries inside RUNNER_TOOL_CACHE', () => {
       const toolCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-tool-cache-'));
       // create a top-level file entry

--- a/tests/chroot-path-ordering.test.sh
+++ b/tests/chroot-path-ordering.test.sh
@@ -2,10 +2,9 @@
 # Unit test for chroot fallback PATH ordering (containers/agent/entrypoint.sh)
 #
 # Validates that when AWF_HOST_PATH is unset (fallback branch):
-#   1. $GITHUB_PATH entries are prepended with highest priority.
-#   2. hostedtoolcache bins are appended (not prepended), so they never
-#      override an explicit setup-* version selection.
-#   3. CRLF line endings in the GITHUB_PATH file are handled correctly.
+#   1. hostedtoolcache bins are appended (not prepended), so standard paths
+#      retain priority.
+#   2. self-hosted runner toolcache bins are scanned as fallbacks.
 
 set -e
 
@@ -17,7 +16,7 @@ fail() { echo "❌ FAIL: $1"; FAIL=$((FAIL + 1)); }
 
 # ---------------------------------------------------------------------------
 # Extract the heredoc PATH-building logic from entrypoint.sh and run it in a
-# temporary sub-shell with a synthetic hostedtoolcache and GITHUB_PATH file.
+# temporary sub-shell with a synthetic hostedtoolcache.
 # ---------------------------------------------------------------------------
 
 # Locate the lines of the heredoc content (between the AWFEOF markers in the
@@ -55,16 +54,15 @@ chmod +x "${RUNNER_TOOLCACHE}/node/20.19.0/x64/bin/node"
 # the resulting PATH with a provided test expression.
 # ---------------------------------------------------------------------------
 run_path_test() {
-  local github_path_file="$1"   # path to the GITHUB_PATH file (or "" to skip)
-  local base_path="$2"           # starting PATH value
-  local check_expr="$3"          # bash expression to evaluate after PATH is set
+  local base_path="$1"           # starting PATH value
+  local check_expr="$2"          # bash expression to evaluate after PATH is set
 
   # Build the inline script from the relevant heredoc section of entrypoint.sh.
   # We replace the toolcache roots with fake test fixtures so the test is
   # self-contained and doesn't depend on the host runner layout.
   local script
   script="$(
-    sed -n '/^# Prepend entries from \$GITHUB_PATH/,/^AWFEOF$/{ /^AWFEOF$/d; p; }' \
+    sed -n '/^# Dynamically scan toolcache roots/,/^AWFEOF$/{ /^AWFEOF$/d; p; }' \
       "${ENTRYPOINT}" |
     sed \
       -e "s|/opt/hostedtoolcache|${TOOLCACHE}|g" \
@@ -74,98 +72,33 @@ run_path_test() {
   # Run the script in a sub-shell with a clean environment
   (
     export PATH="${base_path}"
-    [ -n "${github_path_file}" ] && export GITHUB_PATH="${github_path_file}"
     eval "${script}"
     eval "${check_expr}"
   )
 }
 
-# ---------------------------------------------------------------------------
-# Test 1: GITHUB_PATH entry for Ruby 3.3 must precede the toolcache scan
-# ---------------------------------------------------------------------------
-GP_FILE="${TMPDIR_TEST}/github_path_test1"
-printf '%s\n' "${TOOLCACHE}/Ruby/3.3.0/x64/bin" > "${GP_FILE}"
-
 BASE_PATH="/usr/local/bin:/usr/bin:/bin"
 
-if run_path_test "${GP_FILE}" "${BASE_PATH}" \
-  "case \"\${PATH}\" in *\"${TOOLCACHE}/Ruby/3.3.0/x64/bin:\"*) exit 0;; *) exit 1;; esac"; then
-  pass "GITHUB_PATH entry is prepended to PATH"
-else
-  fail "GITHUB_PATH entry is not prepended to PATH"
-fi
-
-# Test that 3.3.0 appears before 3.1.0 in PATH
-if run_path_test "${GP_FILE}" "${BASE_PATH}" "
-  pos33=\$(echo \"\${PATH}\" | tr ':' '\n' | grep -n '3.3.0' | cut -d: -f1 | head -1)
-  pos31=\$(echo \"\${PATH}\" | tr ':' '\n' | grep -n '3.1.0' | cut -d: -f1 | head -1)
-  [ -n \"\${pos33}\" ] && [ -n \"\${pos31}\" ] && [ \"\${pos33}\" -lt \"\${pos31}\" ]
-"; then
-  pass "setup-* version (3.3.0) precedes older toolcache version (3.1.0) in PATH"
-else
-  fail "setup-* version (3.3.0) does not precede older toolcache version (3.1.0) in PATH"
-fi
-
-# Test that the correct ruby is found first
-if run_path_test "${GP_FILE}" "${BASE_PATH}" \
-  '[ "$(ruby 2>/dev/null)" = "ruby 3.3.0" ]'; then
-  pass "ruby resolves to setup-* selected version (3.3.0)"
-else
-  fail "ruby does not resolve to setup-* selected version (3.3.0)"
-fi
-
 # ---------------------------------------------------------------------------
-# Test 2: Without GITHUB_PATH, toolcache bins are still appended (not prepend)
+# Test 1: Toolcache bins are appended (not prepended)
 # ---------------------------------------------------------------------------
-if run_path_test "" "${BASE_PATH}" "
+if run_path_test "${BASE_PATH}" "
   case \"\${PATH}\" in
     \"${TOOLCACHE}/Ruby\"*) exit 1;;   # toolcache prepended — wrong
     *) exit 0;;                         # toolcache appended or absent — ok
   esac
 "; then
-  pass "without GITHUB_PATH, toolcache bins are not prepended to PATH"
+  pass "toolcache bins are not prepended to PATH"
 else
-  fail "without GITHUB_PATH, toolcache bins were incorrectly prepended to PATH"
+  fail "toolcache bins were incorrectly prepended to PATH"
 fi
 
 # ---------------------------------------------------------------------------
-# Test 3: CRLF entries in GITHUB_PATH file are stripped
-# ---------------------------------------------------------------------------
-GP_FILE_CRLF="${TMPDIR_TEST}/github_path_crlf"
-printf '%s\r\n' "${TOOLCACHE}/Ruby/3.3.0/x64/bin" > "${GP_FILE_CRLF}"
-
-if run_path_test "${GP_FILE_CRLF}" "${BASE_PATH}" "
-  case \"\${PATH}\" in
-    *$'\r'*) exit 1;;   # CR leaked into PATH — wrong
-    *) exit 0;;
-  esac
-"; then
-  pass "CRLF line endings in GITHUB_PATH are stripped correctly"
-else
-  fail "CRLF line endings in GITHUB_PATH leaked into PATH"
-fi
-
-# ---------------------------------------------------------------------------
-# Test 4: Duplicate entries in GITHUB_PATH are not added twice by toolcache scan
-# ---------------------------------------------------------------------------
-GP_FILE_DUP="${TMPDIR_TEST}/github_path_dup"
-printf '%s\n' "${TOOLCACHE}/Ruby/3.3.0/x64/bin" > "${GP_FILE_DUP}"
-
-if run_path_test "${GP_FILE_DUP}" "${BASE_PATH}" "
-  count=\$(echo \"\${PATH}\" | tr ':' '\n' | grep -c '3.3.0' || true)
-  [ \"\${count}\" -eq 1 ]
-"; then
-  pass "toolcache scan does not duplicate a directory already in PATH from GITHUB_PATH"
-else
-  fail "toolcache scan duplicated a directory already in PATH from GITHUB_PATH"
-fi
-
-# ---------------------------------------------------------------------------
-# Test 5: Self-hosted runner toolcache is scanned for fallback binaries
+# Test 2: Self-hosted runner toolcache is scanned for fallback binaries
 # ---------------------------------------------------------------------------
 FALLBACK_BASE_PATH="/tmp/awf-empty-path"
 
-if run_path_test "" "${FALLBACK_BASE_PATH}" "
+if run_path_test "${FALLBACK_BASE_PATH}" "
   case \"\${PATH}\" in
     *\"${RUNNER_TOOLCACHE}/node/20.19.0/x64/bin\"*) exit 0;;
     *) exit 1;;
@@ -176,7 +109,7 @@ else
   fail "self-hosted runner toolcache bins were not added to PATH"
 fi
 
-if run_path_test "" "${FALLBACK_BASE_PATH}" \
+if run_path_test "${FALLBACK_BASE_PATH}" \
   '[ "$(command -v node 2>/dev/null)" = "${RUNNER_TOOLCACHE}/node/20.19.0/x64/bin/node" ]'; then
   pass "node resolves from self-hosted runner toolcache fallback"
 else

--- a/tests/chroot-path-ordering.test.sh
+++ b/tests/chroot-path-ordering.test.sh
@@ -71,6 +71,10 @@ run_path_test() {
 
   # Run the script in a sub-shell with a clean environment
   (
+    local isolated_home
+    isolated_home="$(mktemp -d "${TMPDIR_TEST}/home-XXXXXX")"
+    trap '/bin/rm -rf "${isolated_home}"' EXIT
+    export HOME="${isolated_home}"
     export PATH="${base_path}"
     eval "${script}"
     eval "${check_expr}"


### PR DESCRIPTION
Summary

Recover runner `toolcache` bin directories into the chroot `PATH` used by the agent container when AWF runs under `sudo` or when the runner tool cache contains needed binaries. This avoids preflight failures (e.g., missing `node`) caused by `sudo` sanitizing `PATH` on self-hosted/DinD runners.

Root cause

When `sudo` is used inside some self-hosted runner environments, `secure_path` in `/etc/sudoers` may remove the runner's tool-cache `bin` directories from `PATH`. AWF's previous attempt to read per-step `GITHUB_PATH` was incorrect (it's per-step and cannot reliably recover prior step changes), which led to brittle behavior and confusing documentation.

What this change does

- Adds discovery of `RUNNER_TOOL_CACHE` bin directories and merges them ahead of the existing `PATH` into `AWF_HOST_PATH` so chrooted agent processes can find tool binaries.
- Removes the previous, incorrect attempt to read `GITHUB_PATH` for PATH recovery.
- Restores toolchain env var recovery from `GITHUB_ENV` when AWF is running under `sudo` (unchanged behavior, but clarified).
- Adds unit tests for edge cases around `RUNNER_TOOL_CACHE` discovery.

Testing

- Unit tests added/updated to cover:
  - discovery of nested `toolcache/*/<version>/<arch>/bin` directories
  - behavior when `RUNNER_TOOL_CACHE` is not set
  - behavior when `RUNNER_TOOL_CACHE` points to non-directories or contains non-directory entries
  - recovery of toolchain vars from `GITHUB_ENV` when running as root with `SUDO_UID` set
- Ran full test suite locally: `npm test -- --coverage` — all tests passed.

Risk and rollout

Low-risk. Changes are localized to host-path recovery logic and tests. If a regression is seen, revert the commit that modifies `src/services/agent-environment/host-path-recovery.ts`.

Notes for reviewers

- Focus on the `discoverRunnerToolCacheBinDirs` logic and the test cases that exercise non-directory entries and permission-safe reads.
- This change intentionally removes the incorrect `GITHUB_PATH` merging; see docs update in the branch for rationale.

Related

- See draft PR #5145 for a complementary, separate change that makes the container entrypoint preflight honor an explicit `GH_AW_NODE_BIN` when set.

