### PR TITLE
fix: harden token tracker against unsupported response encodings and WS fragmentation

### DIFF
--- a/containers/api-proxy/proxy-utils.accept-encoding.test.js
+++ b/containers/api-proxy/proxy-utils.accept-encoding.test.js
@@ -15,8 +15,8 @@ describe('sanitizeAcceptEncoding', () => {
     expect(sanitizeAcceptEncoding('gzip;q=1.0, zstd;q=0.8, br;q=0.5')).toBe('gzip;q=1.0, br;q=0.5');
   });
 
-  it('handles zstd-only Accept-Encoding by returning defaults', () => {
-    expect(sanitizeAcceptEncoding('zstd')).toBe('gzip, deflate, br');
+  it('handles zstd-only Accept-Encoding by returning identity', () => {
+    expect(sanitizeAcceptEncoding('zstd')).toBe('identity');
   });
 
   it('preserves identity encoding', () => {

--- a/containers/api-proxy/proxy-utils.accept-encoding.test.js
+++ b/containers/api-proxy/proxy-utils.accept-encoding.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { sanitizeAcceptEncoding } = require('./proxy-utils');
+
+describe('sanitizeAcceptEncoding', () => {
+  it('passes through supported encodings unchanged', () => {
+    expect(sanitizeAcceptEncoding('gzip, deflate, br')).toBe('gzip, deflate, br');
+  });
+
+  it('strips zstd from the list', () => {
+    expect(sanitizeAcceptEncoding('gzip, br, zstd')).toBe('gzip, br');
+  });
+
+  it('strips zstd with quality value', () => {
+    expect(sanitizeAcceptEncoding('gzip;q=1.0, zstd;q=0.8, br;q=0.5')).toBe('gzip;q=1.0, br;q=0.5');
+  });
+
+  it('handles zstd-only Accept-Encoding by returning defaults', () => {
+    expect(sanitizeAcceptEncoding('zstd')).toBe('gzip, deflate, br');
+  });
+
+  it('preserves identity encoding', () => {
+    expect(sanitizeAcceptEncoding('identity, gzip, zstd')).toBe('identity, gzip');
+  });
+
+  it('returns defaults for empty/undefined input', () => {
+    expect(sanitizeAcceptEncoding('')).toBe('gzip, deflate, br');
+    expect(sanitizeAcceptEncoding(undefined)).toBe('gzip, deflate, br');
+  });
+
+  it('strips unknown encodings', () => {
+    expect(sanitizeAcceptEncoding('gzip, compress, deflate')).toBe('gzip, deflate');
+  });
+});

--- a/containers/api-proxy/proxy-utils.js
+++ b/containers/api-proxy/proxy-utils.js
@@ -270,6 +270,32 @@ function makeUnconfiguredHealthResponse(service, error, status = 'not_configured
   return { statusCode: 503, body: { status, service, error } };
 }
 
+/**
+ * Encodings that the token tracker can decompress for response inspection.
+ * If the upstream responds with an encoding not in this set, the tracker
+ * receives raw compressed bytes and fails to extract usage data.
+ */
+const SUPPORTED_ENCODINGS = new Set(['gzip', 'deflate', 'br', 'identity']);
+
+/**
+ * Sanitize Accept-Encoding to only include encodings the token tracker can
+ * decompress. This prevents upstream APIs from responding with unsupported
+ * encodings (e.g. zstd) that the tracker cannot parse.
+ *
+ * @param {string|undefined} value - Original Accept-Encoding header value
+ * @returns {string} Filtered Accept-Encoding value
+ */
+function sanitizeAcceptEncoding(value) {
+  if (!value) return 'gzip, deflate, br';
+  const parts = value.split(',').map(p => p.trim()).filter(Boolean);
+  const supported = parts.filter(p => {
+    // Extract encoding name (strip quality value like ";q=0.5")
+    const encoding = p.split(';')[0].trim().toLowerCase();
+    return SUPPORTED_ENCODINGS.has(encoding);
+  });
+  return supported.length > 0 ? supported.join(', ') : 'gzip, deflate, br';
+}
+
 module.exports = {
   normalizeApiTarget,
   parseApiTargetAndBasePath,
@@ -280,4 +306,5 @@ module.exports = {
   composeBodyTransforms,
   makeProviderNotConfiguredResponse,
   makeUnconfiguredHealthResponse,
+  sanitizeAcceptEncoding,
 };

--- a/containers/api-proxy/proxy-utils.js
+++ b/containers/api-proxy/proxy-utils.js
@@ -293,7 +293,7 @@ function sanitizeAcceptEncoding(value) {
     const encoding = p.split(';')[0].trim().toLowerCase();
     return SUPPORTED_ENCODINGS.has(encoding);
   });
-  return supported.length > 0 ? supported.join(', ') : 'gzip, deflate, br';
+  return supported.length > 0 ? supported.join(', ') : 'identity';
 }
 
 module.exports = {

--- a/containers/api-proxy/request-headers.js
+++ b/containers/api-proxy/request-headers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { logRequest } = require('./logging');
-const { shouldStripHeader } = require('./proxy-utils');
+const { shouldStripHeader, sanitizeAcceptEncoding } = require('./proxy-utils');
 const { maybeStripLearnedHeaderValues } = require('./deprecated-header-tracker');
 
 /**
@@ -48,6 +48,13 @@ function buildRequestHeaders(body, inboundBytes, req, { injectHeaders, provider,
   if (body.length !== inboundBytes) {
     headers['content-length'] = String(body.length);
     delete headers['transfer-encoding'];
+  }
+
+  // Restrict Accept-Encoding to encodings the token tracker can decompress.
+  // Without this, upstream APIs may respond with unsupported encodings (e.g.
+  // zstd) that the tracker cannot parse, causing silent token-usage data loss.
+  if (headers['accept-encoding']) {
+    headers['accept-encoding'] = sanitizeAcceptEncoding(headers['accept-encoding']);
   }
 
   const injectedKey = Object.entries(injectHeaders).find(([k]) =>

--- a/containers/api-proxy/token-parsers.js
+++ b/containers/api-proxy/token-parsers.js
@@ -19,16 +19,28 @@ function isStreamingResponse(headers) {
 }
 
 /**
- * Check if a response is gzip or deflate compressed.
+ * Check if a response is compressed with a known encoding.
+ * Includes zstd detection — even though we cannot decompress it natively,
+ * recognizing it allows the tracker to skip parsing garbage bytes and log
+ * an actionable warning.
  */
 function isCompressedResponse(headers) {
   const ce = (headers['content-encoding'] || '').toLowerCase();
-  return ce === 'gzip' || ce === 'deflate' || ce === 'br';
+  return ce === 'gzip' || ce === 'deflate' || ce === 'br' || ce === 'zstd';
+}
+
+/**
+ * Check if a response uses an encoding we cannot decompress.
+ * Currently only zstd (Node.js has no built-in zstd support).
+ */
+function isUnsupportedEncoding(headers) {
+  const ce = (headers['content-encoding'] || '').toLowerCase();
+  return ce === 'zstd';
 }
 
 /**
  * Create a decompression transform stream based on content-encoding.
- * Returns null if the encoding is not supported.
+ * Returns null if the encoding is not supported (including zstd).
  */
 function createDecompressor(headers) {
   const ce = (headers['content-encoding'] || '').toLowerCase();
@@ -414,6 +426,7 @@ function normalizeUsage(usage) {
 module.exports = {
   isStreamingResponse,
   isCompressedResponse,
+  isUnsupportedEncoding,
   createDecompressor,
   extractReasoningTokens,
   extractCacheReadTokens,

--- a/containers/api-proxy/token-persistence.js
+++ b/containers/api-proxy/token-persistence.js
@@ -16,6 +16,7 @@ const { logRequest } = require('./logging');
 const TOKEN_LOG_DIR = process.env.AWF_TOKEN_LOG_DIR || '/var/log/api-proxy';
 const TOKEN_LOG_FILE = path.join(TOKEN_LOG_DIR, 'token-usage.jsonl');
 const DIAG_LOG_FILE = path.join(TOKEN_LOG_DIR, 'token-diag.jsonl');
+const AUDIT_LOG_FILE = path.join(TOKEN_LOG_DIR, 'token-tracker-audit.jsonl');
 const DIAG_ENABLED = process.env.AWF_DEBUG_TOKENS === '1';
 
 // AWF version used to identify schema version in JSONL records.
@@ -33,6 +34,7 @@ const TOKEN_DIAG_SCHEMA = `token-diag/v${AWF_VERSION || '0.0.0-dev'}`;
 
 let logStream = null;
 let diagStream = null;
+let auditStream = null;
 
 /**
  * Write a diagnostic line to the diagnostics log file.
@@ -69,6 +71,25 @@ function diag(msg, data) {
     const record = buildTokenDiagRecord(msg, data);
     if (!validateTokenDiagRecord(record)) return;
     diagStream.write(JSON.stringify(record) + '\n');
+  } catch { /* best-effort */ }
+}
+
+/**
+ * Always-on audit trail for token tracking lifecycle.
+ *
+ * Writes minimal structured events to token-tracker-audit.jsonl so that CI
+ * failures can be diagnosed without AWF_DEBUG_TOKENS=1.  Each tracked
+ * request emits exactly two lines: TRACK_START and TRACK_END (with result).
+ */
+function auditTrack(event, data) {
+  try {
+    if (!auditStream) {
+      fs.mkdirSync(TOKEN_LOG_DIR, { recursive: true });
+      auditStream = fs.createWriteStream(AUDIT_LOG_FILE, { flags: 'a', mode: 0o644 });
+      auditStream.on('error', () => { auditStream = null; });
+    }
+    const line = { ts: Date.now(), event, ...data };
+    auditStream.write(JSON.stringify(line) + '\n');
   } catch { /* best-effort */ }
 }
 
@@ -258,6 +279,10 @@ function closeLogStream() {
         pending++;
         diagStream.end(() => { diagStream = null; pending--; check(); });
       }
+      if (auditStream) {
+        pending++;
+        auditStream.end(() => { auditStream = null; pending--; check(); });
+      }
       if (pending === 0) resolve();
     }),
     closeBlockedRequestDiagStream(),
@@ -269,6 +294,7 @@ module.exports = {
   TOKEN_USAGE_SCHEMA,
   TOKEN_DIAG_SCHEMA,
   diag,
+  auditTrack,
   buildTokenDiagRecord,
   buildTokenUsageRecord,
   incrementTokenMetrics,

--- a/containers/api-proxy/token-tracker-http.js
+++ b/containers/api-proxy/token-tracker-http.js
@@ -34,6 +34,7 @@ const {
   buildTokenUsageRecord,
   incrementTokenMetrics,
   diag,
+  auditTrack,
 } = require('./token-persistence');
 const { warnCacheReadRollupMismatch, mergeBudgetFields } = require('./token-tracker-shared');
 
@@ -286,6 +287,7 @@ function finalizeHttpTracking(state, proxyRes, opts) {
 
   // Only process successful responses (2xx)
   if (proxyRes.statusCode < 200 || proxyRes.statusCode >= 300) {
+    auditTrack('TRACK_END', { rid: requestId, result: 'skip_status', status: proxyRes.statusCode });
     logRequest('debug', 'token_track_skip_status', {
       request_id: requestId,
       provider,
@@ -314,6 +316,7 @@ function finalizeHttpTracking(state, proxyRes, opts) {
 
   const normalized = normalizeUsage(usage);
   if (!normalized) {
+    auditTrack('TRACK_END', { rid: requestId, result: 'no_usage', streaming, bytes: state.totalBytes, overflow: state.overflow, ct: state.contentType, ce: contentEncoding });
     // Log at info level so failed extraction is visible in CI without debug mode
     logRequest('info', 'token_track_no_usage', {
       request_id: requestId,
@@ -329,6 +332,9 @@ function finalizeHttpTracking(state, proxyRes, opts) {
     if (typeof onSpanEnd === 'function') onSpanEnd(proxyRes.statusCode);
     return;
   }
+
+  auditTrack('TRACK_END', { rid: requestId, result: 'ok', streaming, model: model || requestModel, input: normalized.input_tokens, output: normalized.output_tokens, cache_read: normalized.cache_read_tokens });
+
   if (state.observedCacheReadTokens > 0 && normalized.cache_read_tokens === 0) {
     warnCacheReadRollupMismatch({ logRequest, diag, requestId, provider, model, observedCacheReadTokens: state.observedCacheReadTokens, normalizedCacheReadTokens: normalized.cache_read_tokens, streaming });
   }
@@ -394,6 +400,8 @@ function trackTokenUsage(proxyRes, opts) {
   const contentEncoding = proxyRes.headers['content-encoding'] || '(none)';
   const compressed = isCompressedResponse(proxyRes.headers);
 
+  auditTrack('TRACK_START', { rid: requestId, provider, path: reqPath, streaming, ct: contentType, ce: contentEncoding, status: proxyRes.statusCode });
+
   logRequest('debug', 'token_track_start', {
     request_id: requestId,
     provider,
@@ -410,6 +418,7 @@ function trackTokenUsage(proxyRes, opts) {
   // If the response uses an encoding we cannot decompress (e.g. zstd), skip
   // token tracking entirely and log a warning so the issue is visible in CI.
   if (compressed && isUnsupportedEncoding(proxyRes.headers)) {
+    auditTrack('TRACK_SKIP_ENCODING', { rid: requestId, ce: contentEncoding });
     logRequest('warn', 'token_track_unsupported_encoding', {
       request_id: requestId,
       provider,

--- a/containers/api-proxy/token-tracker-http.js
+++ b/containers/api-proxy/token-tracker-http.js
@@ -22,6 +22,7 @@ const { logRequest } = require('./logging');
 const {
   isStreamingResponse,
   isCompressedResponse,
+  isUnsupportedEncoding,
   createDecompressor,
   parseSseDataLines,
   extractUsageFromSseLine,
@@ -313,6 +314,18 @@ function finalizeHttpTracking(state, proxyRes, opts) {
 
   const normalized = normalizeUsage(usage);
   if (!normalized) {
+    // Log at info level so failed extraction is visible in CI without debug mode
+    logRequest('info', 'token_track_no_usage', {
+      request_id: requestId,
+      provider,
+      path: reqPath,
+      streaming,
+      total_bytes: state.totalBytes,
+      overflow: state.overflow,
+      content_encoding: contentEncoding,
+      content_type: state.contentType,
+      message: 'No token usage extracted from 2xx response',
+    });
     if (typeof onSpanEnd === 'function') onSpanEnd(proxyRes.statusCode);
     return;
   }
@@ -393,6 +406,22 @@ function trackTokenUsage(proxyRes, opts) {
   diag('HTTP_TRACK_START', { request_id: requestId, provider, path: reqPath, streaming, content_type: contentType, content_encoding: contentEncoding, status: proxyRes.statusCode });
 
   const state = initHttpState({ streaming, compressed, contentType, contentEncoding });
+
+  // If the response uses an encoding we cannot decompress (e.g. zstd), skip
+  // token tracking entirely and log a warning so the issue is visible in CI.
+  if (compressed && isUnsupportedEncoding(proxyRes.headers)) {
+    logRequest('warn', 'token_track_unsupported_encoding', {
+      request_id: requestId,
+      provider,
+      path: reqPath,
+      content_encoding: contentEncoding,
+      message: `Cannot decompress ${contentEncoding} responses; token usage will not be extracted. ` +
+        'The Accept-Encoding sanitizer should have prevented this — check if the client bypassed the proxy header rewrite.',
+    });
+    diag('HTTP_TRACK_UNSUPPORTED_ENCODING', { request_id: requestId, provider, path: reqPath, content_encoding: contentEncoding });
+    if (typeof opts.onSpanEnd === 'function') opts.onSpanEnd(proxyRes.statusCode);
+    return;
+  }
 
   // If the response is compressed, create a decompressor.
   // We feed raw chunks into it and listen on the decompressed output.

--- a/containers/api-proxy/token-tracker-ws.fragmentation.test.js
+++ b/containers/api-proxy/token-tracker-ws.fragmentation.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const { parseWebSocketFrames } = require('./token-tracker-ws');
+
+/**
+ * Build a WebSocket frame buffer.
+ * @param {string} payload - Text payload
+ * @param {object} opts
+ * @param {boolean} [opts.fin=true] - FIN bit
+ * @param {number} [opts.opcode=1] - Opcode (1=text, 0=continuation)
+ */
+function buildFrame(payload, { fin = true, opcode = 1 } = {}) {
+  const buf = Buffer.from(payload, 'utf8');
+  const len = buf.length;
+  let header;
+
+  const firstByte = (fin ? 0x80 : 0x00) | (opcode & 0x0F);
+
+  if (len < 126) {
+    header = Buffer.alloc(2);
+    header[0] = firstByte;
+    header[1] = len;
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = firstByte;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = firstByte;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+
+  return Buffer.concat([header, buf]);
+}
+
+describe('parseWebSocketFrames', () => {
+  describe('unfragmented messages', () => {
+    it('extracts a single text frame', () => {
+      const frame = buildFrame('{"type":"response.done"}');
+      const { messages, consumed } = parseWebSocketFrames(frame);
+      expect(messages).toEqual(['{"type":"response.done"}']);
+      expect(consumed).toBe(frame.length);
+    });
+
+    it('extracts multiple text frames from a single buffer', () => {
+      const frame1 = buildFrame('hello');
+      const frame2 = buildFrame('world');
+      const buf = Buffer.concat([frame1, frame2]);
+      const { messages } = parseWebSocketFrames(buf);
+      expect(messages).toEqual(['hello', 'world']);
+    });
+  });
+
+  describe('fragmented messages', () => {
+    it('reassembles a text message split across two frames', () => {
+      const fragments = [];
+      // First frame: FIN=0, opcode=text
+      const frame1 = buildFrame('{"type":"resp', { fin: false, opcode: 1 });
+      // Final continuation frame: FIN=1, opcode=continuation
+      const frame2 = buildFrame('onse.done"}', { fin: true, opcode: 0 });
+
+      const buf = Buffer.concat([frame1, frame2]);
+      const { messages } = parseWebSocketFrames(buf, fragments);
+      expect(messages).toEqual(['{"type":"response.done"}']);
+    });
+
+    it('reassembles a text message split across three frames', () => {
+      const fragments = [];
+      const frame1 = buildFrame('{"type"', { fin: false, opcode: 1 });
+      const frame2 = buildFrame(':"response', { fin: false, opcode: 0 });
+      const frame3 = buildFrame('.done"}', { fin: true, opcode: 0 });
+
+      const buf = Buffer.concat([frame1, frame2, frame3]);
+      const { messages } = parseWebSocketFrames(buf, fragments);
+      expect(messages).toEqual(['{"type":"response.done"}']);
+    });
+
+    it('handles fragmentation across multiple data events', () => {
+      const fragments = [];
+
+      // First data event: start of fragmented message
+      const frame1 = buildFrame('{"part":"one"', { fin: false, opcode: 1 });
+      const result1 = parseWebSocketFrames(frame1, fragments);
+      expect(result1.messages).toEqual([]);
+      expect(fragments.length).toBe(1);
+
+      // Second data event: final continuation frame
+      const frame2 = buildFrame(', "part":"two"}', { fin: true, opcode: 0 });
+      const result2 = parseWebSocketFrames(frame2, fragments);
+      expect(result2.messages).toEqual(['{"part":"one", "part":"two"}']);
+      expect(fragments.length).toBe(0);
+    });
+
+    it('handles mix of unfragmented and fragmented messages', () => {
+      const fragments = [];
+      const unfragmented = buildFrame('{"simple":true}');
+      const frag1 = buildFrame('{"frag":', { fin: false, opcode: 1 });
+      const frag2 = buildFrame('"yes"}', { fin: true, opcode: 0 });
+
+      const buf = Buffer.concat([unfragmented, frag1, frag2]);
+      const { messages } = parseWebSocketFrames(buf, fragments);
+      expect(messages).toEqual(['{"simple":true}', '{"frag":"yes"}']);
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('works without fragments parameter (unfragmented only)', () => {
+      const frame = buildFrame('hello');
+      const { messages } = parseWebSocketFrames(frame);
+      expect(messages).toEqual(['hello']);
+    });
+
+    it('silently skips fragmented messages without fragments parameter', () => {
+      // FIN=0 text frame without fragments array — should be skipped
+      const frame = buildFrame('partial', { fin: false, opcode: 1 });
+      const { messages } = parseWebSocketFrames(frame);
+      expect(messages).toEqual([]);
+    });
+  });
+});

--- a/containers/api-proxy/token-tracker-ws.js
+++ b/containers/api-proxy/token-tracker-ws.js
@@ -16,6 +16,7 @@ const {
   buildTokenUsageRecord,
   incrementTokenMetrics,
   diag,
+  auditTrack,
 } = require('./token-persistence');
 const { warnCacheReadRollupMismatch, mergeBudgetFields } = require('./token-tracker-shared');
 
@@ -135,6 +136,7 @@ function parseWebSocketFrames(buf, fragments) {
 function trackWebSocketTokenUsage(upstreamSocket, opts) {
   const { requestId, provider, path: reqPath, startTime, metrics: metricsRef, onUsage } = opts;
 
+  auditTrack('WS_TRACK_START', { rid: requestId, provider, path: reqPath });
   logRequest('debug', 'ws_token_track_start', {
     request_id: requestId,
     provider,
@@ -213,19 +215,22 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
     if (finalized) return;
     finalized = true;
 
+    const hasUsage = Object.keys(streamingUsage).length > 0;
+    auditTrack('WS_TRACK_END', { rid: requestId, result: hasUsage ? 'ok' : 'no_usage', frames: frameCount, msgs: textMessageCount, bytes: totalBytes });
+
     logRequest('debug', 'ws_token_track_end', {
       request_id: requestId,
       provider,
       total_bytes: totalBytes,
       frame_count: frameCount,
       text_message_count: textMessageCount,
-      has_usage: Object.keys(streamingUsage).length > 0,
+      has_usage: hasUsage,
       usage_keys: Object.keys(streamingUsage),
       model: streamingModel,
     });
-    diag('WS_TRACK_END', { request_id: requestId, provider, total_bytes: totalBytes, frame_count: frameCount, text_message_count: textMessageCount, has_usage: Object.keys(streamingUsage).length > 0, usage_keys: Object.keys(streamingUsage), model: streamingModel });
+    diag('WS_TRACK_END', { request_id: requestId, provider, total_bytes: totalBytes, frame_count: frameCount, text_message_count: textMessageCount, has_usage: hasUsage, usage_keys: Object.keys(streamingUsage), model: streamingModel });
 
-    if (Object.keys(streamingUsage).length === 0) return;
+    if (!hasUsage) return;
 
     const duration = Date.now() - startTime;
     const normalized = normalizeUsage(streamingUsage);

--- a/containers/api-proxy/token-tracker-ws.js
+++ b/containers/api-proxy/token-tracker-ws.js
@@ -166,6 +166,7 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
     // Safety: drop buffer if it grows too large (malformed frames)
     if (buffer.length > MAX_WS_BUFFER) {
       buffer = Buffer.alloc(0);
+      fragments.length = 0; // clear in-progress fragment state
       httpHeaderParsed = true; // skip header parsing
       return;
     }

--- a/containers/api-proxy/token-tracker-ws.js
+++ b/containers/api-proxy/token-tracker-ws.js
@@ -26,14 +26,19 @@ const { warnCacheReadRollupMismatch, mergeBudgetFields } = require('./token-trac
  *   - messages: Array of decoded text frame payloads (strings)
  *   - consumed: Number of bytes consumed from the buffer
  *
- * Only handles non-fragmented text frames (FIN=1, opcode=1).
- * Other frame types (binary, ping, pong, close, continuation) are consumed
- * but their payloads are not returned.
+ * Handles both unfragmented text frames (FIN=1, opcode=1) and fragmented
+ * messages (FIN=0 initial frame + continuation frames with opcode=0,
+ * terminated by a FIN=1 continuation frame). The `fragments` array is
+ * carried across calls to support fragmentation that spans data events.
+ *
+ * Other frame types (binary, ping, pong, close) are consumed but their
+ * payloads are not returned.
  *
  * @param {Buffer} buf - Buffer containing WebSocket frame data
+ * @param {Buffer[]} [fragments] - Mutable array for accumulating fragment payloads across calls
  * @returns {{ messages: string[], consumed: number }}
  */
-function parseWebSocketFrames(buf) {
+function parseWebSocketFrames(buf, fragments) {
   const messages = [];
   let pos = 0;
 
@@ -64,22 +69,42 @@ function parseWebSocketFrames(buf) {
     const frameEnd = pos + headerSize + payloadLength;
     if (frameEnd > buf.length) break;
 
-    // Extract text frames (opcode 1) with FIN set
+    // Extract payload from the frame
+    const payloadStart = pos + headerSize;
+    let payload;
+    if (masked) {
+      const maskKeyStart = payloadStart - 4;
+      const maskingKey = buf.slice(maskKeyStart, maskKeyStart + 4);
+      const maskedPayload = buf.slice(payloadStart, frameEnd);
+      payload = Buffer.allocUnsafe(payloadLength);
+      for (let i = 0; i < payloadLength; i++) {
+        payload[i] = maskedPayload[i] ^ maskingKey[i % 4];
+      }
+    } else {
+      payload = buf.slice(payloadStart, frameEnd);
+    }
+
     if (opcode === 1 && fin) {
-      const payloadStart = pos + headerSize;
-      if (masked) {
-        const maskKeyStart = payloadStart - 4;
-        const maskingKey = buf.slice(maskKeyStart, maskKeyStart + 4);
-        const maskedPayload = buf.slice(payloadStart, frameEnd);
-        const unmasked = Buffer.allocUnsafe(payloadLength);
-        for (let i = 0; i < payloadLength; i++) {
-          unmasked[i] = maskedPayload[i] ^ maskingKey[i % 4];
+      // Unfragmented text frame — complete message in a single frame
+      messages.push(payload.toString('utf8'));
+    } else if (opcode === 1 && !fin) {
+      // Start of a fragmented text message (FIN=0, opcode=text)
+      if (fragments) {
+        fragments.length = 0; // reset any prior incomplete fragment
+        fragments.push(payload);
+      }
+    } else if (opcode === 0) {
+      // Continuation frame
+      if (fragments && fragments.length > 0) {
+        fragments.push(payload);
+        if (fin) {
+          // Final continuation frame — reassemble the full message
+          messages.push(Buffer.concat(fragments).toString('utf8'));
+          fragments.length = 0;
         }
-        messages.push(unmasked.toString('utf8'));
-      } else {
-        messages.push(buf.slice(payloadStart, frameEnd).toString('utf8'));
       }
     }
+    // Other opcodes (binary=2, close=8, ping=9, pong=10) are silently consumed
 
     pos = frameEnd;
   }
@@ -128,6 +153,9 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
   let textMessageCount = 0;
   let observedCacheReadTokens = 0;
 
+  // Accumulates payloads from fragmented WebSocket text messages across frames
+  const fragments = [];
+
   // Max buffer to prevent unbounded memory growth (1 MB)
   const MAX_WS_BUFFER = 1 * 1024 * 1024;
 
@@ -152,7 +180,7 @@ function trackWebSocketTokenUsage(upstreamSocket, opts) {
     }
 
     // Parse any complete WebSocket frames
-    const { messages, consumed } = parseWebSocketFrames(buffer);
+    const { messages, consumed } = parseWebSocketFrames(buffer, fragments);
     if (consumed > 0) {
       buffer = buffer.slice(consumed);
     }

--- a/containers/api-proxy/token-tracker.schema.test.js
+++ b/containers/api-proxy/token-tracker.schema.test.js
@@ -266,8 +266,9 @@ describe('token-usage JSONL record schema field', () => {
     proxyRes.emit('end');
 
     setTimeout(() => {
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed._schema).toMatch(/^token-usage\/v\d+\.\d+\.\d+(-\w+)?$/);
       expect(parsed.request_id).toBe('schema-field-http');
       done();
@@ -289,8 +290,9 @@ describe('token-usage JSONL record schema field', () => {
     socket.emit('close');
 
     setTimeout(() => {
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed._schema).toMatch(/^token-usage\/v\d+\.\d+\.\d+(-\w+)?$/);
       expect(parsed.request_id).toBe('schema-field-ws');
       done();
@@ -324,8 +326,9 @@ describe('token-usage JSONL record schema field', () => {
     proxyRes.emit('end');
 
     setTimeout(() => {
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed).toMatchObject({
         request_id: 'budget-fields-http',
         effective_tokens_this_response: 40,
@@ -359,8 +362,9 @@ describe('token-usage JSONL record schema field', () => {
     proxyRes.emit('end');
 
     setTimeout(() => {
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed.effective_tokens_this_response).toBeUndefined();
       expect(parsed.effective_tokens_total).toBeUndefined();
       expect(parsed.model_multiplier).toBeUndefined();
@@ -392,8 +396,9 @@ describe('token-usage JSONL record schema field', () => {
     socket.emit('close');
 
     setTimeout(() => {
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed).toMatchObject({
         request_id: 'budget-fields-ws',
         effective_tokens_this_response: 112,
@@ -422,8 +427,9 @@ describe('token-usage JSONL record schema field', () => {
     socket.emit('close');
 
     setTimeout(() => {
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed.effective_tokens_this_response).toBeUndefined();
       expect(parsed.effective_tokens_total).toBeUndefined();
       expect(parsed.model_multiplier).toBeUndefined();
@@ -481,8 +487,9 @@ describe('token-usage _schema exact version from AWF_VERSION', () => {
       writeStreamSpy.mockRestore();
       await isolated.closeLogStream();
 
-      expect(mockStream.write).toHaveBeenCalledTimes(1);
-      const parsed = mockStream.writtenRecords[0];
+      const usageRecords = mockStream.writtenRecords.filter(r => r._schema);
+      expect(usageRecords).toHaveLength(1);
+      const parsed = usageRecords[0];
       expect(parsed._schema).toBe('token-usage/v9.8.7');
       expect(parsed.request_id).toBe('exact-version-test');
       done();

--- a/scripts/ci/check-token-usage.js
+++ b/scripts/ci/check-token-usage.js
@@ -282,6 +282,22 @@ function main(argv) {
       '::error::Could not locate token-usage.jsonl in the agent artifact. ' +
         'The api-proxy did not record token usage.',
     );
+    // Print audit trail if available to diagnose why tracking failed
+    const auditFile = findFileRecursive(options.artifactRoot, 'token-tracker-audit.jsonl');
+    if (auditFile) {
+      try {
+        const auditContent = fs.readFileSync(auditFile, 'utf8').trim();
+        const lines = auditContent.split('\n').filter(Boolean);
+        console.error(`\n--- Token tracker audit trail (${lines.length} events) ---`);
+        for (const line of lines.slice(0, 100)) {
+          console.error(`  ${line}`);
+        }
+        if (lines.length > 100) console.error(`  ... (${lines.length - 100} more lines)`);
+        console.error('--- End audit trail ---\n');
+      } catch { /* ignore read errors */ }
+    } else {
+      console.error('  (no token-tracker-audit.jsonl found — tracker may not have been invoked)');
+    }
     return 1;
   }
 


### PR DESCRIPTION
## Problem

Intermittent `token-usage.jsonl` failures in Smoke Codex CI — multiple unrelated PRs failed the `verify_token_usage` step simultaneously, then runs immediately after succeeded. Root cause: transient upstream API behavior (likely `content-encoding: zstd`) that the token tracker couldn't decompress, causing silent data loss.

**Evidence of transient failure (not code-related):**
| Run | Branch | Result |
|-----|--------|--------|
| 28907953012 | fix-claude-sonnet-5-credits | ❌ verify_token_usage |
| 28908000014 | refactor-split-server-js | ❌ verify_token_usage |
| 28908020313 | refactor-split-proxy-request-module | ✅ (1 min later) |

## Root Cause

Two gaps in the token tracker's response parsing:

1. **Unsupported compression encoding** — If the upstream API responds with `content-encoding: zstd`, the tracker's `isCompressedResponse()` returned `false` (only knew gzip/deflate/br). Raw compressed bytes were then fed to the SSE parser as UTF-8 text → garbage → no usage extracted → `token-usage.jsonl` never written.

2. **WebSocket frame fragmentation** — `parseWebSocketFrames()` only extracted unfragmented text frames (`FIN=1, opcode=1`). Fragmented messages (FIN=0 initial frame + continuation frames) were consumed but payloads silently discarded.

## Fixes

1. **Strip unsupported encodings from `Accept-Encoding`** before forwarding to upstream APIs. This prevents them from responding with encodings the tracker cannot decompress. (`proxy-utils.js`, `request-headers.js`)

2. **Detect zstd in `isCompressedResponse`** so the tracker recognizes it's compressed and bails early with a clear warning instead of parsing garbage. (`token-parsers.js`, `token-tracker-http.js`)

3. **Add info-level logging** when usage extraction fails on 2xx responses, making the issue visible in CI without `AWF_DEBUG_TOKENS`. (`token-tracker-http.js`)

4. **Handle WebSocket frame fragmentation** — reassemble fragmented text messages across continuation frames. (`token-tracker-ws.js`)

## Testing

- All 1429 api-proxy tests pass
- All 3536 project tests pass
- Added 15 new tests covering `sanitizeAcceptEncoding` and WS fragmentation reassembly