### PR TITLE
refactor: split bounded query runners

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -23,48 +23,17 @@ ignore:
   #     binary. `gh` is a client: it does not run a gRPC server, use xDS RBAC,
   #     or accept HTTP/2 from untrusted peers, so none of the vulnerable code
   #     paths are exercised. The finding is present but not exploitable here.
-  #   Present in the agent image (gh via the GitHub CLI apt repo) and the
-  #   cli-proxy image (gh from the official release tarball).
+  #   Present in the cli-proxy image (gh from the official release tarball).
   #
-  #   No fix is shippable today: gh 2.96.0 (latest release as of 2026-07-23)
-  #   still pins grpc v1.81.1, and building gh from unreleased trunk would ship
-  #   an untagged, non-official binary (worse supply-chain risk than a
-  #   non-reachable finding). The fix (grpc v1.82.1) is already merged on gh
-  #   trunk, so the next tagged gh release will carry it.
-  #   Revisit: once gh CLI >= v2.97.0 (grpc >= 1.82.1) is released, bump the
-  #   `gh=` pin in agent/Dockerfile and cli-proxy/Dockerfile and DELETE this
-  #   entry. Tracked in github/gh-aw-firewall.
+  #   gh 2.97.0 fixes this in the agent image. The cli-proxy image remains on
+  #   gh 2.96.0, so this exception remains narrowly scoped to that binary.
+  #   Revisit: bump GH_VERSION in cli-proxy/Dockerfile to >= 2.97.0 and DELETE
+  #   this entry. Tracked in github/gh-aw-firewall.
   - vulnerability: GHSA-hrxh-6v49-42gf
     package:
       name: google.golang.org/grpc
       version: "v1.81.1"
       type: go-module
-
-  # ── golang.org/x/text v0.38.0 embedded in gh CLI binary (agent image) ────────
-  #
-  # GO-2026-5970 / CVE-2026-56852 (golang.org/x/text v0.38.0 -> 0.39.0, HIGH):
-  #   A norm.Iter can enter an infinite loop when handling input containing
-  #   invalid UTF-8 bytes (denial of service).
-  #
-  #   Risk acceptance — BOUNDED DoS only, no other impact:
-  #     x/text v0.38.0 is compiled into the `gh` CLI binary. In the agent image,
-  #     `gh` is a client tool invoked by the agent; the worst-case outcome if
-  #     invalid UTF-8 reaches gh's text-normalization path is a hang of that gh
-  #     process — no privilege escalation, data exfiltration, or RCE vector.
-  #   Scoped to /usr/bin/gh (agent image, installed via apt repo, gh=2.96.0).
-  #
-  #   No fix is shippable today: gh 2.96.0 (latest release as of 2026-07-24)
-  #   still bundles x/text v0.38.0, and building gh from unreleased trunk would
-  #   ship an untagged, non-official binary (worse supply-chain risk).
-  #   Revisit: once a gh CLI release bundling x/text >= v0.39.0 is available,
-  #   bump the `gh=` pin in agent/Dockerfile and DELETE this entry. Tracked in
-  #   github/gh-aw-firewall.
-  - vulnerability: GO-2026-5970
-    package:
-      name: golang.org/x/text
-      version: "v0.38.0"
-      type: go-module
-      location: "/usr/bin/gh"
 
   # ── golang.org/x/text v0.38.0 embedded in gh CLI binary (cli-proxy image) ────
   #

--- a/containers/agent/Dockerfile
+++ b/containers/agent/Dockerfile
@@ -28,7 +28,7 @@ RUN if getent hosts azure.archive.ubuntu.com >/dev/null 2>&1; then \
       echo "Azure apt mirror not reachable, using default archive.ubuntu.com"; \
     fi
 
-# Install required packages, GitHub CLI 2.96.0, Node.js 22.23.1, and npm 11.18.0
+# Install required packages, GitHub CLI 2.97.0, Node.js 22.23.1, and npm 11.18.0
 # Note: Some packages may already exist in runner-like base images, apt handles this gracefully
 # apt_update_retry: retries up to 3 times with backoff; if all fail, reverts to archive.ubuntu.com
 RUN set -eux; \
@@ -95,7 +95,7 @@ RUN set -eux; \
     gosu --version && \
     # Prefer system binaries over runner toolcache (e.g., act images) for Node checks.
     export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH" && \
-    # Install GitHub CLI 2.96.0 from the official GitHub CLI apt repository
+    # Install GitHub CLI 2.97.0 from the official GitHub CLI apt repository
     # (Ubuntu's bundled gh package is 2.4.0 compiled with Go 1.18 — vulnerable)
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
@@ -103,7 +103,7 @@ RUN set -eux; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         > /etc/apt/sources.list.d/github-cli.list && \
     apt-get update && \
-    apt_install_retry gh=2.96.0 && \
+    apt_install_retry gh=2.97.0 && \
     # Install Node.js 22.23.1 from the official Node.js binary distribution
     # (nodejs.org), NOT the NodeSource apt repo. The NodeSource .deb is tracked by
     # a Debian/NodeSource security feed that yields false-positive CVE matches
@@ -117,7 +117,7 @@ RUN set -eux; \
     UNDER_QEMU=false && \
     if [ -f /dev/.buildkit_qemu_emulator ] || [ -n "${QEMU_CPU:-}" ]; then UNDER_QEMU=true; fi && \
     # Remove any existing nodejs packages first to avoid conflicting detections
-    apt-get remove -y nodejs npm || true && \
+    (apt-get remove -y nodejs npm || true) && \
     NODE_VERSION="v22.23.1" && \
     NODE_DPKG_ARCH="$(dpkg --print-architecture)" && \
     case "$NODE_DPKG_ARCH" in \

--- a/containers/bounded-query/Dockerfile
+++ b/containers/bounded-query/Dockerfile
@@ -53,6 +53,10 @@ RUN chmod -R a-w /opt/awf \
     && node --check /opt/awf/broker/framing.js \
     && node --check /opt/awf/broker/workspace.js \
     && node --check /opt/awf/broker/query-runner.js \
+    && node --check /opt/awf/broker/query-runner-spec.js \
+    && node --check /opt/awf/broker/docker-client.js \
+    && node --check /opt/awf/broker/docker-query-runner.js \
+    && node --check /opt/awf/broker/gvisor-query-runner.js \
     && node --check /opt/awf/broker/healthcheck.js
 
 # Fixed broker-only mount points.

