### PR TITLE
fix: export missing symbols required by tests

### DIFF
--- a/src/services/api-proxy-env-config.ts
+++ b/src/services/api-proxy-env-config.ts
@@ -8,6 +8,7 @@ import { NetworkConfig } from './squid-service';
 /**
  * Builds provider API target/basePath environment variables for the api-proxy container.
  * Centralizes the repetitive per-provider target/basePath conditional env generation.
+ * @internal Exported for testing
  */
 export function buildProviderTargetEnv(config: WrapperConfig): Record<string, string> {
   const copilotProviderType = config.copilotProviderType || getConfigEnvValue(config, COPILOT_ENV.PROVIDER_TYPE);

--- a/src/services/api-proxy-env-config.ts
+++ b/src/services/api-proxy-env-config.ts
@@ -9,7 +9,7 @@ import { NetworkConfig } from './squid-service';
  * Builds provider API target/basePath environment variables for the api-proxy container.
  * Centralizes the repetitive per-provider target/basePath conditional env generation.
  */
-function buildProviderTargetEnv(config: WrapperConfig): Record<string, string> {
+export function buildProviderTargetEnv(config: WrapperConfig): Record<string, string> {
   const copilotProviderType = config.copilotProviderType || getConfigEnvValue(config, COPILOT_ENV.PROVIDER_TYPE);
   const copilotProviderBaseUrl = config.copilotProviderBaseUrl || getConfigEnvValue(config, COPILOT_ENV.PROVIDER_BASE_URL);
   const copilotProviderApiKey = config.copilotProviderApiKey;

--- a/src/services/api-proxy-service-split.test.ts
+++ b/src/services/api-proxy-service-split.test.ts
@@ -3,7 +3,7 @@ import { parseImageTag } from '../image-tag';
 import { COPILOT_PLACEHOLDER_TOKEN } from '../constants/placeholders';
 import { baseConfig } from '../test-helpers/docker-test-fixtures.test-utils';
 import { buildApiProxyServiceConfig } from './api-proxy-service-config';
-import { buildApiProxyBaseEnv } from './api-proxy-env-config';
+import { buildApiProxyBaseEnv, buildProviderTargetEnv } from './api-proxy-env-config';
 import { buildApiProxyLifecycleConfig } from './api-proxy-lifecycle-config';
 import { buildAgentCredentialEnv } from './api-proxy-credential-env';
 

--- a/src/ssl-key-storage.ts
+++ b/src/ssl-key-storage.ts
@@ -77,6 +77,7 @@ export async function unmountSslTmpfs(sslDir: string): Promise<void> {
  * cannot be guaranteed on all filesystems (for example, journaling/COW).
  *
  * @param filePath - Path to the file to securely wipe
+ * @internal Exported for testing
  */
 export function secureWipeFile(filePath: string): void {
   let fd: number | undefined;

--- a/src/ssl-key-storage.ts
+++ b/src/ssl-key-storage.ts
@@ -78,7 +78,7 @@ export async function unmountSslTmpfs(sslDir: string): Promise<void> {
  *
  * @param filePath - Path to the file to securely wipe
  */
-function secureWipeFile(filePath: string): void {
+export function secureWipeFile(filePath: string): void {
   let fd: number | undefined;
 
   try {


### PR DESCRIPTION
## Summary

Fixes 2 failing test suites on `main` caused by missing exports/imports:

### `src/ssl-key-storage.test.ts`
- **Problem**: Test imports `secureWipeFile` but it was not exported from `ssl-key-storage.ts`
- **Fix**: Add `export` keyword to `secureWipeFile` function

### `src/services/api-proxy-service-split.test.ts`
- **Problem**: Test uses `buildProviderTargetEnv` but it was neither exported from its module nor imported in the test file
- **Fix**: Export `buildProviderTargetEnv` from `api-proxy-env-config.ts` and add the import to the test file

### Verification

All 200 test suites (3321 tests) pass after these changes.