### PR TITLE
fix(agent): restore python3 in agent image for seccomp regression check

### DIFF
--- a/containers/agent/Dockerfile
+++ b/containers/agent/Dockerfile
@@ -198,7 +198,10 @@ RUN set -eux; \
       force_archive_mirror; \
       apt-get install -y --no-install-recommends "$@"; \
     }; \
-    PARITY_PKGS="libgdiplus libev-dev libssl-dev php-intl php-gd"; \
+    # python3 is commonly needed by workflows and is also required by the
+    # release-time seccomp regression check (scripts/ci/check-agent-seccomp-syscalls.sh),
+    # which uses python3+ctypes to fire name_to_handle_at/open_by_handle_at.
+    PARITY_PKGS="libgdiplus libev-dev libssl-dev php-intl php-gd python3"; \
     apt_update_retry && \
     apt_install_retry $PARITY_PKGS && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

The release workflow's **"Verify seccomp blocks name_to_handle_at/open_by_handle_at"** step started failing ([run 30055796826](https://github.com/github/gh-aw-firewall/actions/runs/30055796826/job/89367103743)) with:

```
Image does not contain python3, cannot run seccomp syscall regression check
```

That release-time check (`scripts/ci/check-agent-seccomp-syscalls.sh`) runs `docker run --entrypoint python3 <agent-image>` and uses `python3` + `ctypes` to fire the raw `name_to_handle_at` / `open_by_handle_at` syscalls and assert the seccomp profile denies them.

`python3` had been present in the agent image **transitively** (via the old NodeSource apt install of Node.js) and the prior release (v0.27.39) ran the probe successfully. **PR #6545** ("resolve High/Critical CVEs in agent, api-proxy, and cli-proxy container images", commit `9bfc7260`) reworked the package install and switched Node.js from the NodeSource `.deb` to the official static tarball — the only change to `containers/agent/Dockerfile` between the passing and failing releases — which inadvertently dropped that transitive `python3`.

## Fix

Restore `python3` explicitly by adding it to the agent image's package list. This returns the image to its prior (working) state for the seccomp check, and `python3` is also commonly needed by agent workflows, matching the GitHub runner images. `--no-install-recommends` still pulls `libpython3.10-stdlib`, so `ctypes` (used by the probe) is available.

The seccomp check script and profile are unchanged.

## Notes

- The CVEs #6545 fixed were in the Node.js/gosu Go binaries, not Python, so restoring `python3` does not undo that remediation.
- Diff is a single line in `containers/agent/Dockerfile`.