### PR TITLE
fix: update gVisor release pin from 20250623.0 to 20250707.0

### DIFF
--- a/.github/workflows/smoke-gvisor-build-test.lock.yml
+++ b/.github/workflows/smoke-gvisor-build-test.lock.yml
@@ -585,8 +585,8 @@ jobs:
 
           echo "::group::Install gVisor (runsc)"
           ARCH=$(uname -m)
-          URL="https://storage.googleapis.com/gvisor/releases/release/20250623.0/${ARCH}"
-          echo "Downloading runsc 20250623.0 for ${ARCH}..."
+          URL="https://storage.googleapis.com/gvisor/releases/release/20250707.0/${ARCH}"
+          echo "Downloading runsc 20250707.0 for ${ARCH}..."
           curl -fsSL "${URL}/runsc" -o /tmp/runsc
           curl -fsSL "${URL}/runsc.sha512" -o /tmp/runsc.sha512
           echo "Verifying SHA-512 for runsc..."

--- a/.github/workflows/smoke-gvisor-claude.lock.yml
+++ b/.github/workflows/smoke-gvisor-claude.lock.yml
@@ -568,8 +568,8 @@ jobs:
 
           echo "::group::Install gVisor (runsc)"
           ARCH=$(uname -m)
-          URL="https://storage.googleapis.com/gvisor/releases/release/20250623.0/${ARCH}"
-          echo "Downloading runsc 20250623.0 for ${ARCH}..."
+          URL="https://storage.googleapis.com/gvisor/releases/release/20250707.0/${ARCH}"
+          echo "Downloading runsc 20250707.0 for ${ARCH}..."
           curl -fsSL "${URL}/runsc" -o /tmp/runsc
           curl -fsSL "${URL}/runsc.sha512" -o /tmp/runsc.sha512
           echo "Verifying SHA-512 for runsc..."

--- a/.github/workflows/smoke-gvisor-codex.lock.yml
+++ b/.github/workflows/smoke-gvisor-codex.lock.yml
@@ -572,8 +572,8 @@ jobs:
 
           echo "::group::Install gVisor (runsc)"
           ARCH=$(uname -m)
-          URL="https://storage.googleapis.com/gvisor/releases/release/20250623.0/${ARCH}"
-          echo "Downloading runsc 20250623.0 for ${ARCH}..."
+          URL="https://storage.googleapis.com/gvisor/releases/release/20250707.0/${ARCH}"
+          echo "Downloading runsc 20250707.0 for ${ARCH}..."
           curl -fsSL "${URL}/runsc" -o /tmp/runsc
           curl -fsSL "${URL}/runsc.sha512" -o /tmp/runsc.sha512
           echo "Verifying SHA-512 for runsc..."

--- a/.github/workflows/smoke-gvisor.lock.yml
+++ b/.github/workflows/smoke-gvisor.lock.yml
@@ -560,8 +560,8 @@ jobs:
 
           echo "::group::Install gVisor (runsc)"
           ARCH=$(uname -m)
-          URL="https://storage.googleapis.com/gvisor/releases/release/20250623.0/${ARCH}"
-          echo "Downloading runsc 20250623.0 for ${ARCH}..."
+          URL="https://storage.googleapis.com/gvisor/releases/release/20250707.0/${ARCH}"
+          echo "Downloading runsc 20250707.0 for ${ARCH}..."
           curl -fsSL "${URL}/runsc" -o /tmp/runsc
           curl -fsSL "${URL}/runsc.sha512" -o /tmp/runsc.sha512
           echo "Verifying SHA-512 for runsc..."


### PR DESCRIPTION
## Problem

All four gVisor smoke test workflows fail at the compiler-generated "Install gVisor (runsc)" step because the pinned release `20250623.0` returns **404** from `storage.googleapis.com`:

```
curl: (22) The requested URL returned error: 404
```

Failed runs: [29198099472](https://github.com/github/gh-aw-firewall/actions/runs/29198099472), [29198101985](https://github.com/github/gh-aw-firewall/actions/runs/29198101985), [29198112085](https://github.com/github/gh-aw-firewall/actions/runs/29198112085), [29198106871](https://github.com/github/gh-aw-firewall/actions/runs/29198106871)

## Fix

Manually update all 4 gVisor smoke test `.lock.yml` files to use release `20250707.0`, which is confirmed valid (HTTP 200).

> **Note:** This is a workaround — the upstream fix belongs in `gh-aw`'s `generateGVisorInstallStep()` which pins the release version.

## Files Changed

- `smoke-gvisor.lock.yml`
- `smoke-gvisor-claude.lock.yml`
- `smoke-gvisor-codex.lock.yml`
- `smoke-gvisor-build-test.lock.yml`