### PR TITLE
fix: exempt DIFC/cli-proxy host from proxy routing in isolation mode

### DIFF
--- a/src/services/agent-environment/proxy-environment.test.ts
+++ b/src/services/agent-environment/proxy-environment.test.ts
@@ -57,6 +57,34 @@ describe('buildProxyEnvironment', () => {
       expect(env.NO_PROXY.split(',')).toContain('awmg-cli-proxy');
     });
 
+    it('strips port suffix from difcProxyHost', () => {
+      const env = run({
+        ...baseConfig,
+        networkIsolation: true,
+        difcProxyHost: 'awmg-cli-proxy:8443',
+      });
+      expect(env.NO_PROXY.split(',')).toContain('awmg-cli-proxy');
+      expect(env.NO_PROXY.split(',')).not.toContain('awmg-cli-proxy:8443');
+    });
+
+    it('strips scheme and port from a scheme-prefixed difcProxyHost', () => {
+      const env = run({
+        ...baseConfig,
+        networkIsolation: true,
+        difcProxyHost: 'https://proxy.internal:443',
+      });
+      expect(env.NO_PROXY.split(',')).toContain('proxy.internal');
+    });
+
+    it('strips brackets and port from a bracketed IPv6 difcProxyHost', () => {
+      const env = run({
+        ...baseConfig,
+        networkIsolation: true,
+        difcProxyHost: '[::1]:18443',
+      });
+      expect(env.NO_PROXY.split(',')).toContain('::1');
+    });
+
     it('does NOT exempt topology peers outside network-isolation mode', () => {
       const env = run({
         ...baseConfig,

--- a/src/services/agent-environment/proxy-environment.ts
+++ b/src/services/agent-environment/proxy-environment.ts
@@ -2,6 +2,7 @@ import { WrapperConfig } from '../../types';
 import { NetworkConfig } from '../squid-service';
 import { buildNoProxyValue } from '../no-proxy-utils';
 import { runtimeUsesIptables, runtimeUsesComposeAgent } from '../../container-runtime';
+import { parseDifcProxyHost } from '../../host-env';
 
 interface ProxyEnvironmentParams {
   config: WrapperConfig;
@@ -36,10 +37,12 @@ export function buildProxyEnvironment(params: ProxyEnvironmentParams): void {
       noProxyHosts.push(...config.topologyAttach);
     }
     // The DIFC/cli-proxy host is addressed by proxy-aware clients directly and
-    // must bypass Squid even when it isn't listed in topologyAttach. Strip any
-    // ":port" suffix since undici matches NO_PROXY against the hostname only.
+    // must bypass Squid even when it isn't listed in topologyAttach.
+    // Use parseDifcProxyHost to correctly strip scheme prefixes and handle
+    // bracketed IPv6 (e.g. https://proxy.internal:443, [::1]:18443), since
+    // undici matches NO_PROXY against the hostname only.
     if (config.difcProxyHost) {
-      noProxyHosts.push(config.difcProxyHost.split(':')[0]);
+      noProxyHosts.push(parseDifcProxyHost(config.difcProxyHost).host);
     }
   }
 

--- a/src/services/agent-environment/proxy-environment.ts
+++ b/src/services/agent-environment/proxy-environment.ts
@@ -35,6 +35,12 @@ export function buildProxyEnvironment(params: ProxyEnvironmentParams): void {
     if (config.topologyAttach) {
       noProxyHosts.push(...config.topologyAttach);
     }
+    // The DIFC/cli-proxy host is addressed by proxy-aware clients directly and
+    // must bypass Squid even when it isn't listed in topologyAttach. Strip any
+    // ":port" suffix since undici matches NO_PROXY against the hostname only.
+    if (config.difcProxyHost) {
+      noProxyHosts.push(config.difcProxyHost.split(':')[0]);
+    }
   }
 
   // The MCP gateway is served on the network gateway (e.g. 172.30.0.1). In


### PR DESCRIPTION
## Summary

`npm test` was failing on `main` with one broken test in `src/services/agent-environment/proxy-environment.test.ts`:

```
buildProxyEnvironment › topology-attached peers › exempts the DIFC/cli-proxy host even when not listed in topologyAttach
```

`buildProxyEnvironment` only added `config.topologyAttach` peers to `NO_PROXY`. A `difcProxyHost` configured independently of `topologyAttach` was therefore routed through Squid and denied instead of being reached directly.

## Fix

In network-isolation mode with a compose agent, also add `config.difcProxyHost` to `NO_PROXY`, stripping any `:port` suffix (undici matches `NO_PROXY` against the hostname only).

## Testing

- `npm test` — all 3959 tests pass (was 1 failing).