### PR TITLE
test: drop stale smoke-copilot-pat references

### DIFF
--- a/scripts/ci/ready-for-aw-workflows.test.ts
+++ b/scripts/ci/ready-for-aw-workflows.test.ts
@@ -12,7 +12,6 @@ const readyForCiLockFiles = [
   'smoke-copilot-byok-aoai-apikey.lock.yml',
   'smoke-copilot-byok-aoai-entra.lock.yml',
   'smoke-copilot-byok.lock.yml',
-  'smoke-copilot-pat.lock.yml',
   'smoke-copilot.lock.yml',
   'smoke-copilot-network-isolation.lock.yml',
   'smoke-gemini.lock.yml',

--- a/scripts/ci/smoke-copilot-workflow.test.ts
+++ b/scripts/ci/smoke-copilot-workflow.test.ts
@@ -9,7 +9,6 @@ const copilotSmokeWorkflows = [
   { name: 'smoke-copilot-byok', file: 'smoke-copilot-byok.md' },
   { name: 'smoke-copilot', file: 'smoke-copilot.md' },
   { name: 'smoke-copilot-network-isolation', file: 'smoke-copilot-network-isolation.md' },
-  { name: 'smoke-copilot-pat', file: 'smoke-copilot-pat.md' },
 ];
 
 describe('smoke copilot workflow output requirements', () => {


### PR DESCRIPTION
## Summary

`npm test` on `main` fails with 2 failing suites because they still reference the `smoke-copilot-pat` workflow, which was deleted in #6570.

## Root cause

Commit `5e5ae7bf` (#6570) deleted `.github/workflows/smoke-copilot-pat.md` and `.github/workflows/smoke-copilot-pat.lock.yml`, but left references in two CI test files, causing `ENOENT` failures:

- `scripts/ci/smoke-copilot-workflow.test.ts`
- `scripts/ci/ready-for-aw-workflows.test.ts`

## Fix

Remove the stale `smoke-copilot-pat` entries from both test lists.

## Verification

```
Test Suites: 252 passed, 252 total
Tests:       4016 passed, 4016 total
```