### PR TITLE
feat: add smoke tests for sink visibility (private-to-public-flows)

### DIFF
--- a/.github/workflows/smoke-sink-visibility-allowed.md
+++ b/.github/workflows/smoke-sink-visibility-allowed.md
@@ -26,9 +26,6 @@ tools:
 safe-outputs:
   threat-detection:
     enabled: false
-sandbox:
-  mcp:
-    version: v0.3.32
 strict: false
 max-turns: 10
 timeout-minutes: 10

--- a/.github/workflows/smoke-sink-visibility-allowed.md
+++ b/.github/workflows/smoke-sink-visibility-allowed.md
@@ -1,0 +1,80 @@
+---
+name: Smoke Sink Visibility Allowed
+description: >-
+  Smoke test verifying that private-to-public-flows: allow correctly disables
+  MCP Gateway sink-visibility enforcement, permitting cross-repo reads from a
+  private repository (github/agentic-workflows). Tests both gh CLI (mcpg proxy
+  mode) and GitHub MCP tools (mcpg gateway mode).
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine:
+  id: copilot
+  version: 1.0.34
+network:
+  allowed:
+    - defaults
+    - github
+tools:
+  bash:
+    - "*"
+  github:
+    github-token: ${{ secrets.GH_AW_CROSS_REPO_PAT }}
+    toolsets: [repos]
+    private-to-public-flows: allow
+safe-outputs:
+  threat-detection:
+    enabled: false
+sandbox:
+  mcp:
+    version: v0.3.32
+strict: false
+max-turns: 10
+timeout-minutes: 10
+---
+
+# Smoke Test: Sink Visibility — Allowed (private-to-public-flows: allow)
+
+This test verifies that `private-to-public-flows: allow` correctly disables
+MCP Gateway sink-visibility enforcement, permitting reads from a private
+repository.
+
+Target private repo: `github/agentic-workflows`
+
+**IMPORTANT: All access to github/agentic-workflows must be READ-ONLY.
+Never create, update, or delete anything in that repository.**
+
+## Test 1 — gh CLI (mcpg proxy mode)
+
+Run the following bash command and capture the exit code and output:
+
+```bash
+gh repo view github/agentic-workflows --json name 2>&1; echo "EXIT_CODE=$?"
+```
+
+**Expected**: The command should SUCCEED (exit code 0, returning the repo name).
+
+## Test 2 — GitHub MCP tools (mcpg gateway mode)
+
+Call the MCP tool `get_file_contents` to read the root path (`/`) of
+`github/agentic-workflows`:
+- owner: `github`
+- repo: `agentic-workflows`
+- path: `/`
+
+**Expected**: The MCP call should SUCCEED, returning a directory listing.
+
+## Report
+
+Summarize the results:
+
+| Test | Method | Expected | Actual | Status |
+|------|--------|----------|--------|--------|
+| 1 | gh CLI (proxy mode) | ALLOWED | ... | ✅/❌ |
+| 2 | MCP tools (gateway mode) | ALLOWED | ... | ✅/❌ |
+
+- ✅ = access was correctly allowed (test passed)
+- ❌ = access was unexpectedly blocked (test failed — opt-out not working)
+
+Call `noop` with the summary table and overall PASS/FAIL status.

--- a/.github/workflows/smoke-sink-visibility-blocked.md
+++ b/.github/workflows/smoke-sink-visibility-blocked.md
@@ -28,9 +28,6 @@ tools:
 safe-outputs:
   threat-detection:
     enabled: false
-sandbox:
-  mcp:
-    version: v0.3.32
 strict: false
 max-turns: 10
 timeout-minutes: 10

