### PR TITLE
fix: upgrade cli-proxy gh to 2.97.0

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,62 +10,6 @@
 # Format reference: https://github.com/anchore/grype?tab=readme-ov-file#configuration
 
 ignore:
-  # ── grpc v1.81.1 embedded in gh CLI binary ───────────────────────────────────
-  #
-  # GHSA-hrxh-6v49-42gf (google.golang.org/grpc v1.81.1 -> 1.82.1, CRITICAL,
-  # CVSS 9.1):
-  #   Three server-side grpc-go issues: an xDS RBAC authorization bypass
-  #   (fail-open on unsupported matchers), an HTTP/2 rapid-reset mitigation
-  #   bypass (DoS), and a panic on crafted xDS RBAC policies.
-  #
-  #   Risk acceptance — NOT REACHABLE in our usage:
-  #     grpc v1.81.1 is a transitive dependency compiled into the `gh` CLI
-  #     binary. `gh` is a client: it does not run a gRPC server, use xDS RBAC,
-  #     or accept HTTP/2 from untrusted peers, so none of the vulnerable code
-  #     paths are exercised. The finding is present but not exploitable here.
-  #   Present in the cli-proxy image (gh from the official release tarball).
-  #
-  #   gh 2.97.0 fixes this in the agent image. The cli-proxy image remains on
-  #   gh 2.96.0, so this exception remains narrowly scoped to that binary.
-  #   Revisit: bump GH_VERSION in cli-proxy/Dockerfile to >= 2.97.0 and DELETE
-  #   this entry. Tracked in github/gh-aw-firewall.
-  - vulnerability: GHSA-hrxh-6v49-42gf
-    package:
-      name: google.golang.org/grpc
-      version: "v1.81.1"
-      type: go-module
-
-  # ── golang.org/x/text v0.38.0 embedded in gh CLI binary (cli-proxy image) ────
-  #
-  # GO-2026-5970 / CVE-2026-56852 (golang.org/x/text v0.38.0 -> 0.39.0, HIGH):
-  #   A norm.Iter can enter an infinite loop when handling input containing
-  #   invalid UTF-8 bytes (denial of service).
-  #
-  #   Risk acceptance — BOUNDED DoS only, mitigated by process timeout:
-  #     x/text v0.38.0 is compiled into the `gh` CLI binary in the cli-proxy
-  #     image. The cli-proxy server forwards agent-supplied args and
-  #     base64-decoded stdin directly to `gh` (containers/cli-proxy/server.js,
-  #     gh-runner.js). Any norm.Iter loop triggered by invalid UTF-8 in those
-  #     inputs would be killed by the COMMAND_TIMEOUT_MS guard (default 30 s,
-  #     gh-runner.js:5), bounding the impact to a single timed-out request.
-  #     There is no privilege escalation, data exfiltration, or RCE vector —
-  #     the vulnerability is DoS only.
-  #   Scoped to /usr/local/bin/gh (cli-proxy image, installed from release
-  #   tarball, gh=2.96.0).
-  #
-  #   No fix is shippable today: gh 2.96.0 (latest release as of 2026-07-24)
-  #   still bundles x/text v0.38.0, and building gh from unreleased trunk would
-  #   ship an untagged, non-official binary (worse supply-chain risk).
-  #   Revisit: once a gh CLI release bundling x/text >= v0.39.0 is available,
-  #   bump the GH_VERSION in cli-proxy/Dockerfile and DELETE this entry.
-  #   Tracked in github/gh-aw-firewall.
-  - vulnerability: GO-2026-5970
-    package:
-      name: golang.org/x/text
-      version: "v0.38.0"
-      type: go-module
-      location: "/usr/local/bin/gh"
-
   # ── stdlib@go1.24.6 embedded in gosu binary ──────────────────────────────────
   #
   # GO-2026-4337 (stdlib go1.24.6 -> 1.24.13 / 1.25.7 / 1.26.0-rc.3, CRITICAL):

--- a/containers/cli-proxy/Dockerfile
+++ b/containers/cli-proxy/Dockerfile
@@ -18,17 +18,17 @@ RUN apk add --no-cache \
     ca-certificates \
     bash
 
-# Install gh CLI 2.96.0 from the official GitHub CLI release.
-# This binary is compiled with Go 1.26.4 (fixing GO-2026-5037 / stdlib 1.26.3->1.26.4)
-# and ships with sigstore/rekor v1.5.2 (fixing GHSA-47q9-m4ww-924m).
-# Checksums sourced from https://github.com/cli/cli/releases/tag/v2.96.0
+# Install gh CLI 2.97.0 from the official GitHub CLI release.
+# This binary is compiled with Go 1.26.5 and ships with grpc v1.82.1 and
+# golang.org/x/text v0.40.0.
+# Checksums sourced from https://github.com/cli/cli/releases/tag/v2.97.0
 RUN set -eux; \
-    GH_VERSION="2.96.0"; \
+    GH_VERSION="2.97.0"; \
     ARCH="$(uname -m)"; \
     case "$ARCH" in \
-      x86_64)  GH_ARCH="amd64"; GH_SHA256="83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60" ;; \
-      aarch64) GH_ARCH="arm64"; GH_SHA256="06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909" ;; \
-      armv6l|armv7l) GH_ARCH="armv6"; GH_SHA256="14ff25ec64823415086214fb05b3e85aef21deba6a8d723a7ef8ead1cb977826" ;; \
+      x86_64)  GH_ARCH="amd64"; GH_SHA256="a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112" ;; \
+      aarch64) GH_ARCH="arm64"; GH_SHA256="73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5" ;; \
+      armv6l|armv7l) GH_ARCH="armv6"; GH_SHA256="83698de1d91d201cc3b9d9b0beb346c221cadb53a68fb82f741ef0a0efc4502c" ;; \
       *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     GH_TGZ="gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"; \


### PR DESCRIPTION
## Summary

- upgrade the CLI-proxy image from `gh` 2.96.0 to 2.97.0 using official per-architecture checksums
- pick up `google.golang.org/grpc` 1.82.1 and `golang.org/x/text` 0.40.0
- remove the obsolete Grype exceptions for GHSA-hrxh-6v49-42gf and GO-2026-5970

## Testing

- `npm test -- --runInBand` (4,964 passed, 1 skipped)
- `npm run lint`
- `npm run build`
- verified the release artifact checksum and embedded Go module versions

Closes #6555