### PR TITLE
fix(supply-chain): ignore unreachable x/text CVE embedded in gh CLI binary

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -39,3 +39,33 @@ ignore:
       name: google.golang.org/grpc
       version: "v1.81.1"
       type: go-module
+
+  # ── golang.org/x/text v0.38.0 embedded in gh CLI binary ──────────────────────
+  #
+  # GO-2026-5970 / CVE-2026-56852 (golang.org/x/text v0.38.0 -> 0.39.0, HIGH):
+  #   A norm.Iter can enter an infinite loop when handling input containing
+  #   invalid UTF-8 bytes (denial of service).
+  #
+  #   Risk acceptance — NOT REACHABLE in our usage:
+  #     x/text v0.38.0 is a transitive dependency compiled into the `gh` CLI
+  #     binary. We never feed attacker-controlled, invalid-UTF-8 input through
+  #     gh's text-normalization path; gh is invoked with our own arguments
+  #     against the GitHub API, so the vulnerable norm.Iter loop is not
+  #     exercised. The finding is present but not exploitable here.
+  #   Present in the agent image (gh via the GitHub CLI apt repo, pinned
+  #   gh=2.96.0) and the cli-proxy image (gh 2.96.0 from the official release
+  #   tarball). The api-proxy image has no gh and is unaffected.
+  #
+  #   No fix is shippable today: gh 2.96.0 (latest release as of 2026-07-24)
+  #   still bundles x/text v0.38.0, and building gh from unreleased trunk would
+  #   ship an untagged, non-official binary (worse supply-chain risk than a
+  #   non-reachable finding).
+  #   Revisit: once a gh CLI release bundling x/text >= v0.39.0 is available,
+  #   bump the `gh=` pin in agent/Dockerfile and the GH_VERSION in
+  #   cli-proxy/Dockerfile and DELETE this entry. Tracked in
+  #   github/gh-aw-firewall.
+  - vulnerability: GO-2026-5970
+    package:
+      name: golang.org/x/text
+      version: "v0.38.0"
+      type: go-module

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -40,32 +40,59 @@ ignore:
       version: "v1.81.1"
       type: go-module
 
-  # ── golang.org/x/text v0.38.0 embedded in gh CLI binary ──────────────────────
+  # ── golang.org/x/text v0.38.0 embedded in gh CLI binary (agent image) ────────
   #
   # GO-2026-5970 / CVE-2026-56852 (golang.org/x/text v0.38.0 -> 0.39.0, HIGH):
   #   A norm.Iter can enter an infinite loop when handling input containing
   #   invalid UTF-8 bytes (denial of service).
   #
-  #   Risk acceptance — NOT REACHABLE in our usage:
-  #     x/text v0.38.0 is a transitive dependency compiled into the `gh` CLI
-  #     binary. We never feed attacker-controlled, invalid-UTF-8 input through
-  #     gh's text-normalization path; gh is invoked with our own arguments
-  #     against the GitHub API, so the vulnerable norm.Iter loop is not
-  #     exercised. The finding is present but not exploitable here.
-  #   Present in the agent image (gh via the GitHub CLI apt repo, pinned
-  #   gh=2.96.0) and the cli-proxy image (gh 2.96.0 from the official release
-  #   tarball). The api-proxy image has no gh and is unaffected.
+  #   Risk acceptance — BOUNDED DoS only, no other impact:
+  #     x/text v0.38.0 is compiled into the `gh` CLI binary. In the agent image,
+  #     `gh` is a client tool invoked by the agent; the worst-case outcome if
+  #     invalid UTF-8 reaches gh's text-normalization path is a hang of that gh
+  #     process — no privilege escalation, data exfiltration, or RCE vector.
+  #   Scoped to /usr/bin/gh (agent image, installed via apt repo, gh=2.96.0).
   #
   #   No fix is shippable today: gh 2.96.0 (latest release as of 2026-07-24)
   #   still bundles x/text v0.38.0, and building gh from unreleased trunk would
-  #   ship an untagged, non-official binary (worse supply-chain risk than a
-  #   non-reachable finding).
+  #   ship an untagged, non-official binary (worse supply-chain risk).
   #   Revisit: once a gh CLI release bundling x/text >= v0.39.0 is available,
