### PR TITLE
fix(docs-site): resolve high-severity js-yaml npm audit finding

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -2590,9 +2590,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
-      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -3723,9 +3723,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4773,9 +4773,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Clears the **high-severity** \`js-yaml\` advisory that is failing the \`dependency-audit\` workflow's \`--audit-level=high\` gate for the docs-site package.

Applied via \`npm audit fix\` (non-breaking, lockfile-only):

| Package | Change | Advisory |
|---|---|---|
| \`js-yaml\` | 4.2.0 → 4.3.0 | **high** — quadratic CPU via YAML merge-key chains (GHSA-52cp-r559-cp3m) |
| \`dompurify\` | → 3.4.12 | moderate — \`ALLOWED_ATTR\` pollution (GHSA-cmwh-pvxp-8882) |
| \`astro\` | 6.4.6 → 6.4.8 | patch |

Only \`docs-site/package-lock.json\` changes — existing \`package.json\` version ranges already permit these.

## Why

The \`Audit Docs Site Package\` job in \`dependency-audit.yml\` fails on any high/critical finding. This unblocks that gate (e.g. on #6445 and any other PR).

## Verification

- \`npm ci\` succeeds with the updated lockfile
- \`npm audit --audit-level=high\` now exits 0 (was exit 1)
- Resolved URLs / integrity hashes kept on the public npm registry (registry.npmjs.org, sha512)

## Out of scope

- Remaining \`astro\`-ecosystem **moderate** advisories require a breaking major bump — left for a separate change since they don't trip the high-level gate.
- A pre-existing \`astro check\` build failure (\`LegacyContentConfigError\`, incomplete astro v6 migration) exists on \`main\` independent of this change.