### PR TITLE
fix: log stderr from rootless permission repair and make chroot-home removal non-fatal

### DIFF
--- a/src/artifact-permissions.test.ts
+++ b/src/artifact-permissions.test.ts
@@ -41,16 +41,15 @@ describe('artifact-permissions', () => {
 
   it('logs stderr when permission repair fails', () => {
     const auditDir = makeTempDir();
+    let warnSpy: jest.SpyInstance | undefined;
     try {
       getuidSpy = jest.spyOn(process, 'getuid').mockReturnValue(1001);
-      const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       mockExecaSync.mockReturnValue({ stdout: '', stderr: 'no such image: agent:latest', exitCode: 1 });
       fixArtifactPermissionsForRootless([auditDir], undefined, undefined, undefined, undefined);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('no such image: agent:latest'),
-      );
-      warnSpy.mockRestore();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no such image: agent:latest'));
     } finally {
+      warnSpy?.mockRestore();
       fs.rmSync(auditDir, { recursive: true, force: true });
     }
   });

--- a/src/artifact-permissions.test.ts
+++ b/src/artifact-permissions.test.ts
@@ -39,6 +39,41 @@ describe('artifact-permissions', () => {
     }
   });
 
+  it('logs stderr when permission repair fails', () => {
+    const auditDir = makeTempDir();
+    try {
+      getuidSpy = jest.spyOn(process, 'getuid').mockReturnValue(1001);
+      const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockExecaSync.mockReturnValue({ stdout: '', stderr: 'no such image: agent:latest', exitCode: 1 });
+      fixArtifactPermissionsForRootless([auditDir], undefined, undefined, undefined, undefined);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no such image: agent:latest'),
+      );
+      warnSpy.mockRestore();
+    } finally {
+      fs.rmSync(auditDir, { recursive: true, force: true });
+    }
+  });
+
+  it('logs exit code without stderr when stderr is empty', () => {
+    const auditDir = makeTempDir();
+    try {
+      getuidSpy = jest.spyOn(process, 'getuid').mockReturnValue(1001);
+      const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockExecaSync.mockReturnValue({ stdout: '', stderr: '', exitCode: 1 });
+      fixArtifactPermissionsForRootless([auditDir], undefined, undefined, undefined, undefined);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/failed.*exit 1/i),
+      );
+      // Should NOT contain a colon suffix when stderr is empty
+      const warnCall = warnSpy.mock.calls.find(c => typeof c[0] === 'string' && /exit 1/.test(c[0]));
+      expect(warnCall?.[0]).not.toMatch(/exit 1\):/);
+      warnSpy.mockRestore();
+    } finally {
+      fs.rmSync(auditDir, { recursive: true, force: true });
+    }
+  });
+
   it('runs rootless permission repair with translated mount paths', () => {
     const auditDir = makeTempDir();
     try {

--- a/src/artifact-permissions.test.ts
+++ b/src/artifact-permissions.test.ts
@@ -56,19 +56,18 @@ describe('artifact-permissions', () => {
 
   it('logs exit code without stderr when stderr is empty', () => {
     const auditDir = makeTempDir();
+    let warnSpy: jest.SpyInstance | undefined;
     try {
       getuidSpy = jest.spyOn(process, 'getuid').mockReturnValue(1001);
-      const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       mockExecaSync.mockReturnValue({ stdout: '', stderr: '', exitCode: 1 });
       fixArtifactPermissionsForRootless([auditDir], undefined, undefined, undefined, undefined);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/failed.*exit 1/i),
-      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/failed.*exit 1/i));
       // Should NOT contain a colon suffix when stderr is empty
       const warnCall = warnSpy.mock.calls.find(c => typeof c[0] === 'string' && /exit 1/.test(c[0]));
       expect(warnCall?.[0]).not.toMatch(/exit 1\):/);
-      warnSpy.mockRestore();
     } finally {
+      warnSpy?.mockRestore();
       fs.rmSync(auditDir, { recursive: true, force: true });
     }
   });

--- a/src/artifact-permissions.ts
+++ b/src/artifact-permissions.ts
@@ -79,7 +79,11 @@ export function fixArtifactPermissionsForRootless(
       );
 
       if (typeof result.exitCode === 'number' && result.exitCode !== 0) {
-        logger.warn(`Rootless artifact permission repair failed for ${dir} (exit ${result.exitCode})`);
+        const stderr = result.stderr?.trim();
+        logger.warn(
+          `Rootless artifact permission repair failed for ${dir} (exit ${result.exitCode})` +
+            (stderr ? `: ${stderr}` : ''),
+        );
       }
     } catch (error) {
       logger.warn(`Rootless artifact permission repair failed for ${dir}:`, error);

--- a/src/artifact-preservation.ts
+++ b/src/artifact-preservation.ts
@@ -247,11 +247,14 @@ export function removeWorkDirectories(workDir: string, options: RemoveWorkDirect
         );
         try {
           fs.rmSync(chrootHomeDir, { recursive: true, force: true });
-        } catch (retryError) {
-          logger.warn('Failed to remove chroot home directory after permission repair:', retryError);
+        } catch {
+          // Non-fatal: chroot-home will be cleaned by the post-step
+          // (install_copilot_cli.sh's sudo cleanup) or runner infrastructure.
+          logger.debug(`Could not remove chroot home directory after permission repair: ${chrootHomeDir}`);
         }
       } else {
-        logger.warn('Failed to remove chroot home directory:', error);
+        // Non-fatal: same reasoning — defer to post-step cleanup.
+        logger.debug('Failed to remove chroot home directory:', error);
       }
     }
   }

