### PR TITLE
fix: ensure chmod runs even when chown fails in rootless permission repair

### DIFF
--- a/src/artifact-permissions.ts
+++ b/src/artifact-permissions.ts
@@ -70,7 +70,7 @@ export function fixArtifactPermissionsForRootless(
           imageRef,
           'sh',
           '-c',
-          'chown -R "$TUID:$TGID" /fix && chmod -R a+rwX /fix',
+          'chown -R "$TUID:$TGID" /fix 2>/dev/null; chmod -R a+rwX /fix',
         ],
         { env: getLocalDockerEnv(), reject: false },
       );


### PR DESCRIPTION
## Problem

In rootless Docker, the `fixArtifactPermissionsForRootless()` function fails to repair file permissions because `chown` fails due to user namespace UID remapping, and the `&&` operator prevents the subsequent `chmod` from running.

**Root cause:** In rootless Docker, UID 1001 inside the container maps to a subordinate UID on the host (not the actual host UID 1001). So `chown -R "$TUID:$TGID" /fix` either fails outright or produces the wrong ownership. Because the command was joined with `&&`, the `chmod -R a+rwX /fix` (which would actually solve the problem) never executed.

This results in:
```
[WARN] Rootless artifact permission repair failed for /tmp/gh-aw/sandbox/firewall/logs (exit 1)
[WARN] Rootless artifact permission repair failed for /tmp/gh-aw/sandbox/firewall/audit (exit 1)
[WARN] Rootless artifact permission repair failed for /tmp/awf-...-chroot-home (exit 1)
[WARN] Failed to remove chroot home directory after permission repair: EACCES
```

## Fix

Change `&&` to `;` so `chmod -R a+rwX` always runs regardless of whether `chown` succeeds. Also suppress `chown` stderr since the failure is expected in rootless mode.

```diff
- 'chown -R "$TUID:$TGID" /fix && chmod -R a+rwX /fix'
+ 'chown -R "$TUID:$TGID" /fix 2>/dev/null; chmod -R a+rwX /fix'
```

The `chown` still runs first (works in rootful Docker), but `chmod` always follows as a fallback (sufficient for rootless since world-readable permissions allow the host user to access files regardless of ownership).

## Observed in

https://github.com/github/gh-aw/actions/runs/28487107941/job/84435983514#step:35:1