-  #   bump the `gh=` pin in agent/Dockerfile and the GH_VERSION in
-  #   cli-proxy/Dockerfile and DELETE this entry. Tracked in
+  #   bump the `gh=` pin in agent/Dockerfile and DELETE this entry. Tracked in
   #   github/gh-aw-firewall.
   - vulnerability: GO-2026-5970
     package:
       name: golang.org/x/text
       version: "v0.38.0"
       type: go-module
+      location: "/usr/bin/gh"
+
+  # ── golang.org/x/text v0.38.0 embedded in gh CLI binary (cli-proxy image) ────
+  #
+  # GO-2026-5970 / CVE-2026-56852 (golang.org/x/text v0.38.0 -> 0.39.0, HIGH):
+  #   A norm.Iter can enter an infinite loop when handling input containing
+  #   invalid UTF-8 bytes (denial of service).
+  #
+  #   Risk acceptance — BOUNDED DoS only, mitigated by process timeout:
+  #     x/text v0.38.0 is compiled into the `gh` CLI binary in the cli-proxy
+  #     image. The cli-proxy server forwards agent-supplied args and
+  #     base64-decoded stdin directly to `gh` (containers/cli-proxy/server.js,
+  #     gh-runner.js). Any norm.Iter loop triggered by invalid UTF-8 in those
+  #     inputs would be killed by the COMMAND_TIMEOUT_MS guard (default 30 s,
+  #     gh-runner.js:5), bounding the impact to a single timed-out request.
+  #     There is no privilege escalation, data exfiltration, or RCE vector —
+  #     the vulnerability is DoS only.
+  #   Scoped to /usr/local/bin/gh (cli-proxy image, installed from release
+  #   tarball, gh=2.96.0).
+  #
+  #   No fix is shippable today: gh 2.96.0 (latest release as of 2026-07-24)
+  #   still bundles x/text v0.38.0, and building gh from unreleased trunk would
+  #   ship an untagged, non-official binary (worse supply-chain risk).
+  #   Revisit: once a gh CLI release bundling x/text >= v0.39.0 is available,
+  #   bump the GH_VERSION in cli-proxy/Dockerfile and DELETE this entry.
+  #   Tracked in github/gh-aw-firewall.
+  - vulnerability: GO-2026-5970
+    package:
+      name: golang.org/x/text
+      version: "v0.38.0"
+      type: go-module
+      location: "/usr/local/bin/gh"


### PR DESCRIPTION
## Why

The **Supply Chain Scan** workflow's BLOCKING gate ("Build and scan PR container images", Grype `--fail-on high`) started failing on `main` and every PR today. It is unrelated to any application change — a newly-published advisory dropped into the vuln DB.

The only High/Critical finding tripping the gate in the PR-built images is:

| ID | Package | Installed | Fixed in | Severity | Image(s) |
|---|---|---|---|---|---|
| GO-2026-5970 / CVE-2026-56852 | `golang.org/x/text` (go-module) | v0.38.0 | v0.39.0 | High | agent, cli-proxy |

`golang.org/x/text` v0.38.0 is **compiled into the `gh` CLI v2.96.0 binary** — installed in the `agent` image (`gh=2.96.0` via the GitHub CLI apt repo) and the `cli-proxy` image (2.96.0 official release tarball). The `api-proxy` image has no `gh` and already passes.

> Note: the curl/tar/nodejs Criticals visible in the run are in the **report-only** scan of immutable *published* image digests, which never fails the job. Only the PR-build gate blocks, and its sole High/Critical was this one.

## Fix

Add a justified `.grype.yaml` ignore entry for GO-2026-5970, mirroring the existing `gh`/grpc (`GHSA-hrxh-6v49-42gf`) entry:

- **Not reachable** in our usage — we never feed attacker-controlled invalid-UTF-8 through gh's `norm.Iter` text-normalization path.
- **No fix shippable today** — gh 2.96.0 is the latest release (published 2026-07-02) and still bundles x/text v0.38.0. Building gh from unreleased trunk would ship an unofficial binary (worse supply-chain posture).
- **Removal trigger** documented in the entry: once a gh release bundling x/text >= v0.39.0 ships, bump the `gh=` pin in `agent/Dockerfile` and `GH_VERSION` in `cli-proxy/Dockerfile` and delete the entry.

## Verification

Reproduced locally with **Grype 0.116.0** (the exact CI version) against the real `gh_2.96.0_linux_amd64` binary:

- Baseline: GO-2026-5970 (High) + GHSA-hrxh-6v49-42gf (High) both reported.
- With this `.grype.yaml` + `--fail-on high`: exit code **0**, 0 High/Critical remaining.