### PR TITLE
fix: filter split-fs-invisible mounts when sysroot-stage is active (arc-dind)

### DIFF
--- a/src/compose-generator.test.ts
+++ b/src/compose-generator.test.ts
@@ -495,5 +495,31 @@ describe('generateDockerCompose', () => {
 
         expect(result.volumes).toEqual({ sysroot: {} });
       });
+
+      it('filters out workDir-based and home-based bind mounts on split-fs', () => {
+        const config = {
+          ...mockConfig,
+          runnerTopology: 'arc-dind' as const,
+          workDir: '/tmp/awf-12345',
+        };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const volumes = result.services.agent.volumes as string[];
+
+        // workDir-based mounts should be dropped
+        expect(volumes.some(v => v.startsWith('/tmp/awf-12345'))).toBe(false);
+
+        // Home-based mounts targeting /host/home should be dropped
+        const homeTargets = volumes.filter(v => {
+          const target = v.split(':')[1];
+          return target.startsWith('/host/home') && !v.startsWith('/dev/null');
+        });
+        expect(homeTargets).toHaveLength(0);
+
+        // Should still have /tmp:/tmp, /sys, /dev, sysroot volume
+        expect(volumes).toContain('/tmp:/tmp:rw');
+        expect(volumes).toContain('/sys:/host/sys:ro');
+        expect(volumes).toContain('/dev:/host/dev:ro');
+        expect(volumes).toContain('sysroot:/host:rw');
+      });
     });
 });

--- a/src/compose-generator.ts
+++ b/src/compose-generator.ts
@@ -139,6 +139,7 @@ export function generateDockerCompose(
 
     const filteredVolumes = agentVolumes.filter(volume => {
       const parts = volume.split(':');
+      if (parts.length < 2) return true; // Keep malformed entries unchanged
       const source = parts[0];
       const target = parts[1];
 

--- a/src/compose-generator.ts
+++ b/src/compose-generator.ts
@@ -126,9 +126,32 @@ export function generateDockerCompose(
       '/host/lib64',
       '/host/opt',
     ]);
+
+    // On split-fs ARC/DinD, the Docker daemon cannot see the runner's
+    // filesystem paths. Filter out bind mounts the daemon can't resolve:
+    //  - Source under workDir (runner's unshared /tmp/awf-*): daemon can't see it
+    //  - Source under effectiveHome with target under /host: sysroot volume provides these
+    //  - Sysroot-shadowed targets: system binaries already in the sysroot volume
+    // Keep: /tmp:/tmp (daemon has its own), /dev/null overlays, /dev and /sys
+    //       (kernel VFS), workspace mounts (ARC shares workspace with daemon).
+    const workDirPrefix = config.workDir;
+    const hostHomeMountPrefix = `/host${effectiveHome}`;
+
     const filteredVolumes = agentVolumes.filter(volume => {
-      const target = volume.split(':')[1];
-      return !sysrootShadowedTargets.has(target);
+      const parts = volume.split(':');
+      const source = parts[0];
+      const target = parts[1];
+
+      // Drop sysroot-shadowed targets (system binaries provided by volume)
+      if (sysrootShadowedTargets.has(target)) return false;
+
+      // Drop mounts sourced from AWF workDir (runner's unshared /tmp/awf-*)
+      if (source.startsWith(workDirPrefix)) return false;
+
+      // Drop home directory mounts targeting /host/home/... — sysroot provides them
+      if (source.startsWith(effectiveHome) && target.startsWith(hostHomeMountPrefix)) return false;
+
+      return true;
     });
     agentVolumes.length = 0;
     agentVolumes.push(...filteredVolumes);

--- a/src/services/agent-volumes/volume-builder.ts
+++ b/src/services/agent-volumes/volume-builder.ts
@@ -42,7 +42,13 @@ export function buildAgentVolumes(params: AgentVolumesParams): string[] {
   agentVolumes.push(...buildSystemMounts(workspaceDir, config.chrootBinariesSourcePath, useSysroot));
   agentVolumes.push(...buildHomeMounts({ config, effectiveHome, agentLogsPath, sessionStatePath }));
   agentVolumes.push(...buildEtcMounts(config));
-  agentVolumes.push(generateHostsFileMount(config));
+  // When sysroot-stage is active, the sysroot volume provides /etc/hosts.
+  // The generated chroot hosts file lives on the runner's /tmp which the
+  // Docker daemon cannot see on split-fs. DNS pre-resolution is skipped;
+  // the agent resolves domains at runtime via the container's DNS config.
+  if (!useSysroot) {
+    agentVolumes.push(generateHostsFileMount(config));
+  }
   agentVolumes.push(...buildDockerSocketMount(config));
   agentVolumes.push(...buildSslMounts(sslConfig));
   agentVolumes.push(...buildCustomVolumeMounts(config.volumeMounts));


### PR DESCRIPTION
## Problem

Follow-up to #5732. On ARC/DinD runners with split filesystem, additional bind mounts fail after the `/etc` mounts fix:

1. **Chroot hosts file** (`/tmp/awf-*/chroot-*/hosts:/host/etc/hosts:ro`) — written to runner's `/tmp` which the Docker daemon can't see
2. **All workDir-based mounts** (`initSignalDir`, `agentLogsPath`, `sessionStatePath`, `chroot-home`) — sourced from runner's unshared `/tmp/awf-*`
3. **Home directory mounts** (`~/.cache`, `~/.config`, etc. targeting `/host/home/...`) — runner's home isn't visible to the daemon

## Fix

Two commits:

**1. Skip chroot hosts mount when sysroot active** (`volume-builder.ts`)
- The sysroot volume already provides `/etc/hosts`
- DNS pre-resolution is traded off; domains resolve at runtime via container DNS config

**2. Filter workDir-based and home-based mounts in compose generator** (`compose-generator.ts`)
- Drop bind mounts whose source starts with `config.workDir` (runner's `/tmp/awf-*`)
- Drop home directory mounts targeting `/host${effectiveHome}/...` (sysroot provides writable home)
- Keep: `/tmp:/tmp` (daemon's own), workspace (ARC-shared), kernel VFS, `/dev/null` overlays, custom `--mount` flags

## What remains after filtering

- `/tmp:/tmp:rw` — daemon has its own `/tmp`
- `${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw` — shared between runner and daemon on ARC
- `/sys:/host/sys:ro`, `/dev:/host/dev:ro` — kernel VFS
- `/dev/null:...` credential-hiding overlays
- Custom `--mount` flags (typically under shared `/tmp/gh-aw/`)
- `sysroot:/host:rw` named volume (provides full glibc filesystem)

## Testing

- All 3387 tests pass
- Added compose-generator test verifying split-fs filtering behavior
- TypeScript compiles cleanly

## Context

Discovered during ARC/DinD canary testing (bbq-beets-four-nines/agentic-workflows-canary):
- Run 28476477775: `/tmp/awf-*/chroot-*/hosts` mount error (after #5732 fixed `/etc` mounts)
- Remaining workDir/home mounts addressed proactively