### PR TITLE
test: fix gvisor runtime matrix fixture

### DIFF
--- a/src/bounded-query/runtime-matrix.test.ts
+++ b/src/bounded-query/runtime-matrix.test.ts
@@ -270,7 +270,7 @@ describe('bounded-query runtime conformance matrix', () => {
         runDocker: async (args: readonly string[]) => {
           dockerCalls.push([...args]);
           if (args[0] === 'info') {
-            return { exitCode: 0, timedOut: false, stdout: '{"runsc":{}}', stderr: '' };
+            return { exitCode: 0, timedOut: false, stdout: 'runc\nrunsc\n', stderr: '' };
           }
           return { exitCode: 0, timedOut: false, stdout: '', stderr: '' };
         },


### PR DESCRIPTION
## Summary

- update the runtime matrix Docker mock to return newline-separated OCI runtime names
- align the fixture with the bounded gVisor capability probe's `docker info` format

## Validation

- `npm test -- --runInBand`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:lint-rules`