### PR TITLE
fix(api-proxy): copy token-tracker-shared + otel modules into image (fixes AIC=0)

### DIFF
--- a/containers/api-proxy/Dockerfile
+++ b/containers/api-proxy/Dockerfile
@@ -17,7 +17,7 @@ RUN npm ci --omit=dev
 # Copy application files
 COPY server.js logging.js metrics.js rate-limiter.js \
      token-tracker.js token-persistence.js token-parsers.js \
-     token-tracker-http.js token-tracker-ws.js \
+     token-tracker-http.js token-tracker-ws.js token-tracker-shared.js \
      model-resolver.js model-utils.js model-body-rewriter.js proxy-utils.js adapter-factory.js anthropic-transforms.js \
      model-config.js key-validation.js server-factory.js startup.js \
      proxy-request.js http-client.js body-handler.js model-discovery.js management.js oidc-token-provider.js \
@@ -27,7 +27,8 @@ COPY server.js logging.js metrics.js rate-limiter.js \
      ai-credits-pricing.js models-dev-catalog.js models.dev.catalog.json \
      oidc-refresh-utils.js body-transform.js body-utils.js rate-limit.js websocket-proxy.js \
      deprecated-header-tracker.js billing-headers.js upstream-response.js \
-     anthropic-cache.js otel.js token-budget-log.js blocked-request-diagnostics.js \
+     anthropic-cache.js otel.js otel-exporters.js otel-serialization.js \
+     token-budget-log.js blocked-request-diagnostics.js \
      provider-env-constants.js ./
 COPY guards/ ./guards/
 COPY providers/ ./providers/

