### PR TITLE
docs: fix broken raw URL placeholder in AWF failure diagnosis guide

### DIFF
--- a/docs/diagnosing-awf-failures.md
+++ b/docs/diagnosing-awf-failures.md
@@ -12,7 +12,7 @@ failing workflow log:
 - [`.github/agents/self-hosted-runner-doctor.md`](../.github/agents/self-hosted-runner-doctor.md)
 - Raw URL (prefer a tag/commit that matches your AWF version):
   `https://raw.githubusercontent.com/github/gh-aw-firewall/<tag-or-sha>/.github/agents/self-hosted-runner-doctor.md`
-  (Fallback: `https://raw.githubusercontent.com/github/gh-aw-firewall/main/.github/agents/self-hosted-runner-doctor.md`)
+  (Fallback: https://raw.githubusercontent.com/github/gh-aw-firewall/main/.github/agents/self-hosted-runner-doctor.md)
 
 ## How it works
 

--- a/docs/diagnosing-awf-failures.md
+++ b/docs/diagnosing-awf-failures.md
@@ -11,8 +11,8 @@ failing workflow log:
 
 - [`.github/agents/self-hosted-runner-doctor.md`](../.github/agents/self-hosted-runner-doctor.md)
 - Raw URL (prefer a tag/commit that matches your AWF version):
-  https://raw.githubusercontent.com/github/gh-aw-firewall/<tag-or-sha>/.github/agents/self-hosted-runner-doctor.md
-  (Fallback: https://raw.githubusercontent.com/github/gh-aw-firewall/main/.github/agents/self-hosted-runner-doctor.md)
+  `https://raw.githubusercontent.com/github/gh-aw-firewall/<tag-or-sha>/.github/agents/self-hosted-runner-doctor.md`
+  (Fallback: `https://raw.githubusercontent.com/github/gh-aw-firewall/main/.github/agents/self-hosted-runner-doctor.md`)
 
 ## How it works
 


### PR DESCRIPTION
## Problem

In `docs/diagnosing-awf-failures.md`, the prose **Raw URL** bullet used a bare `<tag-or-sha>` placeholder:

```
https://raw.githubusercontent.com/github/gh-aw-firewall/<tag-or-sha>/.github/agents/self-hosted-runner-doctor.md
```

GitHub's markdown renderer treats `<tag-or-sha>` as an HTML tag and strips it, so the link rendered with a broken double slash:

```
https://raw.githubusercontent.com/github/gh-aw-firewall//.github/agents/self-hosted-runner-doctor.md
```

## Fix

Wrap the two URLs in that bullet in backticks so the `<tag-or-sha>` placeholder renders literally instead of being parsed as HTML.

The identical placeholder inside the fenced ```` ```text ```` prompt block is unaffected (code blocks don't strip HTML), so it's left as-is.