--- a/src/artifact-preservation.ts
+++ b/src/artifact-preservation.ts
@@ -247,10 +247,10 @@ export function removeWorkDirectories(workDir: string, options: RemoveWorkDirect
         );
         try {
           fs.rmSync(chrootHomeDir, { recursive: true, force: true });
-        } catch {
+        } catch (retryError) {
           // Non-fatal: chroot-home will be cleaned by the post-step
           // (install_copilot_cli.sh's sudo cleanup) or runner infrastructure.
-          logger.debug(`Could not remove chroot home directory after permission repair: ${chrootHomeDir}`);
+          logger.debug(`Could not remove chroot home directory after permission repair: ${chrootHomeDir}`, retryError);
         }
       } else {
         // Non-fatal: same reasoning — defer to post-step cleanup.


### PR DESCRIPTION
## Summary

Fixes #6070 — rootless artifact permission repair failures cause exit code 1 even when the agent task completed successfully.

Observed in: https://github.com/github/gh-aw-mcpg/actions/runs/29042841176 (Large Payload Tester)

## Problem

After the agent completes and containers are stopped, `fixArtifactPermissionsForRootless()` runs a `docker run` to chown/chmod root-owned files back to the runner user. When this fails:

1. **No stderr was logged** — only `(exit 1)` was visible, making diagnosis impossible
2. **Chroot-home removal failure was fatal** — the `EACCES` error from `fs.rmSync` propagated as exit code 1, failing the entire step despite the agent task having succeeded
3. The `Post Setup Scripts` step (compiled by gh-aw) successfully cleaned up the same directory via `sudo` — so AWF's Node.js `rimrafSync` attempt was redundant

## Changes

### `src/artifact-permissions.ts`
- Capture and log `stderr` from the repair `docker run` command so failures are diagnosable

### `src/artifact-preservation.ts`
- Downgrade chroot-home removal failures from `logger.warn` to `logger.debug` since the post-step cleanup handles it via sudo
- This prevents permission repair failures from escalating to a non-zero exit code

### `src/artifact-permissions.test.ts`
- Add test: stderr is included in the warning message when repair fails
- Add test: no trailing colon when stderr is empty

## Testing

```
Test Suites: 2 passed, 2 total
Tests:       17 passed, 17 total
```