### PR TITLE
fix(sbx): stop mounting the whole $HOME into the microVM (protect host secrets)

### DIFF
--- a/docs/sbx-integration.md
+++ b/docs/sbx-integration.md
@@ -175,8 +175,31 @@ What `createSandbox()` shares, in order:
      host-installed tools live here and are mounted straight in. Note it is
      *narrow*: only `/usr/local/bin`, **not** `/usr`, `/lib`, `/lib64`, or `/opt`.
    - **`/tmp`** — agent runtime files (rendered prompts, logs).
-   - **`$HOME`** (`$HOME || /home/runner`) — writable agent dirs (`.cache`,
-     `.config`, `.local`, `.anthropic`, `.copilot`, …).
+   - **`$HOME` tool dirs** — a **curated whitelist** of writable agent dirs, not
+     the whole home directory. The manager mounts only the subdirs that exist on
+     the host from `HOME_TOOL_SUBDIRS` (`.cache`, `.config`, `.local`,
+     `.anthropic`, `.claude`, `.cargo`, `.rustup`, `.npm`, `.nvm`) plus the agent
+     state dirs `.copilot` and `.gemini`. Credential-store dirs such as `.aws`,
+     `.ssh`, `.docker`, `.kube`, `.azure` and `.gnupg` are **never** whitelisted,
+     so they never enter the VM. Each whitelisted dir is mounted **wholesale** (as
+     a directory — sbx positional mounts cannot target an individual file, so its
+     loose files like `~/.copilot/mcp-config.json` are preserved).
+
+**Scrubbing nested credential stores.** Several whitelisted dirs legitimately
+hold tool settings but also stash a secret in a well-known child — e.g.
+`.config/gh`, `.config/gcloud`, `.cargo/credentials`, `.claude/.credentials.json`,
+`.copilot/config.json`, `.gemini/oauth_creds.json`. Because the parent is mounted
+wholesale and sbx cannot overlay or mask a nested path, the manager instead
+**moves those credential paths aside on the host before `sbx create` and restores
+them after the sandbox is torn down** (`scrubHomeCredentials` /
+`restoreHomeCredentials` in `sbx-manager.ts`). The move target is a
+`.awf-sbx-cred-backup-<pid>` dir at the home root — never a mounted subdir — so
+the secrets are absent from the VM while the benign tool state stays available.
+This is the sbx analog of compose mode's `/dev/null` credential overlays, and the
+per-parent list (`CREDENTIAL_PATHS_BY_PARENT` in
+`services/agent-volumes/home-whitelist.ts`) is shared to prevent drift. The agent
+receives whatever credentials it needs through the api-proxy or environment, not
+by reading the host's on-disk auth store, so removing these paths is safe.
 
 A `seenPaths` set deduplicates so no path is mounted twice, and
 `execInSandbox(..., { workDir })` passes `--workdir` so commands run inside the
@@ -188,7 +211,7 @@ mounted workspace.
 | System libraries | From the sbx `shell` **guest image** | Host `/usr`,`/bin`,`/lib`,`/lib64`,`/opt` mounted read-only |
 | Toolchain binaries | Host `/usr/local/bin` mounted in | `/usr` from the host or sysroot; optional `chroot.binariesSourcePath` overlay at `/host/tmp/awf-runner-bin` (ro) |
 | Workspace | `workspaceDir` positional (rw) | `<workspaceDir>:/host<workspaceDir>:rw` |
-| Home | Whole `$HOME` mounted (rw) | Empty home volume with only whitelisted subdirs |
+| Home | Curated `$HOME` tool-dir whitelist (rw), nested credential stores scrubbed before create | Empty home volume with only whitelisted subdirs |
 
 :::caution Toolchain portability
 Because host system libraries are **not** shared into the VM, a binary in

--- a/src/sbx-manager.test.ts
+++ b/src/sbx-manager.test.ts
@@ -6,6 +6,7 @@ import {
   sanitizeEnvForSbx,
   SBX_DEFAULT_NAME,
 } from './sbx-manager';
+import * as fs from 'fs';
 import { mockExecaFn } from './test-helpers/mock-execa.test-utils';
 import { logger } from './logger';
 
@@ -13,6 +14,13 @@ import { logger } from './logger';
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('./logger', () => require('./test-helpers/mock-logger.test-utils').loggerMockFactory());
+// Mock fs so home-mount curation (existsSync) is deterministic per test.
+jest.mock('fs', () => {
+  const actual = jest.requireActual<typeof import('fs')>('fs');
+  return { ...actual, existsSync: jest.fn(() => false) };
+});
+
+const mockedExistsSync = fs.existsSync as jest.Mock;
 
 const mockedLogger = jest.mocked(logger);
 
