### PR TITLE
fix: use tag-only image ref in rootless permission repair

### DIFF
--- a/src/artifact-permissions.ts
+++ b/src/artifact-permissions.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import execa from 'execa';
 import { getSafeHostGid, getSafeHostUid } from './host-identity';
-import { buildRuntimeImageRef, parseImageTag } from './image-tag';
+import { parseImageTag } from './image-tag';
 import { logger } from './logger';
 import { applyHostPathPrefixToVolumes } from './services/host-path-prefix';
 import { getLocalDockerEnv } from './docker-host';
@@ -12,7 +12,10 @@ function resolvePermFixerImageRef(imageRegistry?: string, imageTag?: string, age
     const registry = imageRegistry || 'ghcr.io/github/gh-aw-firewall';
     const parsedImageTag = parseImageTag(imageTag || 'latest');
     const imageName = agentImage === 'act' ? 'agent-act' : 'agent';
-    return buildRuntimeImageRef(registry, imageName, parsedImageTag);
+    // Use tag-only ref (no digest) because this runs with --pull never.
+    // Including the digest causes Docker to attempt registry verification
+    // even with --pull never, which times out if credentials are unavailable.
+    return `${registry}/${imageName}:${parsedImageTag.tag}`;
   } catch {
     return 'ghcr.io/github/gh-aw-firewall/agent:latest';
   }


### PR DESCRIPTION
## Problem

`fixArtifactPermissionsForRootless()` builds compound `tag@digest` image references (e.g., `agent:0.27.22@sha256:55f065...`) for its `docker run --pull never` command. Despite `--pull never`, Docker still attempts registry manifest verification for compound references. When GHCR credentials are unavailable (cleaned in an earlier workflow step), this verification times out after ~30 seconds per directory.

**Observed in:** https://github.com/github/gh-aw-mcpg/actions/runs/28965706129/job/85948370446#step:29:317

```
[WARN] Rootless artifact permission repair failed for /tmp/gh-aw/sandbox/firewall/logs (exit 1)
[WARN] Rootless artifact permission repair failed for /tmp/gh-aw/sandbox/firewall/audit (exit 1)
[WARN] Rootless artifact permission repair failed for /tmp/awf-1783534966689-chroot-home (exit 1)
[WARN] Failed to remove chroot home directory after permission repair: Error: EACCES: permission denied
```

Each repair attempt takes exactly ~30s (TCP connect timeout), wasting ~90s total per run.

## Fix

Strip the `@sha256:...` digest from the image ref in `resolvePermFixerImageRef()`. This is a local-only operation (`--pull never`) and the image is already tagged locally (e.g., `agent:0.27.22`) by the download step — no digest verification is needed.

## Impact

- Eliminates ~90s of wasted CI time (3 directories × 30s timeout)
- Fixes cascading EACCES error when chroot-home cleanup fails after permission repair timeout
- No functional change to the permission repair itself (same image, just referenced by tag only)