### PR TITLE
refactor: extract fallback-selection logic into model-fallback.js

### DIFF
--- a/containers/api-proxy/Dockerfile
+++ b/containers/api-proxy/Dockerfile
@@ -18,7 +18,7 @@ RUN npm ci --omit=dev
 COPY server.js logging.js metrics.js rate-limiter.js rate-limiter-window.js \
      token-tracker.js token-persistence.js token-parsers.js \
      token-tracker-http.js token-tracker-ws.js token-tracker-shared.js \
-     model-resolver.js model-utils.js model-body-rewriter.js proxy-utils.js oidc-adapter-utils.js adapter-factory.js anthropic-transforms.js \
+     model-resolver.js model-fallback.js model-utils.js model-body-rewriter.js proxy-utils.js oidc-adapter-utils.js adapter-factory.js anthropic-transforms.js \
      model-config.js key-validation.js server-factory.js startup.js \
      proxy-request.js proxy-guards.js http-client.js body-handler.js model-discovery.js management.js oidc-token-provider.js \
      oidc-token-provider-base.js \

--- a/containers/api-proxy/model-fallback.js
+++ b/containers/api-proxy/model-fallback.js
@@ -1,0 +1,132 @@
+/**
+ * Model fallback selection logic for AWF API proxy.
+ *
+ * Provides the heuristic for selecting a lower-cost fallback model when
+ * the requested model is unavailable. Extracted from model-resolver.js
+ * for independent testability.
+ */
+
+const { getTierSortedModels } = require('./model-discovery');
+
+const DEFAULT_MODEL_FALLBACK = Object.freeze({
+  enabled: true,
+  strategy: 'middle_power',
+});
+
+/**
+ * Normalize raw fallback config into a consistent shape.
+ * @param {object|null|undefined} modelFallbackConfig
+ * @returns {{ enabled: boolean, strategy: string }}
+ */
+function normalizeFallbackConfig(modelFallbackConfig) {
+  const config = modelFallbackConfig && typeof modelFallbackConfig === 'object'
+    ? modelFallbackConfig
+    : DEFAULT_MODEL_FALLBACK;
+  return {
+    enabled: config.enabled !== false,
+    strategy: config.strategy || 'middle_power',
+  };
+}
+
+/**
+ * Normalize a raw alias definition into { patterns, fallback } shape.
+ * @param {string[]|object} rawAlias
+ * @returns {{ patterns: string[], fallback: boolean }}
+ */
+function resolveAliasDefinition(rawAlias) {
+  if (Array.isArray(rawAlias)) {
+    return { patterns: rawAlias, fallback: true };
+  }
+  if (!rawAlias || typeof rawAlias !== 'object' || Array.isArray(rawAlias)) {
+    return { patterns: [], fallback: true };
+  }
+  return {
+    patterns: Array.isArray(rawAlias.patterns) ? rawAlias.patterns : [],
+    fallback: rawAlias.fallback !== false,
+  };
+}
+
+/**
+ * Infer the model family prefix from a requested model name.
+ * @param {string} requestedModel
+ * @returns {string|null}
+ */
+function inferModelFamilyPrefix(requestedModel) {
+  const key = String(requestedModel || '').toLowerCase();
+  const gptFamily = key.match(/^(gpt-\d+(?:\.\d+)?)/)?.[1];
+  if (gptFamily) return gptFamily;
+  if (key.includes('claude')) return 'claude';
+  if (key.includes('gemini')) return 'gemini';
+  return null;
+}
+
+/**
+ * Select a middle-power fallback model from the provider's available models.
+ *
+ * @param {string} requestedModel - The original requested model name
+ * @param {Record<string, string[]|null>} availableModels - Models per provider
+ * @param {string} currentProvider - The target provider
+ * @param {string} reason - Why fallback was triggered
+ * @param {object} modelFallbackConfig - Raw fallback config
+ * @returns {{ resolvedModel: string, fallback: object } | null}
+ */
+function selectMiddlePowerFallback(requestedModel, availableModels, currentProvider, reason, modelFallbackConfig) {
+  const fallbackConfig = normalizeFallbackConfig(modelFallbackConfig);
+  if (!fallbackConfig.enabled || fallbackConfig.strategy !== 'middle_power') return null;
+
+  const providerModels = Array.isArray(availableModels[currentProvider]) ? availableModels[currentProvider] : [];
+  if (providerModels.length === 0) return null;
+
+  const familyPrefix = inferModelFamilyPrefix(requestedModel);
+  const familyCandidates = familyPrefix
+    ? providerModels.filter(model => model.toLowerCase().startsWith(familyPrefix))
+    : [];
+  const selectedPool = familyCandidates.length > 0 ? familyCandidates : providerModels;
+  const sortedCandidates = getTierSortedModels(currentProvider, selectedPool);
+  if (sortedCandidates.length === 0) return null;
+
+  const medianIndex = Math.floor((sortedCandidates.length - 1) / 2);
+  return {
+    resolvedModel: sortedCandidates[medianIndex].model,
+    fallback: {
+      activated: true,
+      reason,
+      selection_method: 'middle_power_median',
+      available_models_count: providerModels.length,
+      used_family_filter: familyCandidates.length > 0,
+      candidates: sortedCandidates,
+    },
+  };
+}
+
+/**
+ * Attempts middle-power fallback and returns a resolution result if successful.
+ * Encapsulates the repeated call + log + return pattern used in two places.
+ *
+ * @param {string} requestedModel
+ * @param {Record<string, string[]|null>} availableModels
+ * @param {string} currentProvider
+ * @param {string} reason
+ * @param {object} fallbackConfig
+ * @param {string[]} log - Accumulator for resolution log messages (mutated in place)
+ * @returns {{ resolvedModel: string, log: string[], fallback: object } | null}
+ */
+function tryMiddlePowerFallback(requestedModel, availableModels, currentProvider, reason, fallbackConfig, log) {
+  const middlePowerFallback = selectMiddlePowerFallback(
+    requestedModel, availableModels, currentProvider, reason, fallbackConfig
+  );
+  if (middlePowerFallback) {
+    log.push(`[model-resolver] middle-power fallback: "${requestedModel}" → "${middlePowerFallback.resolvedModel}"`);
+    return { resolvedModel: middlePowerFallback.resolvedModel, log, fallback: middlePowerFallback.fallback };
+  }
+  return null;
+}
+
+module.exports = {
+  DEFAULT_MODEL_FALLBACK,
+  normalizeFallbackConfig,
+  resolveAliasDefinition,
+  inferModelFamilyPrefix,
+  selectMiddlePowerFallback,
+  tryMiddlePowerFallback,
+};

