### PR TITLE
fix: escape $d as $$d in sysroot-stage compose command

### DIFF
--- a/src/services/sysroot-service.test.ts
+++ b/src/services/sysroot-service.test.ts
@@ -125,6 +125,17 @@ describe('buildSysrootStageService', () => {
     expect(service.command[0]).toContain('.awf-sysroot-ready');
   });
 
+  it('escapes $d as $$d for Docker Compose variable interpolation', () => {
+    const service = buildSysrootStageService({
+      config: makeConfig({ runnerTopology: 'arc-dind' }),
+      registry: 'ghcr.io/github/gh-aw-firewall',
+      imageTag: 'latest',
+    });
+    // Docker Compose treats $var as variable interpolation; $$ escapes to literal $
+    expect(service.command[0]).toContain('/$$d');
+    expect(service.command[0]).not.toMatch(/\/\$d[^$]/);
+  });
+
   it('uses network_mode none (no network needed for copy)', () => {
     const service = buildSysrootStageService({
       config: makeConfig({ runnerTopology: 'arc-dind' }),

--- a/src/services/sysroot-service.ts
+++ b/src/services/sysroot-service.ts
@@ -44,7 +44,9 @@ export function buildSysrootStageService(params: SysrootServiceParams): any {
       'fi; ' +
       'echo "Copying sysroot filesystem..."; ' +
       'for d in usr lib bin sbin etc; do ' +
-      '  [ -d "/$d" ] && cp -a "/$d" /sysroot/; ' +
+      // Use $$ to escape Docker Compose variable interpolation — Compose
+      // treats bare $d as a variable reference and replaces it with "".
+      '  [ -d "/$$d" ] && cp -a "/$$d" /sysroot/; ' +
       'done; ' +
       'if [ -d /lib64 ]; then cp -a /lib64 /sysroot/; fi; ' +
       'touch /sysroot/.awf-sysroot-ready; ' +


### PR DESCRIPTION
## Problem

The sysroot-stage init container (used for ARC/DinD topology) fails with exit code 1 after ~3.5 minutes.

**Root cause:** Docker Compose interprets `$d` in the shell command as a Compose variable interpolation:

```
time="..." level=warning msg="The \"d\" variable is not set. Defaulting to a blank string."
```

This replaces `$d` with empty string, so the for-loop becomes:
```sh
for d in usr lib bin sbin etc; do
  [ -d "/" ] && cp -a "/" /sysroot/;   # ← copies ENTIRE root filesystem!
done
```

Instead of copying individual directories (`/usr`, `/lib`, etc.), it copies `/` (the entire container root) to `/sysroot/`, which exhausts time/space and exits 1.

## Fix

Use `$$d` which Docker Compose passes through as literal `$d` to the shell interpreter. This is the [standard Compose escaping mechanism](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#escape-a-dollar-sign).

## Testing

- Added test verifying `$$d` escaping is present and bare `$d` is not
- All existing sysroot-service tests pass
- Validated on ARC/DinD canary runner (bbq-beets-four-nines/agentic-workflows-canary)