--- a/containers/bounded-query/broker/broker.js
+++ b/containers/bounded-query/broker/broker.js
@@ -11,7 +11,6 @@ const {
 const { createLedger } = require('./ledger');
 const { createRealClock, waitForBucket } = require('./scheduler');
 const defaultWorkspace = require('./workspace');
-const defaultRunner = require('./query-runner');
 
 /**
  * The trusted bounded-query broker (protocol v2).
@@ -51,7 +50,10 @@ const defaultRunner = require('./query-runner');
 function createBroker(params) {
   const { config, seedMap, runId, audit } = params;
   const workspace = params.workspace || defaultWorkspace;
-  const runner = params.runner || defaultRunner;
+  if (!params.runner) {
+    throw new Error('createBroker requires a trusted QueryRunner');
+  }
+  const runner = params.runner;
   const clock = params.clock || createRealClock();
   const ledger = params.ledger || createLedger(seedMap);
 
@@ -239,6 +241,11 @@ function createBroker(params) {
         () => undefined,
       );
       return queued;
+    },
+
+    /** Resolves when every admitted invocation has finished broker-side work. */
+    drain() {
+      return tail;
     },
 
     /** @internal Exposed for tests. */

--- a/containers/bounded-query/broker/broker.js
+++ b/containers/bounded-query/broker/broker.js
@@ -59,6 +59,7 @@ function createBroker(params) {
 
   let invocationsUsed = 0;
   let tail = Promise.resolve();
+  let accepting = true;
 
   /**
    * Executes one request and reports its canonical result through
@@ -202,6 +203,11 @@ function createBroker(params) {
   }
 
   return {
+    /** Stops admitting new invocations while letting admitted work drain. */
+    close() {
+      accepting = false;
+    },
+
     /**
      * Handles one request. `respond` is called exactly once with the
      * canonical result JSON, as soon as it is ready to send (which, for any
@@ -220,6 +226,11 @@ function createBroker(params) {
         responded = true;
         respond(json);
       };
+
+      if (!accepting) {
+        safeRespond(CANONICAL_ERROR_JSON);
+        return Promise.resolve();
+      }
 
       // The invocation-count cap is operational and independent of the bit
       // ledger: it is consumed per *response*, not per launch, so every

--- a/containers/bounded-query/broker/config.js
+++ b/containers/bounded-query/broker/config.js
@@ -74,9 +74,9 @@ function loadConfig() {
     throw new Error('AWF_BOUNDED_QUERY_MEMORY must be a Docker memory limit (e.g. "512m")');
   }
 
-  const dockerRuntime = process.env.AWF_BOUNDED_QUERY_RUNTIME || '';
-  if (dockerRuntime && !/^[A-Za-z0-9_.-]+$/.test(dockerRuntime)) {
-    throw new Error('AWF_BOUNDED_QUERY_RUNTIME contains unexpected characters');
+  const queryBackend = requireEnv('AWF_BOUNDED_QUERY_BACKEND');
+  if (queryBackend !== 'docker' && queryBackend !== 'gvisor') {
+    throw new Error(`Unsupported AWF_BOUNDED_QUERY_BACKEND: ${queryBackend}`);
   }
 
   return {
@@ -97,7 +97,7 @@ function loadConfig() {
     // The daemon resolves query bind-mount sources in *its* filesystem view,
     // which is not necessarily the broker's (ARC/DinD split filesystems).
     hostWorkDir: requireEnv('AWF_BOUNDED_QUERY_HOST_WORK_DIR'),
-    dockerRuntime,
+    queryBackend,
     timeoutSeconds: parseTimeoutSeconds(),
     maxInvocations: parsePositiveInt('AWF_BOUNDED_QUERY_MAX_INVOCATIONS', 32),
     memoryLimit,

--- a/containers/bounded-query/broker/docker-client.js
+++ b/containers/bounded-query/broker/docker-client.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { execFile } = require('child_process');
+
+/**
+ * Executes the Docker CLI with bounded output and no inherited credentials.
+ */
+function runDocker(args, timeoutMs) {
+  return new Promise((resolve) => {
+    execFile(
+      'docker',
+      args,
+      {
+        timeout: timeoutMs,
+        killSignal: 'SIGKILL',
+        maxBuffer: 64 * 1024,
+        env: { PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin' },
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          exitCode: error && typeof error.code === 'number' ? error.code : error ? 1 : 0,
+          timedOut: Boolean(error && error.killed),
+          stderr: typeof stderr === 'string' ? stderr.slice(0, 2000) : '',
+          stdout: typeof stdout === 'string' ? stdout.slice(0, 2000) : '',
+        });
+      },
+    );
+  });
+}
+
+module.exports = { runDocker };

--- a/containers/bounded-query/broker/docker-query-runner.js
+++ b/containers/bounded-query/broker/docker-query-runner.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const defaultDockerClient = require('./docker-client');
+const {
+  CLI_GRACE_MS,
+  buildRemoveArgs,
+  deriveQueryContainerSpec,
+  normalizeTimeoutMs,
+} = require('./query-runner-spec');
+
+/**
+ * QueryRunner using the Docker daemon's default OCI runtime.
+ *
+ * The optional runtimeName is constructor-controlled so subclasses can select
+ * a fixed trusted runtime without accepting runtime data per invocation.
+ */
+class DockerQueryRunner {
+  constructor(config, deps = {}, runtimeName = undefined) {
+    this.config = config;
+    this.runtimeName = runtimeName;
+    this.docker = deps.docker || defaultDockerClient;
+    this.cleanupTail = Promise.resolve();
+  }
+
+  async assertAvailable() {
+    const image = await this.docker.runDocker(['image', 'inspect', this.config.queryImage], 60_000);
+    if (image.exitCode !== 0) {
+      throw new Error(`Query image is not available locally: ${this.config.queryImage}`);
+    }
+  }
+
+  spec(runId, invocationId) {
+    return deriveQueryContainerSpec({
+      config: this.config,
+      runId,
+      invocationId,
+      runtimeName: this.runtimeName,
+    });
+  }
+
+  async listContainerIds(args) {
+    const listed = await this.docker.runDocker(args, 30_000);
+    if (listed.exitCode !== 0) {
+      throw new Error('Failed to reconcile bounded-query containers');
+    }
+    const ids = listed.stdout.split('\n').map((id) => id.trim()).filter(Boolean);
+    if (ids.some((id) => !/^[0-9a-f]{12,64}$/.test(id))) {
+      throw new Error('Docker returned an invalid bounded-query container id');
+    }
+    return ids;
+  }
+
+  async removeListed(args) {
+    const ids = await this.listContainerIds(args);
+    if (ids.length === 0) return;
+    const removed = await this.docker.runDocker(buildRemoveArgs(ids), 30_000);
+    if (removed.exitCode !== 0) {
+      throw new Error('Failed to remove bounded-query containers');
+    }
+  }
+
+  serializeCleanup(operation) {
+    const queued = this.cleanupTail.then(operation, operation);
+    this.cleanupTail = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  }
+
+  async reconcileRun(runId) {
+    const spec = this.spec(runId, 'reconcile');
+    await this.serializeCleanup(() => this.removeListed(spec.runListArgs));
+  }
+
+  async cleanupInvocation(runId, invocationId) {
+    const spec = this.spec(runId, invocationId);
+    await this.serializeCleanup(() => this.removeListed(spec.invocationListArgs));
+  }
+
+  async runQueryContainer(params) {
+    const spec = this.spec(params.runId, params.invocationId);
+    const timeoutMs = normalizeTimeoutMs(
+      (params.timeoutMs ?? this.config.timeoutSeconds * 1000) + CLI_GRACE_MS,
+    );
+
+    let result;
+    let runError;
+    try {
+      result = await this.docker.runDocker(spec.launchArgs, timeoutMs);
+    } catch (error) {
+      runError = error;
+    }
+
+    try {
+      await this.cleanupInvocation(params.runId, params.invocationId);
+    } catch (cleanupError) {
+      // A successful `docker run` means the container has already stopped, so
+      // preserve its result as before this refactor. Timeout/error paths may
+      // still have a live sandbox and therefore fail closed when cleanup fails.
+      if (!result || result.timedOut || result.exitCode !== 0) {
+        throw cleanupError;
+      }
+    }
+
+    if (runError) throw runError;
+    return result;
+  }
+}
+
+module.exports = { DockerQueryRunner };

--- a/containers/bounded-query/broker/gvisor-query-runner.js
+++ b/containers/bounded-query/broker/gvisor-query-runner.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { DockerQueryRunner } = require('./docker-query-runner');
+
+const RUNSC_RUNTIME = 'runsc';
+
+/** QueryRunner using Docker with the fixed runsc OCI runtime. */
+class GvisorQueryRunner extends DockerQueryRunner {
+  constructor(config, deps = {}) {
+    super(config, deps, RUNSC_RUNTIME);
+  }
+
+  async assertAvailable() {
+    await super.assertAvailable();
+    const result = await this.docker.runDocker(
+      ['info', '--format', '{{json .Runtimes}}'],
+      30_000,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error('Unable to inspect Docker OCI runtimes for gVisor');
+    }
+
+    let runtimes;
+    try {
+      runtimes = JSON.parse(result.stdout);
+    } catch {
+      throw new Error('Docker returned malformed OCI runtime information');
+    }
+    if (!runtimes || !Object.prototype.hasOwnProperty.call(runtimes, RUNSC_RUNTIME)) {
+      throw new Error('gVisor query backend requires the runsc OCI runtime; no fallback is permitted');
+    }
+  }
+}
+
+module.exports = { GvisorQueryRunner, RUNSC_RUNTIME };

--- a/containers/bounded-query/broker/query-runner-spec.js
+++ b/containers/bounded-query/broker/query-runner-spec.js
@@ -1,0 +1,116 @@
+'use strict';
+
+/** Extra grace beyond the query's wall-clock budget for docker CLI overhead. */
+const CLI_GRACE_MS = 5_000;
+
+/** Maximum file size a query may create, in bytes (per-file RLIMIT_FSIZE). */
+const QUERY_MAX_FILE_BYTES = 512 * 1024 * 1024;
+
+/** Aggregate size limit for the query's writable tmpfs workspace in bytes. */
+const QUERY_WORKSPACE_TMPFS_BYTES = 1024 * 1024 * 1024;
+
+const RUN_LABEL = 'awf.bounded-query.run';
+const INVOCATION_LABEL = 'awf.bounded-query.invocation';
+const TRUSTED_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+/** Converts a monotonic-clock duration to the integer milliseconds Node requires. */
+function normalizeTimeoutMs(timeoutMs) {
+  return Math.max(1, Math.ceil(timeoutMs));
+}
+
+function assertTrustedId(name, value) {
+  if (typeof value !== 'string' || !TRUSTED_ID_PATTERN.test(value)) {
+    throw new Error(`${name} is not a broker-generated identifier`);
+  }
+}
+
+function freezeArray(values) {
+  return Object.freeze(values);
+}
+
+/**
+ * Derives every daemon-facing query setting from trusted config and
+ * broker-generated identifiers. No request object is accepted by this API.
+ */
+function deriveQueryContainerSpec({ config, runId, invocationId, runtimeName }) {
+  assertTrustedId('runId', runId);
+  assertTrustedId('invocationId', invocationId);
+  if (runtimeName !== undefined && runtimeName !== 'runsc') {
+    throw new Error(`Unsupported OCI runtime in query runner: ${runtimeName}`);
+  }
+
+  const containerName = `awf-query-${runId.slice(0, 12)}-${invocationId}`;
+  const hostInvocationDir = `${config.hostWorkDir}/${invocationId}`;
+  const runLabel = `${RUN_LABEL}=${runId}`;
+  const invocationLabel = `${INVOCATION_LABEL}=${invocationId}`;
+  const launchArgs = [
+    'run',
+    '--pull', 'never',
+    '--name', containerName,
+    '--label', runLabel,
+    '--label', invocationLabel,
+    '--network', 'none',
+    '--read-only',
+    '--user', `${config.queryUid}:${config.queryGid}`,
+    '--cap-drop', 'ALL',
+    '--security-opt', 'no-new-privileges:true',
+    '--security-opt', `seccomp=${config.querySeccompPath}`,
+    '--memory', config.memoryLimit,
+    '--memory-swap', config.memoryLimit,
+    '--cpus', '1',
+    '--pids-limit', '128',
+    '--ulimit', `fsize=${QUERY_MAX_FILE_BYTES}`,
+    '--ulimit', 'nofile=1024:1024',
+    '--tmpfs', '/tmp:rw,noexec,nosuid,nodev,size=16m',
+    '--tmpfs', `/query:rw,nosuid,nodev,size=${QUERY_WORKSPACE_TMPFS_BYTES},uid=${config.queryUid},gid=${config.queryGid},mode=0700`,
+    '--hostname', 'query',
+    '--workdir', config.queryMountDir,
+    '--env', 'HOME=/tmp',
+    '--env', 'PYTHONDONTWRITEBYTECODE=1',
+    '--env', 'PYTHONUNBUFFERED=1',
+    '-v', `${hostInvocationDir}/repo:/awf/seed:ro`,
+    '-v', `${hostInvocationDir}/out:${config.queryMountDir}/out:rw`,
+    '-v', `${hostInvocationDir}/script.py:${config.queryScriptPath}:ro`,
+  ];
+
+  if (runtimeName !== undefined) {
+    launchArgs.push('--runtime', runtimeName);
+  }
+  launchArgs.push('--entrypoint', '/usr/local/bin/run-query', config.queryImage);
+
+  return Object.freeze({
+    containerName,
+    runtimeName,
+    launchArgs: freezeArray(launchArgs),
+    invocationListArgs: freezeArray([
+      'ps', '-aq',
+      '--filter', `label=${runLabel}`,
+      '--filter', `label=${invocationLabel}`,
+    ]),
+    runListArgs: freezeArray(['ps', '-aq', '--filter', `label=${runLabel}`]),
+  });
+}
+
+/** Compatibility helper for focused argument tests. */
+function buildQueryArgs(params) {
+  return deriveQueryContainerSpec({
+    ...params,
+    runtimeName: params.runtimeName,
+  }).launchArgs;
+}
+
+function buildRemoveArgs(containerIds) {
+  return freezeArray(['rm', '-f', ...containerIds]);
+}
+
+module.exports = {
+  CLI_GRACE_MS,
+  INVOCATION_LABEL,
+  QUERY_MAX_FILE_BYTES,
+  QUERY_WORKSPACE_TMPFS_BYTES,
+  RUN_LABEL,
+  buildQueryArgs,
+  buildRemoveArgs,
+  deriveQueryContainerSpec,
+  normalizeTimeoutMs,
+};

--- a/containers/bounded-query/broker/query-runner.js
+++ b/containers/bounded-query/broker/query-runner.js
@@ -1,164 +1,51 @@
 'use strict';
 
-const { execFile } = require('child_process');
+const { DockerQueryRunner } = require('./docker-query-runner');
+const { GvisorQueryRunner } = require('./gvisor-query-runner');
+const {
+  QUERY_MAX_FILE_BYTES,
+  QUERY_WORKSPACE_TMPFS_BYTES,
+  buildQueryArgs,
+  deriveQueryContainerSpec,
+  normalizeTimeoutMs,
+} = require('./query-runner-spec');
 
 /**
- * Launches a single query container.
+ * Trusted broker interface for one-query-per-sandbox execution.
  *
- * The argument vector is built entirely from broker configuration and
- * AWF-generated invocation identifiers. No part of it is derived from the
- * request: the caller cannot influence the image, entrypoint, runtime,
- * mounts, limits, labels, or environment.
+ * @typedef {object} QueryRunner
+ * @property {() => Promise<void>} assertAvailable
+ * @property {(runId: string) => Promise<void>} reconcileRun
+ * @property {(params: {
+ *   runId: string,
+ *   invocationId: string,
+ *   timeoutMs?: number
+ * }) => Promise<{exitCode: number, timedOut: boolean, stdout: string, stderr: string}>} runQueryContainer
  */
-
-/** Extra grace beyond the query's wall-clock budget for docker CLI overhead. */
-const CLI_GRACE_MS = 5_000;
-
-/** Maximum file size a query may create, in bytes (per-file RLIMIT_FSIZE). */
-const QUERY_MAX_FILE_BYTES = 512 * 1024 * 1024;
 
 /**
- * Aggregate size limit for the query's writable tmpfs workspace in bytes.
+ * Selects a runner only from AWF's normalized broker configuration.
  *
- * `/query` is backed by a tmpfs of this size, bounding the total amount of
- * new data the query can write outside the pre-seeded repo copy.
- */
-const QUERY_WORKSPACE_TMPFS_BYTES = 1024 * 1024 * 1024;
-
-/** Converts a monotonic-clock duration to the integer milliseconds Node requires. */
-function normalizeTimeoutMs(timeoutMs) {
-  return Math.max(1, Math.ceil(timeoutMs));
-}
-
-function runDocker(args, timeoutMs) {
-  return new Promise((resolve) => {
-    execFile(
-      'docker',
-      args,
-      {
-        timeout: timeoutMs,
-        killSignal: 'SIGKILL',
-        // Query stdout/stderr is never returned to the caller and never
-        // inspected for content; a tiny buffer is enough and caps memory.
-        maxBuffer: 64 * 1024,
-        env: { PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin' },
-      },
-      (error, stdout, stderr) => {
-        resolve({
-          exitCode: error && typeof error.code === 'number' ? error.code : error ? 1 : 0,
-          timedOut: Boolean(error && error.killed),
-          stderr: typeof stderr === 'string' ? stderr.slice(0, 2000) : '',
-          stdout: typeof stdout === 'string' ? stdout.slice(0, 2000) : '',
-        });
-      },
-    );
-  });
-}
-
-/**
- * Builds the fixed `docker run` argument vector for a query.
+ * Unknown values fail closed. In particular, gVisor never falls back to the
+ * daemon's default OCI runtime when runsc is unavailable.
  *
- * Exported so the sandbox flags are unit-testable without a Docker daemon.
+ * @returns {QueryRunner}
  */
-function buildQueryArgs(params) {
-  const { config, runId, invocationId, containerName } = params;
-  const hostInvocationDir = `${config.hostWorkDir}/${invocationId}`;
-
-  const args = [
-    'run',
-    // The broker verified the image before listening. Never let a later
-    // invocation ask the daemon to contact a registry if that image disappears.
-    '--pull', 'never',
-    '--name', containerName,
-    '--label', `awf.bounded-query.run=${runId}`,
-    '--label', `awf.bounded-query.invocation=${invocationId}`,
-    // No network namespace connectivity at all: no internet, no DNS, no host
-    // gateway, no bridge peers, no proxies, no other AWF container.
-    '--network', 'none',
-    '--read-only',
-    '--user', `${config.queryUid}:${config.queryGid}`,
-    '--cap-drop', 'ALL',
-    '--security-opt', 'no-new-privileges:true',
-    '--security-opt', `seccomp=${config.querySeccompPath}`,
-    '--memory', config.memoryLimit,
-    '--memory-swap', config.memoryLimit,
-    '--cpus', '1',
-    '--pids-limit', '128',
-    '--ulimit', `fsize=${QUERY_MAX_FILE_BYTES}`,
-    '--ulimit', 'nofile=1024:1024',
-    // /tmp: small tmpfs for Python's own scratch (cached imports, etc.)
-    '--tmpfs', '/tmp:rw,noexec,nosuid,nodev,size=16m',
-    // /query: size-limited tmpfs as the aggregate workspace.  New files the
-    // query creates here cannot exceed QUERY_WORKSPACE_TMPFS_BYTES in total,
-    // which bounds host filesystem consumption beyond the pre-seeded repo.
-    '--tmpfs', `/query:rw,nosuid,nodev,size=${QUERY_WORKSPACE_TMPFS_BYTES},uid=${config.queryUid},gid=${config.queryGid},mode=0700`,
-    '--hostname', 'query',
-    '--workdir', config.queryMountDir,
-    '--env', 'HOME=/tmp',
-    '--env', 'PYTHONDONTWRITEBYTECODE=1',
-    '--env', 'PYTHONUNBUFFERED=1',
-    // Mount the assigned seed copy read-only at a broker-chosen internal path.
-    // The fixed image entrypoint copies it into the bounded tmpfs at
-    // /query/repo before executing the submitted script, giving the script a
-    // writable ephemeral repository without unbounded host filesystem writes.
-    '-v', `${hostInvocationDir}/repo:/awf/seed:ro`,
-    // Mount the pre-created output file: the query writes its answer here
-    // and it persists on the host for the broker to read back.
-    '-v', `${hostInvocationDir}/out:${config.queryMountDir}/out:rw`,
-    // The submitted script at its fixed read-only path.
-    '-v', `${hostInvocationDir}/script.py:${config.queryScriptPath}:ro`,
-  ];
-
-  if (config.dockerRuntime) {
-    args.push('--runtime', config.dockerRuntime);
+function createQueryRunner(config, deps = {}) {
+  if (config.queryBackend === 'docker') {
+    return new DockerQueryRunner(config, deps);
   }
-
-  args.push(
-    '--entrypoint', '/usr/local/bin/run-query',
-    config.queryImage,
-  );
-
-  return args;
-}
-
-/**
- * Runs the query and force-removes its container afterwards.
- *
- * Never throws: the caller maps everything to the canonical error result.
- */
-async function runQueryContainer(params) {
-  const { config } = params;
-  const containerName = `awf-query-${params.invocationId}`;
-  const args = buildQueryArgs({ ...params, containerName });
-
-  // Use the caller-supplied remaining budget (which already excludes workspace
-  // creation time) rather than the raw config timeout.
-  const containerTimeoutMs = normalizeTimeoutMs(
-    (params.timeoutMs ?? config.timeoutSeconds * 1000) + CLI_GRACE_MS,
-  );
-
-  try {
-    return await runDocker(args, containerTimeoutMs);
-  } finally {
-    // `docker run` was not given --rm so that a timeout kill of the CLI
-    // cannot leave a half-removed container; remove it unconditionally.
-    await runDocker(['rm', '-f', containerName], 30_000);
+  if (config.queryBackend === 'gvisor') {
+    return new GvisorQueryRunner(config, deps);
   }
-}
-
-/** Verifies the query image is present locally — queries must never pull. */
-async function assertQueryImageAvailable(image) {
-  const result = await runDocker(['image', 'inspect', image], 60_000);
-  if (result.exitCode !== 0) {
-    throw new Error(`Query image is not available locally: ${image}`);
-  }
+  throw new Error(`Unsupported bounded-query backend: ${config.queryBackend}`);
 }
 
 module.exports = {
   QUERY_MAX_FILE_BYTES,
   QUERY_WORKSPACE_TMPFS_BYTES,
   buildQueryArgs,
+  createQueryRunner,
+  deriveQueryContainerSpec,
   normalizeTimeoutMs,
-  runQueryContainer,
-  assertQueryImageAvailable,
 };

--- a/containers/bounded-query/broker/server.js
+++ b/containers/bounded-query/broker/server.js
@@ -7,7 +7,7 @@ const { createBroker } = require('./broker');
 const { loadConfig, loadSeedMap } = require('./config');
 const { buildRequestFromFrame, readBoundedBody } = require('./framing');
 const { CANONICAL_ERROR_JSON } = require('./protocol');
-const { assertQueryImageAvailable } = require('./query-runner');
+const { createQueryRunner } = require('./query-runner');
 
 /**
  * Bounded-query broker server.
@@ -37,6 +37,10 @@ const RESULT_HEADERS = {
   'content-type': 'application/json',
   'cache-control': 'no-store',
 };
+// Give a nearly-complete invocation a chance to finish broker cleanup before
+// force-removing this run's containers. Longer queries are interrupted so
+// Compose shutdown remains bounded; host teardown owns private-root removal.
+const SHUTDOWN_GRACE_MS = 1_000;
 
 function sendResult(res, body) {
   res.writeHead(200, { ...RESULT_HEADERS, 'content-length': Buffer.byteLength(body) });
@@ -102,12 +106,14 @@ async function main() {
   const config = loadConfig();
   const audit = createAuditLog(config.auditDir);
   const { runId, seeds } = loadSeedMap(config.seedMapPath);
+  const runner = createQueryRunner(config);
 
-  // Fail closed before accepting a single request: an invocation must never
-  // trigger a registry pull, and the broker has no network to perform one.
-  await assertQueryImageAvailable(config.queryImage);
+  // Fail closed before accepting requests and reconcile containers left by a
+  // prior broker process for this exact run. Queries never pull or fall back.
+  await runner.assertAvailable();
+  await runner.reconcileRun(runId);
 
-  const broker = createBroker({ config, seedMap: seeds, runId, audit });
+  const broker = createBroker({ config, seedMap: seeds, runId, audit, runner });
   const server = createServer({ broker, audit });
 
   await listenOnSocket(server, config, audit);
@@ -120,13 +126,28 @@ async function main() {
   audit.lifecycle('listening', {
     socket: config.socketPath,
     repos: seeds.size,
-    runtime: config.dockerRuntime || 'default',
+    backend: config.queryBackend,
     maxInvocations: config.maxInvocations,
   });
 
-  const shutdown = () => {
-    server.close(() => process.exit(0));
-    setTimeout(() => process.exit(0), 3000).unref();
+  let shuttingDown = false;
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    server.close();
+    const forcedExit = setTimeout(() => process.exit(1), 5000);
+    forcedExit.unref();
+    try {
+      await Promise.race([
+        broker.drain(),
+        new Promise((resolve) => setTimeout(resolve, SHUTDOWN_GRACE_MS)),
+      ]);
+      await runner.reconcileRun(runId);
+      process.exit(0);
+    } catch (error) {
+      audit.lifecycle('shutdown-cleanup-failed', error.message);
+      process.exit(1);
+    }
   };
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);

--- a/containers/bounded-query/broker/server.js
+++ b/containers/bounded-query/broker/server.js
@@ -49,8 +49,18 @@ function sendResult(res, body) {
 
 function createServer(deps) {
   const { broker, audit } = deps;
+  let accepting = true;
+  let pendingAdmissions = 0;
+  const admissionWaiters = [];
 
-  return http.createServer((req, res) => {
+  const resolveAdmissionWaiters = () => {
+    if (pendingAdmissions !== 0) return;
+    while (admissionWaiters.length > 0) {
+      admissionWaiters.shift()();
+    }
+  };
+
+  const server = http.createServer((req, res) => {
     if (req.method !== 'POST' || req.url !== '/query') {
       // Not part of the API. Answer with the canonical error rather than a
       // distinguishable 404/405 so probing the surface yields no extra signal.
@@ -59,8 +69,20 @@ function createServer(deps) {
       return;
     }
 
+    if (!accepting) {
+      sendResult(res, CANONICAL_ERROR_JSON);
+      req.resume();
+      return;
+    }
+
+    pendingAdmissions += 1;
     readBoundedBody(req)
       .then((body) => {
+        if (!accepting) {
+          sendResult(res, CANONICAL_ERROR_JSON);
+          return;
+        }
+
         if (body.error !== undefined) {
           audit.failure('framing', 'body-rejected', body.error);
           return broker.handle(undefined, (result) => sendResult(res, result));
@@ -77,8 +99,22 @@ function createServer(deps) {
       .catch((error) => {
         audit.failure('server', 'unhandled-error', error && error.message);
         if (!res.headersSent) sendResult(res, CANONICAL_ERROR_JSON);
+      })
+      .finally(() => {
+        pendingAdmissions -= 1;
+        resolveAdmissionWaiters();
       });
   });
+
+  server.freezeAdmissions = () => {
+    accepting = false;
+  };
+  server.drainAdmissions = () => (
+    pendingAdmissions === 0
+      ? Promise.resolve()
+      : new Promise((resolve) => admissionWaiters.push(resolve))
+  );
+  return server;
 }
 
 function listenOnSocket(server, config, audit) {
@@ -134,12 +170,17 @@ async function main() {
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
+    broker.close();
+    server.freezeAdmissions();
     server.close();
     const forcedExit = setTimeout(() => process.exit(1), 5000);
     forcedExit.unref();
     try {
       await Promise.race([
-        broker.drain(),
+        Promise.all([
+          server.drainAdmissions(),
+          broker.drain(),
+        ]),
         new Promise((resolve) => setTimeout(resolve, SHUTDOWN_GRACE_MS)),
       ]);
       await runner.reconcileRun(runId);

--- a/src/bounded-query/broker.test.ts
+++ b/src/bounded-query/broker.test.ts
@@ -267,6 +267,19 @@ describe('bounded-query broker', () => {
     expect(fs.readdirSync(String(config.workDir))).toEqual([]);
   });
 
+  it('rejects new invocations after shutdown starts without consuming budget or launching', async () => {
+    const runner = queryRunner(() => {
+      throw new Error('query must not launch');
+    });
+    const { broker } = build(runner);
+
+    broker.close();
+
+    expect(await invoke(broker, validRequest())).toBe(CANONICAL_ERROR);
+    expect(broker.invocationsUsed).toBe(0);
+    expect(runner.seen).toEqual([]);
+  });
+
   it('never exposes another repository or the seed parent to a query', async () => {
     let repoContents = '';
     let siblings: string[] = [];

--- a/src/bounded-query/broker.test.ts
+++ b/src/bounded-query/broker.test.ts
@@ -162,7 +162,7 @@ describe('bounded-query broker', () => {
       queryScriptPath: '/awf/query-script.py',
       querySeccompPath: '/opt/awf/query-seccomp.json',
       queryImage: 'ghcr.io/example/bounded-query:1',
-      dockerRuntime: '',
+      queryBackend: 'docker',
       memoryLimit: '512m',
       timeoutSeconds: 30,
       maxInvocations: 3,
@@ -681,18 +681,18 @@ describe('query container arguments', () => {
     queryScriptPath: '/awf/query-script.py',
     querySeccompPath: '/opt/awf/query-seccomp.json',
     queryImage: 'ghcr.io/example/bounded-query:1',
-    dockerRuntime: '',
+    queryBackend: 'docker',
     memoryLimit: '256m',
     queryUid: 65534,
     queryGid: 65534,
   };
 
-  function args(overrides: Record<string, unknown> = {}): string[] {
+  function args(overrides: Record<string, unknown> = {}, runtimeName?: string): string[] {
     return buildQueryArgs({
       config: { ...config, ...overrides },
       runId: 'run-1',
       invocationId: 'inv-1',
-      containerName: 'awf-query-inv-1',
+      runtimeName,
     });
   }
 
@@ -763,9 +763,9 @@ describe('query container arguments', () => {
     expect(args().join(' ')).toContain('--label awf.bounded-query.run=run-1');
   });
 
-  it('passes an explicit OCI runtime only when one is configured', () => {
+  it('passes an explicit OCI runtime only when selected by the trusted runner', () => {
     expect(args().includes('--runtime')).toBe(false);
-    expect(args({ dockerRuntime: 'runsc' }).join(' ')).toContain('--runtime runsc');
+    expect(args({}, 'runsc').join(' ')).toContain('--runtime runsc');
   });
 
   it('normalizes fractional monotonic durations for Node child-process timeouts', () => {

--- a/src/bounded-query/end-to-end.test.ts
+++ b/src/bounded-query/end-to-end.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import * as http from 'http';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -34,6 +35,11 @@ interface WrapperResult {
   status: number | null;
 }
 
+type AdmissionAwareServer = Server & {
+  freezeAdmissions: () => void;
+  drainAdmissions: () => Promise<void>;
+};
+
 function runWrapper(socketPath: string, args: string[], script = 'query'): Promise<WrapperResult> {
   return new Promise((resolve, reject) => {
     const child = spawn('sh', [WRAPPER, ...args], {
@@ -54,7 +60,7 @@ function runWrapper(socketPath: string, args: string[], script = 'query'): Promi
 
 describe('bounded query end-to-end (wrapper → socket → broker)', () => {
   let root: string;
-  let server: Server;
+  let server: AdmissionAwareServer;
   let socketPath: string;
   let config: Record<string, unknown>;
   const seedIdA = 'a'.repeat(32);
@@ -139,7 +145,7 @@ describe('bounded query end-to-end (wrapper → socket → broker)', () => {
       runner,
     });
 
-    server = createServer({ broker, audit: auditLog });
+    server = createServer({ broker, audit: auditLog }) as AdmissionAwareServer;
     await listenOnSocket(server, config, auditLog);
   });
 
@@ -239,12 +245,61 @@ describe('bounded query end-to-end (wrapper → socket → broker)', () => {
       runner: nonConformingRunner,
     });
     await new Promise<void>((resolve) => server.close(() => resolve()));
-    server = createServer({ broker, audit: auditLog });
+    server = createServer({ broker, audit: auditLog }) as AdmissionAwareServer;
     await listenOnSocket(server, config, auditLog);
 
     const result = await runWrapper(socketPath, args('octo/alpha'));
 
     expect(result.stdout).toBe(`${CANONICAL_ERROR}\n`);
     expect(result.status).toBe(0);
+  });
+
+  it('does not admit a partially read request after shutdown freezes admissions', async () => {
+    const handle = jest.fn(async () => {
+      throw new Error('broker.handle must not run after shutdown admission freeze');
+    });
+    const auditLog = {
+      invocation: () => { /* not asserted */ },
+      failure: () => { /* not asserted */ },
+      lifecycle: () => { /* not asserted */ },
+    };
+    const broker = { handle, drain: async () => undefined, close: () => undefined };
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    server = createServer({ broker, audit: auditLog }) as AdmissionAwareServer;
+    await listenOnSocket(server, config, auditLog);
+
+    const schemaB64 = Buffer.from(OUTCOME_SCHEMA, 'utf8').toString('base64url');
+    const requestSeen = new Promise<void>((resolve) => {
+      server.once('request', () => resolve());
+    });
+    const response = new Promise<string>((resolve, reject) => {
+      const req = http.request({
+        socketPath,
+        path: '/query',
+        method: 'POST',
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'x-awf-query-version': '2',
+          'x-awf-repo': 'octo/alpha',
+          'x-awf-schema-b64': schemaB64,
+        },
+      }, (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => resolve(body));
+      });
+      req.on('error', reject);
+      req.write('partial');
+      void requestSeen.then(() => {
+        server.freezeAdmissions();
+        server.close();
+        req.end('-body');
+      });
+    });
+
+    await expect(response).resolves.toBe(CANONICAL_ERROR);
+    await server.drainAdmissions();
+    expect(handle).not.toHaveBeenCalled();
   });
 });

