### PR TITLE
fix(cli-proxy): surface HTTP status in DIFC probe diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,4 +73,6 @@ jobs:
 
       - name: Run shell unit tests
         if: matrix.node-version == '20'
-        run: bash tests/setup-iptables-port-spec.test.sh
+        run: |
+          bash tests/setup-iptables-port-spec.test.sh
+          bash tests/cli-proxy-probe-classify.test.sh

--- a/containers/cli-proxy/entrypoint.sh
+++ b/containers/cli-proxy/entrypoint.sh
@@ -59,38 +59,87 @@ echo "[cli-proxy] gh CLI configured to route through DIFC proxy at ${GH_HOST}"
 # Probe external DIFC proxy liveness before serving agent traffic.
 # Retries with exponential backoff to handle transient startup delays.
 # Distinct error messages help distinguish "not yet ready" from "unreachable".
+
+# Classify a failed DIFC-proxy liveness probe into a diagnostic category.
+# Args: $1=gh stderr, $2=gh stdout (response body), $3=gh/timeout exit code.
+# Echoes the diagnosis string. Kept as a pure function so it can be unit-tested
+# in isolation — see tests/cli-proxy-probe-classify.test.sh (#5615).
+#   ECONNREFUSED ("connection refused" in gh output)  → not yet ready
+#   Timeout (exit 124, or "deadline"/"timed out")      → unreachable / slow
+#   EAI_AGAIN / ENOTFOUND / getaddrinfo                → DNS not yet resolved
+#     (peer may not yet be joined to awf-net; keep retrying, do not fail fast)
+#   HTTP NNN in gh output                              → proxy reachable, but the
+#     forwarded API call returned an error (wrong host / auth / tenant) — this is
+#     the common GHEC data-residency (*.ghe.com) case, NOT "unknown"
+#   Other                                              → unknown
+classify_probe_failure() {
+  local probe_err="$1" probe_out="$2" probe_exit="$3" http_status
+  http_status="$(printf '%s\n%s\n' "${probe_err}" "${probe_out}" | grep -oiE "HTTP[/ ][0-9.]* ?[0-9]{3}|HTTP [0-9]{3}" | grep -oE "[0-9]{3}" | head -1 || true)"
+  if echo "${probe_err}" | grep -qiE "connection refused|ECONNREFUSED"; then
+    echo "not-yet-ready (ECONNREFUSED)"
+  elif [ "${probe_exit}" -eq 124 ] || echo "${probe_err}" | grep -qiE "timeout|deadline|timed out"; then
+    echo "unreachable (timeout)"
+  elif echo "${probe_err}" | grep -qiE "EAI_AGAIN|ENOTFOUND|getaddrinfo|no such host|name or service not known"; then
+    echo "dns-not-yet-ready"
+  elif [ -n "${http_status}" ]; then
+    echo "reachable-but-api-error (HTTP ${http_status})"
+  else
+    echo "unknown"
+  fi
+}
+
 MAX_LIVENESS_ATTEMPTS="${AWF_CLI_PROXY_LIVENESS_ATTEMPTS:-10}"
 LIVENESS_SLEEP_SECONDS="${AWF_CLI_PROXY_LIVENESS_SLEEP_SECONDS:-1}"
 LIVENESS_TIMEOUT_SECONDS="${AWF_CLI_PROXY_LIVENESS_TIMEOUT_SECONDS:-5}"
+PROBE_OUT_FILE="$(mktemp)"
+PROBE_ERR_FILE="$(mktemp)"
+trap 'rm -f "${PROBE_OUT_FILE}" "${PROBE_ERR_FILE}"' EXIT
 ATTEMPT=1
 while [ "$ATTEMPT" -le "$MAX_LIVENESS_ATTEMPTS" ]; do
