### PR TITLE
fix(api-proxy): use 'token' auth prefix for Copilot Business endpoint

### DIFF
--- a/containers/api-proxy/copilot-adapter-enterprise.test.js
+++ b/containers/api-proxy/copilot-adapter-enterprise.test.js
@@ -126,6 +126,64 @@ describe('createCopilotAdapter — GHE enterprise auth format', () => {
   });
 });
 
+describe('createCopilotAdapter — Copilot Business auth format', () => {
+  // Regression for github/gh-aw#38575: Copilot Business customers set
+  // COPILOT_API_TARGET=api.business.githubcopilot.com (often on a *.ghe.com
+  // server). The business host authenticates the GitHub token directly and
+  // requires the 'token' prefix; sending 'Bearer' yields
+  // "400 bad request: Authorization header is badly formatted".
+  const fakeReq = { url: '/v1/chat/completions', method: 'POST', headers: {} };
+  const fakeModelsReq = { url: '/models', method: 'GET', headers: {} };
+
+  it('uses "token" prefix for the Business target (api.business.githubcopilot.com)', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_business_token_123',
+      COPILOT_API_TARGET: 'api.business.githubcopilot.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('token ghu_business_token_123');
+  });
+
+  it('uses "token" prefix for the Business target even on a *.ghe.com server', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_business_token_123',
+      COPILOT_API_TARGET: 'api.business.githubcopilot.com',
+      GITHUB_SERVER_URL: 'https://mycompany.ghe.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('token ghu_business_token_123');
+  });
+
+  it('uses "token" prefix for /models on the Business target', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_business_token_123',
+      COPILOT_API_TARGET: 'api.business.githubcopilot.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeModelsReq);
+    expect(headers['Authorization']).toBe('token ghu_business_token_123');
+  });
+
+  it('uses "Bearer" prefix for a BYOK key even on the Business target', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'ghu_business_token_123',
+      COPILOT_PROVIDER_API_KEY: 'sk-byok-key',
+      COPILOT_API_TARGET: 'api.business.githubcopilot.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe(['Bearer', 'sk-byok-key'].join(' '));
+  });
+
+  it('strips an accidental "token " prefix before re-prefixing for the Business target', () => {
+    const adapter = createCopilotAdapter({
+      COPILOT_GITHUB_TOKEN: 'token ghu_business_token_123',
+      COPILOT_API_TARGET: 'api.business.githubcopilot.com',
+    });
+    const headers = adapter.getAuthHeaders(fakeReq);
+    expect(headers['Authorization']).toBe('token ghu_business_token_123');
+    expect(headers['Authorization']).not.toContain('token token');
+  });
+});
+
 describe('createCopilotAdapter — Azure OIDC (Entra) getAuthHeaders', () => {
   const fakeReq = { url: '/v1/chat/completions', method: 'POST', headers: {} };
 

--- a/containers/api-proxy/copilot-auth.test.js
+++ b/containers/api-proxy/copilot-auth.test.js
@@ -4,6 +4,7 @@ const {
     resolveApiKey,
     stripBearerPrefix,
     isGhesInstance,
+    copilotTargetRequiresGitHubTokenPrefix,
   },
 } = require('./providers/copilot-auth');
 const {
@@ -212,5 +213,53 @@ describe('isGhesInstance', () => {
       AWF_PLATFORM_TYPE: 'ghec-self-hosted',
       GITHUB_SERVER_URL: 'https://ghes.mycompany.com',
     })).toBe(false);
+  });
+});
+
+describe('copilotTargetRequiresGitHubTokenPrefix', () => {
+  it('returns true for the Enterprise Copilot endpoint', () => {
+    expect(copilotTargetRequiresGitHubTokenPrefix('api.enterprise.githubcopilot.com', {})).toBe(true);
+  });
+
+  it('returns true for the Business Copilot endpoint', () => {
+    expect(copilotTargetRequiresGitHubTokenPrefix('api.business.githubcopilot.com', {})).toBe(true);
+  });
+
+  it('returns true for the Business endpoint even on a *.ghe.com (GHEC) server', () => {
+    // Regression: Copilot Business customers set COPILOT_API_TARGET to the
+    // business host while running against a *.ghe.com server. isGhesInstance
+    // returns false for this combination, so the business host must be matched
+    // directly to apply the 'token' prefix. See github/gh-aw#38575.
+    expect(copilotTargetRequiresGitHubTokenPrefix('api.business.githubcopilot.com', {
+      GITHUB_SERVER_URL: 'https://myorg.ghe.com',
+    })).toBe(true);
+  });
+
+  it('returns false when an explicit non-GHES AWF_PLATFORM_TYPE overrides the Business host', () => {
+    // The explicit platform override is the documented escape hatch and wins
+    // even for the Business host, matching isGhesInstance semantics.
+    expect(copilotTargetRequiresGitHubTokenPrefix('api.business.githubcopilot.com', {
+      AWF_PLATFORM_TYPE: 'ghec',
+    })).toBe(false);
+  });
+
+  it('returns true for any GHES instance via the GITHUB_SERVER_URL heuristic', () => {
+    expect(copilotTargetRequiresGitHubTokenPrefix('custom-proxy.internal', {
+      GITHUB_SERVER_URL: 'https://ghes.mycompany.com',
+    })).toBe(true);
+  });
+
+  it('returns false for the standard api.githubcopilot.com endpoint', () => {
+    expect(copilotTargetRequiresGitHubTokenPrefix('api.githubcopilot.com', {})).toBe(false);
+  });
+
+  it('returns false for a *.ghe.com (GHEC) Copilot target', () => {
+    expect(copilotTargetRequiresGitHubTokenPrefix('copilot-api.myorg.ghe.com', {
+      GITHUB_SERVER_URL: 'https://myorg.ghe.com',
+    })).toBe(false);
+  });
+
+  it('returns false when no token-prefix indicators are present', () => {
+    expect(copilotTargetRequiresGitHubTokenPrefix('custom-proxy.internal', {})).toBe(false);
   });
 });

