### PR TITLE
fix: only count inference calls against maxRuns limit

### DIFF
--- a/containers/api-proxy/upstream-log.js
+++ b/containers/api-proxy/upstream-log.js
@@ -3,6 +3,22 @@
 const { COPILOT_PLACEHOLDER_TOKEN } = require('./providers/copilot-byok');
 const { stripBearerPrefix } = require('./providers/copilot-auth');
 
+// Paths that represent actual LLM inference calls (should count against maxRuns).
+// Non-inference endpoints (e.g., GET /models) are excluded.
+const INFERENCE_PATHS = [
+  '/v1/chat/completions',
+  '/chat/completions',
+  '/v1/responses',
+  '/responses',
+  '/v1/messages',
+];
+
+function isInferenceRequest(method, url) {
+  if (method !== 'POST') return false;
+  const path = url.split('?')[0];
+  return INFERENCE_PATHS.some((p) => path === p || path.endsWith(p));
+}
+
 function buildCopilotAuthErrorMessage(statusCode, env = process.env) {
   const baseMessage = `Upstream returned ${statusCode}`;
   const byokBaseUrl = (env.COPILOT_PROVIDER_BASE_URL || '').trim();
@@ -36,7 +52,7 @@ function createLogRequestCompletion({ metrics, logRequest, sanitizeForLog, apply
     metrics.increment('requests_total', { provider, method: req.method, status_class: sc });
     metrics.increment('response_bytes_total', { provider }, responseBytes);
     metrics.observe('request_duration_ms', duration, { provider });
-    if (statusCode >= 200 && statusCode < 300) {
+    if (statusCode >= 200 && statusCode < 300 && isInferenceRequest(req.method, req.url)) {
       applyMaxRunsInvocation();
     }
     const logFields = {
@@ -86,4 +102,5 @@ module.exports = {
   createLogRequestCompletion,
   createLogUpstreamAuthError,
   buildCopilotAuthErrorMessage,
+  isInferenceRequest,
 };

--- a/containers/api-proxy/upstream-log.js
+++ b/containers/api-proxy/upstream-log.js
@@ -13,10 +13,21 @@ const INFERENCE_PATHS = [
   '/v1/messages',
 ];
 
+// Gemini inference endpoints use method-style suffixes: :generateContent and
+// :streamGenerateContent (POST /v1beta/models/<model>:generateContent, etc.)
+const INFERENCE_SUFFIXES = [
+  ':generateContent',
+  ':streamGenerateContent',
+];
+
 function isInferenceRequest(method, url) {
+  if (typeof method !== 'string' || typeof url !== 'string') return false;
   if (method !== 'POST') return false;
-  const path = url.split('?')[0];
-  return INFERENCE_PATHS.some((p) => path === p || path.endsWith(p));
+  // Strip query string, fragment, and trailing slashes before matching.
+  const path = url.split('?')[0].split('#')[0].replace(/\/+$/, '');
+  if (INFERENCE_PATHS.some((p) => path === p || path.endsWith(p))) return true;
+  if (INFERENCE_SUFFIXES.some((s) => path.endsWith(s))) return true;
+  return false;
 }
 
 function buildCopilotAuthErrorMessage(statusCode, env = process.env) {

--- a/containers/api-proxy/upstream-log.test.js
+++ b/containers/api-proxy/upstream-log.test.js
@@ -97,21 +97,41 @@ describe('upstream-log', () => {
 
   describe('isInferenceRequest', () => {
     test.each([
+      // OpenAI / Copilot / Anthropic paths
       ['POST', '/v1/chat/completions'],
       ['POST', '/chat/completions'],
       ['POST', '/v1/responses'],
       ['POST', '/responses'],
       ['POST', '/v1/messages'],
+      // Gemini generateContent endpoints
+      ['POST', '/v1beta/models/gemini-pro:generateContent'],
+      ['POST', '/v1/models/gemini-2.0-flash:generateContent'],
+      ['POST', '/v1beta/models/gemini-pro:streamGenerateContent'],
+      // Normalization: trailing slash is stripped before matching
+      ['POST', '/v1/chat/completions/'],
+      // Normalization: fragment is stripped before matching
+      ['POST', '/v1/chat/completions#section'],
     ])('returns true for %s %s', (method, url) => {
       expect(isInferenceRequest(method, url)).toBe(true);
     });
 
     test.each([
+      // Non-inference GET endpoints
       ['GET', '/models'],
       ['GET', '/v1/models'],
+      ['GET', '/v1beta/models'],
+      // Non-inference POST endpoints
       ['POST', '/v1/embeddings'],
+      // Wrong method for an inference path
       ['GET', '/v1/chat/completions'],
+      // POST /models is not inference
       ['POST', '/models'],
+      // Non-inference Gemini endpoint (model list, not generation)
+      ['GET', '/v1beta/models/gemini-pro'],
+      // Non-string inputs
+      [null, '/v1/chat/completions'],
+      ['POST', null],
+      [undefined, '/v1/chat/completions'],
     ])('returns false for %s %s', (method, url) => {
       expect(isInferenceRequest(method, url)).toBe(false);
     });

--- a/containers/api-proxy/upstream-log.test.js
+++ b/containers/api-proxy/upstream-log.test.js
@@ -1,10 +1,11 @@
 const {
   createLogRequestCompletion,
   createLogUpstreamAuthError,
+  isInferenceRequest,
 } = require('./upstream-log');
 
 describe('upstream-log', () => {
-  test('logRequestCompletion records metrics and invokes max-runs on success', () => {
+  test('logRequestCompletion records metrics and invokes max-runs on inference POST', () => {
     const metrics = {
       statusClass: jest.fn(() => '2xx'),
       gaugeDec: jest.fn(),
@@ -36,6 +37,84 @@ describe('upstream-log', () => {
       status: 200,
       x_initiator: 'agent',
     }));
+  });
+
+  test('logRequestCompletion does NOT invoke max-runs for GET /models', () => {
+    const metrics = {
+      statusClass: jest.fn(() => '2xx'),
+      gaugeDec: jest.fn(),
+      increment: jest.fn(),
+      observe: jest.fn(),
+    };
+    const logRequest = jest.fn();
+    const applyMaxRunsInvocation = jest.fn();
+    const logRequestCompletion = createLogRequestCompletion({
+      metrics,
+      logRequest,
+      sanitizeForLog: (value) => value,
+      applyMaxRunsInvocation,
+    });
+
+    logRequestCompletion(200, 100, null, null, {
+      startTime: Date.now() - 3,
+      provider: 'openai',
+      req: { method: 'GET', url: '/models' },
+      requestBytes: 0,
+      targetHost: 'api.openai.com',
+      requestId: 'req-2',
+    });
+
+    expect(applyMaxRunsInvocation).not.toHaveBeenCalled();
+  });
+
+  test('logRequestCompletion does NOT invoke max-runs for non-inference POST', () => {
+    const metrics = {
+      statusClass: jest.fn(() => '2xx'),
+      gaugeDec: jest.fn(),
+      increment: jest.fn(),
+      observe: jest.fn(),
+    };
+    const logRequest = jest.fn();
+    const applyMaxRunsInvocation = jest.fn();
+    const logRequestCompletion = createLogRequestCompletion({
+      metrics,
+      logRequest,
+      sanitizeForLog: (value) => value,
+      applyMaxRunsInvocation,
+    });
+
+    logRequestCompletion(200, 50, null, null, {
+      startTime: Date.now() - 2,
+      provider: 'openai',
+      req: { method: 'POST', url: '/v1/embeddings' },
+      requestBytes: 20,
+      targetHost: 'api.openai.com',
+      requestId: 'req-3',
+    });
+
+    expect(applyMaxRunsInvocation).not.toHaveBeenCalled();
+  });
+
+  describe('isInferenceRequest', () => {
+    test.each([
+      ['POST', '/v1/chat/completions'],
+      ['POST', '/chat/completions'],
+      ['POST', '/v1/responses'],
+      ['POST', '/responses'],
+      ['POST', '/v1/messages'],
+    ])('returns true for %s %s', (method, url) => {
+      expect(isInferenceRequest(method, url)).toBe(true);
+    });
+
+    test.each([
+      ['GET', '/models'],
+      ['GET', '/v1/models'],
+      ['POST', '/v1/embeddings'],
+      ['GET', '/v1/chat/completions'],
+      ['POST', '/models'],
+    ])('returns false for %s %s', (method, url) => {
+      expect(isInferenceRequest(method, url)).toBe(false);
+    });
   });
 
   test('logUpstreamAuthError suppresses 400 model-not-supported auth log noise', () => {


### PR DESCRIPTION
## Problem

The `maxRuns` guard in the API proxy counted **all** successful upstream requests (any 2xx response) toward the limit, including non-inference calls like `GET /models`. This meant workflows with tight `maxRuns` budgets lost slots to model discovery requests.

## Fix

Added an `isInferenceRequest(method, url)` helper that identifies actual LLM inference endpoints:
- `POST /v1/chat/completions`
- `POST /chat/completions`
- `POST /v1/responses`
- `POST /responses`
- `POST /v1/messages`

The `applyMaxRunsInvocation()` call in `logRequestCompletion` now only fires when the request matches an inference endpoint. Non-inference calls (`GET /models`, `POST /v1/embeddings`, etc.) no longer consume maxRuns budget.

## Testing

- Updated existing test to clarify it tests inference POST behavior
- Added tests for `GET /models` not counting
- Added tests for non-inference POST not counting
- Added `isInferenceRequest` unit tests with parameterized cases

Fixes #5618