### PR TITLE
fix: skip /etc bind mounts when sysroot-stage is active (arc-dind)

### DIFF
--- a/src/services/agent-volumes/etc-mounts.test.ts
+++ b/src/services/agent-volumes/etc-mounts.test.ts
@@ -16,6 +16,28 @@ function createMinimalConfig(overrides: Partial<WrapperConfig> = {}): WrapperCon
 }
 
 describe('buildEtcMounts', () => {
+  describe('arc-dind with sysroot-stage', () => {
+    it('returns empty array when runnerTopology is arc-dind (sysroot provides /etc)', () => {
+      const config = createMinimalConfig({ runnerTopology: 'arc-dind' });
+      const mounts = buildEtcMounts(config);
+      expect(mounts).toEqual([]);
+    });
+
+    it('still mounts /etc files when runnerTopology is standard', () => {
+      const config = createMinimalConfig({ runnerTopology: 'standard' });
+      const mounts = buildEtcMounts(config);
+      expect(mounts.length).toBeGreaterThan(0);
+      expect(mounts).toContain('/etc/ld.so.cache:/host/etc/ld.so.cache:ro');
+    });
+
+    it('still mounts /etc files when runnerTopology is undefined', () => {
+      const config = createMinimalConfig({ runnerTopology: undefined });
+      const mounts = buildEtcMounts(config);
+      expect(mounts.length).toBeGreaterThan(0);
+      expect(mounts).toContain('/etc/ld.so.cache:/host/etc/ld.so.cache:ro');
+    });
+  });
+
   describe('non-DinD mode', () => {
     it('mounts /etc/passwd and /etc/group directly', () => {
       const config = createMinimalConfig({ dockerHostPathPrefix: undefined });

--- a/src/services/agent-volumes/etc-mounts.test.ts
+++ b/src/services/agent-volumes/etc-mounts.test.ts
@@ -16,7 +16,7 @@ function createMinimalConfig(overrides: Partial<WrapperConfig> = {}): WrapperCon
 }
 
 describe('buildEtcMounts', () => {
-  describe('arc-dind with sysroot-stage', () => {
+  describe('sysroot gating by runnerTopology', () => {
     it('returns empty array when runnerTopology is arc-dind (sysroot provides /etc)', () => {
       const config = createMinimalConfig({ runnerTopology: 'arc-dind' });
       const mounts = buildEtcMounts(config);

--- a/src/services/agent-volumes/etc-mounts.ts
+++ b/src/services/agent-volumes/etc-mounts.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { WrapperConfig } from '../../types';
 import { shouldUseDockerHostStaging, stageHostFile, getDockerHostStageRoot } from './docker-host-staging';
 import { getSafeHostUid, getSafeHostGid } from '../../host-identity';
+import { isSysrootEnabled } from '../sysroot-service';
 
 /**
  * Synthesize a minimal /etc/passwd or /etc/group file in the staging directory.
@@ -58,6 +59,13 @@ function resolveUniqueName(content: string, preferredName: string, id: string): 
 }
 
 export function buildEtcMounts(config: WrapperConfig): string[] {
+  // When sysroot-stage is active (arc-dind), the sysroot volume already provides
+  // a complete /etc from the build-tools image. Bind-mounting the host's /etc files
+  // on top would fail on split-fs (Docker daemon can't resolve runner paths).
+  if (isSysrootEnabled(config)) {
+    return [];
+  }
+
   const mounts: string[] = [
     '/etc/ssl:/host/etc/ssl:ro',
     '/etc/ca-certificates:/host/etc/ca-certificates:ro',


### PR DESCRIPTION
## Problem

On ARC/DinD runners with split filesystem, the agent container fails to start with OCI runtime mount errors. The Docker daemon cannot see the runner's filesystem paths, so bind mounts sourced from the runner fail.

Three categories of broken mounts were identified:

1. **`/etc` file mounts** (e.g., `/etc/ld.so.cache:/host/etc/ld.so.cache:ro`) — daemon can't find these on its Alpine-based root
2. **Chroot hosts file** (`/tmp/awf-*/chroot-*/hosts:/host/etc/hosts:ro`) — written to runner's `/tmp` which daemon can't see
3. **All workDir-based and home-based mounts** (`initSignalDir`, `agentLogsPath`, `sessionStatePath`, `chroot-home`, `~/.cache`, etc.) — sourced from runner's unshared `/tmp/awf-*` or `/home/runner/`

## Fix

When `isSysrootEnabled(config)` is true (i.e., `runner.topology: arc-dind`), the sysroot named volume at `/host` already provides a complete glibc filesystem from the build-tools image. These fixes skip or filter mounts the daemon cannot resolve:

1. **`buildEtcMounts()`** returns `[]` — sysroot volume has `/etc`
2. **`generateHostsFileMount()`** is skipped — sysroot volume has `/etc/hosts`; domains resolve via DNS at runtime
3. **Compose generator** filters bind mounts whose source starts with `config.workDir` or whose source starts with `effectiveHome` targeting `/host/home/...` — the sysroot volume provides writable home directories

Mounts that are kept:
- `/tmp:/tmp:rw` (daemon's own `/tmp`)
- Workspace (`${GITHUB_WORKSPACE}:...`) — ARC shares workspace with daemon
- Kernel VFS (`/sys`, `/dev`)
- `/dev/null` credential-hiding overlays
- Custom `--mount` flags (typically under shared `/tmp/gh-aw/`)
- `sysroot:/host:rw` named volume

## Testing

- All 3387 tests pass
- Added tests for sysroot gating in `etc-mounts.test.ts` and `compose-generator.test.ts`
- TypeScript compiles cleanly

## Context

Iterative fix discovered during ARC/DinD canary testing. Each run revealed the next mount failure after the previous was fixed:
- Run 28472890469: `/etc/ld.so.cache` mount error
- Run 28476477775: `/tmp/awf-*/chroot-*/hosts` mount error
- Next expected: `initSignalDir`, `agentLogsPath`, home mounts (addressed proactively)