### PR TITLE
refactor: deduplicate OIDC auth env var mappings via shared constant

### DIFF
--- a/src/api-proxy-env-constants.ts
+++ b/src/api-proxy-env-constants.ts
@@ -39,3 +39,35 @@ export const COPILOT_ENV = {
   API_TARGET: 'COPILOT_API_TARGET',
   API_BASE_PATH: 'COPILOT_API_BASE_PATH',
 } as const;
+
+/**
+ * OIDC authentication env var mappings.
+ * Each entry maps a WrapperConfig field name to its corresponding environment variable.
+ * Used by both build-config.ts (env → config) and api-proxy-env-config.ts (config → env).
+ */
+export const OIDC_AUTH_ENV_MAPPING: ReadonlyArray<{ configKey: string; envVar: string }> = [
+  { configKey: 'authType', envVar: 'AWF_AUTH_TYPE' },
+  { configKey: 'authProvider', envVar: 'AWF_AUTH_PROVIDER' },
+  { configKey: 'authOidcAudience', envVar: 'AWF_AUTH_OIDC_AUDIENCE' },
+  // Azure
+  { configKey: 'authAzureTenantId', envVar: 'AWF_AUTH_AZURE_TENANT_ID' },
+  { configKey: 'authAzureClientId', envVar: 'AWF_AUTH_AZURE_CLIENT_ID' },
+  { configKey: 'authAzureScope', envVar: 'AWF_AUTH_AZURE_SCOPE' },
+  { configKey: 'authAzureCloud', envVar: 'AWF_AUTH_AZURE_CLOUD' },
+  // AWS
+  { configKey: 'authAwsRoleArn', envVar: 'AWF_AUTH_AWS_ROLE_ARN' },
+  { configKey: 'authAwsRegion', envVar: 'AWF_AUTH_AWS_REGION' },
+  { configKey: 'authAwsRoleSessionName', envVar: 'AWF_AUTH_AWS_ROLE_SESSION_NAME' },
+  // GCP
+  { configKey: 'authGcpWorkloadIdentityProvider', envVar: 'AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER' },
+  { configKey: 'authGcpServiceAccount', envVar: 'AWF_AUTH_GCP_SERVICE_ACCOUNT' },
+  { configKey: 'authGcpScope', envVar: 'AWF_AUTH_GCP_SCOPE' },
+  // Anthropic
+  { configKey: 'authAnthropicFederationRuleId', envVar: 'AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID' },
+  { configKey: 'authAnthropicOrganizationId', envVar: 'AWF_AUTH_ANTHROPIC_ORGANIZATION_ID' },
+  { configKey: 'authAnthropicServiceAccountId', envVar: 'AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID' },
+  { configKey: 'authAnthropicWorkspaceId', envVar: 'AWF_AUTH_ANTHROPIC_WORKSPACE_ID' },
+];
+
+/** Env var names for OIDC auth — use with pickEnvVars() to forward host env to sidecar */
+export const OIDC_AUTH_ENV_VARS = OIDC_AUTH_ENV_MAPPING.map(m => m.envVar);

