### PR TITLE
chore: upgrade gh-aw to v0.82.13 (pre-release) and recompile workflows

### DIFF
--- a/.github/workflows/secret-digger-codex.lock.yml
+++ b/.github/workflows/secret-digger-codex.lock.yml
@@ -1607,7 +1607,6 @@ jobs:
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
           base_url = "http://172.30.0.30:10000"
-          env_key = "OPENAI_API_KEY"
           supports_websockets = false
           [shell_environment_policy]
           inherit = "core"


### PR DESCRIPTION
## Summary

Upgrades the `gh-aw` extension to the latest pre-release version (v0.82.13) and recompiles all agentic workflow lock files.

## Changes

- Upgraded `gh-aw` extension to latest pre-release v0.82.13 via `gh aw upgrade --pre-releases`
- Recompiled all agentic workflow lock files with post-processing applied
- Removed legacy `env_key` from openai-proxy provider in codex config (`secret-digger-codex.lock.yml`)

## Testing

- All 3885 tests pass (`npm test` — 245 test suites)