### PR TITLE
fix: eliminate catastrophic regex backtracking in postprocess script

### DIFF
--- a/scripts/ci/postprocess-smoke-workflows.ts
+++ b/scripts/ci/postprocess-smoke-workflows.ts
@@ -826,8 +826,20 @@ for (const workflowPath of workflowPaths) {
 const codexConfigTomlHeredocRegex =
   /^(\s+)(cat > "\/tmp\/gh-aw\/mcp-config\/config\.toml" << GH_AW_CODEX_SHELL_POLICY_\w+_EOF\n)(?:\1[^\n]*\n)*?(\1\[shell_environment_policy\])/m;
 const CODEX_PROXY_PROVIDER_SENTINEL = 'model_providers.openai-proxy';
+// IMPORTANT: the repeated inner line atom uses `^[ \t].*` (a single leading
+// space/tab, then the rest of the line) rather than `^\s+.*` or `^[ \t]+.*`.
+// Two distinct ambiguities caused catastrophic backtracking that hung the script
+// for minutes whenever this regex failed to match (e.g. the provider block was
+// already present but env_key was absent, the normal state after the first
+// post-process run):
+//   1. `\s` also matches newlines, so `^\s+.*\n` could consume line breaks two
+//      different ways.
+//   2. `[ \t]+` is itself variable-length, so `^[ \t]+.*` could split the indent
+//      and the body of a single line many different ways.
+// Anchoring each repetition to exactly one leading space/tab makes every line
+// match a single way, so matching is linear even on large lock files.
 const CODEX_PROXY_ENV_KEY_REGEX =
-  /(^\s+\[model_providers\.openai-proxy\]\n(?:^\s+.*\n)*?)^\s+env_key = "OPENAI_API_KEY"\n/m;
+  /(^[ \t]+\[model_providers\.openai-proxy\]\n(?:^[ \t].*\n)*?)^[ \t]+env_key = "OPENAI_API_KEY"\n/m;
 
 // Apply Codex-specific transformations to OpenAI/Codex workflow files only.
 // These transformations must not be applied to Claude, Copilot, or other
@@ -874,8 +886,13 @@ for (const workflowPath of codexWorkflowPaths) {
   }
 
   // Remove legacy env_key for openai-proxy so Codex doesn't require OPENAI_API_KEY
-  // in the sandbox when auth is provided by the sidecar.
-  if (CODEX_PROXY_ENV_KEY_REGEX.test(content)) {
+  // in the sandbox when auth is provided by the sidecar. The cheap includes()
+  // guard skips the regex entirely when there is no env_key line to strip, which
+  // is the common case on already-processed lock files.
+  if (
+    content.includes('env_key = "OPENAI_API_KEY"') &&
+    CODEX_PROXY_ENV_KEY_REGEX.test(content)
+  ) {
     content = content.replace(CODEX_PROXY_ENV_KEY_REGEX, '$1');
     modified = true;
     console.log('  Removed legacy env_key from openai-proxy provider');


### PR DESCRIPTION
## Problem

`scripts/ci/postprocess-smoke-workflows.ts` hung for **minutes** on every run. Root cause: `CODEX_PROXY_ENV_KEY_REGEX` triggered catastrophic backtracking whenever it **failed** to match — which is the common case once the `[model_providers.openai-proxy]` block exists but the `env_key` line has already been stripped (the normal state after the first post-process run).

Two ambiguities drove the exponential backtracking:
1. `\s` also matches newlines, so `^\s+.*\n` could consume line breaks two different ways.
2. `[ \t]+` is variable-length, so `^[ \t]+.*` could split a single line's indent and body many ways.

## Fix

- Anchor each repeated inner line to **exactly one** leading space/tab (`^[ \t].*`) so every physical line matches a single way → linear matching.
- Add a cheap `content.includes('env_key = "OPENAI_API_KEY"')` short-circuit guard so the regex is skipped entirely on already-processed files.

## Result

Script runtime drops from **minutes → ~1.4s**. `tsc --noEmit` clean; output (the env_key strip + xpia transforms) is unchanged on the codex lock files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>