### PR TITLE
chore: upgrade gh-aw to v0.82.1 (pre-release) and recompile workflows

### DIFF
--- a/.github/workflows/ci-cd-gaps-assessment.lock.yml
+++ b/.github/workflows/ci-cd-gaps-assessment.lock.yml
@@ -53,7 +53,7 @@
 name: "CI/CD Pipelines and Integration Tests Gap Assessment"
 on:
   schedule:
-  - cron: "37 4 * * 1"
+  - cron: "54 12 * * 1"
     # Friendly format: weekly on Monday (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/claude-token-usage-analyzer.lock.yml
+++ b/.github/workflows/claude-token-usage-analyzer.lock.yml
@@ -59,7 +59,7 @@
 name: "Daily Claude Token Usage Analyzer"
 on:
   schedule:
-  - cron: "9 8 * * *"
+  - cron: "20 6 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cli-flag-consistency-checker.lock.yml
+++ b/.github/workflows/cli-flag-consistency-checker.lock.yml
@@ -52,7 +52,7 @@
 name: "CLI Flag Consistency Checker"
 on:
   schedule:
-  - cron: "52 17 * * 1"
+  - cron: "5 11 * * 0"
     # Friendly format: weekly (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/config-consistency-auditor.lock.yml
+++ b/.github/workflows/config-consistency-auditor.lock.yml
@@ -55,7 +55,7 @@
 name: "Config Consistency Auditor"
 on:
   schedule:
-  - cron: "19 9 * * 1-5"
+  - cron: "40 19 * * 1-5"
     # Friendly format: daily on weekdays (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -59,7 +59,7 @@
 name: "Daily Copilot Token Usage Analyzer"
 on:
   schedule:
-  - cron: "23 8 * * *"
+  - cron: "9 8 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/dependency-security-monitor.lock.yml
+++ b/.github/workflows/dependency-security-monitor.lock.yml
@@ -59,7 +59,7 @@
 name: "Dependency Security Monitor"
 on:
   schedule:
-  - cron: "49 5 * * *"
+  - cron: "34 2 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/doc-maintainer.lock.yml
+++ b/.github/workflows/doc-maintainer.lock.yml
@@ -51,7 +51,7 @@
 name: "Documentation Maintainer"
 on:
   schedule:
-  - cron: "34 4 * * *"
+  - cron: "21 16 * * *"
     # Friendly format: daily (scattered)
   # skip-if-match: # Skip-if-match processed as search check in pre-activation job
     # max: 1

--- a/.github/workflows/duplicate-code-detector.lock.yml
+++ b/.github/workflows/duplicate-code-detector.lock.yml
@@ -55,7 +55,7 @@
 name: "Duplicate Code Detector"
 on:
   schedule:
-  - cron: "34 21 * * *"
+  - cron: "38 5 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/firewall-issue-dispatcher.lock.yml
+++ b/.github/workflows/firewall-issue-dispatcher.lock.yml
@@ -53,7 +53,7 @@
 name: "Firewall Issue Dispatcher"
 on:
   schedule:
-  - cron: "20 */12 * * *"
+  - cron: "54 */12 * * *"
     # Friendly format: every 12h (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -56,7 +56,7 @@ on:
     types:
     - opened
   schedule:
-  - cron: "18 */1 * * *"
+  - cron: "12 */1 * * *"
     # Friendly format: every 1h (scattered)
   # skip-if-match: # Skip-if-match processed as search check in pre-activation job
     # max: 9

--- a/.github/workflows/model-api-mapping-updater.lock.yml
+++ b/.github/workflows/model-api-mapping-updater.lock.yml
@@ -55,7 +55,7 @@
 name: "Model API Mapping Updater"
 on:
   schedule:
-  - cron: "48 6 * * *"
+  - cron: "7 5 * * *"
     # Friendly format: daily around 06:00 UTC (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pelis-agent-factory-advisor.lock.yml
+++ b/.github/workflows/pelis-agent-factory-advisor.lock.yml
@@ -60,7 +60,7 @@
 name: "Pelis Agent Factory Advisor"
 on:
   schedule:
