### PR TITLE
fix(test): sync doc-maintainer test with max-turns 15 + prompt rewrite

### DIFF
--- a/scripts/ci/doc-maintainer-workflow.test.ts
+++ b/scripts/ci/doc-maintainer-workflow.test.ts
@@ -11,12 +11,12 @@ describe('doc maintainer workflow optimization config', () => {
 
     expect(source).toContain('description: Daily documentation review with a 7-day change gate and 48-hour agent context');
     expect(source).toContain("if: needs.check_relevant_changes.outputs.has_changes == 'true' && needs.check_relevant_changes.outputs.skip_agent != 'true'");
-    expect(source).toContain('max-turns: 8');
+    expect(source).toContain('max-turns: 15');
     expect(source).toContain('bash: false');
     expect(source).toContain('github: false');
     expect(source).toContain('Read `/tmp/gh-aw/doc-maintainer-context/context.md` first.');
     expect(source).toContain('Use the **Recent Git Diffs** section from that file as your **sole source**');
-    expect(source).toContain('**Do not run any `git` commands**');
+    expect(source).toContain('**Do not use the `shell` tool** (and the `bash` tool is disabled). Do not attempt to run `git`, `npm test`, `ls`, or any other shell command');
     expect(source).toContain('The workflow gate already checked the past 7 days to decide whether this run is needed.');
     expect(source).toContain('files listed under **Affected Documentation** in `/tmp/gh-aw/doc-maintainer-context/context.md`');
     expect(source).toContain('echo "## Changes"');
@@ -60,7 +60,7 @@ describe('doc maintainer workflow optimization config', () => {
     const lock = fs.readFileSync(lockPath, 'utf-8');
 
     expect(lock).toContain('# Daily documentation review with a 7-day change gate and 48-hour agent context');
-    expect(lock).toContain('GH_AW_MAX_TURNS: 8');
+    expect(lock).toContain('GH_AW_MAX_TURNS: 15');
     expect(lock).toContain("(needs.check_relevant_changes.outputs.has_changes == 'true' && needs.check_relevant_changes.outputs.skip_agent != 'true')");
     expect(lock).toContain('Build documentation maintainer context');
     expect(lock).toContain('skip_agent: ${{ steps.check.outputs.skip_agent }}');


### PR DESCRIPTION
## Problem

`npm test` is currently **red on `main`**: `scripts/ci/doc-maintainer-workflow.test.ts` has 2 failing assertions.

PR #5564 (`fix(doc-maintainer): prevent maxRuns 403 from wasted shell turns`) raised the Documentation Maintainer `max-turns` from **8 → 15** and rewrote the shell-restriction prompt line in `.github/workflows/doc-maintainer.md` (and recompiled the lock), but did **not** update the test guarding those values.

### Failing assertions
```
Expected substring: "max-turns: 8"          (source)  -> now max-turns: 15
Expected substring: "GH_AW_MAX_TURNS: 8"     (lock)    -> now GH_AW_MAX_TURNS: 15
Expected substring: "**Do not run any `git` commands**"  -> replaced by new wording
```

## Fix

Update the three stale assertions to match the current source workflow and lock:
- `max-turns: 8` → `max-turns: 15`
- `GH_AW_MAX_TURNS: 8` → `GH_AW_MAX_TURNS: 15`
- `**Do not run any \`git\` commands**` → `**Do not use the \`shell\` tool** (and the \`bash\` tool is disabled). Do not attempt to run \`git\`, \`npm test\`, \`ls\`, or any other shell command`

No production code changes — test-only sync.

## Verification

```
Test Suites: 196 passed, 196 total
Tests:       3220 passed, 3220 total
```

`npm test` is fully green.