### PR TITLE
feat(api-proxy): forward COPILOT_INTEGRATION_ID from host env

### DIFF
--- a/src/services/api-proxy-service-api-targets.test.ts
+++ b/src/services/api-proxy-service-api-targets.test.ts
@@ -505,165 +505,125 @@ describe('API proxy sidecar: API targets and auth forwarding', () => {
       });
 
       describe('COPILOT_INTEGRATION_ID forwarding', () => {
-        it('should not forward GITHUB_COPILOT_INTEGRATION_ID as COPILOT_INTEGRATION_ID to api-proxy', () => {
-          const orig = process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          process.env.GITHUB_COPILOT_INTEGRATION_ID = 'agentic-workflows';
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (orig !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = orig;
+        let savedEnv: Record<string, string | undefined>;
+
+        beforeEach(() => {
+          // Save both env vars to prevent test flakiness if host has COPILOT_INTEGRATION_ID set
+          savedEnv = {
+            COPILOT_INTEGRATION_ID: process.env.COPILOT_INTEGRATION_ID,
+            GITHUB_COPILOT_INTEGRATION_ID: process.env.GITHUB_COPILOT_INTEGRATION_ID,
+          };
+        });
+
+        afterEach(() => {
+          // Restore original env state
+          for (const key of Object.keys(savedEnv)) {
+            if (savedEnv[key] !== undefined) {
+              process.env[key] = savedEnv[key];
             } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+              delete process.env[key];
             }
           }
+        });
+
+        it('should not forward GITHUB_COPILOT_INTEGRATION_ID as COPILOT_INTEGRATION_ID to api-proxy', () => {
+          process.env.GITHUB_COPILOT_INTEGRATION_ID = 'agentic-workflows';
+          delete process.env.COPILOT_INTEGRATION_ID;
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
         });
 
         it('should not set COPILOT_INTEGRATION_ID when GITHUB_COPILOT_INTEGRATION_ID is not set', () => {
-          const orig = process.env.GITHUB_COPILOT_INTEGRATION_ID;
           delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (orig !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = orig;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          delete process.env.COPILOT_INTEGRATION_ID;
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
         });
 
         it('should forward COPILOT_INTEGRATION_ID from host env when explicitly set', () => {
-          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
-          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
           process.env.COPILOT_INTEGRATION_ID = 'my-custom-integration';
           delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
-          } finally {
-            if (origCopilot !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = origCopilot;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-            if (origGhCopilot !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test', envAll: true };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
         });
 
         it('should not set COPILOT_INTEGRATION_ID when host env var is empty', () => {
-          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
-          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
           process.env.COPILOT_INTEGRATION_ID = '';
           delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (origCopilot !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = origCopilot;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-            if (origGhCopilot !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test', envAll: true };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
         });
 
         it('should not set COPILOT_INTEGRATION_ID when host env var is whitespace only', () => {
-          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
-          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
           process.env.COPILOT_INTEGRATION_ID = '   ';
           delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (origCopilot !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = origCopilot;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-            if (origGhCopilot !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test', envAll: true };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
         });
 
         it('should trim surrounding whitespace before forwarding', () => {
-          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
-          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
           process.env.COPILOT_INTEGRATION_ID = '  my-custom-integration  ';
           delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
-          } finally {
-            if (origCopilot !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = origCopilot;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-            if (origGhCopilot !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test', envAll: true };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
         });
 
         it('should not set COPILOT_INTEGRATION_ID when nothing is set', () => {
-          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
-          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
           delete process.env.COPILOT_INTEGRATION_ID;
           delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-          try {
-            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
-            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
-            const proxy = result.services['api-proxy'];
-            const env = proxy.environment as Record<string, string>;
-            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
-          } finally {
-            if (origCopilot !== undefined) {
-              process.env.COPILOT_INTEGRATION_ID = origCopilot;
-            } else {
-              delete process.env.COPILOT_INTEGRATION_ID;
-            }
-            if (origGhCopilot !== undefined) {
-              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
-            } else {
-              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
-            }
-          }
+          const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
+        });
+
+        it('should forward COPILOT_INTEGRATION_ID from config.additionalEnv (--env flag)', () => {
+          delete process.env.COPILOT_INTEGRATION_ID;
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          const configWithProxy = {
+            ...mockConfig,
+            enableApiProxy: true,
+            copilotGithubToken: 'ghu_test',
+            additionalEnv: { COPILOT_INTEGRATION_ID: 'from-cli-flag' },
+          };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBe('from-cli-flag');
+        });
+
+        it('should prefer config.additionalEnv over process.env', () => {
+          process.env.COPILOT_INTEGRATION_ID = 'from-host-env';
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          const configWithProxy = {
+            ...mockConfig,
+            enableApiProxy: true,
+            copilotGithubToken: 'ghu_test',
+            additionalEnv: { COPILOT_INTEGRATION_ID: 'from-cli-flag' },
+          };
+          const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+          const proxy = result.services['api-proxy'];
+          const env = proxy.environment as Record<string, string>;
+          expect(env.COPILOT_INTEGRATION_ID).toBe('from-cli-flag');
         });
       });
 });

--- a/src/services/api-proxy-service-api-targets.test.ts
+++ b/src/services/api-proxy-service-api-targets.test.ts
@@ -540,5 +540,130 @@ describe('API proxy sidecar: API targets and auth forwarding', () => {
             }
           }
         });
+
+        it('should forward COPILOT_INTEGRATION_ID from host env when explicitly set', () => {
+          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
+          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          process.env.COPILOT_INTEGRATION_ID = 'my-custom-integration';
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
+          } finally {
+            if (origCopilot !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = origCopilot;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+            if (origGhCopilot !== undefined) {
+              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
+            } else {
+              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
+
+        it('should not set COPILOT_INTEGRATION_ID when host env var is empty', () => {
+          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
+          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          process.env.COPILOT_INTEGRATION_ID = '';
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
+          } finally {
+            if (origCopilot !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = origCopilot;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+            if (origGhCopilot !== undefined) {
+              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
+            } else {
+              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
+
+        it('should not set COPILOT_INTEGRATION_ID when host env var is whitespace only', () => {
+          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
+          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          process.env.COPILOT_INTEGRATION_ID = '   ';
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
+          } finally {
+            if (origCopilot !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = origCopilot;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+            if (origGhCopilot !== undefined) {
+              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
+            } else {
+              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
+
+        it('should trim surrounding whitespace before forwarding', () => {
+          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
+          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          process.env.COPILOT_INTEGRATION_ID = '  my-custom-integration  ';
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBe('my-custom-integration');
+          } finally {
+            if (origCopilot !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = origCopilot;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+            if (origGhCopilot !== undefined) {
+              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
+            } else {
+              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
+
+        it('should not set COPILOT_INTEGRATION_ID when nothing is set', () => {
+          const origCopilot = process.env.COPILOT_INTEGRATION_ID;
+          const origGhCopilot = process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          delete process.env.COPILOT_INTEGRATION_ID;
+          delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+          try {
+            const configWithProxy = { ...mockConfig, enableApiProxy: true, copilotGithubToken: 'ghu_test' };
+            const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+            const proxy = result.services['api-proxy'];
+            const env = proxy.environment as Record<string, string>;
+            expect(env.COPILOT_INTEGRATION_ID).toBeUndefined();
+          } finally {
+            if (origCopilot !== undefined) {
+              process.env.COPILOT_INTEGRATION_ID = origCopilot;
+            } else {
+              delete process.env.COPILOT_INTEGRATION_ID;
+            }
+            if (origGhCopilot !== undefined) {
+              process.env.GITHUB_COPILOT_INTEGRATION_ID = origGhCopilot;
+            } else {
+              delete process.env.GITHUB_COPILOT_INTEGRATION_ID;
+            }
+          }
+        });
       });
 });

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -117,6 +117,14 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
       // Forward GITHUB_API_URL so api-proxy can route /models to the correct GitHub REST API
       // target on GHES/GHEC (e.g. api.mycompany.ghe.com instead of api.github.com)
       ...(process.env.GITHUB_API_URL && { GITHUB_API_URL: process.env.GITHUB_API_URL }),
+      // Forward COPILOT_INTEGRATION_ID if explicitly set on the host so callers
+      // can identify themselves to the Copilot API with their own integration ID
+      // instead of being attributed to AWF's default 'agentic-workflows'.
+      // Whitespace-only values are treated as unset to avoid accidentally
+      // shipping a meaningless integration ID.
+      ...(process.env.COPILOT_INTEGRATION_ID?.trim() && {
+        COPILOT_INTEGRATION_ID: process.env.COPILOT_INTEGRATION_ID.trim(),
+      }),
       // Do not forward GITHUB_COPILOT_INTEGRATION_ID — api-proxy defaults to
       // 'agentic-workflows' which is the correct integration ID for AWF.
       // Note: AWF_VERSION is intentionally NOT forwarded here. It is baked into the api-proxy

--- a/src/services/api-proxy-service-config.ts
+++ b/src/services/api-proxy-service-config.ts
@@ -117,13 +117,13 @@ export function buildApiProxyServiceConfig(params: ApiProxyServiceConfigParams):
       // Forward GITHUB_API_URL so api-proxy can route /models to the correct GitHub REST API
       // target on GHES/GHEC (e.g. api.mycompany.ghe.com instead of api.github.com)
       ...(process.env.GITHUB_API_URL && { GITHUB_API_URL: process.env.GITHUB_API_URL }),
-      // Forward COPILOT_INTEGRATION_ID if explicitly set on the host so callers
-      // can identify themselves to the Copilot API with their own integration ID
+      // Forward COPILOT_INTEGRATION_ID if explicitly set (via --env, --env-file, or host env with --env-all)
+      // so callers can identify themselves to the Copilot API with their own integration ID
       // instead of being attributed to AWF's default 'agentic-workflows'.
       // Whitespace-only values are treated as unset to avoid accidentally
       // shipping a meaningless integration ID.
-      ...(process.env.COPILOT_INTEGRATION_ID?.trim() && {
-        COPILOT_INTEGRATION_ID: process.env.COPILOT_INTEGRATION_ID.trim(),
+      ...(getConfigEnvValue(config, 'COPILOT_INTEGRATION_ID')?.trim() && {
+        COPILOT_INTEGRATION_ID: getConfigEnvValue(config, 'COPILOT_INTEGRATION_ID')!.trim(),
       }),
       // Do not forward GITHUB_COPILOT_INTEGRATION_ID — api-proxy defaults to
       // 'agentic-workflows' which is the correct integration ID for AWF.


### PR DESCRIPTION
## Summary

Adds support for forwarding `COPILOT_INTEGRATION_ID` environment variable from host to api-proxy container, allowing consumers to override the default 'agentic-workflows' integration ID when needed for specific model allowlists or other integration requirements.

## Implementation

- Forward `COPILOT_INTEGRATION_ID` from `--env`, `--env-file`, or host env (with `--env-all`)
- Trim and validate the value (ignore empty/whitespace-only values)  
- Fall back to api-proxy's default 'agentic-workflows' when unset
- Do NOT forward `GITHUB_COPILOT_INTEGRATION_ID` (remains unused)

## Testing

Added 7 new test cases covering:
- ✅ Forwarding when explicitly set (host env with --env-all)
- ✅ Not setting when empty string
- ✅ Not setting when whitespace-only
- ✅ Trimming surrounding whitespace
- ✅ Not setting when nothing is set
- ✅ Forwarding from --env flag (config.additionalEnv)
- ✅ Preferring --env over host env

All unit tests pass.

## Why This Approach

This is **intentionally undocumented** for limited use cases:

1. **Not in schema** - Only accessible via env var or `--env` CLI flag, not stdin config
2. **Not documented** - Won't be added to README or docs/environment.md
3. **Direct communication** - We'll provide this directly to the user who needs it via private channel

## Usage

Users can set it via `--env` flag:
```bash
awf --env COPILOT_INTEGRATION_ID=copilot-developer-cli --allow-domains api.githubcopilot.com ...
```

Or via host env with `--env-all`:
```bash
export COPILOT_INTEGRATION_ID=copilot-developer-cli
awf --env-all --allow-domains api.githubcopilot.com ...
```

Or in GitHub Actions:
```yaml
env:
  COPILOT_INTEGRATION_ID: copilot-developer-cli
```