-  - cron: "8 22 * * *"
+  - cron: "37 20 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/red-team-benchmark.lock.yml
+++ b/.github/workflows/red-team-benchmark.lock.yml
@@ -56,7 +56,7 @@
 name: "Red-Team Benchmark"
 on:
   schedule:
-  - cron: "51 16 * * 6"
+  - cron: "11 3 * * 6"
     # Friendly format: weekly (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/refactoring-scanner.lock.yml
+++ b/.github/workflows/refactoring-scanner.lock.yml
@@ -55,7 +55,7 @@
 name: "Refactoring Opportunity Scanner"
 on:
   schedule:
-  - cron: "53 14 * * *"
+  - cron: "5 4 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/schema-sync.lock.yml
+++ b/.github/workflows/schema-sync.lock.yml
@@ -55,7 +55,7 @@
 name: "Schema & Spec Sync"
 on:
   schedule:
-  - cron: "22 12 * * 1-5"
+  - cron: "11 4 * * 1-5"
     # Friendly format: daily on weekdays (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/secret-digger-codex.lock.yml
+++ b/.github/workflows/secret-digger-codex.lock.yml
@@ -1600,6 +1600,7 @@ jobs:
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
           base_url = "http://172.30.0.30:10000"
+          env_key = "OPENAI_API_KEY"
           supports_websockets = false
           [shell_environment_policy]
           inherit = "core"

--- a/.github/workflows/security-review.lock.yml
+++ b/.github/workflows/security-review.lock.yml
@@ -57,7 +57,7 @@
 name: "Daily Security Review and Threat Modeling"
 on:
   schedule:
-  - cron: "11 12 * * *"
+  - cron: "51 6 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/self-hosted-runner-doctor-updater.lock.yml
+++ b/.github/workflows/self-hosted-runner-doctor-updater.lock.yml
@@ -57,7 +57,7 @@
 name: "Runner Doctor Updater"
 on:
   schedule:
-  - cron: "21 16 * * *"
+  - cron: "50 18 * * *"
     # Friendly format: daily (scattered)
   # skip-if-match: # Skip-if-match processed as search check in pre-activation job
     # max: 1

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -55,7 +55,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "30 */12 * * *"
+  - cron: "22 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-codex.lock.yml
+++ b/.github/workflows/smoke-codex.lock.yml
@@ -67,7 +67,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "23 */12 * * *"
+  - cron: "43 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-copilot-byok-aoai-entra.lock.yml
+++ b/.github/workflows/smoke-copilot-byok-aoai-entra.lock.yml
@@ -65,7 +65,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "6 */12 * * *"
+  - cron: "18 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-copilot-byok.lock.yml
+++ b/.github/workflows/smoke-copilot-byok.lock.yml
@@ -59,7 +59,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "26 */12 * * *"
+  - cron: "54 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-copilot-pat.lock.yml
+++ b/.github/workflows/smoke-copilot-pat.lock.yml
@@ -56,7 +56,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "50 */12 * * *"
+  - cron: "46 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -55,7 +55,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "28 */12 * * *"
+  - cron: "20 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-gemini.lock.yml
+++ b/.github/workflows/smoke-gemini.lock.yml
@@ -57,7 +57,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "31 */12 * * *"
+  - cron: "33 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-otel-tracing.lock.yml
+++ b/.github/workflows/smoke-otel-tracing.lock.yml
@@ -58,7 +58,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "22 14 * * 4"
+  - cron: "50 10 * * 0"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/smoke-services.lock.yml
+++ b/.github/workflows/smoke-services.lock.yml
@@ -56,7 +56,7 @@ on:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "14 */12 * * *"
+  - cron: "30 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/test-coverage-reporter.lock.yml
+++ b/.github/workflows/test-coverage-reporter.lock.yml
@@ -61,7 +61,7 @@ on:
     paths:
     - src/**/*.ts
   schedule:
-  - cron: "25 4 * * *"
+  - cron: "25 18 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Upgrades the `gh-aw` extension to the latest pre-release version (v0.82.1) and recompiles all agentic workflow lock files with post-processing applied.

## Changes

- Upgraded `gh-aw` extension to v0.82.1 (pre-release)
- Recompiled all workflow `.lock.yml` files
- Applied post-processing script (`postprocess-smoke-workflows.ts`)

## Verification

- All 3419 tests pass (`npm test` ✅)