--- a/containers/api-proxy/dockerfile-copy-coverage.test.js
+++ b/containers/api-proxy/dockerfile-copy-coverage.test.js
@@ -109,7 +109,7 @@ describe('Dockerfile COPY coverage', () => {
     };
 
     const missing = [...closure]
-      .map((abs) => path.relative(ROOT, abs))
+      .map((abs) => path.relative(ROOT, abs).split(path.sep).join('/'))
       .filter((rel) => !rel.startsWith('node_modules'))
       .filter((rel) => !isCopied(rel))
       .sort();

--- a/containers/api-proxy/dockerfile-copy-coverage.test.js
+++ b/containers/api-proxy/dockerfile-copy-coverage.test.js
@@ -1,0 +1,119 @@
+/**
+ * Guard test: every local module reachable from the runtime entrypoint
+ * (server.js) MUST be present in the Dockerfile COPY list.
+ *
+ * Background: the api-proxy image copies source files individually by name
+ * (no bundler). When a refactor adds a new module but forgets to update the
+ * Dockerfile, `require()` throws MODULE_NOT_FOUND inside the container. The
+ * proxy's graceful-degradation guards then silently stub the affected
+ * subsystem (e.g. token tracking, OTEL), so the container still boots but
+ * produces no token-usage.jsonl — causing AI-credit accounting to report 0.
+ *
+ * This regression has happened at least twice (OIDC modules, then
+ * token-tracker-shared.js). This test fails fast in CI instead.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = __dirname;
+const ENTRYPOINT = path.join(ROOT, 'server.js');
+
+/** Resolve a relative require spec to an existing file path, or null. */
+function resolveLocal(fromFile, spec) {
+  const base = path.resolve(path.dirname(fromFile), spec);
+  const candidates = [base, `${base}.js`, `${base}.json`, path.join(base, 'index.js')];
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) return c;
+  }
+  return null;
+}
+
+/** Compute the transitive closure of local (./ and ../) requires from an entry file. */
+function computeRequireClosure(entry) {
+  const seen = new Set();
+  const stack = [entry];
+  const requireRe = /require\(\s*(["'])(\.{1,2}\/[^"']+)\1\s*\)/g;
+
+  while (stack.length > 0) {
+    const file = stack.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    let src;
+    try {
+      src = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    let m;
+    while ((m = requireRe.exec(src)) !== null) {
+      const resolved = resolveLocal(file, m[2]);
+      if (resolved && !resolved.includes(`${path.sep}node_modules${path.sep}`)) {
+        stack.push(resolved);
+      }
+    }
+  }
+  return seen;
+}
+
+/** Parse the Dockerfile into a set of copied files and copied directory prefixes. */
+function parseDockerfileCopies(dockerfilePath) {
+  const lines = fs.readFileSync(dockerfilePath, 'utf8').split('\n');
+  const files = new Set();
+  const dirs = new Set();
+
+  let inCopy = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.startsWith('#')) continue;
+
+    let body = line;
+    if (line.startsWith('COPY ')) {
+      inCopy = true;
+      body = line.slice('COPY '.length);
+    } else if (!inCopy) {
+      continue;
+    }
+
+    const continues = body.endsWith('\\');
+    body = body.replace(/\\$/, '').trim();
+
+    for (const tok of body.split(/\s+/)) {
+      if (!tok || tok === '.' || tok === './') continue;
+      const clean = tok.replace(/^\.\//, '');
+      if (clean.endsWith('/')) {
+        dirs.add(clean);
+      } else if (/\.(js|json)$/.test(clean)) {
+        files.add(clean);
+      }
+    }
+
+    if (!continues) inCopy = false;
+  }
+  return { files, dirs };
+}
+
+describe('Dockerfile COPY coverage', () => {
+  test('every module reachable from server.js is copied into the image', () => {
+    const closure = computeRequireClosure(ENTRYPOINT);
+    const { files, dirs } = parseDockerfileCopies(path.join(ROOT, 'Dockerfile'));
+
+    const isCopied = (relPath) => {
+      if (files.has(relPath)) return true;
+      for (const dir of dirs) {
+        if (relPath.startsWith(dir)) return true;
+      }
+      return false;
+    };
+
+    const missing = [...closure]
+      .map((abs) => path.relative(ROOT, abs))
+      .filter((rel) => !rel.startsWith('node_modules'))
+      .filter((rel) => !isCopied(rel))
+      .sort();
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Root cause of AIC=0

The api-proxy Docker image copies source files **individually by name** (no bundler — see `Dockerfile`). PR #4780 (*"extract shared token-tracker budget helpers"*, first released in **v0.27.3**) introduced `token-tracker-shared.js`, required by `token-tracker-http.js` and `token-tracker-ws.js`, **but never added it to the Dockerfile COPY list**.

In the running container:

1. `require('./token-tracker')` → `token-tracker-http.js` → `require('./token-tracker-shared')` throws **`MODULE_NOT_FOUND`**.
2. The graceful-degradation guard in `proxy-request.js` catches `MODULE_NOT_FOUND` and stubs `trackTokenUsage` to a **no-op**.
3. The container boots and proxies traffic normally — but **no `token-usage.jsonl` is ever written**, so AI-credit accounting reports **0** for every run since v0.27.3.
4. `models.json` still appears (written by `model-discovery.js`, which doesn't depend on the missing module), which is why the log dir looked healthy.

### Reproduction (deterministic)

```
$ mv token-tracker-shared.js /tmp/ && node -e "require('./token-tracker')"
require threw: MODULE_NOT_FOUND - Cannot find module './token-tracker-shared'
=> proxy-request.js stubs trackTokenUsage to no-op (token tracking SILENTLY DISABLED)
model-discovery loads fine => models.json still written
```

Matches every observation from the real example run (github/gh-aw run 27768989380, image `api-proxy:0.27.4`): 73 upstream Copilot CONNECTs from the api-proxy, valid responses **with** usage returned to the CLI, `models.json` present, `token-usage.jsonl` absent.

## Audit: 3 files missing

Computing the full `require` closure from `server.js` against the COPY list found **three** silently-disabled modules:

| file | required by | subsystem silently disabled |
|---|---|---|
| `token-tracker-shared.js` | token-tracker-http/ws | **token tracking (AIC)** |
| `otel-exporters.js` | otel.js | OTEL tracing |
| `otel-serialization.js` | otel.js | OTEL tracing |

## Fix

- Add all three files to the Dockerfile COPY list.
- Add `dockerfile-copy-coverage.test.js`: computes the require closure from `server.js` and asserts every local module is present in the Dockerfile. **This is the second occurrence of this exact bug class** (OIDC modules were missed the same way previously), so the guard fails fast in CI.

## Tests

- New guard test passes against the fix and fails when any required file is removed (verified both directions).
- Full api-proxy suite green: **1228 passed**.

## Relationship to #5253

#5253 fixes a separate **cache-split fidelity** bug in usage parsing. **This** PR is the actual AIC=0 root cause — without it, the parser fixed in #5253 is never even invoked inside the container.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>