### PR TITLE
fix: mock accessSync in workdir-setup test to avoid macOS false failure

### DIFF
--- a/src/workdir-setup.test.ts
+++ b/src/workdir-setup.test.ts
@@ -534,8 +534,10 @@ describe('ensureDirectory EACCES diagnostic', () => {
       { code: 'EACCES' }
     );
     (fs.mkdirSync as jest.Mock).mockImplementationOnce(() => { throw eacces; });
-    // accessSync delegates to actualFs (all real dirs are writable), so no ancestor
-    // fails the check and the code falls back to the nearest existing ancestor.
+    // Mock accessSync to always pass so no ancestor fails the check and the code
+    // falls back to the nearest existing ancestor. Without this, system directories
+    // (e.g. /var/folders on macOS) may fail W_OK|X_OK and become the blocker.
+    (fs.accessSync as jest.Mock).mockImplementation(() => undefined);
 
     expect(() => workdirSetupTestHelpers.ensureDirectory(targetDir)).toThrow(
       new RegExp(`Blocked by: .*existing-parent`)


### PR DESCRIPTION
## Problem

The test `ensureDirectory EACCES diagnostic › falls back to nearest existing ancestor when no ancestor fails the access check` fails on macOS because it assumes all real ancestor directories pass the `W_OK|X_OK` access check.

On macOS, `/var/folders/dl` (a system-managed temp directory parent) fails this check, causing the `blocker` variable to be set to a system directory instead of falling through to the `nearestExisting` fallback as the test expects.

## Fix

Mock `fs.accessSync` to always pass (return `undefined`) in this specific test, ensuring the "no ancestor fails" fallback path is reliably exercised regardless of host filesystem permissions.

This is consistent with the test's intent — it explicitly tests the fallback behavior when **no** ancestor fails the access check.