### PR TITLE
fix: pass host-gateway IP to iptables-init container for NAT bypass

### DIFF
--- a/containers/agent/setup-iptables.sh
+++ b/containers/agent/setup-iptables.sh
@@ -294,6 +294,13 @@ configure_host_access_rules() {
       allow_host_access_to_gateway "$HOST_GATEWAY_IP" "host gateway"
     elif [ -n "$HOST_GATEWAY_IP" ]; then
       echo "[iptables] WARNING: host.docker.internal resolved to invalid IP '${HOST_GATEWAY_IP}', skipping host gateway bypass"
+    elif [ -n "$AWF_HOST_GATEWAY_IP" ] && is_valid_ipv4 "$AWF_HOST_GATEWAY_IP"; then
+      # Fallback: the CLI detected the host-gateway IP and passed it via env var.
+      # This handles hosts where the init container cannot resolve host.docker.internal
+      # (Docker rejects extra_hosts on containers using network_mode: service:agent).
+      echo "[iptables] host.docker.internal not resolvable in init container, using CLI-provided host gateway IP"
+      HOST_GATEWAY_IP="$AWF_HOST_GATEWAY_IP"
+      allow_host_access_to_gateway "$HOST_GATEWAY_IP" "host gateway (from AWF_HOST_GATEWAY_IP)"
     else
       echo "[iptables] WARNING: host.docker.internal could not be resolved, skipping host gateway bypass"
     fi
@@ -319,8 +326,11 @@ configure_host_access_rules() {
     # Parse port list once, before resolving gateway IPs, so both blocks can use it
     IFS=',' read -ra HSP_PORTS <<< "$AWF_HOST_SERVICE_PORTS"
 
-    # Resolve host gateway IP
+    # Resolve host gateway IP (with AWF_HOST_GATEWAY_IP fallback, same as host access block)
     HSP_HOST_GW_IP=$(getent hosts host.docker.internal 2>/dev/null | awk 'NR==1 { print $1 }')
+    if [ -z "$HSP_HOST_GW_IP" ] && [ -n "$AWF_HOST_GATEWAY_IP" ]; then
+      HSP_HOST_GW_IP="$AWF_HOST_GATEWAY_IP"
+    fi
     HSP_NET_GW_IP=$(route -n 2>/dev/null | awk '/^0\.0\.0\.0/ { print $2; exit }')
 
     if [ -n "$HSP_HOST_GW_IP" ] && is_valid_ipv4 "$HSP_HOST_GW_IP"; then

--- a/src/compose-generator.test.ts
+++ b/src/compose-generator.test.ts
@@ -13,6 +13,12 @@ import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 
+// Mock host-gateway resolution (runs execa.sync against Docker, which we don't want in unit tests)
+const mockResolveDockerHostGateway = jest.fn();
+jest.mock('./services/host-gateway', () => ({
+  resolveDockerHostGateway: (...args: any[]) => mockResolveDockerHostGateway(...args),
+}));
+
 let mockConfig: WrapperConfig;
 
 describe('generateDockerCompose', () => {
@@ -311,6 +317,39 @@ describe('generateDockerCompose', () => {
         expect(result.networks['awf-net'].external).toBe(true);
         expect(result.networks['awf-ext']).toBeUndefined();
         expect(result.services.agent.environment?.AWF_NETWORK_ISOLATION).toBeUndefined();
+      });
+    });
+
+    describe('host-gateway IP passthrough (AWF_HOST_GATEWAY_IP)', () => {
+      afterEach(() => {
+        mockResolveDockerHostGateway.mockReset();
+      });
+
+      it('should pass AWF_HOST_GATEWAY_IP to iptables-init when enableHostAccess is true', () => {
+        mockResolveDockerHostGateway.mockReturnValue('192.168.1.100');
+        const config = { ...mockConfig, enableHostAccess: true };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const initEnv = result.services['iptables-init']?.environment as Record<string, string>;
+
+        expect(mockResolveDockerHostGateway).toHaveBeenCalled();
+        expect(initEnv.AWF_HOST_GATEWAY_IP).toBe('192.168.1.100');
+      });
+
+      it('should set AWF_HOST_GATEWAY_IP to empty when enableHostAccess is false', () => {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const initEnv = result.services['iptables-init']?.environment as Record<string, string>;
+
+        expect(mockResolveDockerHostGateway).not.toHaveBeenCalled();
+        expect(initEnv.AWF_HOST_GATEWAY_IP).toBe('');
+      });
+
+      it('should set AWF_HOST_GATEWAY_IP to empty when detection fails', () => {
+        mockResolveDockerHostGateway.mockReturnValue(undefined);
+        const config = { ...mockConfig, enableHostAccess: true };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const initEnv = result.services['iptables-init']?.environment as Record<string, string>;
+
+        expect(initEnv.AWF_HOST_GATEWAY_IP).toBe('');
       });
     });
 

--- a/src/compose-generator.ts
+++ b/src/compose-generator.ts
@@ -13,6 +13,7 @@ import { buildApiProxyService } from './services/api-proxy-service';
 import { buildDohProxyService } from './services/doh-proxy-service';
 import { buildCliProxyService } from './services/cli-proxy-service';
 import { buildSysrootStageService, isSysrootEnabled } from './services/sysroot-service';
+import { resolveDockerHostGateway } from './services/host-gateway';
 import { TOPOLOGY_NETWORK_NAME } from './topology';
 
 /**
@@ -193,12 +194,18 @@ export function generateDockerCompose(
   }
 
   if (!networkIsolation) {
+    // Resolve the host-gateway IP so the init container can create NAT bypass rules
+    // for host.docker.internal traffic. The init container cannot resolve this itself
+    // because Docker rejects extra_hosts on containers using network_mode: service:agent.
+    const hostGatewayIp = config.enableHostAccess ? resolveDockerHostGateway() : undefined;
+
     const iptablesInitService = buildIptablesInitService({
       agentService,
       environment,
       networkConfig,
       initSignalDir,
       dockerHostPathPrefix: config.dockerHostPathPrefix,
+      hostGatewayIp,
     });
     services['iptables-init'] = iptablesInitService;
   }

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -246,6 +246,12 @@ interface IptablesInitServiceParams {
   // iptables-init containers land on two different daemon-side directories and the
   // ready/output.log handshake silently fails ("No init container output log found").
   dockerHostPathPrefix?: string;
+  // The IP that Docker resolves `host-gateway` to (i.e., the IP behind
+  // `host.docker.internal` in the agent container). Passed to the init container
+  // so it can create NAT bypass rules even though it cannot resolve
+  // `host.docker.internal` itself (Docker rejects extra_hosts on containers
+  // using network_mode: service:<other>).
+  hostGatewayIp?: string;
 }
 
 /**
@@ -254,7 +260,7 @@ interface IptablesInitServiceParams {
  * without ever granting NET_ADMIN to the agent itself.
  */
 export function buildIptablesInitService(params: IptablesInitServiceParams): any {
-  const { agentService, environment, networkConfig, initSignalDir, dockerHostPathPrefix } = params;
+  const { agentService, environment, networkConfig, initSignalDir, dockerHostPathPrefix, hostGatewayIp } = params;
 
   // The init-signal mount must use the same source path that the agent container uses,
   // otherwise the two containers bind to different daemon-side directories and the
@@ -293,6 +299,7 @@ export function buildIptablesInitService(params: IptablesInitServiceParams): any
       AWF_CLI_PROXY_IP: environment.AWF_CLI_PROXY_IP || '',
       AWF_SSL_BUMP_ENABLED: environment.AWF_SSL_BUMP_ENABLED || '',
       AWF_SSL_BUMP_INTERCEPT_PORT: environment.AWF_SSL_BUMP_INTERCEPT_PORT || '',
+      AWF_HOST_GATEWAY_IP: hostGatewayIp || '',
     },
     depends_on: {
       'agent': {

--- a/src/services/host-gateway.test.ts
+++ b/src/services/host-gateway.test.ts
@@ -1,0 +1,54 @@
+import { resolveDockerHostGateway } from './host-gateway';
+
+// Mock execa module
+const mockExecaSync = jest.fn();
+jest.mock('execa', () => {
+  const fn = (...args: any[]) => fn.sync(...args);
+  fn.sync = (...args: any[]) => mockExecaSync(...args);
+  return fn;
+});
+
+describe('resolveDockerHostGateway', () => {
+  beforeEach(() => {
+    mockExecaSync.mockReset();
+  });
+
+  it('should return bridge gateway IP when docker network inspect succeeds', () => {
+    mockExecaSync.mockReturnValueOnce({ stdout: '172.17.0.1' });
+
+    expect(resolveDockerHostGateway()).toBe('172.17.0.1');
+    expect(mockExecaSync).toHaveBeenCalledWith(
+      'docker',
+      ['network', 'inspect', 'bridge', '-f', '{{(index .IPAM.Config 0).Gateway}}'],
+      expect.objectContaining({ timeout: 5000 }),
+    );
+  });
+
+  it('should fall back to ip route when docker inspect fails', () => {
+    mockExecaSync
+      .mockImplementationOnce(() => { throw new Error('docker not available'); })
+      .mockReturnValueOnce({ stdout: '1.1.1.1 via 10.0.0.1 dev eth0 src 192.168.1.50 uid 1000' });
+
+    expect(resolveDockerHostGateway()).toBe('192.168.1.50');
+  });
+
+  it('should return undefined when all methods fail', () => {
+    mockExecaSync.mockImplementation(() => { throw new Error('command failed'); });
+
+    expect(resolveDockerHostGateway()).toBeUndefined();
+  });
+
+  it('should skip invalid IPs from docker inspect and try fallback', () => {
+    mockExecaSync
+      .mockReturnValueOnce({ stdout: 'not-an-ip' })
+      .mockReturnValueOnce({ stdout: '1.1.1.1 via 10.0.0.1 dev eth0 src 10.0.0.5 uid 1000' });
+
+    expect(resolveDockerHostGateway()).toBe('10.0.0.5');
+  });
+
+  it('should trim whitespace from docker inspect output', () => {
+    mockExecaSync.mockReturnValueOnce({ stdout: '  172.17.0.1\n' });
+
+    expect(resolveDockerHostGateway()).toBe('172.17.0.1');
+  });
+});

--- a/src/services/host-gateway.ts
+++ b/src/services/host-gateway.ts
@@ -1,0 +1,55 @@
+import execa from 'execa';
+import { logger } from '../logger';
+
+const IPV4_REGEX = /^(\d{1,3}\.){3}\d{1,3}$/;
+
+/**
+ * Resolves the IP address that Docker will use for the `host-gateway` special
+ * string (i.e., what `host.docker.internal` maps to inside containers with
+ * `extra_hosts: ['host.docker.internal:host-gateway']`).
+ *
+ * This is needed because the iptables-init container shares the agent's network
+ * namespace (`network_mode: service:agent`) but NOT its mount namespace, so it
+ * has no `/etc/hosts` entry for `host.docker.internal`. Without this value,
+ * `setup-iptables.sh` cannot create the NAT bypass rules for the correct host IP,
+ * causing MCP gateway traffic to be DNAT'd to Squid where it fails.
+ *
+ * Detection order:
+ *   1. Default bridge network gateway (`docker network inspect bridge`)
+ *   2. Host default-route source IP (`ip route get 1.1.1.1`)
+ *
+ * Returns the resolved IPv4 address, or undefined if detection fails.
+ */
+export function resolveDockerHostGateway(): string | undefined {
+  // Method 1: Docker bridge network gateway (matches most Docker setups)
+  try {
+    const { stdout } = execa.sync('docker', [
+      'network', 'inspect', 'bridge',
+      '-f', '{{(index .IPAM.Config 0).Gateway}}',
+    ], { timeout: 5000, maxBuffer: 1024 });
+    const ip = stdout.trim();
+    if (ip && IPV4_REGEX.test(ip)) {
+      logger.debug(`Resolved Docker host-gateway IP via bridge network: ${ip}`);
+      return ip;
+    }
+  } catch (err) {
+    logger.debug(`Could not inspect Docker bridge network: ${err}`);
+  }
+
+  // Method 2: Host default-route source IP (Linux fallback)
+  try {
+    const { stdout } = execa.sync('ip', [
+      'route', 'get', '1.1.1.1',
+    ], { timeout: 5000, maxBuffer: 1024 });
+    const match = stdout.match(/src\s+(\d+\.\d+\.\d+\.\d+)/);
+    if (match?.[1] && IPV4_REGEX.test(match[1])) {
+      logger.debug(`Resolved Docker host-gateway IP via default route: ${match[1]}`);
+      return match[1];
+    }
+  } catch (err) {
+    logger.debug(`Could not detect host default-route source IP: ${err}`);
+  }
+
+  logger.debug('Could not resolve Docker host-gateway IP');
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Fixes #5705

When `--enable-host-access` is used, the iptables-init container needs to create NAT bypass rules for `host.docker.internal` traffic. However, Docker rejects `extra_hosts` on containers using `network_mode: service:agent`, so the init container has no `/etc/hosts` entry for `host.docker.internal` and `getent hosts host.docker.internal` returns empty.

On hosts where `host.docker.internal` resolves to the host's **primary NIC IP** (not the awf-net bridge gateway), the init container cannot discover this IP. MCP gateway traffic is then DNAT'd to Squid, which fails with `ERR_INVALID_URL` on relative-URL MCP requests — a silent failure where workflows complete "green" but produce no output.

## Changes

### New: `src/services/host-gateway.ts`
- `resolveDockerHostGateway()` — detects the IP that Docker will use for `host-gateway` from the CLI host side
- Detection order: Docker bridge network gateway → host default-route source IP
- Returns the IP or `undefined` if detection fails

### Modified: `src/compose-generator.ts`
- When `enableHostAccess` is true, resolves the host-gateway IP and passes it to `buildIptablesInitService`

### Modified: `src/services/agent-service.ts`
- `IptablesInitServiceParams` gains optional `hostGatewayIp` field
- `buildIptablesInitService` passes `AWF_HOST_GATEWAY_IP` env var to the init container

### Modified: `containers/agent/setup-iptables.sh`
- `configure_host_access_rules()`: when `getent hosts host.docker.internal` fails, falls back to `AWF_HOST_GATEWAY_IP` before skipping the bypass entirely
- Host-service-ports section: same `AWF_HOST_GATEWAY_IP` fallback applied for consistency

### Tests
- `src/services/host-gateway.test.ts` — unit tests for the detection utility (bridge gateway, ip route fallback, failure cases)
- `src/compose-generator.test.ts` — 3 new tests verifying the env var is passed through correctly

## Backward compatibility

Fully backward-compatible:
- When `getent` resolves in the init container (the common case), behavior is unchanged
- `AWF_HOST_GATEWAY_IP` is only used as a fallback
- When detection fails, the env var is empty and the existing warning is emitted