-  PROBE_ERR=""
-  if PROBE_ERR="$(timeout "${LIVENESS_TIMEOUT_SECONDS}" gh api rate_limit 2>&1 >/dev/null)"; then
+  # Capture stdout (the gh response body) and stderr separately so a
+  # "reachable but the forwarded API call failed" result (e.g. wrong API host
+  # on *.ghe.com data-residency tenants) can surface the actual HTTP status and
+  # body instead of being reported as an opaque diagnosis=unknown. See #5615.
+  if timeout "${LIVENESS_TIMEOUT_SECONDS}" gh api rate_limit \
+       >"${PROBE_OUT_FILE}" 2>"${PROBE_ERR_FILE}"; then
     echo "[cli-proxy] DIFC proxy liveness probe succeeded on attempt ${ATTEMPT}/${MAX_LIVENESS_ATTEMPTS}"
     break
   fi
   PROBE_EXIT=$?
-  # Classify the failure for clearer diagnostics:
-  #   ECONNREFUSED (exit 7 for curl, or "connection refused" in gh output) → not yet ready
-  #   Timeout (exit 28 for curl, or "context deadline" in gh output)        → unreachable / slow
-  #   EAI_AGAIN / ENOTFOUND / getaddrinfo                                   → DNS not yet resolved
-  #     (peer may not yet be joined to awf-net; keep retrying, do not fail fast)
-  #   Other                                                                  → unknown / auth error
-  DIAG_TYPE="unknown"
-  if echo "${PROBE_ERR}" | grep -qiE "connection refused|ECONNREFUSED"; then
-    DIAG_TYPE="not-yet-ready (ECONNREFUSED)"
-  elif [ "${PROBE_EXIT}" -eq 124 ] || echo "${PROBE_ERR}" | grep -qiE "timeout|deadline|timed out"; then
-    DIAG_TYPE="unreachable (timeout)"
-  elif echo "${PROBE_ERR}" | grep -qiE "EAI_AGAIN|ENOTFOUND|getaddrinfo|no such host|name or service not known"; then
-    DIAG_TYPE="dns-not-yet-ready"
-  fi
+  PROBE_ERR="$(cat "${PROBE_ERR_FILE}")"
+  PROBE_OUT="$(cat "${PROBE_OUT_FILE}")"
+  DIAG_TYPE="$(classify_probe_failure "${PROBE_ERR}" "${PROBE_OUT}" "${PROBE_EXIT}")"
   if [ "$ATTEMPT" -ge "$MAX_LIVENESS_ATTEMPTS" ]; then
     echo "[cli-proxy] ERROR: DIFC proxy liveness probe failed for ${GH_HOST} (gh api exit=${PROBE_EXIT}, diagnosis=${DIAG_TYPE})"
     if [ -n "${PROBE_ERR}" ]; then
-      echo "[cli-proxy] gh api error: ${PROBE_ERR}"
+      echo "[cli-proxy] gh api stderr: ${PROBE_ERR}"
     fi
+    if [ -n "${PROBE_OUT}" ]; then
+      echo "[cli-proxy] gh api response body: $(printf '%s' "${PROBE_OUT}" | head -c 1000)"
+    fi
+    # When the forwarded call is reachable but errors on an enterprise tenant,
+    # the most likely cause is that the external DIFC proxy is not targeting the
+    # enterprise API host. Surface a targeted hint (companion issues:
+    # github/gh-aw-mcpg#8202, github/gh-aw#41911).
+    case "${GITHUB_SERVER_URL:-}" in
+      *ghe.com* | *ghe.localhost*)
+        case "${DIAG_TYPE}" in
+          reachable-but-api-error* | unknown)
+            echo "[cli-proxy] HINT: GITHUB_SERVER_URL=${GITHUB_SERVER_URL} looks like a GitHub Enterprise"
+            echo "[cli-proxy]       data-residency tenant. The external DIFC proxy may be targeting the"
+            echo "[cli-proxy]       wrong API host (github.com instead of the enterprise host), so the"
+            echo "[cli-proxy]       forwarded 'gh api' call fails. See github/gh-aw-firewall#5615."
+            ;;
+        esac
+        ;;
+    esac
     echo "[cli-proxy] Failing fast to avoid repeated in-agent retries"
     exit 1