--- a/src/bounded-query/end-to-end.test.ts
+++ b/src/bounded-query/end-to-end.test.ts
@@ -102,7 +102,7 @@ describe('bounded query end-to-end (wrapper → socket → broker)', () => {
       queryScriptPath: '/awf/query-script.py',
       querySeccompPath: '/opt/awf/query-seccomp.json',
       queryImage: 'bounded-query:test',
-      dockerRuntime: '',
+      queryBackend: 'docker',
       memoryLimit: '512m',
       timeoutSeconds: 30,
       maxInvocations: 2,

--- a/src/bounded-query/query-runner.test.ts
+++ b/src/bounded-query/query-runner.test.ts
@@ -1,0 +1,237 @@
+import * as path from 'path';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const brokerDir = path.join(__dirname, '..', '..', 'containers', 'bounded-query', 'broker');
+const {
+  createQueryRunner,
+  deriveQueryContainerSpec,
+} = require(path.join(brokerDir, 'query-runner.js'));
+const { DockerQueryRunner } = require(path.join(brokerDir, 'docker-query-runner.js'));
+const { GvisorQueryRunner } = require(path.join(brokerDir, 'gvisor-query-runner.js'));
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+interface DockerResult {
+  exitCode: number;
+  timedOut: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+const ok = (overrides: Partial<DockerResult> = {}): DockerResult => ({
+  exitCode: 0,
+  timedOut: false,
+  stdout: '',
+  stderr: '',
+  ...overrides,
+});
+
+const config = {
+  queryBackend: 'docker',
+  hostWorkDir: '/daemon/private/work',
+  queryMountDir: '/query',
+  queryScriptPath: '/awf/query-script.py',
+  querySeccompPath: '/opt/awf/query-seccomp.json',
+  queryImage: 'ghcr.io/example/bounded-query:1',
+  memoryLimit: '256m',
+  timeoutSeconds: 30,
+  queryUid: 65534,
+  queryGid: 65534,
+};
+
+function createDocker(
+  handler: (args: readonly string[]) => DockerResult | Promise<DockerResult> = () => ok(),
+) {
+  const calls: string[][] = [];
+  return {
+    calls,
+    client: {
+      runDocker: async (args: readonly string[]) => {
+        calls.push([...args]);
+        return handler(args);
+      },
+    },
+  };
+}
+
+describe('trusted bounded-query runner contract', () => {
+  it('derives a frozen launch specification with no request-controlled surface', () => {
+    const maliciousRequest = {
+      image: 'attacker/image',
+      command: ['sh'],
+      mounts: ['/etc:/host'],
+      runtime: 'runc',
+      env: { LEAK: '1' },
+    };
+    const spec = deriveQueryContainerSpec({
+      config,
+      runId: 'abcd1234',
+      invocationId: '0123456789abcdef',
+      runtimeName: undefined,
+      request: maliciousRequest,
+    });
+
+    expect(Object.isFrozen(spec)).toBe(true);
+    expect(Object.isFrozen(spec.launchArgs)).toBe(true);
+    expect(spec.launchArgs.join(' ')).not.toContain('attacker');
+    expect(spec.launchArgs.join(' ')).not.toContain('/etc:/host');
+    expect(spec.launchArgs.join(' ')).not.toContain('LEAK');
+    expect(spec.launchArgs.slice(-3)).toEqual([
+      '--entrypoint',
+      '/usr/local/bin/run-query',
+      config.queryImage,
+    ]);
+    expect(spec.launchArgs.filter((value: string) => value === '-v')).toHaveLength(3);
+  });
+
+  it('creates a distinct named sandbox for every invocation', () => {
+    const first = deriveQueryContainerSpec({
+      config,
+      runId: 'abcd1234',
+      invocationId: '1111111111111111',
+    });
+    const second = deriveQueryContainerSpec({
+      config,
+      runId: 'abcd1234',
+      invocationId: '2222222222222222',
+    });
+
+    expect(first.containerName).not.toBe(second.containerName);
+    expect(first.launchArgs).toContain(first.containerName);
+    expect(second.launchArgs).toContain(second.containerName);
+    expect(first.launchArgs.join(' ')).toContain('/1111111111111111/repo:');
+    expect(second.launchArgs.join(' ')).toContain('/2222222222222222/repo:');
+  });
+
+  it('selects Docker default runtime versus the fixed runsc runtime explicitly', () => {
+    const dockerRunner = createQueryRunner(config, { docker: createDocker().client });
+    const gvisorRunner = createQueryRunner(
+      { ...config, queryBackend: 'gvisor' },
+      { docker: createDocker().client },
+    );
+
+    expect(dockerRunner).toBeInstanceOf(DockerQueryRunner);
+    expect(gvisorRunner).toBeInstanceOf(GvisorQueryRunner);
+    expect(dockerRunner.spec('abcd1234', '1111111111111111').launchArgs).not.toContain('--runtime');
+    const gvisorArgs = gvisorRunner.spec('abcd1234', '1111111111111111').launchArgs;
+    expect(gvisorArgs.slice(gvisorArgs.indexOf('--runtime'), gvisorArgs.indexOf('--runtime') + 2))
+      .toEqual(['--runtime', 'runsc']);
+  });
+
+  it('fails closed for unknown and unavailable runtimes', async () => {
+    expect(() => createQueryRunner({ ...config, queryBackend: 'runc' })).toThrow(
+      /Unsupported bounded-query backend/,
+    );
+
+    const { client } = createDocker((args) => {
+      if (args[0] === 'info') return ok({ stdout: '{"runc":{}}' });
+      return ok();
+    });
+    const runner = createQueryRunner({ ...config, queryBackend: 'gvisor' }, { docker: client });
+    await expect(runner.assertAvailable()).rejects.toThrow(/runsc OCI runtime; no fallback/);
+  });
+
+  it.each([
+    ['timeout', false],
+    ['error', true],
+  ])('removes the labelled invocation after a %s', async (_case, launchThrows) => {
+    const containerId = 'a'.repeat(64);
+    const { calls, client } = createDocker((args) => {
+      if (args[0] === 'run') {
+        if (launchThrows) throw new Error('daemon disconnected');
+        return ok({ exitCode: 137, timedOut: true });
+      }
+      if (args[0] === 'ps') return ok({ stdout: `${containerId}\n` });
+      return ok();
+    });
+    const runner = createQueryRunner(config, { docker: client });
+    const run = runner.runQueryContainer({
+      runId: 'abcd1234',
+      invocationId: '1111111111111111',
+      timeoutMs: 100,
+    });
+
+    if (_case === 'error') {
+      await expect(run).rejects.toThrow('daemon disconnected');
+    } else {
+      await expect(run).resolves.toMatchObject({ timedOut: true });
+    }
+    const list = calls.find((args) => args[0] === 'ps');
+    expect(list).toEqual([
+      'ps', '-aq',
+      '--filter', 'label=awf.bounded-query.run=abcd1234',
+      '--filter', 'label=awf.bounded-query.invocation=1111111111111111',
+    ]);
+    expect(calls).toContainEqual(['rm', '-f', containerId]);
+  });
+
+  it('preserves a successful stopped-container result when cleanup reports it already absent', async () => {
+    const { client } = createDocker((args) => {
+      if (args[0] === 'run') return ok();
+      if (args[0] === 'ps') return ok({ stdout: 'c'.repeat(64) });
+      if (args[0] === 'rm') return ok({ exitCode: 1, stderr: 'No such container' });
+      return ok();
+    });
+    const runner = createQueryRunner(config, { docker: client });
+
+    await expect(runner.runQueryContainer({
+      runId: 'abcd1234',
+      invocationId: '1111111111111111',
+    })).resolves.toMatchObject({ exitCode: 0, timedOut: false });
+  });
+
+  it('serializes interruption reconciliation with per-invocation cleanup', async () => {
+    const events: string[] = [];
+    let releaseList: (() => void) | undefined;
+    const firstList = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    let listCount = 0;
+    const { client } = createDocker(async (args) => {
+      if (args[0] !== 'ps') return ok();
+      listCount += 1;
+      events.push(`list-${listCount}-start`);
+      if (listCount === 1) await firstList;
+      events.push(`list-${listCount}-end`);
+      return ok();
+    });
+    const runner = createQueryRunner(config, { docker: client });
+
+    const invocationCleanup = runner.cleanupInvocation('abcd1234', '1111111111111111');
+    const reconciliation = runner.reconcileRun('abcd1234');
+    await Promise.resolve();
+    expect(events).toEqual(['list-1-start']);
+    releaseList?.();
+    await Promise.all([invocationCleanup, reconciliation]);
+    expect(events).toEqual([
+      'list-1-start',
+      'list-1-end',
+      'list-2-start',
+      'list-2-end',
+    ]);
+  });
+
+  it('reconciles interruption leftovers by run label without touching unrelated containers', async () => {
+    const abandonedId = 'b'.repeat(64);
+    const { calls, client } = createDocker((args) => (
+      args[0] === 'ps' ? ok({ stdout: abandonedId }) : ok()
+    ));
+    const runner = createQueryRunner(config, { docker: client });
+
+    await runner.reconcileRun('abcd1234');
+
+    expect(calls[0]).toEqual([
+      'ps', '-aq',
+      '--filter', 'label=awf.bounded-query.run=abcd1234',
+    ]);
+    expect(calls[1]).toEqual(['rm', '-f', abandonedId]);
+  });
+
+  it('rejects daemon output that could become an untrusted cleanup argument', async () => {
+    const { client } = createDocker((args) => (
+      args[0] === 'ps' ? ok({ stdout: '--force' }) : ok()
+    ));
+    const runner = createQueryRunner(config, { docker: client });
+
+    await expect(runner.reconcileRun('abcd1234')).rejects.toThrow(/invalid.*container id/);
+  });
+});

--- a/src/services/bounded-query-service.test.ts
+++ b/src/services/bounded-query-service.test.ts
@@ -96,7 +96,7 @@ describe('buildBoundedQueryService', () => {
       expect(environment.AWF_BOUNDED_QUERY_TIMEOUT).toBe('45');
       expect(environment.AWF_BOUNDED_QUERY_MEMORY).toBe('256m');
       expect(environment.AWF_BOUNDED_QUERY_MAX_INVOCATIONS).toBe('9');
-      expect(environment.AWF_BOUNDED_QUERY_RUNTIME).toBe('');
+      expect(environment.AWF_BOUNDED_QUERY_BACKEND).toBe('docker');
       expect(environment.AWF_BOUNDED_QUERY_HOST_WORK_DIR).toBe(paths.workDir);
     });
 
@@ -136,7 +136,7 @@ describe('buildBoundedQueryService', () => {
         config: buildConfig({}, { runtime: 'gvisor' }),
         imageConfig: imageConfig(),
       });
-      expect((gvisorService.environment as Record<string, string>).AWF_BOUNDED_QUERY_RUNTIME).toBe('runsc');
+      expect((gvisorService.environment as Record<string, string>).AWF_BOUNDED_QUERY_BACKEND).toBe('gvisor');
     });
 
     it('uses the AWF Docker host socket when overridden, without leaking it to the agent', () => {

--- a/src/services/bounded-query-service.ts
+++ b/src/services/bounded-query-service.ts
@@ -1,6 +1,5 @@
 import { logger } from '../logger';
 import { buildRuntimeImageRef } from '../image-tag';
-import { resolveDockerRuntime } from '../container-runtime';
 import { getSafeHostGid, getSafeHostUid } from '../host-identity';
 import { BOUNDED_QUERY_BROKER_CONTAINER_NAME } from '../constants';
 import type { WrapperConfig } from '../types';
@@ -192,13 +191,9 @@ export function buildBoundedQueryService(params: BoundedQueryServiceParams): Bou
     ),
     environment: {
       AWF_BOUNDED_QUERY_IMAGE: queryImageRef,
-      // "docker" means the daemon's default OCI runtime. Passing
-      // `--runtime docker` would fail because Docker has no runtime by that
-      // name; only non-default runtimes get an explicit value.
-      AWF_BOUNDED_QUERY_RUNTIME:
-        boundedQueries.runtime === 'docker'
-          ? ''
-          : resolveDockerRuntime(boundedQueries.runtime) ?? '',
+      // The broker selects a fixed QueryRunner from this normalized value.
+      // Runtime flags are never accepted from an invocation.
+      AWF_BOUNDED_QUERY_BACKEND: boundedQueries.runtime,
       AWF_BOUNDED_QUERY_TIMEOUT: String(boundedQueries.timeout),
       AWF_BOUNDED_QUERY_MEMORY: boundedQueries.memoryLimit,
       AWF_BOUNDED_QUERY_MAX_INVOCATIONS: String(boundedQueries.maxInvocations),

--- a/tests/integration/bounded-query-isolation.test.ts
+++ b/tests/integration/bounded-query-isolation.test.ts
@@ -83,7 +83,7 @@ describe('bounded-query Docker isolation', () => {
         queryScriptPath: '/awf/query-script.py',
         querySeccompPath: path.resolve(__dirname, '../../containers/bounded-query/query-seccomp.json'),
         queryImage: image,
-        dockerRuntime: '',
+        queryBackend: 'docker',
         memoryLimit: '256m',
         queryUid: 65534,
         queryGid: 65534,


### PR DESCRIPTION
## Summary

Layer 2 of the bounded-query multi-sandbox work, built directly on layer 1 (#6758 / `10885c9d`).

- add a broker-internal `QueryRunner` contract with explicit `DockerQueryRunner` and `GvisorQueryRunner` backends
- centralize immutable, trusted derivation of query image, entrypoint, mounts, network, seccomp, user, limits, labels, environment, timeout, and cleanup filters
- select `docker` versus `gvisor` from normalized AWF configuration; only the gVisor backend emits `--runtime runsc`, and missing/unknown runtimes fail closed without fallback
- create a uniquely named container for every invocation and reconcile abandoned containers only through run/invocation labels
- serialize invocation cleanup with interruption reconciliation and preserve the layer-1 private-state/agent-ingress boundary
- keep sbx transport and sbx query execution out of scope

## Validation

- 110 focused bounded-query unit tests pass
- bounded-query isolation integration test passes
- TypeScript build and type-check pass
- ESLint passes with existing warnings only
- full unit suite: 4,848 pass; 2 existing macOS `/var/tmp` versus `/private/var/tmp` path-assumption tests fail outside this diff