### PR TITLE
fix: update test assertions for gh-aw-actions v0.82.0 and github-mcp-server v1.5.0

### DIFF
--- a/scripts/ci/export-audit-workflow.test.ts
+++ b/scripts/ci/export-audit-workflow.test.ts
@@ -81,6 +81,6 @@ describe('export audit workflow optimization config', () => {
     expect(lock).not.toContain('TypeScript build output:\n```');
 
     // github-mcp-server image reference present
-    expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.4.0');
+    expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.5.0');
   });
 });

--- a/scripts/ci/security-guard-workflow.test.ts
+++ b/scripts/ci/security-guard-workflow.test.ts
@@ -40,8 +40,8 @@ describe('security guard workflow optimization config', () => {
     expect(lock).toContain('COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode');
     expect(lock).not.toContain(`COPILOT_DUMMY_BYOK: ${COPILOT_PLACEHOLDER_TOKEN}`);
     expect(lock).toContain('GH_AW_MAX_TURNS: 6');
-    expect(lock).toContain('github/gh-aw-actions/setup@ba6380cc6e5be5d21677bebe04d52fb48e3abec7 # v0.81.6');
+    expect(lock).toContain('github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0');
     expect(lock).not.toContain('github/gh-aw-actions/setup@v0.80.6');
-    expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.4.0');
+    expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.5.0');
   });
 });

--- a/scripts/ci/self-hosted-runner-doctor-updater-workflow.test.ts
+++ b/scripts/ci/self-hosted-runner-doctor-updater-workflow.test.ts
@@ -28,6 +28,6 @@ describe('runner doctor updater workflow config', () => {
     expect(lock).toContain('🩺 Runner Doctor Update');
     expect(lock).toContain('shared/self-hosted-failure-modes.md');
     expect(lock).toContain('Compute scan window');
-    expect(lock).toContain('github/gh-aw-actions/setup@ba6380cc6e5be5d21677bebe04d52fb48e3abec7');
+    expect(lock).toContain('github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f');
   });
 });

--- a/scripts/ci/self-hosted-runner-doctor-workflow.test.ts
+++ b/scripts/ci/self-hosted-runner-doctor-workflow.test.ts
@@ -29,6 +29,6 @@ describe('self-hosted runner doctor workflow config', () => {
     expect(lock).toContain('pull-requests: read');
     expect(lock).toContain('🩺 Runner Doctor');
     expect(lock).toContain('shared/self-hosted-failure-modes.md');
-    expect(lock).toContain('github/gh-aw-actions/setup@ba6380cc6e5be5d21677bebe04d52fb48e3abec7');
+    expect(lock).toContain('github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f');
   });
 });

--- a/scripts/ci/test-coverage-improver-workflow.test.ts
+++ b/scripts/ci/test-coverage-improver-workflow.test.ts
@@ -75,9 +75,9 @@ describe('test coverage improver workflow token optimization config', () => {
     expect(lock).not.toContain("shell(cat:src/*.test.ts)");
     expect(lock).not.toContain("shell(npm run lint)");
     expect(lock).not.toContain("shell(npm run test)");
-    expect(lock).toContain('github/gh-aw-actions/setup@ba6380cc6e5be5d21677bebe04d52fb48e3abec7 # v0.81.6');
+    expect(lock).toContain('github/gh-aw-actions/setup@2ad2a516e432f0a0000cfaed33d262a380f9e58f # v0.82.0');
     expect(lock).not.toContain('github/gh-aw-actions/setup@v0.80.6');
-    expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.4.0');
+    expect(lock).toContain('ghcr.io/github/github-mcp-server:v1.5.0');
 
     expect(lock).not.toContain("shell(cat:src/docker-manager.ts)");
     expect(lock).not.toContain("shell(cat:src/cli.ts)");


### PR DESCRIPTION
## Summary

The lock files were updated to `gh-aw-actions/setup` v0.82.0 (sha `2ad2a516e432f0a0000cfaed33d262a380f9e58f`) and `github-mcp-server` v1.5.0 in #5718, but 5 CI workflow tests still asserted the old v0.81.6 (`ba6380cc6e5be5d21677bebe04d52fb48e3abec7`) and v1.4.0 references.

## Changes

Updated assertions in:
- `scripts/ci/export-audit-workflow.test.ts`
- `scripts/ci/security-guard-workflow.test.ts`
- `scripts/ci/self-hosted-runner-doctor-updater-workflow.test.ts`
- `scripts/ci/self-hosted-runner-doctor-workflow.test.ts`
- `scripts/ci/test-coverage-improver-workflow.test.ts`

## Testing

All 3367 tests pass locally after this change.