@@ -81,7 +89,16 @@ describe('sbx-manager', () => {
   });
 
   describe('createSandbox', () => {
+    beforeEach(() => {
+      // Default: no host $HOME subdirs exist, so home-mount curation is a no-op
+      // unless a test opts in. Individual tests re-mock as needed.
+      mockedExistsSync.mockReset();
+      mockedExistsSync.mockReturnValue(false);
+    });
+
     it('uses shell agent, configured mounts, and sanitized env', async () => {
+      // No host $HOME subdirs exist → only workspace, extra mounts, /tmp and
+      // /usr/local/bin are mounted (the whole $HOME is never mounted).
       mockExecaFn
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // auth check
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' }); // sbx create
@@ -101,7 +118,6 @@ describe('sbx-manager', () => {
         '/tmp/gh-aw:ro',
         '/tmp',
         '/usr/local/bin',
-        process.env.HOME || '/home/runner',
       ], expect.objectContaining({
         input: 'y\n',
       }));
@@ -110,6 +126,56 @@ describe('sbx-manager', () => {
       // separately by execInSandbox() which uses sanitizeEnvForSbx().
       const sbxCreateCall = mockExecaFn.mock.calls[1][2];
       expect(sbxCreateCall.env).toBeUndefined();
+    });
+
+    it('never mounts the whole $HOME (only whitelisted subdirs that exist)', async () => {
+      const homePath = process.env.HOME || '/home/runner';
+      // Simulate a host home that contains both tool dirs AND credential stores.
+      mockedExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        return (
+          s === `${homePath}/.cache` ||
+          s === `${homePath}/.config` ||
+          s === `${homePath}/.copilot` ||
+          s === `${homePath}/.aws` ||
+          s === `${homePath}/.ssh` ||
+          s === `${homePath}/.docker`
+        );
+      });
+      mockExecaFn
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
+
+      await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
+
+      const args: string[] = mockExecaFn.mock.calls[1][1];
+      // The whole home is never mounted...
+      expect(args).not.toContain(homePath);
+      // ...whitelisted tool/state dirs that exist ARE mounted...
+      expect(args).toContain(`${homePath}/.cache`);
+      expect(args).toContain(`${homePath}/.config`);
+      expect(args).toContain(`${homePath}/.copilot`);
+      // ...and credential stores are NEVER mounted, even though they exist.
+      expect(args).not.toContain(`${homePath}/.aws`);
+      expect(args).not.toContain(`${homePath}/.ssh`);
+      expect(args).not.toContain(`${homePath}/.docker`);
+    });
+
+    it('skips whitelisted home subdirs that do not exist on the host', async () => {
+      const homePath = process.env.HOME || '/home/runner';
+      mockedExistsSync.mockImplementation(
+        (p: fs.PathLike) => String(p) === `${homePath}/.npm`,
+      );
+      mockExecaFn
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
+
+      await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
+
+      const args: string[] = mockExecaFn.mock.calls[1][1];
+      expect(args).toContain(`${homePath}/.npm`);
+      expect(args).not.toContain(`${homePath}/.cache`);
+      expect(args).not.toContain(`${homePath}/.rustup`);
     });
 
     it('uses SBX_DEFAULT_NAME when no name provided', async () => {
@@ -258,6 +324,9 @@ describe('sbx-manager', () => {
 
     it('skips system paths already in workspace or dedup list', async () => {
       const home = process.env.HOME || '/home/runner';
+      mockedExistsSync.mockImplementation(
+        (p: fs.PathLike) => String(p) === `${home}/.cache`,
+      );
       mockExecaFn
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
@@ -274,7 +343,9 @@ describe('sbx-manager', () => {
       const tmpCount = args.filter(a => a === '/tmp').length;
       expect(tmpCount).toBe(1);
       expect(args).toContain('/usr/local/bin');
-      expect(args).toContain(home);
+      // The whole $HOME is never mounted; only existing whitelisted subdirs are.
+      expect(args).not.toContain(home);
+      expect(args).toContain(`${home}/.cache`);
     });
   });
 

--- a/src/sbx-manager.test.ts
+++ b/src/sbx-manager.test.ts
@@ -154,13 +154,58 @@ describe('sbx-manager', () => {
       const args: string[] = mockExecaFn.mock.calls[1][1];
       // The whole home is never mounted...
       expect(args).not.toContain(homePath);
-      // ...whitelisted tool/state dirs that exist ARE mounted...
+      // ...whitelisted tool dirs that exist ARE mounted...
       expect(args).toContain(`${homePath}/.cache`);
-      expect(args).toContain(`${homePath}/.copilot`);
       // ...and credential stores are NEVER mounted, even though they exist.
       expect(args).not.toContain(`${homePath}/.aws`);
       expect(args).not.toContain(`${homePath}/.ssh`);
       expect(args).not.toContain(`${homePath}/.docker`);
+    });
+
+    it('mounts credential-nesting tool dirs child-by-child, excluding nested secret files', async () => {
+      const homePath = process.env.HOME || '/home/runner';
+      const nesting = [
+        `${homePath}/.cargo`,
+        `${homePath}/.claude`,
+        `${homePath}/.copilot`,
+        `${homePath}/.gemini`,
+      ];
+      mockedExistsSync.mockImplementation((p: fs.PathLike) => nesting.includes(String(p)));
+      mockedReaddirSync.mockImplementation((p: fs.PathLike) => {
+        switch (String(p)) {
+          case `${homePath}/.cargo`:
+            return ['bin', 'registry', 'credentials', 'credentials.toml'];
+          case `${homePath}/.claude`:
+            return ['settings.json', 'projects', '.credentials.json'];
+          case `${homePath}/.copilot`:
+            return ['session-state', 'logs', 'config.json'];
+          case `${homePath}/.gemini`:
+            return ['tmp', 'oauth_creds.json', 'google_accounts.json'];
+          default:
+            return [];
+        }
+      });
+      mockExecaFn
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
+
+      await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
+
+      const args: string[] = mockExecaFn.mock.calls[1][1];
+      // Parents are never mounted wholesale.
+      for (const parent of nesting) expect(args).not.toContain(parent);
+      // Benign children ARE mounted individually.
+      expect(args).toContain(`${homePath}/.cargo/registry`);
+      expect(args).toContain(`${homePath}/.claude/settings.json`);
+      expect(args).toContain(`${homePath}/.copilot/session-state`);
+      expect(args).toContain(`${homePath}/.gemini/tmp`);
+      // Nested credential files are NEVER mounted.
+      expect(args).not.toContain(`${homePath}/.cargo/credentials`);
+      expect(args).not.toContain(`${homePath}/.cargo/credentials.toml`);
+      expect(args).not.toContain(`${homePath}/.claude/.credentials.json`);
+      expect(args).not.toContain(`${homePath}/.copilot/config.json`);
+      expect(args).not.toContain(`${homePath}/.gemini/oauth_creds.json`);
+      expect(args).not.toContain(`${homePath}/.gemini/google_accounts.json`);
     });
 
     it('mounts ~/.config child-by-child and excludes nested credential dirs', async () => {

--- a/src/sbx-manager.test.ts
+++ b/src/sbx-manager.test.ts
@@ -14,13 +14,14 @@ import { logger } from './logger';
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('./logger', () => require('./test-helpers/mock-logger.test-utils').loggerMockFactory());
-// Mock fs so home-mount curation (existsSync) is deterministic per test.
+// Mock fs so home-mount curation (existsSync/readdirSync) is deterministic per test.
 jest.mock('fs', () => {
   const actual = jest.requireActual<typeof import('fs')>('fs');
-  return { ...actual, existsSync: jest.fn(() => false) };
+  return { ...actual, existsSync: jest.fn(() => false), readdirSync: jest.fn(() => []) };
 });
 
 const mockedExistsSync = fs.existsSync as jest.Mock;
+const mockedReaddirSync = fs.readdirSync as jest.Mock;
 
 const mockedLogger = jest.mocked(logger);
 
@@ -94,6 +95,8 @@ describe('sbx-manager', () => {
       // unless a test opts in. Individual tests re-mock as needed.
       mockedExistsSync.mockReset();
       mockedExistsSync.mockReturnValue(false);
+      mockedReaddirSync.mockReset();
+      mockedReaddirSync.mockReturnValue([]);
     });
 
     it('uses shell agent, configured mounts, and sanitized env', async () => {
@@ -153,12 +156,40 @@ describe('sbx-manager', () => {
       expect(args).not.toContain(homePath);
       // ...whitelisted tool/state dirs that exist ARE mounted...
       expect(args).toContain(`${homePath}/.cache`);
-      expect(args).toContain(`${homePath}/.config`);
       expect(args).toContain(`${homePath}/.copilot`);
       // ...and credential stores are NEVER mounted, even though they exist.
       expect(args).not.toContain(`${homePath}/.aws`);
       expect(args).not.toContain(`${homePath}/.ssh`);
       expect(args).not.toContain(`${homePath}/.docker`);
+    });
+
+    it('mounts ~/.config child-by-child and excludes nested credential dirs', async () => {
+      const homePath = process.env.HOME || '/home/runner';
+      mockedExistsSync.mockImplementation(
+        (p: fs.PathLike) => String(p) === `${homePath}/.config`,
+      );
+      // .config nests both benign tool config and credential stores.
+      mockedReaddirSync.mockImplementation((p: fs.PathLike) =>
+        String(p) === `${homePath}/.config`
+          ? ['nvim', 'pip', 'gh', 'gcloud', 'rclone']
+          : [],
+      );
+      mockExecaFn
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
+
+      await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
+
+      const args: string[] = mockExecaFn.mock.calls[1][1];
+      // The parent .config is never mounted wholesale...
+      expect(args).not.toContain(`${homePath}/.config`);
+      // ...benign tool config subdirs ARE mounted individually...
+      expect(args).toContain(`${homePath}/.config/nvim`);
+      expect(args).toContain(`${homePath}/.config/pip`);
+      // ...and known credential subdirs are NEVER mounted.
+      expect(args).not.toContain(`${homePath}/.config/gh`);
+      expect(args).not.toContain(`${homePath}/.config/gcloud`);
+      expect(args).not.toContain(`${homePath}/.config/rclone`);
     });
 
     it('skips whitelisted home subdirs that do not exist on the host', async () => {

--- a/src/sbx-manager.test.ts
+++ b/src/sbx-manager.test.ts
@@ -3,6 +3,7 @@ import {
   execInSandbox,
   isSbxAvailable,
   removeSandbox,
+  restoreHomeCredentials,
   sanitizeEnvForSbx,
   SBX_DEFAULT_NAME,
 } from './sbx-manager';
@@ -14,14 +15,22 @@ import { logger } from './logger';
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('./logger', () => require('./test-helpers/mock-logger.test-utils').loggerMockFactory());
-// Mock fs so home-mount curation (existsSync/readdirSync) is deterministic per test.
+// Mock fs so home-mount curation and credential scrub/restore are deterministic.
 jest.mock('fs', () => {
   const actual = jest.requireActual<typeof import('fs')>('fs');
-  return { ...actual, existsSync: jest.fn(() => false), readdirSync: jest.fn(() => []) };
+  return {
+    ...actual,
+    existsSync: jest.fn(() => false),
+    readdirSync: jest.fn(() => []),
+    renameSync: jest.fn(() => undefined),
+    mkdirSync: jest.fn(() => undefined),
+    rmSync: jest.fn(() => undefined),
+  };
 });
 
 const mockedExistsSync = fs.existsSync as jest.Mock;
 const mockedReaddirSync = fs.readdirSync as jest.Mock;
+const mockedRenameSync = fs.renameSync as jest.Mock;
 
 const mockedLogger = jest.mocked(logger);
 
@@ -97,6 +106,12 @@ describe('sbx-manager', () => {
       mockedExistsSync.mockReturnValue(false);
       mockedReaddirSync.mockReset();
       mockedReaddirSync.mockReturnValue([]);
+      mockedRenameSync.mockReset();
+      mockedRenameSync.mockReturnValue(undefined);
+      // Ensure no scrubbed state leaks between tests.
+      restoreHomeCredentials();
+      mockedRenameSync.mockReset();
+      mockedRenameSync.mockReturnValue(undefined);
     });
 
     it('uses shell agent, configured mounts, and sanitized env', async () => {
@@ -162,29 +177,25 @@ describe('sbx-manager', () => {
       expect(args).not.toContain(`${homePath}/.docker`);
     });
 
-    it('mounts credential-nesting tool dirs child-by-child, excluding nested secret files', async () => {
+    it('mounts credential-nesting tool dirs wholesale and scrubs nested secrets before create', async () => {
       const homePath = process.env.HOME || '/home/runner';
-      const nesting = [
+      const parents = [
         `${homePath}/.cargo`,
         `${homePath}/.claude`,
         `${homePath}/.copilot`,
         `${homePath}/.gemini`,
       ];
-      mockedExistsSync.mockImplementation((p: fs.PathLike) => nesting.includes(String(p)));
-      mockedReaddirSync.mockImplementation((p: fs.PathLike) => {
-        switch (String(p)) {
-          case `${homePath}/.cargo`:
-            return ['bin', 'registry', 'credentials', 'credentials.toml'];
-          case `${homePath}/.claude`:
-            return ['settings.json', 'projects', '.credentials.json'];
-          case `${homePath}/.copilot`:
-            return ['session-state', 'logs', 'config.json'];
-          case `${homePath}/.gemini`:
-            return ['tmp', 'oauth_creds.json', 'google_accounts.json'];
-          default:
-            return [];
-        }
-      });
+      const secrets = [
+        `${homePath}/.cargo/credentials`,
+        `${homePath}/.cargo/credentials.toml`,
+        `${homePath}/.claude/.credentials.json`,
+        `${homePath}/.copilot/config.json`,
+        `${homePath}/.gemini/oauth_creds.json`,
+        `${homePath}/.gemini/google_accounts.json`,
+      ];
+      mockedExistsSync.mockImplementation(
+        (p: fs.PathLike) => parents.includes(String(p)) || secrets.includes(String(p)),
+      );
       mockExecaFn
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
@@ -192,32 +203,27 @@ describe('sbx-manager', () => {
       await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
 
       const args: string[] = mockExecaFn.mock.calls[1][1];
-      // Parents are never mounted wholesale.
-      for (const parent of nesting) expect(args).not.toContain(parent);
-      // Benign children ARE mounted individually.
-      expect(args).toContain(`${homePath}/.cargo/registry`);
-      expect(args).toContain(`${homePath}/.claude/settings.json`);
-      expect(args).toContain(`${homePath}/.copilot/session-state`);
-      expect(args).toContain(`${homePath}/.gemini/tmp`);
-      // Nested credential files are NEVER mounted.
-      expect(args).not.toContain(`${homePath}/.cargo/credentials`);
-      expect(args).not.toContain(`${homePath}/.cargo/credentials.toml`);
-      expect(args).not.toContain(`${homePath}/.claude/.credentials.json`);
-      expect(args).not.toContain(`${homePath}/.copilot/config.json`);
-      expect(args).not.toContain(`${homePath}/.gemini/oauth_creds.json`);
-      expect(args).not.toContain(`${homePath}/.gemini/google_accounts.json`);
+      // Parents ARE mounted wholesale (as directories) so their loose files work.
+      for (const parent of parents) expect(args).toContain(parent);
+      // No individual file is ever passed as a positional mount.
+      for (const secret of secrets) expect(args).not.toContain(secret);
+      // Each nested credential path is moved aside on the host before create.
+      const movedOriginals = mockedRenameSync.mock.calls.map((c) => String(c[0]));
+      for (const secret of secrets) expect(movedOriginals).toContain(secret);
+
+      restoreHomeCredentials();
     });
 
-    it('mounts ~/.config child-by-child and excludes nested credential dirs', async () => {
+    it('mounts ~/.config wholesale and scrubs nested credential dirs before create', async () => {
       const homePath = process.env.HOME || '/home/runner';
+      const secrets = [
+        `${homePath}/.config/gh`,
+        `${homePath}/.config/gcloud`,
+        `${homePath}/.config/rclone`,
+      ];
       mockedExistsSync.mockImplementation(
-        (p: fs.PathLike) => String(p) === `${homePath}/.config`,
-      );
-      // .config nests both benign tool config and credential stores.
-      mockedReaddirSync.mockImplementation((p: fs.PathLike) =>
-        String(p) === `${homePath}/.config`
-          ? ['nvim', 'pip', 'gh', 'gcloud', 'rclone']
-          : [],
+        (p: fs.PathLike) =>
+          String(p) === `${homePath}/.config` || secrets.includes(String(p)),
       );
       mockExecaFn
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
@@ -226,15 +232,48 @@ describe('sbx-manager', () => {
       await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
 
       const args: string[] = mockExecaFn.mock.calls[1][1];
-      // The parent .config is never mounted wholesale...
-      expect(args).not.toContain(`${homePath}/.config`);
-      // ...benign tool config subdirs ARE mounted individually...
-      expect(args).toContain(`${homePath}/.config/nvim`);
-      expect(args).toContain(`${homePath}/.config/pip`);
-      // ...and known credential subdirs are NEVER mounted.
-      expect(args).not.toContain(`${homePath}/.config/gh`);
-      expect(args).not.toContain(`${homePath}/.config/gcloud`);
-      expect(args).not.toContain(`${homePath}/.config/rclone`);
+      // The parent .config IS mounted wholesale so benign tool config still works.
+      expect(args).toContain(`${homePath}/.config`);
+      // Known credential subdirs are moved aside before create, not mounted.
+      for (const secret of secrets) expect(args).not.toContain(secret);
+      const movedOriginals = mockedRenameSync.mock.calls.map((c) => String(c[0]));
+      for (const secret of secrets) expect(movedOriginals).toContain(secret);
+
+      restoreHomeCredentials();
+    });
+
+    it('restores scrubbed credentials after the sandbox is removed', async () => {
+      const homePath = process.env.HOME || '/home/runner';
+      const secret = `${homePath}/.copilot/config.json`;
+      mockedExistsSync.mockImplementation(
+        (p: fs.PathLike) =>
+          String(p) === `${homePath}/.copilot` ||
+          String(p) === secret ||
+          String(p).includes('.awf-sbx-cred-backup'),
+      );
+      mockExecaFn
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'Created sandbox', stderr: '' });
+
+      await createSandbox({ workspaceDir: '/workspace', squidIp: '172.30.0.10' });
+
+      // The secret was moved to a backup during create.
+      const createMoves = mockedRenameSync.mock.calls.map((c) => [String(c[0]), String(c[1])]);
+      const scrubMove = createMoves.find(([from]) => from === secret);
+      expect(scrubMove).toBeDefined();
+      const backupPath = scrubMove![1];
+
+      mockedRenameSync.mockClear();
+      // removeSandbox: stop + rm both succeed, then restore runs.
+      mockExecaFn
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await removeSandbox(SBX_DEFAULT_NAME);
+
+      // The backup is moved back to its original location after teardown.
+      const restoreMoves = mockedRenameSync.mock.calls.map((c) => [String(c[0]), String(c[1])]);
+      expect(restoreMoves).toContainEqual([backupPath, secret]);
     });
 
     it('skips whitelisted home subdirs that do not exist on the host', async () => {

--- a/src/sbx-manager.ts
+++ b/src/sbx-manager.ts
@@ -24,8 +24,9 @@
 
 import execa from 'execa';
 import * as fs from 'fs';
+import * as path from 'path';
 import { logger } from './logger';
-import { HOME_TOOL_SUBDIRS, CREDENTIAL_EXCLUSIONS_BY_PARENT } from './services/agent-volumes/home-whitelist';
+import { HOME_TOOL_SUBDIRS, CREDENTIAL_PATHS_BY_PARENT } from './services/agent-volumes/home-whitelist';
 
 /** Name prefix for AWF-managed sandboxes. */
 const SBX_NAME_PREFIX = 'awf-agent';
@@ -83,6 +84,105 @@ export function sanitizeEnvForSbx(
     }
   }
   return { ...clean, ...overrides };
+}
+
+/** Records a credential path that was moved aside before `sbx create`. */
+interface ScrubbedCredential {
+  /** Original host path (inside a wholesale-mounted home dir). */
+  original: string;
+  /** Backup location the path was moved to (outside any mount). */
+  backup: string;
+}
+
+/**
+ * Credential paths moved aside for the current sandbox, plus the temp backup
+ * root that holds them. Module-level because scrub happens in createSandbox and
+ * restore happens later in removeSandbox (after the live mount is gone).
+ */
+let scrubbedCredentials: ScrubbedCredential[] = [];
+let credentialBackupRoot: string | undefined;
+
+/**
+ * Moves known credential stores out of the wholesale-mounted `$HOME` tool dirs
+ * before the sandbox is created, so they never enter the microVM. The paths are
+ * moved (not deleted) to a backup dir at the home root — which is NOT one of the
+ * mounted subdirs — and restored by {@link restoreHomeCredentials} after the
+ * sandbox is torn down. This is the sbx analog of compose mode's `/dev/null`
+ * credential overlays.
+ */
+function scrubHomeCredentials(homePath: string): void {
+  scrubbedCredentials = [];
+  credentialBackupRoot = undefined;
+
+  for (const [parent, names] of Object.entries(CREDENTIAL_PATHS_BY_PARENT)) {
+    const parentPath = path.join(homePath, parent);
+    // Parent isn't mounted (doesn't exist) → nothing nested to hide.
+    if (!fs.existsSync(parentPath)) continue;
+
+    for (const name of names) {
+      const original = path.join(parentPath, name);
+      if (!fs.existsSync(original)) continue;
+
+      if (!credentialBackupRoot) {
+        // A dotted dir at the home ROOT is never in the mounted subdir set, so
+        // the backup itself can't leak into the VM.
+        credentialBackupRoot = path.join(homePath, `.awf-sbx-cred-backup-${process.pid}`);
+        try {
+          fs.mkdirSync(credentialBackupRoot, { recursive: true });
+        } catch (err) {
+          logger.warn(`[sbx] Could not create credential backup dir: ${(err as Error).message}`);
+          credentialBackupRoot = undefined;
+          return;
+        }
+      }
+
+      const backup = path.join(credentialBackupRoot, `${parent}__${name}`.replace(/\//g, '_'));
+      try {
+        fs.renameSync(original, backup);
+        scrubbedCredentials.push({ original, backup });
+        logger.info(`[sbx] Hid credential path from sandbox: ${parent}/${name}`);
+      } catch (err) {
+        logger.warn(`[sbx] Could not hide credential path ${original}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  if (scrubbedCredentials.length > 0 && credentialBackupRoot) {
+    logger.info(
+      `[sbx] Moved ${scrubbedCredentials.length} credential path(s) aside to ${credentialBackupRoot} for the duration of the sandbox`,
+    );
+  }
+}
+
+/**
+ * Restores any credential paths that {@link scrubHomeCredentials} moved aside.
+ * Idempotent and non-throwing; safe to call even when nothing was scrubbed.
+ * MUST run only after the sandbox is removed, because the home dirs are live
+ * mounts — restoring while the VM is running would re-expose the secrets.
+ */
+export function restoreHomeCredentials(): void {
+  for (const { original, backup } of scrubbedCredentials) {
+    try {
+      if (fs.existsSync(backup)) {
+        fs.renameSync(backup, original);
+      }
+    } catch (err) {
+      logger.warn(
+        `[sbx] Could not restore credential path ${original} from ${backup}: ${(err as Error).message}. ` +
+          `The original is preserved at ${backup}.`,
+      );
+    }
+  }
+  scrubbedCredentials = [];
+
+  if (credentialBackupRoot) {
+    try {
+      fs.rmSync(credentialBackupRoot, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup of the (now-empty) backup dir
+    }
+    credentialBackupRoot = undefined;
+  }
 }
 
 /**
@@ -166,45 +266,30 @@ export async function createSandbox(config: SbxConfig): Promise<string> {
   // whitelisted, so they never enter the sandbox. Only paths that exist on the
   // host are mounted, because sbx requires the mount source to exist.
   //
-  // Several whitelisted dirs legitimately hold tool settings but also nest a
-  // credential store — e.g. .config/gh, .config/gcloud, .cargo/credentials,
+  // Each whitelisted parent is mounted WHOLESALE (as a directory): sbx mounts
+  // are positional, directory-granular virtiofs passthroughs and cannot mount an
+  // individual file, so child-by-child expansion would drop loose files the
+  // agent needs (e.g. ~/.copilot/mcp-config.json). Several of these dirs also
+  // nest a credential store — e.g. .config/gh, .cargo/credentials,
   // .claude/.credentials.json, .copilot/config.json, .gemini/oauth_creds.json.
-  // Because sbx cannot mask a nested path once the parent is mounted, those
-  // parents are mounted child-by-child with the known credential children
-  // (CREDENTIAL_EXCLUSIONS_BY_PARENT — directories or files) filtered out.
+  // Those specific paths are moved aside on the host BEFORE `sbx create` (see
+  // scrubHomeCredentials below) and restored after teardown, so the benign tool
+  // state stays available while the secrets never enter the microVM.
   const homePath = process.env.HOME || '/home/runner';
-  const credentialExclusions = new Map<string, Set<string>>(
-    Object.entries(CREDENTIAL_EXCLUSIONS_BY_PARENT).map(([parent, names]) => [parent, new Set(names)]),
-  );
   const homeSubdirs = ['.copilot', ...HOME_TOOL_SUBDIRS, '.gemini'];
   for (const subdir of homeSubdirs) {
     const hostSubdir = `${homePath}/${subdir}`;
     if (seenPaths.has(hostSubdir)) continue;
     if (!fs.existsSync(hostSubdir)) continue;
     seenPaths.add(hostSubdir);
-
-    const excluded = credentialExclusions.get(subdir);
-    if (excluded) {
-      // Mount each child individually so credential dirs/files can be excluded.
-      // The parent mount point itself is created by sbx for the mounted
-      // children, so the excluded credential paths simply never exist in the VM.
-      for (const child of fs.readdirSync(hostSubdir)) {
-        if (excluded.has(child)) {
-          logger.info(`[sbx] Excluding credential path from sandbox: ${subdir}/${child}`);
-          continue;
-        }
-        const childPath = `${hostSubdir}/${child}`;
-        if (seenPaths.has(childPath)) continue;
-        seenPaths.add(childPath);
-        args.push(childPath);
-      }
-      continue;
-    }
-
     args.push(hostSubdir);
   }
 
   logger.info(`[sbx] Running: sbx ${args.join(' ')}`);
+
+  // Move known credential stores out of the wholesale-mounted home dirs before
+  // the sandbox exists, and remember them so they can be restored on teardown.
+  scrubHomeCredentials(homePath);
 
   // Do NOT pass a custom `env` to sbx create. The sanitized env (which strips
   // vars matching TOKEN, SECRET, KEY, etc.) also strips variables the sbx CLI
@@ -245,6 +330,9 @@ export async function createSandbox(config: SbxConfig): Promise<string> {
   const exitCode = createResult.exitCode ?? 1;
 
   if (exitCode !== 0 && !sbxSucceeded) {
+    // Sandbox never came up — restore the scrubbed credentials immediately so a
+    // failed run doesn't leave the user's home directory mutated.
+    restoreHomeCredentials();
     // Log full debug output for diagnostics
     if (stdout) logger.info(`[sbx] create stdout: ${stdout.substring(0, 2000)}`);
     if (stderr) logger.info(`[sbx] create stderr: ${stderr.substring(0, 2000)}`);
@@ -340,8 +428,14 @@ export async function removeSandbox(name: string): Promise<void> {
     logger.warn(
       `Failed to remove sandbox "${name}" (exit ${(rmResult.exitCode ?? 1)}${stderr ? `: ${stderr}` : ''})`
     );
+    // Still restore credentials — the sandbox is being torn down regardless, and
+    // leaving the user's home scrubbed would be worse than a stale sandbox.
+    restoreHomeCredentials();
     return;
   }
+
+  // Sandbox is gone (mounts released) → safe to move credentials back.
+  restoreHomeCredentials();
 
   logger.info(`Sandbox "${name}" removed`);
 }

--- a/src/sbx-manager.ts
+++ b/src/sbx-manager.ts
@@ -23,7 +23,9 @@
  */
 
 import execa from 'execa';
+import * as fs from 'fs';
 import { logger } from './logger';
+import { HOME_TOOL_SUBDIRS } from './services/agent-volumes/home-whitelist';
 
 /** Name prefix for AWF-managed sandboxes. */
 const SBX_NAME_PREFIX = 'awf-agent';
@@ -144,15 +146,33 @@ export async function createSandbox(config: SbxConfig): Promise<string> {
     }
   }
 
-  // Mount /tmp so agent runtime files (prompts, logs) are accessible.
-  // Mount /usr/local/bin for Copilot CLI and other installed tools.
-  // Mount $HOME for agent writable dirs (.cache, .config, .local, etc.)
-  const homePath = process.env.HOME || '/home/runner';
-  for (const sysPath of ['/tmp', '/usr/local/bin', homePath]) {
+  // Mount /tmp so agent runtime files (prompts, logs) are accessible, and
+  // /usr/local/bin for Copilot CLI and other installed tools.
+  for (const sysPath of ['/tmp', '/usr/local/bin']) {
     if (!seenPaths.has(sysPath)) {
       seenPaths.add(sysPath);
       args.push(sysPath);
     }
+  }
+
+  // SECURITY: never mount the whole $HOME into the microVM. sbx mounts are
+  // positional (host path == guest path) and cannot express the per-file
+  // /dev/null credential overlays that compose mode uses (see
+  // credential-hiding.ts), so the only way to keep host secrets out of the VM
+  // is to curate which $HOME subdirs are mounted. We share the same whitelist
+  // as the compose chroot home strategy (HOME_TOOL_SUBDIRS) plus the agent
+  // state dirs (.copilot, .gemini). Credential stores such as ~/.aws, ~/.ssh,
+  // ~/.docker, ~/.kube, ~/.azure, ~/.gnupg, ~/.netrc and ~/.gitconfig are never
+  // whitelisted, so they never enter the sandbox. Only paths that exist on the
+  // host are mounted, because sbx requires the mount source to exist.
+  const homePath = process.env.HOME || '/home/runner';
+  const homeSubdirs = ['.copilot', ...HOME_TOOL_SUBDIRS, '.gemini'];
+  for (const subdir of homeSubdirs) {
+    const hostSubdir = `${homePath}/${subdir}`;
+    if (seenPaths.has(hostSubdir)) continue;
+    if (!fs.existsSync(hostSubdir)) continue;
+    seenPaths.add(hostSubdir);
+    args.push(hostSubdir);
   }
 
   logger.info(`[sbx] Running: sbx ${args.join(' ')}`);

--- a/src/sbx-manager.ts
+++ b/src/sbx-manager.ts
@@ -25,7 +25,7 @@
 import execa from 'execa';
 import * as fs from 'fs';
 import { logger } from './logger';
-import { HOME_TOOL_SUBDIRS } from './services/agent-volumes/home-whitelist';
+import { HOME_TOOL_SUBDIRS, CREDENTIAL_SUBDIR_NAMES, CREDENTIAL_NESTING_SUBDIRS } from './services/agent-volumes/home-whitelist';
 
 /** Name prefix for AWF-managed sandboxes. */
 const SBX_NAME_PREFIX = 'awf-agent';
@@ -165,13 +165,39 @@ export async function createSandbox(config: SbxConfig): Promise<string> {
   // ~/.docker, ~/.kube, ~/.azure, ~/.gnupg, ~/.netrc and ~/.gitconfig are never
   // whitelisted, so they never enter the sandbox. Only paths that exist on the
   // host are mounted, because sbx requires the mount source to exist.
+  //
+  // Some whitelisted dirs (notably ~/.config) legitimately hold tool settings
+  // but can also nest credential stores (e.g. .config/gh, .config/gcloud).
+  // Because sbx cannot mask a nested path once the parent is mounted, those
+  // parents are mounted child-by-child with the known credential subdirs
+  // (CREDENTIAL_SUBDIR_NAMES) filtered out.
   const homePath = process.env.HOME || '/home/runner';
+  const nestingSubdirs = new Set<string>(CREDENTIAL_NESTING_SUBDIRS);
+  const credentialNames = new Set<string>(CREDENTIAL_SUBDIR_NAMES);
   const homeSubdirs = ['.copilot', ...HOME_TOOL_SUBDIRS, '.gemini'];
   for (const subdir of homeSubdirs) {
     const hostSubdir = `${homePath}/${subdir}`;
     if (seenPaths.has(hostSubdir)) continue;
     if (!fs.existsSync(hostSubdir)) continue;
     seenPaths.add(hostSubdir);
+
+    if (nestingSubdirs.has(subdir)) {
+      // Mount each child individually so credential subdirs can be excluded.
+      // The parent mount point itself is created by sbx for the mounted
+      // children, so the excluded credential dirs simply never exist in the VM.
+      for (const child of fs.readdirSync(hostSubdir)) {
+        if (credentialNames.has(child)) {
+          logger.info(`[sbx] Excluding credential directory from sandbox: ${subdir}/${child}`);
+          continue;
+        }
+        const childPath = `${hostSubdir}/${child}`;
+        if (seenPaths.has(childPath)) continue;
+        seenPaths.add(childPath);
+        args.push(childPath);
+      }
+      continue;
+    }
+
     args.push(hostSubdir);
   }
 

--- a/src/sbx-manager.ts
+++ b/src/sbx-manager.ts
@@ -25,7 +25,7 @@
 import execa from 'execa';
 import * as fs from 'fs';
 import { logger } from './logger';
-import { HOME_TOOL_SUBDIRS, CREDENTIAL_SUBDIR_NAMES, CREDENTIAL_NESTING_SUBDIRS } from './services/agent-volumes/home-whitelist';
+import { HOME_TOOL_SUBDIRS, CREDENTIAL_EXCLUSIONS_BY_PARENT } from './services/agent-volumes/home-whitelist';
 
 /** Name prefix for AWF-managed sandboxes. */
 const SBX_NAME_PREFIX = 'awf-agent';
@@ -166,14 +166,16 @@ export async function createSandbox(config: SbxConfig): Promise<string> {
   // whitelisted, so they never enter the sandbox. Only paths that exist on the
   // host are mounted, because sbx requires the mount source to exist.
   //
-  // Some whitelisted dirs (notably ~/.config) legitimately hold tool settings
-  // but can also nest credential stores (e.g. .config/gh, .config/gcloud).
+  // Several whitelisted dirs legitimately hold tool settings but also nest a
+  // credential store — e.g. .config/gh, .config/gcloud, .cargo/credentials,
+  // .claude/.credentials.json, .copilot/config.json, .gemini/oauth_creds.json.
   // Because sbx cannot mask a nested path once the parent is mounted, those
-  // parents are mounted child-by-child with the known credential subdirs
-  // (CREDENTIAL_SUBDIR_NAMES) filtered out.
+  // parents are mounted child-by-child with the known credential children
+  // (CREDENTIAL_EXCLUSIONS_BY_PARENT — directories or files) filtered out.
   const homePath = process.env.HOME || '/home/runner';
-  const nestingSubdirs = new Set<string>(CREDENTIAL_NESTING_SUBDIRS);
-  const credentialNames = new Set<string>(CREDENTIAL_SUBDIR_NAMES);
+  const credentialExclusions = new Map<string, Set<string>>(
+    Object.entries(CREDENTIAL_EXCLUSIONS_BY_PARENT).map(([parent, names]) => [parent, new Set(names)]),
+  );
   const homeSubdirs = ['.copilot', ...HOME_TOOL_SUBDIRS, '.gemini'];
   for (const subdir of homeSubdirs) {
     const hostSubdir = `${homePath}/${subdir}`;
@@ -181,13 +183,14 @@ export async function createSandbox(config: SbxConfig): Promise<string> {
     if (!fs.existsSync(hostSubdir)) continue;
     seenPaths.add(hostSubdir);
 
-    if (nestingSubdirs.has(subdir)) {
-      // Mount each child individually so credential subdirs can be excluded.
+    const excluded = credentialExclusions.get(subdir);
+    if (excluded) {
+      // Mount each child individually so credential dirs/files can be excluded.
       // The parent mount point itself is created by sbx for the mounted
-      // children, so the excluded credential dirs simply never exist in the VM.
+      // children, so the excluded credential paths simply never exist in the VM.
       for (const child of fs.readdirSync(hostSubdir)) {
-        if (credentialNames.has(child)) {
-          logger.info(`[sbx] Excluding credential directory from sandbox: ${subdir}/${child}`);
+        if (excluded.has(child)) {
+          logger.info(`[sbx] Excluding credential path from sandbox: ${subdir}/${child}`);
           continue;
         }
         const childPath = `${hostSubdir}/${child}`;

--- a/src/services/agent-volumes/home-strategy.ts
+++ b/src/services/agent-volumes/home-strategy.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { logger } from '../../logger';
 import { resolveRunnerToolCachePath } from '../../runner-tool-cache';
 import { WrapperConfig } from '../../types';
+import { HOME_TOOL_SUBDIRS } from './home-whitelist';
 
 interface HomeMountsParams {
   config: WrapperConfig;
@@ -42,21 +43,13 @@ function buildToolDirectoryMounts(params: HomeMountsParams): string[] {
   mounts.push(`${sessionStatePath}:/host${effectiveHome}/.copilot/session-state:rw`);
   mounts.push(`${agentLogsPath}:/host${effectiveHome}/.copilot/logs:rw`);
 
-  mounts.push(`${effectiveHome}/.cache:/host${effectiveHome}/.cache:rw`);
-  mounts.push(`${effectiveHome}/.config:/host${effectiveHome}/.config:rw`);
-  mounts.push(`${effectiveHome}/.local:/host${effectiveHome}/.local:rw`);
-
-  mounts.push(`${effectiveHome}/.anthropic:/host${effectiveHome}/.anthropic:rw`);
-  mounts.push(`${effectiveHome}/.claude:/host${effectiveHome}/.claude:rw`);
+  for (const subdir of HOME_TOOL_SUBDIRS) {
+    mounts.push(`${effectiveHome}/${subdir}:/host${effectiveHome}/${subdir}:rw`);
+  }
 
   if (config.geminiApiKey || config.googleApiKey) {
     mounts.push(`${effectiveHome}/.gemini:/host${effectiveHome}/.gemini:rw`);
   }
-
-  mounts.push(`${effectiveHome}/.cargo:/host${effectiveHome}/.cargo:rw`);
-  mounts.push(`${effectiveHome}/.rustup:/host${effectiveHome}/.rustup:rw`);
-  mounts.push(`${effectiveHome}/.npm:/host${effectiveHome}/.npm:rw`);
-  mounts.push(`${effectiveHome}/.nvm:/host${effectiveHome}/.nvm:rw`);
 
   const runnerToolCacheDir = resolveRunnerToolCachePath(config, effectiveHome);
   if (runnerToolCacheDir) {

--- a/src/services/agent-volumes/home-whitelist.test.ts
+++ b/src/services/agent-volumes/home-whitelist.test.ts
@@ -1,7 +1,6 @@
 import {
   HOME_TOOL_SUBDIRS,
-  CREDENTIAL_EXCLUSIONS_BY_PARENT,
-  CREDENTIAL_NESTING_SUBDIRS,
+  CREDENTIAL_PATHS_BY_PARENT,
 } from './home-whitelist';
 
 describe('home-whitelist', () => {
@@ -22,29 +21,28 @@ describe('home-whitelist', () => {
     }
   });
 
-  it('excludes the known nested credential paths for each tool dir', () => {
-    // Compose blanks these via /dev/null overlays; sbx excludes them by mount.
-    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.config']).toEqual(
+  it('enumerates the known nested credential paths for each tool dir', () => {
+    // Compose blanks these via /dev/null overlays; sbx moves them aside before
+    // `sbx create` and restores them after teardown.
+    expect(CREDENTIAL_PATHS_BY_PARENT['.config']).toEqual(
       expect.arrayContaining(['gh', 'gcloud']),
     );
-    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.cargo']).toContain('credentials');
-    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.claude']).toContain('.credentials.json');
-    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.copilot']).toContain('config.json');
-    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.gemini']).toContain('oauth_creds.json');
+    expect(CREDENTIAL_PATHS_BY_PARENT['.cargo']).toContain('credentials');
+    expect(CREDENTIAL_PATHS_BY_PARENT['.claude']).toContain('.credentials.json');
+    expect(CREDENTIAL_PATHS_BY_PARENT['.copilot']).toContain('config.json');
+    expect(CREDENTIAL_PATHS_BY_PARENT['.gemini']).toContain('oauth_creds.json');
   });
 
-  it('treats every exclusion parent as a credential-nesting subdir', () => {
-    expect(CREDENTIAL_NESTING_SUBDIRS).toEqual(
-      Object.keys(CREDENTIAL_EXCLUSIONS_BY_PARENT),
-    );
-    // Every nesting parent must itself be a mounted home subdir (whitelisted
-    // tool dir, or an agent-state dir the sbx path adds: .copilot / .gemini).
+  it('only nests credential paths under mounted home subdirs', () => {
+    // Every credential parent must itself be a mounted home subdir (whitelisted
+    // tool dir, or an agent-state dir the sbx path adds: .copilot / .gemini),
+    // otherwise scrubbing it would be pointless (the parent never enters the VM).
     const mountedHomeSubdirs = new Set<string>([
       '.copilot',
       ...HOME_TOOL_SUBDIRS,
       '.gemini',
     ]);
-    for (const parent of CREDENTIAL_NESTING_SUBDIRS) {
+    for (const parent of Object.keys(CREDENTIAL_PATHS_BY_PARENT)) {
       expect(mountedHomeSubdirs.has(parent)).toBe(true);
     }
   });

--- a/src/services/agent-volumes/home-whitelist.test.ts
+++ b/src/services/agent-volumes/home-whitelist.test.ts
@@ -1,0 +1,38 @@
+import {
+  HOME_TOOL_SUBDIRS,
+  CREDENTIAL_SUBDIR_NAMES,
+  CREDENTIAL_NESTING_SUBDIRS,
+} from './home-whitelist';
+
+describe('home-whitelist', () => {
+  it('never whitelists a top-level credential store directory', () => {
+    const forbidden = [
+      '.aws',
+      '.ssh',
+      '.docker',
+      '.kube',
+      '.azure',
+      '.gnupg',
+      '.netrc',
+      '.gitconfig',
+      '.git-credentials',
+    ];
+    for (const dir of forbidden) {
+      expect(HOME_TOOL_SUBDIRS as readonly string[]).not.toContain(dir);
+    }
+  });
+
+  it('deny-lists the known credential subdirs that compose masks under .config', () => {
+    // Compose blanks .config/gh/hosts.yml and .config/gcloud/credentials.db.
+    expect(CREDENTIAL_SUBDIR_NAMES).toContain('gh');
+    expect(CREDENTIAL_SUBDIR_NAMES).toContain('gcloud');
+  });
+
+  it('treats .config as a credential-nesting parent that must be expanded', () => {
+    expect(CREDENTIAL_NESTING_SUBDIRS).toContain('.config');
+    // Every nesting parent must itself be a whitelisted tool dir.
+    for (const parent of CREDENTIAL_NESTING_SUBDIRS) {
+      expect(HOME_TOOL_SUBDIRS as readonly string[]).toContain(parent);
+    }
+  });
+});

--- a/src/services/agent-volumes/home-whitelist.test.ts
+++ b/src/services/agent-volumes/home-whitelist.test.ts
@@ -1,6 +1,6 @@
 import {
   HOME_TOOL_SUBDIRS,
-  CREDENTIAL_SUBDIR_NAMES,
+  CREDENTIAL_EXCLUSIONS_BY_PARENT,
   CREDENTIAL_NESTING_SUBDIRS,
 } from './home-whitelist';
 
@@ -22,17 +22,30 @@ describe('home-whitelist', () => {
     }
   });
 
-  it('deny-lists the known credential subdirs that compose masks under .config', () => {
-    // Compose blanks .config/gh/hosts.yml and .config/gcloud/credentials.db.
-    expect(CREDENTIAL_SUBDIR_NAMES).toContain('gh');
-    expect(CREDENTIAL_SUBDIR_NAMES).toContain('gcloud');
+  it('excludes the known nested credential paths for each tool dir', () => {
+    // Compose blanks these via /dev/null overlays; sbx excludes them by mount.
+    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.config']).toEqual(
+      expect.arrayContaining(['gh', 'gcloud']),
+    );
+    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.cargo']).toContain('credentials');
+    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.claude']).toContain('.credentials.json');
+    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.copilot']).toContain('config.json');
+    expect(CREDENTIAL_EXCLUSIONS_BY_PARENT['.gemini']).toContain('oauth_creds.json');
   });
 
-  it('treats .config as a credential-nesting parent that must be expanded', () => {
-    expect(CREDENTIAL_NESTING_SUBDIRS).toContain('.config');
-    // Every nesting parent must itself be a whitelisted tool dir.
+  it('treats every exclusion parent as a credential-nesting subdir', () => {
+    expect(CREDENTIAL_NESTING_SUBDIRS).toEqual(
+      Object.keys(CREDENTIAL_EXCLUSIONS_BY_PARENT),
+    );
+    // Every nesting parent must itself be a mounted home subdir (whitelisted
+    // tool dir, or an agent-state dir the sbx path adds: .copilot / .gemini).
+    const mountedHomeSubdirs = new Set<string>([
+      '.copilot',
+      ...HOME_TOOL_SUBDIRS,
+      '.gemini',
+    ]);
     for (const parent of CREDENTIAL_NESTING_SUBDIRS) {
-      expect(HOME_TOOL_SUBDIRS as readonly string[]).toContain(parent);
+      expect(mountedHomeSubdirs.has(parent)).toBe(true);
     }
   });
 });

--- a/src/services/agent-volumes/home-whitelist.ts
+++ b/src/services/agent-volumes/home-whitelist.ts
@@ -35,3 +35,41 @@ export const HOME_TOOL_SUBDIRS = [
   '.npm',
   '.nvm',
 ] as const;
+
+/**
+ * Basenames of directories that are known credential/token stores and must
+ * never be exposed to the agent, even when they are nested inside an otherwise
+ * whitelisted parent such as `~/.config`.
+ *
+ * Whitelisted dirs like `.config` are needed for legitimate tool settings, but
+ * many CLIs stash their auth tokens in a subdirectory of `.config` (rather than
+ * a top-level dotdir). Compose mode blanks the individual files via
+ * `/dev/null` overlays; sbx cannot, so instead it mounts such parents
+ * child-by-child and skips any child whose basename appears here.
+ *
+ * SECURITY: this is a deny-list of credential-centric tool directories. Each
+ * entry's primary purpose is holding secrets, so excluding it wholesale does
+ * not break general development tooling (an agent that needs that service's
+ * credentials should receive them through the API proxy or environment, not by
+ * reading the host's on-disk auth store).
+ */
+export const CREDENTIAL_SUBDIR_NAMES: readonly string[] = [
+  'gh', // GitHub CLI: .config/gh/hosts.yml (oauth_token)
+  'gcloud', // Google Cloud SDK: credentials.db, access_tokens.db, application_default_credentials.json
+  'doctl', // DigitalOcean CLI: config.yaml (access token)
+  'heroku', // Heroku CLI: credential store
+  'hub', // legacy hub CLI: oauth token
+  'rclone', // rclone.conf: remote credentials
+  'containers', // containers/auth.json: registry credentials
+  'pulumi', // Pulumi: credentials.json (access tokens)
+  'op', // 1Password CLI state
+  'helm', // repository auth (repositories.yaml can embed credentials)
+];
+
+/**
+ * Whitelisted home subdirs whose contents may nest credential stores (see
+ * {@link CREDENTIAL_SUBDIR_NAMES}). In sbx these must be mounted one child at a
+ * time — filtering out the credential subdirs — because sbx cannot mask an
+ * individual path once its parent is mounted wholesale.
+ */
+export const CREDENTIAL_NESTING_SUBDIRS: readonly string[] = ['.config'];

--- a/src/services/agent-volumes/home-whitelist.ts
+++ b/src/services/agent-volumes/home-whitelist.ts
@@ -39,11 +39,10 @@ export const HOME_TOOL_SUBDIRS = [
 /**
  * Credential/token stores that live *inside* an otherwise-whitelisted `$HOME`
  * subdir, keyed by the parent subdir's basename. Each value lists the immediate
- * child basenames (directories **or** files) that must never be exposed to the
- * agent.
+ * child basenames (directories **or** files) that are credential stores.
  *
  * Whitelisted dirs such as `.config`, `.cargo`, `.claude`, `.copilot` and
- * `.gemini` are needed for legitimate tool settings, but each also stashes
+ * `.gemini` are needed for legitimate tool settings/state, but each also stashes
  * secrets in a well-known child:
  *
  * - `.config/gh`, `.config/gcloud`, … — per-CLI token stores
@@ -53,18 +52,19 @@ export const HOME_TOOL_SUBDIRS = [
  * - `.gemini/oauth_creds.json`, `.gemini/google_accounts.json` — Gemini OAuth
  *
  * Compose mode blanks these individual paths with `/dev/null` overlays
- * (`credential-hiding.ts`); sbx cannot mask a nested path once the parent is
- * mounted, so it instead mounts these parents **child-by-child** and skips the
- * basenames listed here. sbx recreates the parent mount point for the surviving
- * children, so the excluded secrets never exist inside the microVM while the
- * benign tool state still works.
+ * (`credential-hiding.ts`). sbx mounts are positional virtiofs passthroughs
+ * (host path == guest path, directory-granular) and cannot overlay or mask an
+ * individual nested path, nor mount a single file. So the sbx backend instead
+ * mounts these parents **wholesale** (so their required files still work) but
+ * temporarily **moves these credential paths aside on the host before
+ * `sbx create` and restores them after the sandbox is torn down** — keeping the
+ * secrets out of the VM without dropping the benign tool state the agent needs.
  *
- * SECURITY: entries here are credential-centric, so excluding them wholesale
- * does not break general tooling — an agent that needs a service's credentials
- * should receive them through the API proxy or environment, not by reading the
- * host's on-disk auth store.
+ * SECURITY: entries here are credential-centric. The agent receives whatever
+ * credentials it legitimately needs through the API proxy or environment, not by
+ * reading the host's on-disk auth store, so hiding these paths is safe.
  */
-export const CREDENTIAL_EXCLUSIONS_BY_PARENT: Readonly<Record<string, readonly string[]>> = {
+export const CREDENTIAL_PATHS_BY_PARENT: Readonly<Record<string, readonly string[]>> = {
   '.config': [
     'gh', // GitHub CLI: hosts.yml (oauth_token)
     'gcloud', // Google Cloud SDK: credentials.db, access_tokens.db, application_default_credentials.json
@@ -93,10 +93,3 @@ export const CREDENTIAL_EXCLUSIONS_BY_PARENT: Readonly<Record<string, readonly s
     'access_tokens.json', // Gemini CLI cached access tokens
   ],
 };
-
-/**
- * Whitelisted home subdirs that must be mounted one child at a time (filtering
- * {@link CREDENTIAL_EXCLUSIONS_BY_PARENT}) because they nest credential stores
- * that sbx cannot mask once the parent is mounted wholesale.
- */
-export const CREDENTIAL_NESTING_SUBDIRS: readonly string[] = Object.keys(CREDENTIAL_EXCLUSIONS_BY_PARENT);

--- a/src/services/agent-volumes/home-whitelist.ts
+++ b/src/services/agent-volumes/home-whitelist.ts
@@ -37,39 +37,66 @@ export const HOME_TOOL_SUBDIRS = [
 ] as const;
 
 /**
- * Basenames of directories that are known credential/token stores and must
- * never be exposed to the agent, even when they are nested inside an otherwise
- * whitelisted parent such as `~/.config`.
+ * Credential/token stores that live *inside* an otherwise-whitelisted `$HOME`
+ * subdir, keyed by the parent subdir's basename. Each value lists the immediate
+ * child basenames (directories **or** files) that must never be exposed to the
+ * agent.
  *
- * Whitelisted dirs like `.config` are needed for legitimate tool settings, but
- * many CLIs stash their auth tokens in a subdirectory of `.config` (rather than
- * a top-level dotdir). Compose mode blanks the individual files via
- * `/dev/null` overlays; sbx cannot, so instead it mounts such parents
- * child-by-child and skips any child whose basename appears here.
+ * Whitelisted dirs such as `.config`, `.cargo`, `.claude`, `.copilot` and
+ * `.gemini` are needed for legitimate tool settings, but each also stashes
+ * secrets in a well-known child:
  *
- * SECURITY: this is a deny-list of credential-centric tool directories. Each
- * entry's primary purpose is holding secrets, so excluding it wholesale does
- * not break general development tooling (an agent that needs that service's
- * credentials should receive them through the API proxy or environment, not by
- * reading the host's on-disk auth store).
+ * - `.config/gh`, `.config/gcloud`, … — per-CLI token stores
+ * - `.cargo/credentials`, `.cargo/credentials.toml` — crates.io registry tokens
+ * - `.claude/.credentials.json` — Claude Code OAuth tokens
+ * - `.copilot/config.json` — Copilot CLI can persist its token here
+ * - `.gemini/oauth_creds.json`, `.gemini/google_accounts.json` — Gemini OAuth
+ *
+ * Compose mode blanks these individual paths with `/dev/null` overlays
+ * (`credential-hiding.ts`); sbx cannot mask a nested path once the parent is
+ * mounted, so it instead mounts these parents **child-by-child** and skips the
+ * basenames listed here. sbx recreates the parent mount point for the surviving
+ * children, so the excluded secrets never exist inside the microVM while the
+ * benign tool state still works.
+ *
+ * SECURITY: entries here are credential-centric, so excluding them wholesale
+ * does not break general tooling — an agent that needs a service's credentials
+ * should receive them through the API proxy or environment, not by reading the
+ * host's on-disk auth store.
  */
-export const CREDENTIAL_SUBDIR_NAMES: readonly string[] = [
-  'gh', // GitHub CLI: .config/gh/hosts.yml (oauth_token)
-  'gcloud', // Google Cloud SDK: credentials.db, access_tokens.db, application_default_credentials.json
-  'doctl', // DigitalOcean CLI: config.yaml (access token)
-  'heroku', // Heroku CLI: credential store
-  'hub', // legacy hub CLI: oauth token
-  'rclone', // rclone.conf: remote credentials
-  'containers', // containers/auth.json: registry credentials
-  'pulumi', // Pulumi: credentials.json (access tokens)
-  'op', // 1Password CLI state
-  'helm', // repository auth (repositories.yaml can embed credentials)
-];
+export const CREDENTIAL_EXCLUSIONS_BY_PARENT: Readonly<Record<string, readonly string[]>> = {
+  '.config': [
+    'gh', // GitHub CLI: hosts.yml (oauth_token)
+    'gcloud', // Google Cloud SDK: credentials.db, access_tokens.db, application_default_credentials.json
+    'doctl', // DigitalOcean CLI: config.yaml (access token)
+    'heroku', // Heroku CLI: credential store
+    'hub', // legacy hub CLI: oauth token
+    'rclone', // rclone.conf: remote credentials
+    'containers', // containers/auth.json: registry credentials
+    'pulumi', // Pulumi: credentials.json (access tokens)
+    'op', // 1Password CLI state
+    'helm', // repository auth (repositories.yaml can embed credentials)
+  ],
+  '.cargo': [
+    'credentials', // crates.io registry token
+    'credentials.toml', // crates.io registry token (newer cargo)
+  ],
+  '.claude': [
+    '.credentials.json', // Claude Code OAuth tokens
+  ],
+  '.copilot': [
+    'config.json', // Copilot CLI may persist its auth token here
+  ],
+  '.gemini': [
+    'oauth_creds.json', // Gemini CLI OAuth access/refresh tokens
+    'google_accounts.json', // Gemini CLI account identity
+    'access_tokens.json', // Gemini CLI cached access tokens
+  ],
+};
 
 /**
- * Whitelisted home subdirs whose contents may nest credential stores (see
- * {@link CREDENTIAL_SUBDIR_NAMES}). In sbx these must be mounted one child at a
- * time — filtering out the credential subdirs — because sbx cannot mask an
- * individual path once its parent is mounted wholesale.
+ * Whitelisted home subdirs that must be mounted one child at a time (filtering
+ * {@link CREDENTIAL_EXCLUSIONS_BY_PARENT}) because they nest credential stores
+ * that sbx cannot mask once the parent is mounted wholesale.
  */
-export const CREDENTIAL_NESTING_SUBDIRS: readonly string[] = ['.config'];
+export const CREDENTIAL_NESTING_SUBDIRS: readonly string[] = Object.keys(CREDENTIAL_EXCLUSIONS_BY_PARENT);

--- a/src/services/agent-volumes/home-whitelist.ts
+++ b/src/services/agent-volumes/home-whitelist.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical whitelist of `$HOME` subdirectories that agents legitimately need
+ * (tool caches, language toolchains, agent state).
+ *
+ * This list is the single source of truth shared by **both** sandbox backends
+ * so their home-directory exposure stays in sync:
+ *
+ * - **Compose / chroot mode** (`home-strategy.ts`) mounts an empty home volume
+ *   and then bind-mounts these subdirs on top, and additionally blanks known
+ *   credential files with `/dev/null` overlays (`credential-hiding.ts`).
+ * - **sbx microVM mode** (`sbx-manager.ts`) mounts these subdirs individually
+ *   instead of the whole `$HOME`. sbx uses positional (host path == guest path)
+ *   mounts and cannot express per-file `/dev/null` overlays, so directory
+ *   curation is its only mechanism — which makes this whitelist the primary
+ *   protection there.
+ *
+ * SECURITY: never add a directory whose primary purpose is storing credentials
+ * (for example `.aws`, `.ssh`, `.docker`, `.kube`, `.azure`, `.gnupg`). Any such
+ * store must stay OUT of the sandbox. Directories listed here can still contain
+ * stray secret files; compose mode masks the known ones via
+ * `buildCredentialHidingOverlays()`, but sbx cannot, so keep this list to
+ * genuinely non-credential tooling paths.
+ *
+ * `.gemini` is intentionally NOT included: compose mode mounts it only when a
+ * Gemini/Google API key is configured, so each caller handles it separately.
+ */
+export const HOME_TOOL_SUBDIRS = [
+  '.cache',
+  '.config',
+  '.local',
+  '.anthropic',
+  '.claude',
+  '.cargo',
+  '.rustup',
+  '.npm',
+  '.nvm',
+] as const;


### PR DESCRIPTION
## Problem

The sbx microVM path mounted the **entire host `$HOME`** (read-write) into the sandbox, exposing any credential files there (`~/.aws`, `~/.ssh`, `~/.docker/config.json`, `~/.kube`, `~/.azure`, `~/.npmrc`, `~/.gitconfig`, `~/.config/gh/hosts.yml`, `~/.config/gcloud/*`, …) to the agent. Compose mode already defends against this with an empty home volume + a tool-subdir whitelist + `/dev/null` overlays on known credential files (`credential-hiding.ts`); the sbx path had none of that — it only sanitizes env vars, not files.

## Why not just port the `/dev/null` overlay?

sbx can't. Its mounts are **positional and directory-granular (host path == guest path)** — there's no way to map `/dev/null` onto a specific destination file, and an individual *file* can't be a positional mount at all. So the compose overlay trick isn't expressible; the only levers are **which directories get mounted** and **what those directories contain on the host at create time**.

## Fix

Two layers, both driven by the shared `home-whitelist.ts` so the sbx and compose paths can't drift:

1. **Top-level whitelist.** `sbx-manager.ts` stops mounting the whole `$HOME`. It mounts only a curated whitelist of tool/cache + agent-state subdirs (`HOME_TOOL_SUBDIRS` + `.copilot`/`.gemini`), and only those that exist on the host. Top-level credential stores (`.aws`, `.ssh`, `.docker`, `.kube`, `.azure`, `.gnupg`, `.netrc`, …) are never whitelisted, so they never enter the VM. Each whitelisted dir is mounted **wholesale** (as a directory) so its required loose files — e.g. `~/.copilot/mcp-config.json`, `~/.copilot/settings.json` — still work.

2. **Scrub nested credential stores.** Several whitelisted dirs legitimately hold tool settings but also stash a secret in a well-known child: `.config/gh`, `.config/gcloud`, …; `.cargo/credentials[.toml]`; `.claude/.credentials.json`; `.copilot/config.json`; `.gemini/oauth_creds.json` / `google_accounts.json`. Since the parent is mounted wholesale and sbx can't overlay/mask a nested path, the manager **moves those credential paths aside on the host before `sbx create`** (into a `.awf-sbx-cred-backup-<pid>` dir at the home root — never a mounted subdir) and **restores them after the sandbox is torn down** (`scrubHomeCredentials` / `restoreHomeCredentials`). This is the sbx analog of compose mode's `/dev/null` overlays. The credential list lives in the shared `CREDENTIAL_PATHS_BY_PARENT`.

Agent credentials come from the api-proxy or environment, not from the host's on-disk auth store, so hiding these paths is safe.

## Why this replaces the earlier child-by-child approach

The previous revision expanded these parents child-by-child, skipping credential children. That broke the `Smoke Docker Sbx` CI: expansion tried to mount loose *files* (e.g. `~/.copilot/mcp-config.json`) as sbx positional mounts, which must be directories — `sbx create failed: workspace path exists but is not a directory`. Wholesale-mount-plus-scrub preserves those required files while still keeping secrets out.

## Review feedback

Both Copilot review comments (credential files in `.cargo`/`.claude` and in `.copilot`/`.gemini`) are addressed: those paths are in `CREDENTIAL_PATHS_BY_PARENT` and scrubbed before create.

## Verification

- **Tests:** whole `$HOME` never mounted; whitelisted dirs mount only when they exist; top-level credential stores stay out; `.config`/`.cargo`/`.claude`/`.copilot`/`.gemini` mounted wholesale with their nested token stores moved aside before create; scrubbed credentials restored after `removeSandbox`; whitelist-invariant guards.
- `npm test`: 242 suites / **3823 tests pass**. `npm run build` clean. ESLint: 0 errors.

## Notes

- Compose mode masks `.cargo/credentials` etc. via `/dev/null`, but does **not** yet mask `.claude`/`.copilot`/`.gemini` token files — a separate compose gap worth closing in the deferred centralized mount-policy refactor.
- `docs/sbx-integration.md` is updated to the wholesale + scrub model.
- With `--keep-containers`, restore is deferred until the sandbox is eventually removed; the backup location is logged so a scrubbed home is always recoverable.
