### PR TITLE
fix: use bounded query smoke API

### DIFF
--- a/containers/bounded-query/broker/query-runner.js
+++ b/containers/bounded-query/broker/query-runner.js
@@ -15,7 +15,7 @@ const { execFile } = require('child_process');
 const CLI_GRACE_MS = 5_000;
 
 /** Maximum file size a query may create, in bytes (per-file RLIMIT_FSIZE). */
-const QUERY_MAX_FILE_BYTES = 64 * 1024 * 1024;
+const QUERY_MAX_FILE_BYTES = 512 * 1024 * 1024;
 
 /**
  * Aggregate size limit for the query's writable tmpfs workspace in bytes.
@@ -23,7 +23,7 @@ const QUERY_MAX_FILE_BYTES = 64 * 1024 * 1024;
  * `/query` is backed by a tmpfs of this size, bounding the total amount of
  * new data the query can write outside the pre-seeded repo copy.
  */
-const QUERY_WORKSPACE_TMPFS_BYTES = 256 * 1024 * 1024;
+const QUERY_WORKSPACE_TMPFS_BYTES = 1024 * 1024 * 1024;
 
 /** Converts a monotonic-clock duration to the integer milliseconds Node requires. */
 function normalizeTimeoutMs(timeoutMs) {

--- a/containers/bounded-query/broker/query-runner.js
+++ b/containers/bounded-query/broker/query-runner.js
@@ -25,6 +25,11 @@ const QUERY_MAX_FILE_BYTES = 64 * 1024 * 1024;
  */
 const QUERY_WORKSPACE_TMPFS_BYTES = 256 * 1024 * 1024;
 
+/** Converts a monotonic-clock duration to the integer milliseconds Node requires. */
+function normalizeTimeoutMs(timeoutMs) {
+  return Math.max(1, Math.ceil(timeoutMs));
+}
+
 function runDocker(args, timeoutMs) {
   return new Promise((resolve) => {
     execFile(
@@ -128,7 +133,9 @@ async function runQueryContainer(params) {
 
   // Use the caller-supplied remaining budget (which already excludes workspace
   // creation time) rather than the raw config timeout.
-  const containerTimeoutMs = (params.timeoutMs ?? config.timeoutSeconds * 1000) + CLI_GRACE_MS;
+  const containerTimeoutMs = normalizeTimeoutMs(
+    (params.timeoutMs ?? config.timeoutSeconds * 1000) + CLI_GRACE_MS,
+  );
 
   try {
     return await runDocker(args, containerTimeoutMs);
@@ -151,6 +158,7 @@ module.exports = {
   QUERY_MAX_FILE_BYTES,
   QUERY_WORKSPACE_TMPFS_BYTES,
   buildQueryArgs,
+  normalizeTimeoutMs,
   runQueryContainer,
   assertQueryImageAvailable,
 };

--- a/scripts/ci/smoke-bounded-queries.sh
+++ b/scripts/ci/smoke-bounded-queries.sh
@@ -12,9 +12,9 @@ fail() {
 }
 
 run_inside_agent() {
-  command -v sealed-probe >/dev/null || fail "sealed-probe is not installed"
-  [[ "${AWF_SEALED_PROBE_REPOS:-}" == "$TARGET_REPO" ]] ||
-    fail "unexpected AWF_SEALED_PROBE_REPOS: ${AWF_SEALED_PROBE_REPOS:-<unset>}"
+  command -v bounded-query >/dev/null || fail "bounded-query is not installed"
+  [[ "${AWF_BOUNDED_QUERY_REPOS:-}" == "$TARGET_REPO" ]] ||
+    fail "unexpected AWF_BOUNDED_QUERY_REPOS: ${AWF_BOUNDED_QUERY_REPOS:-<unset>}"
   [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]] ||
     fail "staging credentials reached the agent environment"
 
@@ -57,22 +57,22 @@ run_inside_agent() {
   for attempt in 0 1 2; do
     if [[ "$result_kind" == "array" ]]; then
       response="$(
-        sealed-probe --repo "$TARGET_REPO" --schema "$schema" <<'PY'
+        bounded-query --repo "$TARGET_REPO" --schema "$schema" <<'PY'
 import json
 from pathlib import Path
 
-go_mod_exists = Path("/probe/repo/go.mod").is_file()
-Path("/probe/out").write_text(json.dumps([go_mod_exists] * 28))
+go_mod_exists = Path("/query/repo/go.mod").is_file()
+Path("/query/out").write_text(json.dumps([go_mod_exists] * 28))
 PY
       )"
     else
       response="$(
-        sealed-probe --repo "$TARGET_REPO" --schema "$schema" <<'PY'
+        bounded-query --repo "$TARGET_REPO" --schema "$schema" <<'PY'
 import json
 from pathlib import Path
 
-go_mod_exists = Path("/probe/repo/go.mod").is_file()
-Path("/probe/out").write_text(json.dumps(go_mod_exists))
+go_mod_exists = Path("/query/repo/go.mod").is_file()
+Path("/query/out").write_text(json.dumps(go_mod_exists))
 PY
       )"
     fi
@@ -96,7 +96,7 @@ elif status == "error":
     if payload != {"status": "error"}:
         raise SystemExit("error response was not canonical")
 else:
-    raise SystemExit(f"unexpected sealed-probe response: {payload!r}")
+    raise SystemExit(f"unexpected bounded-query response: {payload!r}")
 
 print(status)
 PY
@@ -134,7 +134,7 @@ run_on_host() {
   "logging": {
     "auditDir": "$audit_dir"
   },
-  "sealedProbes": {
+  "boundedQueries": {
     "enabled": true,
     "privateRepos": [
       {

--- a/scripts/ci/smoke-bounded-queries.sh
+++ b/scripts/ci/smoke-bounded-queries.sh
@@ -144,7 +144,7 @@ run_on_host() {
     ],
     "runtime": "docker",
     "timeout": 30,
-    "memoryLimit": "512m",
+    "memoryLimit": "2g",
     "interpreter": "python3",
     "maxInvocations": 10
   }

--- a/scripts/ci/smoke-bounded-queries.sh
+++ b/scripts/ci/smoke-bounded-queries.sh
@@ -159,7 +159,7 @@ JSON
         --container-workdir "$workspace" \
         --env "SMOKE_SENSITIVITY=$sensitivity" \
         -- bash "$workspace/scripts/ci/smoke-bounded-queries.sh" --inside-agent; then
-      audit_log="$work_dir/bounded-queries/audit/bounded-query.jsonl"
+      audit_log="$audit_dir/bounded-query.jsonl"
       if [[ -f "$audit_log" ]]; then
         echo "::group::bounded query broker audit"
         sudo cat "$audit_log"

--- a/scripts/ci/smoke-bounded-queries.sh
+++ b/scripts/ci/smoke-bounded-queries.sh
@@ -119,7 +119,7 @@ run_on_host() {
   root="${RUNNER_TEMP:-/tmp}/smoke-bounded-queries-${GITHUB_RUN_ID:-local}"
   mkdir -p "$root"
 
-  local sensitivity config work_dir audit_dir workspace
+  local sensitivity config work_dir audit_dir audit_log workspace
   workspace="${GITHUB_WORKSPACE:-$(pwd)}"
   for sensitivity in public internal confidential sealed; do
     config="$root/$sensitivity.json"
@@ -152,13 +152,21 @@ run_on_host() {
 JSON
 
     echo "::group::bounded queries: $sensitivity"
-    awf \
-      --build-local \
-      --config "$config" \
-      --work-dir "$work_dir" \
-      --container-workdir "$workspace" \
-      --env "SMOKE_SENSITIVITY=$sensitivity" \
-      -- bash "$workspace/scripts/ci/smoke-bounded-queries.sh" --inside-agent
+    if ! awf \
+        --build-local \
+        --config "$config" \
+        --work-dir "$work_dir" \
+        --container-workdir "$workspace" \
+        --env "SMOKE_SENSITIVITY=$sensitivity" \
+        -- bash "$workspace/scripts/ci/smoke-bounded-queries.sh" --inside-agent; then
+      audit_log="$work_dir/bounded-queries/audit/bounded-query.jsonl"
+      if [[ -f "$audit_log" ]]; then
+        echo "::group::bounded query broker audit"
+        sudo cat "$audit_log"
+        echo "::endgroup::"
+      fi
+      fail "$sensitivity bounded-query run failed"
+    fi
     echo "::endgroup::"
   done
 }

--- a/src/artifact-preservation.ts
+++ b/src/artifact-preservation.ts
@@ -12,14 +12,27 @@ import { fixArtifactPermissionsForRootless } from './artifact-permissions';
  */
 export function preserveIptablesAudit(workDir: string, auditDir?: string): void {
   const iptablesAuditSrc = path.join(workDir, 'init-signal', 'iptables-audit.txt');
+  const boundedQueryAuditSrc = path.join(workDir, 'bounded-queries', 'audit', 'bounded-query.jsonl');
   const targetAuditDir = auditDir || path.join(workDir, 'audit');
-  if (fs.existsSync(iptablesAuditSrc) && fs.existsSync(targetAuditDir)) {
+  if (!fs.existsSync(targetAuditDir)) return;
+
+  if (fs.existsSync(iptablesAuditSrc)) {
     try {
       fs.copyFileSync(iptablesAuditSrc, path.join(targetAuditDir, 'iptables-audit.txt'));
       fs.chmodSync(path.join(targetAuditDir, 'iptables-audit.txt'), 0o644);
       logger.debug('Copied iptables audit state to audit directory');
     } catch (error) {
       logger.debug('Could not copy iptables audit file:', error);
+    }
+  }
+
+  if (fs.existsSync(boundedQueryAuditSrc)) {
+    try {
+      fs.copyFileSync(boundedQueryAuditSrc, path.join(targetAuditDir, 'bounded-query.jsonl'));
+      fs.chmodSync(path.join(targetAuditDir, 'bounded-query.jsonl'), 0o644);
+      logger.debug('Copied bounded-query broker audit to audit directory');
+    } catch (error) {
+      logger.debug('Could not copy bounded-query audit file:', error);
     }
   }
 }

--- a/src/artifact-preservation.ts
+++ b/src/artifact-preservation.ts
@@ -4,6 +4,10 @@ import * as os from 'os';
 import execa from 'execa';
 import { logger } from './logger';
 import { fixArtifactPermissionsForRootless } from './artifact-permissions';
+import { getLocalDockerEnv } from './host-env';
+
+const BOUNDED_QUERY_AUDIT_CONTAINER_PATH =
+  'awf-bounded-query-broker:/var/log/awf-bounded-query/bounded-query.jsonl';
 
 /**
  * Copies the iptables audit dump from the init-signal volume to the audit directory.
@@ -12,7 +16,7 @@ import { fixArtifactPermissionsForRootless } from './artifact-permissions';
  */
 export function preserveIptablesAudit(workDir: string, auditDir?: string): void {
   const iptablesAuditSrc = path.join(workDir, 'init-signal', 'iptables-audit.txt');
-  const boundedQueryAuditSrc = path.join(workDir, 'bounded-queries', 'audit', 'bounded-query.jsonl');
+  const boundedQueryRoot = path.join(workDir, 'bounded-queries');
   const targetAuditDir = auditDir || path.join(workDir, 'audit');
   if (!fs.existsSync(targetAuditDir)) return;
 
@@ -26,11 +30,19 @@ export function preserveIptablesAudit(workDir: string, auditDir?: string): void 
     }
   }
 
-  if (fs.existsSync(boundedQueryAuditSrc)) {
+  if (fs.existsSync(boundedQueryRoot)) {
     try {
-      fs.copyFileSync(boundedQueryAuditSrc, path.join(targetAuditDir, 'bounded-query.jsonl'));
-      fs.chmodSync(path.join(targetAuditDir, 'bounded-query.jsonl'), 0o644);
-      logger.debug('Copied bounded-query broker audit to audit directory');
+      const destination = path.join(targetAuditDir, 'bounded-query.jsonl');
+      const result = execa.sync(
+        'docker',
+        ['cp', BOUNDED_QUERY_AUDIT_CONTAINER_PATH, destination],
+        { env: getLocalDockerEnv(), reject: false },
+      );
+      if (result.exitCode === 0) {
+        logger.debug('Copied bounded-query broker audit to audit directory');
+      } else {
+        logger.debug('Could not copy bounded-query audit file:', result.stderr);
+      }
     } catch (error) {
       logger.debug('Could not copy bounded-query audit file:', error);
     }

--- a/src/bounded-query/broker.test.ts
+++ b/src/bounded-query/broker.test.ts
@@ -21,7 +21,12 @@ import { EventEmitter } from 'events';
 const brokerDir = path.join(__dirname, '..', '..', 'containers', 'bounded-query', 'broker');
 const { createBroker } = require(path.join(brokerDir, 'broker.js'));
 const workspace = require(path.join(brokerDir, 'workspace.js'));
-const { buildQueryArgs, normalizeTimeoutMs } = require(path.join(brokerDir, 'query-runner.js'));
+const {
+  QUERY_MAX_FILE_BYTES,
+  QUERY_WORKSPACE_TMPFS_BYTES,
+  buildQueryArgs,
+  normalizeTimeoutMs,
+} = require(path.join(brokerDir, 'query-runner.js'));
 const { buildRequestFromFrame, readBoundedBody } = require(path.join(brokerDir, 'framing.js'));
 const { TIMING_BUCKETS_MS } = require(path.join(brokerDir, 'scheduler.js'));
 /* eslint-enable @typescript-eslint/no-require-imports */
@@ -683,7 +688,7 @@ describe('query container arguments', () => {
     expect(joined).toContain('--memory-swap 256m');
     expect(joined).toContain('--cpus 1');
     expect(joined).toContain('--pids-limit 128');
-    expect(joined).toContain('--ulimit fsize=');
+    expect(joined).toContain(`--ulimit fsize=${512 * 1024 * 1024}`);
     expect(joined).toContain('--ulimit nofile=1024:1024');
   });
 
@@ -702,9 +707,16 @@ describe('query container arguments', () => {
 
   it('backs /query with a size-limited tmpfs for aggregate storage enforcement', () => {
     const joined = args().join(' ');
-    expect(joined).toMatch(/--tmpfs \/query:rw,nosuid,nodev,size=\d+,uid=65534,gid=65534,mode=0700/);
+    expect(joined).toContain(
+      `--tmpfs /query:rw,nosuid,nodev,size=${1024 * 1024 * 1024},uid=65534,gid=65534,mode=0700`,
+    );
     expect(joined).not.toContain(':/query:rw');
     expect(joined).not.toContain(':/query/repo:rw');
+  });
+
+  it('fits the bounded github/gh-aw smoke-test seed', () => {
+    expect(QUERY_MAX_FILE_BYTES).toBe(512 * 1024 * 1024);
+    expect(QUERY_WORKSPACE_TMPFS_BYTES).toBe(1024 * 1024 * 1024);
   });
 
   it('never mounts the Docker socket, the seeds root, or a workspace', () => {

--- a/src/bounded-query/broker.test.ts
+++ b/src/bounded-query/broker.test.ts
@@ -21,7 +21,7 @@ import { EventEmitter } from 'events';
 const brokerDir = path.join(__dirname, '..', '..', 'containers', 'bounded-query', 'broker');
 const { createBroker } = require(path.join(brokerDir, 'broker.js'));
 const workspace = require(path.join(brokerDir, 'workspace.js'));
-const { buildQueryArgs } = require(path.join(brokerDir, 'query-runner.js'));
+const { buildQueryArgs, normalizeTimeoutMs } = require(path.join(brokerDir, 'query-runner.js'));
 const { buildRequestFromFrame, readBoundedBody } = require(path.join(brokerDir, 'framing.js'));
 const { TIMING_BUCKETS_MS } = require(path.join(brokerDir, 'scheduler.js'));
 /* eslint-enable @typescript-eslint/no-require-imports */
@@ -730,6 +730,10 @@ describe('query container arguments', () => {
   it('passes an explicit OCI runtime only when one is configured', () => {
     expect(args().includes('--runtime')).toBe(false);
     expect(args({ dockerRuntime: 'runsc' }).join(' ')).toContain('--runtime runsc');
+  });
+
+  it('normalizes fractional monotonic durations for Node child-process timeouts', () => {
+    expect(normalizeTimeoutMs(31_872.77068800002)).toBe(31_873);
   });
 });
 

--- a/src/docker-manager-diagnostics.test.ts
+++ b/src/docker-manager-diagnostics.test.ts
@@ -159,5 +159,23 @@ describe('docker-manager diagnostics', () => {
 
       expect(fs.existsSync(path.join(defaultAuditDir, 'iptables-audit.txt'))).toBe(true);
     });
+
+    it('should copy the bounded-query broker audit before work directory cleanup', () => {
+      const brokerAuditDir = path.join(getDir(), 'bounded-queries', 'audit');
+      fs.mkdirSync(brokerAuditDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(brokerAuditDir, 'bounded-query.jsonl'),
+        '{"kind":"failure","reason":"non-zero-exit"}\n',
+      );
+
+      const auditDir = path.join(getDir(), 'audit');
+      fs.mkdirSync(auditDir);
+
+      preserveIptablesAudit(getDir(), auditDir);
+
+      expect(fs.readFileSync(path.join(auditDir, 'bounded-query.jsonl'), 'utf8')).toBe(
+        '{"kind":"failure","reason":"non-zero-exit"}\n',
+      );
+    });
   });
 });

--- a/src/docker-manager-diagnostics.test.ts
+++ b/src/docker-manager-diagnostics.test.ts
@@ -3,7 +3,7 @@ import { collectDiagnosticLogs } from './diagnostic-collector';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { mockExecaFn } from './test-helpers/mock-execa.test-utils';
+import { mockExecaFn, mockExecaSync } from './test-helpers/mock-execa.test-utils';
 import { useTempDir } from './test-helpers/docker-test-fixtures.test-utils';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('execa', () => require('./test-helpers/mock-execa.test-utils').execaMockFactory());
@@ -173,8 +173,14 @@ describe('docker-manager diagnostics', () => {
 
       preserveIptablesAudit(getDir(), auditDir);
 
-      expect(fs.readFileSync(path.join(auditDir, 'bounded-query.jsonl'), 'utf8')).toBe(
-        '{"kind":"failure","reason":"non-zero-exit"}\n',
+      expect(mockExecaSync).toHaveBeenCalledWith(
+        'docker',
+        [
+          'cp',
+          'awf-bounded-query-broker:/var/log/awf-bounded-query/bounded-query.jsonl',
+          path.join(auditDir, 'bounded-query.jsonl'),
+        ],
+        expect.objectContaining({ reject: false }),
       );
     });
   });


### PR DESCRIPTION
## Summary

- replace the removed `sealedProbes` config with `boundedQueries`
- invoke `bounded-query` through `AWF_BOUNDED_QUERY_REPOS`
- use the current `/query` filesystem contract
- remove legacy sealed-probe terminology from the smoke test

## Context

The first merged smoke run failed immediately because current `main` rejects `config.sealedProbes`.

## Validation

- no legacy sealed-probe references remain in the smoke workflow or driver
- all four expected confidentiality-level response sequences pass
- bounded-query protocol and end-to-end suites pass (148 tests)