### PR TITLE
fix: allow node preflight to use explicit binary

### DIFF
--- a/containers/agent/entrypoint.sh
+++ b/containers/agent/entrypoint.sh
@@ -952,11 +952,17 @@ AWFEOF
   echo 'export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"' >> "/host${SCRIPT_FILE}"
   if [ "${AWF_REQUIRE_NODE:-}" = "1" ]; then
     cat >> "/host${SCRIPT_FILE}" << 'AWFEOF'
-if ! command -v node >/dev/null 2>&1; then
+if [ -n "${GH_AW_NODE_BIN:-}" ] && [ -x "${GH_AW_NODE_BIN}" ]; then
+  echo "[entrypoint] Node.js available via GH_AW_NODE_BIN: ${GH_AW_NODE_BIN}"
+elif command -v node >/dev/null 2>&1; then
+  echo "[entrypoint] Node.js available on PATH: $(command -v node)"
+else
   echo "[entrypoint][ERROR] Copilot CLI requires Node.js, but 'node' is not available inside AWF chroot." >&2
   echo "[entrypoint][ERROR] Ensure Node.js is installed on the runner and reachable from PATH inside the chroot." >&2
   echo "[entrypoint][ERROR] If using setup-node or nvm, verify the install path is present and bind-mounted into /host." >&2
   echo "[entrypoint][ERROR] Example locations include /opt/hostedtoolcache/..., $HOME/work/_tool/..., and $HOME/.nvm/..." >&2
+  echo "[entrypoint][ERROR] GH_AW_NODE_BIN=${GH_AW_NODE_BIN:-<unset>}" >&2
+  echo "[entrypoint][ERROR] PATH=$PATH" >&2
   exit 127
 fi
 AWFEOF


### PR DESCRIPTION
## Summary

- Update the Copilot Node.js preflight to accept `GH_AW_NODE_BIN` when it points to an executable.
- Keep the existing `command -v node` fallback for normal PATH-based resolution.
- Include `GH_AW_NODE_BIN` and `PATH` in the error output when Node cannot be found.

## Problem

Copilot workflows can run through AWF with Node installed by `actions/setup-node` in the runner tool cache. The generated `gh-aw` workflow records the resolved Node executable before invoking AWF:

```bash
GH_AW_NODE_BIN=$(command -v node 2>/dev/null || true)
export GH_AW_NODE_BIN
```

The generated command later uses that value to run the Copilot harness inside the chroot.

However, AWF performs its own Node preflight before the generated command runs. That preflight only checked `command -v node`, so it could fail when `sudo secure_path` removed the setup-node tool-cache directory from `PATH`, even though `GH_AW_NODE_BIN` already pointed at the correct executable and the tool cache was mounted into the chroot.

## Fix

The preflight now first checks whether `GH_AW_NODE_BIN` is set and executable. If so, it accepts that as proof that Node is available. If not, it falls back to the existing `command -v node` behavior.

This aligns AWF's early preflight with the Node executable the generated agent command would use.

## Test

Not run; shell-only entrypoint change.