### PR TITLE
test: fix stale assertions breaking npm test on main

### DIFF
--- a/scripts/ci/security-guard-workflow.test.ts
+++ b/scripts/ci/security-guard-workflow.test.ts
@@ -40,7 +40,7 @@ describe('security guard workflow optimization config', () => {
     expect(lock).toContain('COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode');
     expect(lock).not.toContain(`COPILOT_DUMMY_BYOK: ${COPILOT_PLACEHOLDER_TOKEN}`);
     expect(lock).toContain('GH_AW_MAX_TURNS: 6');
-    expect(lock).toContain('github/gh-aw-actions/setup@3c7f3b6f423dd721e2f115b7c8fda65287e1f137 # v0.81.0');
+    expect(lock).toContain('github/gh-aw-actions/setup@b5cde6c5013569c8b0229dd2d7ffd63eaf2c9ad2 # v0.81.2');
     expect(lock).not.toContain('github/gh-aw-actions/setup@v0.80.6');
     expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.4.0');
   });

--- a/scripts/ci/self-hosted-runner-doctor-updater-workflow.test.ts
+++ b/scripts/ci/self-hosted-runner-doctor-updater-workflow.test.ts
@@ -28,6 +28,6 @@ describe('runner doctor updater workflow config', () => {
     expect(lock).toContain('🩺 Runner Doctor Update');
     expect(lock).toContain('shared/self-hosted-failure-modes.md');
     expect(lock).toContain('Compute scan window');
-    expect(lock).toContain('github/gh-aw-actions/setup@3c7f3b6f423dd721e2f115b7c8fda65287e1f137');
+    expect(lock).toContain('github/gh-aw-actions/setup@b5cde6c5013569c8b0229dd2d7ffd63eaf2c9ad2');
   });
 });

--- a/scripts/ci/self-hosted-runner-doctor-workflow.test.ts
+++ b/scripts/ci/self-hosted-runner-doctor-workflow.test.ts
@@ -29,6 +29,6 @@ describe('self-hosted runner doctor workflow config', () => {
     expect(lock).toContain('pull-requests: read');
     expect(lock).toContain('🩺 Runner Doctor');
     expect(lock).toContain('shared/self-hosted-failure-modes.md');
-    expect(lock).toContain('github/gh-aw-actions/setup@3c7f3b6f423dd721e2f115b7c8fda65287e1f137');
+    expect(lock).toContain('github/gh-aw-actions/setup@b5cde6c5013569c8b0229dd2d7ffd63eaf2c9ad2');
   });
 });

--- a/scripts/ci/test-coverage-improver-workflow.test.ts
+++ b/scripts/ci/test-coverage-improver-workflow.test.ts
@@ -75,7 +75,7 @@ describe('test coverage improver workflow token optimization config', () => {
     expect(lock).not.toContain("shell(cat:src/*.test.ts)");
     expect(lock).not.toContain("shell(npm run lint)");
     expect(lock).not.toContain("shell(npm run test)");
-    expect(lock).toContain('github/gh-aw-actions/setup@3c7f3b6f423dd721e2f115b7c8fda65287e1f137 # v0.81.0');
+    expect(lock).toContain('github/gh-aw-actions/setup@b5cde6c5013569c8b0229dd2d7ffd63eaf2c9ad2 # v0.81.2');
     expect(lock).not.toContain('github/gh-aw-actions/setup@v0.80.6');
     expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.4.0');
 

--- a/src/commands/main-action.test.ts
+++ b/src/commands/main-action.test.ts
@@ -251,6 +251,7 @@ describe('createMainAction', () => {
         STUB_CONFIG.dockerHostPathPrefix,
         STUB_CONFIG.imageRegistry,
         STUB_CONFIG.imageTag,
+        STUB_CONFIG.agentImage,
       );
       expect(mockedHostIptables.cleanupHostIptables).not.toHaveBeenCalled();
       expect(processExitSpy).toHaveBeenCalledWith(1);


### PR DESCRIPTION
## Problem

`npm test` was failing on `main` with **5 failures across 5 suites** — two unrelated bits of test rot that landed with recent merges:

1. **`src/commands/main-action.test.ts`** — `cleanup()` gained a 9th `agentImage` parameter in the rootless perm-fixer work (#5546), but the `toHaveBeenCalledWith` assertion still expected only 8 args (received a trailing `undefined`).
2. **4 workflow lock tests** (`security-guard`, `self-hosted-runner-doctor`, `test-coverage-improver`, `self-hosted-runner-doctor-updater`) — pinned `github/gh-aw-actions/setup@3c7f3b6f… # v0.81.0`, but the committed `.lock.yml` files were upgraded to `@b5cde6c… # v0.81.2`.

## Fix

- Add the trailing `STUB_CONFIG.agentImage` arg to the `cleanup` call assertion.
- Update the `setup` action pin in the 4 workflow tests to `b5cde6c5013569c8b0229dd2d7ffd63eaf2c9ad2 # v0.81.2` to match the regenerated lock files.

Test-only changes; no runtime/source code touched.

## Verification

`npm test` → **3211 passed, 182 suites, 0 failures.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>