### PR TITLE
Fix split-fs test to use actual effectiveHome instead of hardcoded /home

### DIFF
--- a/src/compose-generator.test.ts
+++ b/src/compose-generator.test.ts
@@ -511,15 +511,16 @@ describe('generateDockerCompose', () => {
         expect(volumes.some(v => v.startsWith('/tmp/awf-12345'))).toBe(false);
 
         // Home dot-directory mounts should be dropped, but workspace mounts under home should remain.
+        const effectiveHomeForFilter = getRealUserHome();
         const homeTargets = volumes
           .filter(v => {
             const target = v.split(':')[1];
-            return target.startsWith('/host/home') && !v.startsWith('/dev/null');
+            return target.startsWith(`/host${effectiveHomeForFilter}`) && !v.startsWith('/dev/null');
           })
           .map(v => v.split(':')[1]);
 
         expect(homeTargets).toContain(`/host${workspaceDir}`);
-        expect(homeTargets.some(target => target.startsWith('/host/home/runner/.'))).toBe(false);
+        expect(homeTargets.some(target => target.startsWith(`/host${effectiveHomeForFilter}/.`))).toBe(false);
 
         // Home root mounts (including trailing slash source) should be dropped.
         const effectiveHome = getRealUserHome();


### PR DESCRIPTION
## Problem

The compose-generator test "filters out workDir and home dot-directory bind mounts on split-fs" was failing on macOS because it hardcoded `/host/home` as the prefix for filtering home-target volumes. This only works on Linux where home directories are under `/home/`.

On macOS (home under `/Users/`), the filter matched nothing, so the `homeTargets` array was empty and the workspace mount assertion failed:

```
Expected value: "/host/Users/lpcox/projects/gh-aw-firewall"
Received array: []
```

## Fix

Use `getRealUserHome()` to derive the actual home prefix dynamically, making the test portable across platforms (Linux `/home/runner` and macOS `/Users/...`).

## Testing

- All 3387 tests pass locally on macOS