--- a/src/api-proxy-env-constants.ts
+++ b/src/api-proxy-env-constants.ts
@@ -45,7 +45,7 @@ export const COPILOT_ENV = {
  * Each entry maps a WrapperConfig field name to its corresponding environment variable.
  * Used by both build-config.ts (env → config) and api-proxy-env-config.ts (config → env).
  */
-export const OIDC_AUTH_ENV_MAPPING: ReadonlyArray<{ configKey: string; envVar: string }> = [
+export const OIDC_AUTH_ENV_MAPPING = [
   { configKey: 'authType', envVar: 'AWF_AUTH_TYPE' },
   { configKey: 'authProvider', envVar: 'AWF_AUTH_PROVIDER' },
   { configKey: 'authOidcAudience', envVar: 'AWF_AUTH_OIDC_AUDIENCE' },
@@ -67,7 +67,10 @@ export const OIDC_AUTH_ENV_MAPPING: ReadonlyArray<{ configKey: string; envVar: s
   { configKey: 'authAnthropicOrganizationId', envVar: 'AWF_AUTH_ANTHROPIC_ORGANIZATION_ID' },
   { configKey: 'authAnthropicServiceAccountId', envVar: 'AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID' },
   { configKey: 'authAnthropicWorkspaceId', envVar: 'AWF_AUTH_ANTHROPIC_WORKSPACE_ID' },
-];
+] as const satisfies ReadonlyArray<{
+  configKey: Extract<keyof import('./types').WrapperConfig, string>;
+  envVar: `AWF_AUTH_${string}`;
+}>;
 
 /** Env var names for OIDC auth — use with pickEnvVars() to forward host env to sidecar */
 export const OIDC_AUTH_ENV_VARS = OIDC_AUTH_ENV_MAPPING.map(m => m.envVar);

--- a/src/commands/build-config.ts
+++ b/src/commands/build-config.ts
@@ -1,5 +1,5 @@
 import { WrapperConfig, LogLevel, UpstreamProxyConfig } from '../types';
-import { OPENAI_ENV, ANTHROPIC_ENV, GEMINI_ENV, COPILOT_ENV } from '../api-proxy-env-constants';
+import { OPENAI_ENV, ANTHROPIC_ENV, GEMINI_ENV, COPILOT_ENV, OIDC_AUTH_ENV_MAPPING } from '../api-proxy-env-constants';
 
 /**
  * Inputs required to assemble a {@link WrapperConfig}.
@@ -204,20 +204,15 @@ export function buildConfig(inputs: BuildConfigInputs): WrapperConfig {
     authType: (options.authType as string | undefined) || process.env.AWF_AUTH_TYPE,
     authProvider: (options.authProvider as string | undefined) || process.env.AWF_AUTH_PROVIDER,
     authOidcAudience: (options.authOidcAudience as string | undefined) || process.env.AWF_AUTH_OIDC_AUDIENCE,
-    authAzureTenantId: (options.authAzureTenantId as string | undefined) || process.env.AWF_AUTH_AZURE_TENANT_ID,
-    authAzureClientId: (options.authAzureClientId as string | undefined) || process.env.AWF_AUTH_AZURE_CLIENT_ID,
-    authAzureScope: (options.authAzureScope as string | undefined) || process.env.AWF_AUTH_AZURE_SCOPE,
-    authAzureCloud: (options.authAzureCloud as string | undefined) || process.env.AWF_AUTH_AZURE_CLOUD,
-    authAwsRoleArn: (options.authAwsRoleArn as string | undefined) || process.env.AWF_AUTH_AWS_ROLE_ARN,
-    authAwsRegion: (options.authAwsRegion as string | undefined) || process.env.AWF_AUTH_AWS_REGION,
-    authAwsRoleSessionName: (options.authAwsRoleSessionName as string | undefined) || process.env.AWF_AUTH_AWS_ROLE_SESSION_NAME,
-    authGcpWorkloadIdentityProvider: (options.authGcpWorkloadIdentityProvider as string | undefined) || process.env.AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER,
-    authGcpServiceAccount: (options.authGcpServiceAccount as string | undefined) || process.env.AWF_AUTH_GCP_SERVICE_ACCOUNT,
-    authGcpScope: (options.authGcpScope as string | undefined) || process.env.AWF_AUTH_GCP_SCOPE,
-    authAnthropicFederationRuleId: (options.authAnthropicFederationRuleId as string | undefined) || process.env.AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID,
-    authAnthropicOrganizationId: (options.authAnthropicOrganizationId as string | undefined) || process.env.AWF_AUTH_ANTHROPIC_ORGANIZATION_ID,
-    authAnthropicServiceAccountId: (options.authAnthropicServiceAccountId as string | undefined) || process.env.AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID,
-    authAnthropicWorkspaceId: (options.authAnthropicWorkspaceId as string | undefined) || process.env.AWF_AUTH_ANTHROPIC_WORKSPACE_ID,
+    ...Object.fromEntries(
+      OIDC_AUTH_ENV_MAPPING
+        .filter(m => !['authType', 'authProvider', 'authOidcAudience'].includes(m.configKey))
+        .map(({ configKey, envVar }) => [
+          configKey,
+          (options[configKey] as string | undefined) || process.env[envVar],
+        ])
+        .filter(([, v]) => v !== undefined)
+    ),
     geminiApiTarget:
       (options.geminiApiTarget as string | undefined) || process.env[GEMINI_ENV.TARGET],
     geminiApiBasePath:

--- a/src/services/api-proxy-env-config.ts
+++ b/src/services/api-proxy-env-config.ts
@@ -2,7 +2,7 @@ import { SQUID_PORT } from '../constants';
 import { stripScheme } from '../host-env';
 import { WrapperConfig } from '../types';
 import { getConfigEnvValue, getLowerCaseProcessEnvValue, pickEnvVars } from '../env-utils';
-import { OPENAI_ENV, ANTHROPIC_ENV, GEMINI_ENV, COPILOT_ENV } from '../api-proxy-env-constants';
+import { OPENAI_ENV, ANTHROPIC_ENV, GEMINI_ENV, COPILOT_ENV, OIDC_AUTH_ENV_VARS, OIDC_AUTH_ENV_MAPPING } from '../api-proxy-env-constants';
 import { NetworkConfig } from './squid-service';
 
 /**
@@ -191,30 +191,7 @@ export function buildApiProxyBaseEnv(config: WrapperConfig, networkConfig: Netwo
       AWF_MAX_BLOCKED_CAPTURE_BYTES: String(config.maxCapturedBytes),
     }),
     // OIDC authentication (Azure, AWS, GCP, Anthropic)
-    ...pickEnvVars(
-      'AWF_AUTH_TYPE',
-      'AWF_AUTH_PROVIDER',
-      'AWF_AUTH_OIDC_AUDIENCE',
-      // Azure
-      'AWF_AUTH_AZURE_TENANT_ID',
-      'AWF_AUTH_AZURE_CLIENT_ID',
-      'AWF_AUTH_AZURE_SCOPE',
-      'AWF_AUTH_AZURE_CLOUD',
-      // AWS
-      'AWF_AUTH_AWS_ROLE_ARN',
-      'AWF_AUTH_AWS_REGION',
-      'AWF_AUTH_AWS_ROLE_SESSION_NAME',
-      // GCP
-      'AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER',
-      'AWF_AUTH_GCP_SERVICE_ACCOUNT',
-      'AWF_AUTH_GCP_SCOPE',
-      // Anthropic
-      'AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID',
-      'AWF_AUTH_ANTHROPIC_ORGANIZATION_ID',
-      'AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID',
-      'AWF_AUTH_ANTHROPIC_WORKSPACE_ID',
-      'AWF_AUTH_ANTHROPIC_TOKEN_URL',
-    ),
+    ...pickEnvVars(...OIDC_AUTH_ENV_VARS, 'AWF_AUTH_ANTHROPIC_TOKEN_URL'),
     // GitHub Actions OIDC runtime tokens (needed by OIDC token provider in api-proxy)
     ...(normalizedAuthType === 'github-oidc' && pickEnvVars(
       'ACTIONS_ID_TOKEN_REQUEST_URL',
@@ -232,23 +209,11 @@ export function buildApiProxyBaseEnv(config: WrapperConfig, networkConfig: Netwo
     ...(config.anthropicApiAuthHeader && { [ANTHROPIC_ENV.AUTH_HEADER]: config.anthropicApiAuthHeader }),
     ...(config.anthropicTokenUrl && { AWF_AUTH_ANTHROPIC_TOKEN_URL: config.anthropicTokenUrl }),
     // OIDC auth config-file values override host env vars (config-file > env fallback precedence)
-    ...(config.authType && { AWF_AUTH_TYPE: config.authType }),
-    ...(config.authProvider && { AWF_AUTH_PROVIDER: config.authProvider }),
-    ...(config.authOidcAudience && { AWF_AUTH_OIDC_AUDIENCE: config.authOidcAudience }),
-    ...(config.authAzureTenantId && { AWF_AUTH_AZURE_TENANT_ID: config.authAzureTenantId }),
-    ...(config.authAzureClientId && { AWF_AUTH_AZURE_CLIENT_ID: config.authAzureClientId }),
-    ...(config.authAzureScope && { AWF_AUTH_AZURE_SCOPE: config.authAzureScope }),
-    ...(config.authAzureCloud && { AWF_AUTH_AZURE_CLOUD: config.authAzureCloud }),
-    ...(config.authAwsRoleArn && { AWF_AUTH_AWS_ROLE_ARN: config.authAwsRoleArn }),
-    ...(config.authAwsRegion && { AWF_AUTH_AWS_REGION: config.authAwsRegion }),
-    ...(config.authAwsRoleSessionName && { AWF_AUTH_AWS_ROLE_SESSION_NAME: config.authAwsRoleSessionName }),
-    ...(config.authGcpWorkloadIdentityProvider && { AWF_AUTH_GCP_WORKLOAD_IDENTITY_PROVIDER: config.authGcpWorkloadIdentityProvider }),
-    ...(config.authGcpServiceAccount && { AWF_AUTH_GCP_SERVICE_ACCOUNT: config.authGcpServiceAccount }),
-    ...(config.authGcpScope && { AWF_AUTH_GCP_SCOPE: config.authGcpScope }),
-    ...(config.authAnthropicFederationRuleId && { AWF_AUTH_ANTHROPIC_FEDERATION_RULE_ID: config.authAnthropicFederationRuleId }),
-    ...(config.authAnthropicOrganizationId && { AWF_AUTH_ANTHROPIC_ORGANIZATION_ID: config.authAnthropicOrganizationId }),
-    ...(config.authAnthropicServiceAccountId && { AWF_AUTH_ANTHROPIC_SERVICE_ACCOUNT_ID: config.authAnthropicServiceAccountId }),
-    ...(config.authAnthropicWorkspaceId && { AWF_AUTH_ANTHROPIC_WORKSPACE_ID: config.authAnthropicWorkspaceId }),
+    ...Object.fromEntries(
+      OIDC_AUTH_ENV_MAPPING
+        .filter(({ configKey }) => (config as unknown as Record<string, unknown>)[configKey])
+        .map(({ configKey, envVar }) => [envVar, (config as unknown as Record<string, unknown>)[configKey] as string])
+    ),
     // NOTE: AWF_ANTHROPIC_TRANSFORM_FILE is intentionally NOT forwarded from the host.
     // The api-proxy container holds live API credentials; loading arbitrary host-side JS
     // files into it would create an arbitrary-code-execution risk.  If you need a custom


### PR DESCRIPTION
## Summary

Eliminate ~40 repeated OIDC env/config mappings between `build-config.ts` and `api-proxy-env-config.ts` by introducing a shared `OIDC_AUTH_ENV_MAPPING` constant.

### Changes
- **`src/api-proxy-env-constants.ts`**: Added `OIDC_AUTH_ENV_MAPPING` (config field ↔ env var pairs) and `OIDC_AUTH_ENV_VARS` (env var name array)
- **`src/commands/build-config.ts`**: Uses mapping to generate config from env/options
- **`src/services/api-proxy-env-config.ts`**: Uses `OIDC_AUTH_ENV_VARS` for `pickEnvVars()` and `OIDC_AUTH_ENV_MAPPING` for config→env projection

### Benefits
- Single source of truth for OIDC auth env vars on the security-critical credential path
- Adding a new OIDC provider requires editing only the constant array
- Net reduction of ~8 lines despite added infrastructure

### Testing
- All api-proxy-env and oidc tests pass (54 tests)
- TypeScript compiles cleanly

Closes #5621