--- a/.github/workflows/smoke-sink-visibility-blocked.md
+++ b/.github/workflows/smoke-sink-visibility-blocked.md
@@ -1,0 +1,83 @@
+---
+name: Smoke Sink Visibility Blocked
+description: >-
+  Smoke test verifying that MCP Gateway sink-visibility enforcement blocks
+  cross-repo reads from a private repository (github/agentic-workflows) when
+  private-to-public-flows is NOT opted out. Tests both gh CLI (mcpg proxy mode)
+  and GitHub MCP tools (mcpg gateway mode).
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine:
+  id: copilot
+  version: 1.0.34
+network:
+  allowed:
+    - defaults
+    - github
+tools:
+  bash:
+    - "*"
+  github:
+    github-token: ${{ secrets.GH_AW_CROSS_REPO_PAT }}
+    toolsets: [repos]
+    # NOTE: private-to-public-flows is intentionally NOT set here.
+    # The MCP Gateway should enforce forcePublicRepos=true, blocking
+    # access to the private repo github/agentic-workflows.
+safe-outputs:
+  threat-detection:
+    enabled: false
+sandbox:
+  mcp:
+    version: v0.3.32
+strict: false
+max-turns: 10
+timeout-minutes: 10
+---
+
+# Smoke Test: Sink Visibility — Blocked (Default Enforcement)
+
+This test verifies that the MCP Gateway **blocks** reads from a private
+repository when `private-to-public-flows` is not opted out.
+
+Target private repo: `github/agentic-workflows`
+
+**IMPORTANT: All access to github/agentic-workflows must be READ-ONLY.
+Never create, update, or delete anything in that repository.**
+
+## Test 1 — gh CLI (mcpg proxy mode)
+
+Run the following bash command and capture the exit code and output:
+
+```bash
+gh repo view github/agentic-workflows --json name 2>&1; echo "EXIT_CODE=$?"
+```
+
+**Expected**: The command should FAIL (non-zero exit code or error message
+indicating the repo is inaccessible / not found).
+
+## Test 2 — GitHub MCP tools (mcpg gateway mode)
+
+Call the MCP tool `get_file_contents` to read the root path (`/`) of
+`github/agentic-workflows`:
+- owner: `github`
+- repo: `agentic-workflows`
+- path: `/`
+
+**Expected**: The MCP call should FAIL with an error (repository not found,
+access denied, or similar).
+
+## Report
+
+Summarize the results:
+
+| Test | Method | Expected | Actual | Status |
+|------|--------|----------|--------|--------|
+| 1 | gh CLI (proxy mode) | BLOCKED | ... | ✅/❌ |
+| 2 | MCP tools (gateway mode) | BLOCKED | ... | ✅/❌ |
+
+- ✅ = access was correctly blocked (test passed)
+- ❌ = access was unexpectedly allowed (test failed — sink visibility not enforced)
+
+Call `noop` with the summary table and overall PASS/FAIL status.


### PR DESCRIPTION
## Summary

Adds two smoke test workflow `.md` files to validate the MCP Gateway `private-to-public-flows` frontmatter implemented in github/gh-aw#45113.

## Workflows

### `smoke-sink-visibility-blocked.md`
Tests that **default** sink-visibility enforcement blocks reads from private repo `github/agentic-workflows` when `private-to-public-flows` is NOT set. Both access methods should be denied:
- **gh CLI** (mcpg proxy mode) — `gh repo view github/agentic-workflows`
- **GitHub MCP tools** (mcpg gateway mode) — `get_file_contents`

### `smoke-sink-visibility-allowed.md`
Tests that `private-to-public-flows: allow` correctly disables enforcement, permitting reads from the private repo. Both access methods should succeed:
- **gh CLI** (mcpg proxy mode)
- **GitHub MCP tools** (mcpg gateway mode)

## Details

- Both workflows use `GH_AW_CROSS_REPO_PAT` for authentication via `tools.github.github-token`
- All access to `github/agentic-workflows` is **read-only**
- Only `.md` files — compilation deferred to a follow-up step
- `strict: false` since `private-to-public-flows: allow` is incompatible with strict mode

## Related

- github/gh-aw#45113 — `private-to-public-flows` frontmatter implementation