### PR TITLE
fix(smoke-copilot): revert agent job to read-only perms to unblock CI

### DIFF
--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -444,8 +444,8 @@ jobs:
       actions: read
       contents: read
       copilot-requests: write
-      issues: write
-      pull-requests: write
+      issues: read
+      pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""

--- a/.github/workflows/smoke-copilot.md
+++ b/.github/workflows/smoke-copilot.md
@@ -11,8 +11,8 @@ on:
   reaction: "eyes"
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
+  pull-requests: read
+  issues: read
   actions: read
   copilot-requests: write
 name: Smoke Copilot


### PR DESCRIPTION
## Problem

The `Smoke Copilot` activation check (`Check workflow lock file`) is failing on **every open PR** — including unrelated ones like #6362 that never touch smoke-copilot — with:

```
ERR_CONFIG: Lock file '.github/workflows/smoke-copilot.lock.yml' is outdated!
The workflow file '.github/workflows/smoke-copilot.md' frontmatter has changed.
```

## Root cause

PR #6366 changed the smoke-copilot **agent job** permissions to `issues: write` / `pull-requests: write`. However, the gh-aw compiler (v0.82.13) **forbids write permissions on the agent job** — writes must go through `safe-outputs`, which uses a scoped GitHub App token.

Because the write-perm `.md` cannot be compiled, its lock file's `frontmatter_hash` was never regenerated and stayed at the **read**-perm value (`008d5a5c…`), while the `.md` advertised **write** perms (hash `81338ace…`). Since PR CI builds the branch **merged with `main`**, every PR inherits main's write-perm `.md` against the read-perm lock hash and fails the activation check.

## Fix

Revert `issues` / `pull-requests` to `read` (safe-outputs already handles the comment/label writes via its scoped token) and recompile so `.md` and `.lock.yml` are consistent again (`frontmatter_hash: 008d5a5c…`).

This unblocks CI across all open PRs.

## Verification

- `gh aw compile smoke-copilot` → 0 errors (v0.82.13)
- `.md` frontmatter hash now matches the committed lock (`008d5a5c…`)
- `npm test` → 244 suites / 3851 tests pass

## Scope

Only two files change: `smoke-copilot.md` and `smoke-copilot.lock.yml`.