+  fi
+  # Surface the captured gh error on every failed attempt so transient and
+  # persistent failures (e.g. a stable HTTP error) are both visible in logs.
+  if [ -n "${PROBE_ERR}" ]; then
+    echo "[cli-proxy] gh api stderr (attempt ${ATTEMPT}): $(printf '%s' "${PROBE_ERR}" | head -c 500)"
   fi
   # Exponential backoff: sleep 1, 2, 4, 8 … seconds (capped at 30s)
   SLEEP_SECS=$(( LIVENESS_SLEEP_SECONDS * (1 << (ATTEMPT - 1)) ))
@@ -99,6 +148,8 @@ while [ "$ATTEMPT" -le "$MAX_LIVENESS_ATTEMPTS" ]; do
   sleep "${SLEEP_SECS}"
   ATTEMPT=$((ATTEMPT + 1))
 done
+rm -f "${PROBE_OUT_FILE}" "${PROBE_ERR_FILE}"
+trap - EXIT
 
 # Cleanup handler: stop the Node HTTP server and TCP tunnel on signal
 cleanup() {

--- a/tests/cli-proxy-probe-classify.test.sh
+++ b/tests/cli-proxy-probe-classify.test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Shell unit tests for classify_probe_failure() in
+# containers/cli-proxy/entrypoint.sh.
+#
+# Verifies the DIFC-proxy liveness probe failure classifier, in particular the
+# "reachable-but-api-error (HTTP NNN)" bucket added in #5615 so that GHEC
+# data-residency (*.ghe.com) failures are no longer reported as diagnosis=unknown.
+#
+# Usage:
+#   bash tests/cli-proxy-probe-classify.test.sh
+#
+# Requires: bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="${SCRIPT_DIR}/../containers/cli-proxy/entrypoint.sh"
+
+if [ ! -f "${ENTRYPOINT}" ]; then
+  echo "❌ Cannot find entrypoint.sh at ${ENTRYPOINT}"
+  exit 1
+fi
+
+# Extract only the classify_probe_failure() definition so we can source it in
+# isolation without running the rest of the entrypoint (which starts servers).
+FUNC_DEF=$(awk '
+  /^classify_probe_failure\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { capture=0; exit }
+' "${ENTRYPOINT}")
+
+if [ -z "${FUNC_DEF}" ]; then
+  echo "❌ classify_probe_failure() not found in ${ENTRYPOINT}"
+  exit 1
+fi
+
+run_classify() {
+  # Run in a subshell so the eval'd definition doesn't leak.
+  (
+    eval "${FUNC_DEF}"
+    classify_probe_failure "$1" "$2" "$3"
+  )
+}
+
+PASS=0
+FAIL=0
+pass() { echo "✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "❌ FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# expect <description> <expected> <stderr> <stdout> <exit>
+expect() {
+  local desc="$1" expected="$2" got
+  got="$(run_classify "$3" "$4" "$5")"
+  if [ "${got}" = "${expected}" ]; then
+    pass "${desc} → '${got}'"
+  else
+    fail "${desc}: expected '${expected}' but got '${got}'"
+  fi
+}
+
+# Connection refused → not yet ready
+expect "ECONNREFUSED" "not-yet-ready (ECONNREFUSED)" \
+  "dial tcp 127.0.0.1:18443: connect: connection refused" "" 1
+
+# Timeout via exit code 124 (GNU timeout) → unreachable
+expect "timeout exit 124" "unreachable (timeout)" "" "" 124
+
+# Timeout via message → unreachable
+expect "context deadline" "unreachable (timeout)" \
+  "Get \"https://localhost:18443\": context deadline exceeded" "" 1
+
+# DNS not yet resolved → keep retrying
+expect "EAI_AGAIN" "dns-not-yet-ready" \
+  "lookup awf-topology-peer: getaddrinfo EAI_AGAIN" "" 1
+
+# HTTP error in stderr → reachable-but-api-error (the *.ghe.com case)
+expect "HTTP 404 in stderr" "reachable-but-api-error (HTTP 404)" \
+  "gh: Not Found (HTTP 404)" "" 1
+
+# HTTP 401 auth error
+expect "HTTP 401 in stderr" "reachable-but-api-error (HTTP 401)" \
+  "gh: Bad credentials (HTTP 401)" '{"message":"Bad credentials"}' 1
+
+# HTTP status only present in the response body
+expect "HTTP status in body" "reachable-but-api-error (HTTP 400)" \
+  "" "HTTP/2 400 bad request" 1
+
+# Unclassifiable → unknown (and must not crash under set -e when no HTTP match)
+expect "unknown fallback" "unknown" \
+  "some completely unexpected failure" "" 1
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ]

--- a/tests/cli-proxy-probe-classify.test.sh
+++ b/tests/cli-proxy-probe-classify.test.sh
@@ -24,9 +24,9 @@ fi
 # Extract only the classify_probe_failure() definition so we can source it in
 # isolation without running the rest of the entrypoint (which starts servers).
 FUNC_DEF=$(awk '
-  /^classify_probe_failure\(\)/ { capture=1 }
+  $0 ~ /^[[:space:]]*classify_probe_failure\(\)[[:space:]]*\{/ { capture=1 }
   capture { print }
-  capture && /^}/ { capture=0; exit }
+  capture && $0 ~ /^[[:space:]]*}[[:space:]]*$/ { exit }
 ' "${ENTRYPOINT}")
 
 if [ -z "${FUNC_DEF}" ]; then


### PR DESCRIPTION
## What & why

Fixes #5615.

The `awf-cli-proxy` sidecar probes the external DIFC proxy with `gh api rate_limit` before serving agent traffic. The classifier in `containers/cli-proxy/entrypoint.sh` only recognized **connection-refused**, **timeout**, and **DNS** failures; anything else became an opaque `diagnosis=unknown`.

On **GitHub Enterprise Cloud data-residency (`*.ghe.com`)** tenants the proxy comes up healthy and is reachable, but the *forwarded* `gh api` call returns an **HTTP error** (the proxy targets the wrong API host). That HTTP error fell into the `unknown` bucket, and the `gh` response body was discarded — so the firewall failed fast with no actionable signal. This is the firewall-side diagnostics ask (#3) from github/gh-aw#41225.

## Changes

- **Capture `gh` stdout (response body) and stderr separately** instead of redirecting stdout to `/dev/null`.
- **New classification bucket** `reachable-but-api-error (HTTP NNN)` that extracts the HTTP status from the gh output.
- **Surface the captured `gh` error on every failed attempt** (not just the last), and print the response body on final failure.
- **Targeted hint** when `GITHUB_SERVER_URL` is a `*.ghe.com` host, pointing at the DIFC-proxy enterprise-host root cause.
- **Refactor** the classifier into a pure `classify_probe_failure()` function and add `tests/cli-proxy-probe-classify.test.sh` (wired into the `build.yml` "Run shell unit tests" step).

No change to the fail-fast / health-gate semantics — this is purely better diagnostics.

## Scope note

This PR is the **firewall-side** piece only. The underlying root cause — the DIFC proxy not being enterprise-host-aware on `*.ghe.com` — is tracked in the companion issues:

- github/gh-aw-mcpg#8202 — DIFC proxy enterprise-host awareness (**root cause**)
- github/gh-aw#41911 — compiler/env propagation into the curated DIFC-proxy env

## Testing

```
$ bash tests/cli-proxy-probe-classify.test.sh
Results: 8 passed, 0 failed
$ bash tests/setup-iptables-port-spec.test.sh
Results: 53 passed, 0 failed
$ bash -n containers/cli-proxy/entrypoint.sh   # syntax OK
```

The new test covers each bucket, including HTTP status in stderr vs body, and confirms the `unknown` fallback does not trip `set -e` when no HTTP status matches.

## Example log (before → after)

Before:
```
[cli-proxy] DIFC proxy probe failed (attempt 1/10, diagnosis=unknown) ...
```
After (on a `*.ghe.com` tenant):
```
[cli-proxy] ERROR: DIFC proxy liveness probe failed ... diagnosis=reachable-but-api-error (HTTP 404)
[cli-proxy] gh api stderr: gh: Not Found (HTTP 404)
[cli-proxy] gh api response body: {"message":"Not Found", ...}
[cli-proxy] HINT: GITHUB_SERVER_URL=... looks like a GitHub Enterprise data-residency tenant ...
```