--- a/containers/api-proxy/model-resolver.js
+++ b/containers/api-proxy/model-resolver.js
@@ -19,7 +19,6 @@
  * case-insensitive, and sorted by semver semantics (highest version first).
  */
 
-const { getTierSortedModels } = require('./model-discovery');
 const { globMatch, extractVersionNumbers, compareByVersion } = require('./model-utils');
 const {
   DEFAULT_MODEL_FALLBACK,

--- a/containers/api-proxy/model-resolver.js
+++ b/containers/api-proxy/model-resolver.js
@@ -25,7 +25,6 @@ const {
   DEFAULT_MODEL_FALLBACK,
   normalizeFallbackConfig,
   resolveAliasDefinition,
-  inferModelFamilyPrefix,
   selectMiddlePowerFallback,
   tryMiddlePowerFallback,
 } = require('./model-fallback');

--- a/containers/api-proxy/model-resolver.js
+++ b/containers/api-proxy/model-resolver.js
@@ -21,6 +21,14 @@
 
 const { getTierSortedModels } = require('./model-discovery');
 const { globMatch, extractVersionNumbers, compareByVersion } = require('./model-utils');
+const {
+  DEFAULT_MODEL_FALLBACK,
+  normalizeFallbackConfig,
+  resolveAliasDefinition,
+  inferModelFamilyPrefix,
+  selectMiddlePowerFallback,
+  tryMiddlePowerFallback,
+} = require('./model-fallback');
 
 /**
  * Check whether a model name is permitted by the given policy config.
@@ -40,11 +48,6 @@ function _isModelPermittedByPolicy(model, policyConfig) {
   if (allowedModels && !allowedModels.some(p => globMatch(p, model))) return false;
   return true;
 }
-
-const DEFAULT_MODEL_FALLBACK = Object.freeze({
-  enabled: true,
-  strategy: 'middle_power',
-});
 
 /**
  * Parse model aliases configuration from a raw JSON string.
@@ -84,82 +87,6 @@ function parseModelAliases(rawConfig) {
   }
 
   return { models: parsed.models };
-}
-
-function normalizeFallbackConfig(modelFallbackConfig) {
-  const config = modelFallbackConfig && typeof modelFallbackConfig === 'object'
-    ? modelFallbackConfig
-    : DEFAULT_MODEL_FALLBACK;
-  return {
-    enabled: config.enabled !== false,
-    strategy: config.strategy || 'middle_power',
-  };
-}
-
-function resolveAliasDefinition(rawAlias) {
-  if (Array.isArray(rawAlias)) {
-    return { patterns: rawAlias, fallback: true };
-  }
-  if (!rawAlias || typeof rawAlias !== 'object' || Array.isArray(rawAlias)) {
-    return { patterns: [], fallback: true };
-  }
-  return {
-    patterns: Array.isArray(rawAlias.patterns) ? rawAlias.patterns : [],
-    fallback: rawAlias.fallback !== false,
-  };
-}
-
-function inferModelFamilyPrefix(requestedModel) {
-  const key = String(requestedModel || '').toLowerCase();
-  const gptFamily = key.match(/^(gpt-\d+(?:\.\d+)?)/)?.[1];
-  if (gptFamily) return gptFamily;
-  if (key.includes('claude')) return 'claude';
-  if (key.includes('gemini')) return 'gemini';
-  return null;
-}
-
-function selectMiddlePowerFallback(requestedModel, availableModels, currentProvider, reason, modelFallbackConfig) {
-  const fallbackConfig = normalizeFallbackConfig(modelFallbackConfig);
-  if (!fallbackConfig.enabled || fallbackConfig.strategy !== 'middle_power') return null;
-
-  const providerModels = Array.isArray(availableModels[currentProvider]) ? availableModels[currentProvider] : [];
-  if (providerModels.length === 0) return null;
-
-  const familyPrefix = inferModelFamilyPrefix(requestedModel);
-  const familyCandidates = familyPrefix
-    ? providerModels.filter(model => model.toLowerCase().startsWith(familyPrefix))
-    : [];
-  const selectedPool = familyCandidates.length > 0 ? familyCandidates : providerModels;
-  const sortedCandidates = getTierSortedModels(currentProvider, selectedPool);
-  if (sortedCandidates.length === 0) return null;
-
-  const medianIndex = Math.floor((sortedCandidates.length - 1) / 2);
-  return {
-    resolvedModel: sortedCandidates[medianIndex].model,
-    fallback: {
-      activated: true,
-      reason,
-      selection_method: 'middle_power_median',
-      available_models_count: providerModels.length,
-      used_family_filter: familyCandidates.length > 0,
-      candidates: sortedCandidates,
-    },
-  };
-}
-
-/**
- * Attempts middle-power fallback and returns a resolution result if successful.
- * Encapsulates the repeated call + log + return pattern used in two places.
- */
-function tryMiddlePowerFallback(requestedModel, availableModels, currentProvider, reason, fallbackConfig, log) {
-  const middlePowerFallback = selectMiddlePowerFallback(
-    requestedModel, availableModels, currentProvider, reason, fallbackConfig
-  );
-  if (middlePowerFallback) {
-    log.push(`[model-resolver] middle-power fallback: "${requestedModel}" → "${middlePowerFallback.resolvedModel}"`);
-    return { resolvedModel: middlePowerFallback.resolvedModel, log, fallback: middlePowerFallback.fallback };
-  }
-  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Split model fallback selection out of `containers/api-proxy/model-resolver.js` (431 lines) into a dedicated `model-fallback.js` module (~130 lines).

### Extracted functions
- `normalizeFallbackConfig` — normalize raw fallback config
- `resolveAliasDefinition` — normalize alias definition shape
- `inferModelFamilyPrefix` — detect model family (GPT, Claude, Gemini)
- `selectMiddlePowerFallback` — median-power fallback selection
- `tryMiddlePowerFallback` — wrapper with log/return pattern

### Changes
- `model-resolver.js` reduced from 431 to ~350 lines
- Imports fallback helpers; continues to re-export `selectMiddlePowerFallback`
- Dockerfile updated to COPY new file

### Benefits
- Fallback selection logic independently unit-testable
- Resolution algorithm easier to read without inline fallback heuristics
- `_resolveAliasPatterns` more focused on pattern matching

Closes #5632