--- a/containers/api-proxy/providers/copilot-auth.js
+++ b/containers/api-proxy/providers/copilot-auth.js
@@ -233,6 +233,53 @@ function isGhesInstance(resolvedTarget, env = process.env) {
   }
 }
 
+/**
+ * GitHub-hosted Copilot endpoints that authenticate a GitHub OAuth/PAT token
+ * directly and therefore require the `token <value>` Authorization prefix
+ * (rather than `Bearer <value>`) for GitHub credentials.
+ *
+ * Both the Enterprise and Business endpoints behave this way; the standard
+ * `api.githubcopilot.com` endpoint instead expects a Copilot token with the
+ * `Bearer` prefix.
+ */
+const GITHUB_TOKEN_PREFIX_COPILOT_TARGETS = new Set([
+  'api.enterprise.githubcopilot.com',
+  'api.business.githubcopilot.com',
+]);
+
+/**
+ * Decide whether a GitHub OAuth/PAT token sent to the Copilot API must use the
+ * `token <value>` Authorization prefix instead of `Bearer <value>`.
+ *
+ * This is true when either:
+ *   1. The environment is a GHES instance (see {@link isGhesInstance}), or
+ *   2. The resolved target is a GitHub-hosted Copilot endpoint that accepts the
+ *      GitHub token directly — i.e. the Enterprise or Business host. This case
+ *      covers Copilot Business customers who set
+ *      COPILOT_API_TARGET=api.business.githubcopilot.com while running against a
+ *      *.ghe.com (GHEC) server, which the GHES heuristics would otherwise miss.
+ *
+ * An explicit non-GHES AWF_PLATFORM_TYPE remains an override that forces
+ * 'Bearer', consistent with {@link isGhesInstance}.
+ *
+ * BYOK API keys always use `Bearer`; this predicate only governs the GitHub
+ * token case (callers gate on the absence of a real BYOK key).
+ *
+ * @param {string} resolvedTarget - The resolved Copilot API target hostname
+ * @param {Record<string, string|undefined>} env - Environment variables
+ * @returns {boolean}
+ */
+function copilotTargetRequiresGitHubTokenPrefix(resolvedTarget, env = process.env) {
+  // An explicit non-GHES platform type is an intentional override that forces
+  // the standard 'Bearer' prefix, even when the resolved host looks like an
+  // Enterprise/Business endpoint. (isGhesInstance honors the same override.)
+  if (env.AWF_PLATFORM_TYPE && env.AWF_PLATFORM_TYPE !== 'ghes') return false;
+
+  if (isGhesInstance(resolvedTarget, env)) return true;
+  const target = normalizeApiTarget(resolvedTarget);
+  return target ? GITHUB_TOKEN_PREFIX_COPILOT_TARGETS.has(target) : false;
+}
+
 module.exports = {
   stripBearerPrefix,
   resolveApiKey,
@@ -242,6 +289,7 @@ module.exports = {
   deriveGitHubApiBasePath,
   isGithubCopilotCatalogTarget,
   isGhesInstance,
+  copilotTargetRequiresGitHubTokenPrefix,
   getCopilotModelFallbackPolicy,
   // Exported for unit-test access only; not part of the public API.
   _testing: {
@@ -253,6 +301,7 @@ module.exports = {
     deriveGitHubApiBasePath,
     isGithubCopilotCatalogTarget,
     isGhesInstance,
+    copilotTargetRequiresGitHubTokenPrefix,
     getCopilotModelFallbackPolicy,
   },
 };

--- a/containers/api-proxy/providers/copilot.js
+++ b/containers/api-proxy/providers/copilot.js
@@ -36,7 +36,7 @@ const {
   resolveApiKey,
   resolveCopilotAuthToken,
   deriveCopilotApiTarget,
-  isGhesInstance,
+  copilotTargetRequiresGitHubTokenPrefix,
 } = require('./copilot-auth');
 const { createProviderOidcAuth } = require('./cloud-oidc-init');
 const { URL } = require('url');
@@ -216,15 +216,15 @@ function createCopilotAdapter(env, deps = {}) {
         reqPathname = req.url || '';
       }
 
-      // Enterprise Copilot API (GHES) requires 'token <value>' for GitHub OAuth tokens.
+      // Enterprise/Business Copilot API requires 'token <value>' for GitHub OAuth tokens.
       // BYOK API keys use 'Bearer' regardless of target.
       // Standard api.githubcopilot.com and GHEC (*.ghe.com) also use 'Bearer' for all credentials.
-      const isEnterprise = isGhesInstance(rawTarget, env);
+      const requiresGitHubTokenPrefix = copilotTargetRequiresGitHubTokenPrefix(rawTarget, env);
 
       const isModelsPath = reqPathname === '/models' || reqPathname.startsWith('/models/');
       if (isModelsPath && req.method === 'GET' && githubToken) {
         // /models always uses the GitHub OAuth token (not BYOK key)
-        const prefix = isEnterprise ? 'token' : 'Bearer';
+        const prefix = requiresGitHubTokenPrefix ? 'token' : 'Bearer';
         return {
           'Authorization': [prefix, githubToken].join(' '),
           'Copilot-Integration-Id': integrationId,
@@ -243,8 +243,8 @@ function createCopilotAdapter(env, deps = {}) {
         return oidcHeaders;
       }
 
-      // For inference: BYOK keys use 'Bearer'; GitHub tokens use 'token' on GHES
-      const authPrefix = (isEnterprise && !apiKey) ? 'token' : 'Bearer';
+      // For inference: BYOK keys use 'Bearer'; GitHub tokens use 'token' on Enterprise/Business/GHES
+      const authPrefix = (requiresGitHubTokenPrefix && !apiKey) ? 'token' : 'Bearer';
       return {
         ...(apiKey ? byokExtraHeaders : {}),
         'Authorization': [authPrefix, authToken].join(' '),


### PR DESCRIPTION
## Problem

Copilot **Business** customers (`COPILOT_API_TARGET=api.business.githubcopilot.com`, typically on a `*.ghe.com` GHEC server) get `400 bad request: Authorization header is badly formatted` on every Copilot request, and the run exits 1.

The auth-prefix logic in `copilot.js#getAuthHeaders` only applied the `token <oauth>` Authorization prefix when `isGhesInstance(rawTarget, env)` was true. `isGhesInstance` only matches the **enterprise** host (`api.enterprise.githubcopilot.com`) directly, and its `GITHUB_SERVER_URL` heuristic explicitly treats `*.ghe.com` as **not** GHES. So for the business host on a `*.ghe.com` server it returns `false`, the GitHub OAuth token goes out as `Bearer <oauth>`, and the business endpoint rejects it.

`api.business.githubcopilot.com` did not appear anywhere in the source. The prior fixes (#4755, #5076) covered enterprise/GHES only.

Reported in github/gh-aw#38575 (still reproducing as of 2026-06-19).

## Fix

Add `copilotTargetRequiresGitHubTokenPrefix(resolvedTarget, env)` in `copilot-auth.js`, and use it in `getAuthHeaders` for both the `/models` path and inference requests.

It returns `true` (→ `token` prefix for GitHub tokens) when **either**:
1. `isGhesInstance()` is true (unchanged GHES behavior), **or**
2. the resolved target is a GitHub-hosted endpoint that authenticates the GitHub token directly — `api.enterprise.githubcopilot.com` **or** `api.business.githubcopilot.com`.

Preserved invariants:
- An explicit non-GHES `AWF_PLATFORM_TYPE` still forces `Bearer` (documented escape hatch, consistent with `isGhesInstance`).
- BYOK API keys always use `Bearer`.
- Standard `api.githubcopilot.com` and GHEC (`*.ghe.com`) Copilot targets keep `Bearer`.

## Tests

- `copilot-auth.test.js`: 8 unit tests for `copilotTargetRequiresGitHubTokenPrefix` (business host, business on `*.ghe.com`, GHES, standard, GHEC, `AWF_PLATFORM_TYPE` override).
- `copilot-adapter-enterprise.test.js`: 5 adapter-level tests for the Business host (inference + `/models` use `token`; BYOK stays `Bearer`; accidental `token ` prefix stripped).
- Full api-proxy suite: **1290 passed**.

Fixes github/gh-aw#38575

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
