### PR TITLE
feat: route unified enclaves exclusively through mcpg

### DIFF
--- a/containers/bounded-query/enclave-mcp/Dockerfile
+++ b/containers/bounded-query/enclave-mcp/Dockerfile
@@ -2,9 +2,9 @@
 #
 # This image owns the Docker socket and the private seed/work/audit mounts for
 # *both* enclave executors, and its Compose service always runs with
-# `network_mode: none` — it has no `awf-net`, no enclave network, no DNS, no
-# Squid, no host gateway, and no egress of any kind. Its only agent-facing
-# surface is one authenticated Unix socket.
+# only the dedicated internal MCP control network. It has no `awf-net`, enclave
+# executor network, Squid, host gateway, published port, or external egress. Its
+# only caller-facing surface is authenticated streamable HTTP through mcpg.
 #
 # BUILD CONTEXT: `containers/` (not `containers/bounded-query/`).  The server
 # drives two audited executors that live in two directories:

--- a/containers/bounded-query/enclave-mcp/config.js
+++ b/containers/bounded-query/enclave-mcp/config.js
@@ -18,11 +18,12 @@ const { MAX_TASK_BYTES } = require('../agent-broker/framing');
 const SEEDS_DIR = '/srv/awf/seeds';
 const WORK_DIR = '/srv/awf/work';
 const SEED_MAP_PATH = '/srv/awf/seed-map.json';
-const SOCKET_DIR = '/run/awf-enclave-mcp';
-const CAPABILITY_PATH = path.join(SOCKET_DIR, 'auth-token');
+const CAPABILITY_DIR = '/run/awf-enclave-mcp';
+const CAPABILITY_PATH = path.join(CAPABILITY_DIR, 'auth-token');
 const CONTROL_DIR = '/run/awf-enclave-mcp-control';
 const AUDIT_DIR = '/var/log/awf-enclave';
 const READY_PATH = path.join(CONTROL_DIR, 'server.ready');
+const MCP_PORT = 8080;
 
 /**
  * Fixed agent-enclave mount points and identity. Never caller-supplied.
@@ -55,16 +56,6 @@ function positiveInt(name, fallback, maximum = Number.MAX_SAFE_INTEGER) {
   const value = Number(raw);
   if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
     throw new Error(`${name} must be an integer between 1 and ${maximum}`);
-  }
-  return value;
-}
-
-function nonnegativeInt(name, fallback) {
-  const raw = process.env[name];
-  if (raw === undefined || raw === '') return fallback;
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value) || value < 0) {
-    throw new Error(`${name} must be a non-negative integer`);
   }
   return value;
 }
@@ -105,8 +96,8 @@ function loadConfig(files = fs) {
     workDir: WORK_DIR,
     seedMapPath: SEED_MAP_PATH,
     hostWorkDir: requireEnv('AWF_ENCLAVE_HOST_WORK_DIR'),
-    socketDir: SOCKET_DIR,
-    socketPath: path.join(SOCKET_DIR, 'server.sock'),
+    listenHost: process.env.AWF_ENCLAVE_LISTEN_HOST || '0.0.0.0',
+    listenPort: MCP_PORT,
     controlDir: CONTROL_DIR,
     readyPath: READY_PATH,
     auditDir: AUDIT_DIR,
@@ -126,8 +117,6 @@ function loadConfig(files = fs) {
     tmpfsLimit: dockerSize('AWF_ENCLAVE_TMPFS', '64m'),
     maxOutputBytes: positiveInt('AWF_ENCLAVE_MAX_OUTPUT_BYTES', MAX_RESULT_BYTES, MAX_RESULT_BYTES),
     maxScriptBytes: positiveInt('AWF_ENCLAVE_MAX_SCRIPT_BYTES', MAX_SCRIPT_BYTES, MAX_SCRIPT_BYTES),
-    socketUid: nonnegativeInt('AWF_ENCLAVE_SOCKET_UID', 0),
-    socketGid: nonnegativeInt('AWF_ENCLAVE_SOCKET_GID', 0),
     capability,
     runLabelKey: ENCLAVE_RUN_LABEL,
     invocationLabelKey: ENCLAVE_INVOCATION_LABEL,
@@ -162,14 +151,12 @@ function loadServerConfig(files = fs) {
   }
   return {
     seedMapPath: SEED_MAP_PATH,
-    socketDir: SOCKET_DIR,
-    socketPath: path.join(SOCKET_DIR, 'server.sock'),
+    listenHost: process.env.AWF_ENCLAVE_LISTEN_HOST || '0.0.0.0',
+    listenPort: MCP_PORT,
     controlDir: CONTROL_DIR,
     readyPath: READY_PATH,
     auditDir: AUDIT_DIR,
     primaryBackend,
-    socketUid: nonnegativeInt('AWF_ENCLAVE_SOCKET_UID', 0),
-    socketGid: nonnegativeInt('AWF_ENCLAVE_SOCKET_GID', 0),
     capability,
   };
 }
@@ -268,7 +255,7 @@ module.exports = {
   READY_PATH,
   SEED_MAP_PATH,
   SEEDS_DIR,
-  SOCKET_DIR,
+  CAPABILITY_DIR,
   WORK_DIR,
   isAgentExecutorEnabled,
   isScriptExecutorEnabled,

--- a/containers/bounded-query/enclave-mcp/mcp-protocol.js
+++ b/containers/bounded-query/enclave-mcp/mcp-protocol.js
@@ -11,6 +11,13 @@ const TOOL_NAME = 'enclave_run_script';
 const AGENT_TOOL_NAME = 'enclave_run_agent';
 const JSONRPC_ERROR = Object.freeze({ status: 'error' });
 
+function canonicalToolError() {
+  return {
+    content: [{ type: 'text', text: '{"status":"error"}' }],
+    structuredContent: JSONRPC_ERROR,
+  };
+}
+
 const FINITE_SCHEMA_INPUT = Object.freeze({
   type: 'object',
   description: 'An AWF finite-disclosure schema (const, boolean, enum, integer, object, tuple, array, or union).',
@@ -145,10 +152,7 @@ function brokerCall(broker, request) {
     broker.handle(request, (canonicalJson) => {
       const parsed = strictParseJson(canonicalJson);
       if (!parsed || !parsed.value || parsed.value.status !== 'ok') {
-        resolve({
-          content: [{ type: 'text', text: '{"status":"error"}' }],
-          structuredContent: JSONRPC_ERROR,
-        });
+        resolve(canonicalToolError());
         return;
       }
       resolve({
@@ -216,7 +220,18 @@ async function dispatchJsonRpc(message, deps) {
       && Buffer.byteLength(args[payloadKey], 'utf8') > limit
     );
     const request = tooLarge ? undefined : args;
-    return rpcResult(message.id, await brokerCall(brokers[name], request));
+    let release;
+    if (typeof deps.tryAcquireToolCall === 'function') {
+      release = deps.tryAcquireToolCall();
+      if (typeof release !== 'function') {
+        return rpcResult(message.id, canonicalToolError());
+      }
+    }
+    try {
+      return rpcResult(message.id, await brokerCall(brokers[name], request));
+    } finally {
+      if (release) release();
+    }
   }
 
   return rpcError(message.id, -32601, 'Method not found');

--- a/containers/bounded-query/enclave-mcp/server.js
+++ b/containers/bounded-query/enclave-mcp/server.js
@@ -67,7 +67,22 @@ function readBody(req) {
   });
 }
 
+function createSingleToolAdmission() {
+  let active = false;
+  return () => {
+    if (active) return undefined;
+    active = true;
+    return () => {
+      active = false;
+    };
+  };
+}
+
 function createMcpServer(deps) {
+  const dispatchDeps = {
+    ...deps,
+    tryAcquireToolCall: createSingleToolAdmission(),
+  };
   const server = http.createServer({ maxHeaderSize: 8 * 1024 }, async (req, res) => {
     const authorizationHeaders = req.rawHeaders.filter(
       (_value, index) => index % 2 === 0 && req.rawHeaders[index].toLowerCase() === 'authorization',
@@ -105,7 +120,7 @@ function createMcpServer(deps) {
 
     let response;
     try {
-      response = await dispatchJsonRpc(message, deps);
+      response = await dispatchJsonRpc(message, dispatchDeps);
     } catch {
       jsonResponse(res, 200, {
         jsonrpc: '2.0',
@@ -273,6 +288,7 @@ if (require.main === module) {
 module.exports = {
   MAX_HTTP_BODY_BYTES,
   createMcpServer,
+  createSingleToolAdmission,
   listenOnPrivateNetwork,
   safeCapabilityEquals,
 };

--- a/containers/bounded-query/enclave-mcp/server.js
+++ b/containers/bounded-query/enclave-mcp/server.js
@@ -128,20 +128,10 @@ function createMcpServer(deps) {
   return server;
 }
 
-function listenOnSocket(server, config) {
-  fs.rmSync(config.socketPath, { force: true });
-  fs.mkdirSync(config.socketDir, { recursive: true, mode: 0o700 });
+function listenOnPrivateNetwork(server, config) {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
-    server.listen(config.socketPath, () => {
-      try {
-        fs.chownSync(config.socketPath, config.socketUid, config.socketGid);
-        fs.chmodSync(config.socketPath, 0o660);
-        resolve();
-      } catch (error) {
-        reject(error);
-      }
-    });
+    server.listen(config.listenPort, config.listenHost, resolve);
   });
 }
 
@@ -234,7 +224,7 @@ async function main() {
     maxScriptBytes,
     maxPromptBytes,
   });
-  await listenOnSocket(server, serverConfig);
+  await listenOnPrivateNetwork(server, serverConfig);
   fs.mkdirSync(serverConfig.controlDir, { recursive: true, mode: 0o700 });
   fs.writeFileSync(serverConfig.readyPath, '', { mode: 0o600 });
   audit.lifecycle('listening', { executors });
@@ -283,6 +273,6 @@ if (require.main === module) {
 module.exports = {
   MAX_HTTP_BODY_BYTES,
   createMcpServer,
-  listenOnSocket,
+  listenOnPrivateNetwork,
   safeCapabilityEquals,
 };

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -2527,9 +2527,10 @@ All four names are unconditionally excluded from primary-agent environment
 passthrough. The mcpg upstream is named `awf-enclave`, uses
 `http://awf-enclave-mcp:8080/mcp`, supplies
 `Authorization: Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}`, allowlists exactly the
-enabled enclave tool names, uses at least a 120-second HTTP connection retry
-window, and sets the per-tool timeout to 30 seconds more than the largest enabled
-executor timeout.
+enabled enclave tool names, sets each upstream attempt's `connectTimeout` to 120
+seconds, and sets the per-tool timeout to 30 seconds more than the largest
+enabled executor timeout. `gateway.startupTimeout` is stdio-only and MUST NOT be
+used as the HTTP recovery bound.
 
 The compiler must also enable `network.isolation` and include the configured
 gateway container in `network.topologyAttach`. The enclave server itself is not
@@ -2542,6 +2543,13 @@ exactly those two members, then performs `initialize` and `tools/list` through
 the gateway route. The complete static tool contracts must match. Failure,
 timeout, authentication failure, identity mismatch, or tool mismatch aborts
 before Compose starts the agent or sbx creates its sandbox.
+
+This integration requires MCP Gateway specification 1.15.0 and the first mcpg
+release after v0.4.8 containing github/gh-aw-mcpg#10784. Until the upstream is
+available, mcpg returns retryable HTTP 503 `backend_unavailable`; AWF retries
+`initialize` with a bounded 500 ms backoff until
+`AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` expires. AWF does not log the 503 response
+body, request headers, bearer capability, or other secret material.
 
 On shutdown AWF stops the primary-agent work first, sends the server a bounded
 graceful stop to close admissions and drain calls, disconnects but does not stop

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -2446,8 +2446,9 @@ private-repository execution. One AWF-owned, no-egress MCP service exposes the
 enabled executors: the script executor launches hardened single-use script
 containers with no network, and the agent executor launches hardened single-use
 enclaves that run a fixed, AWF-authored model loop on a dedicated
-API-proxy-only network. The service is not yet attached to the primary agent; a
-later migration layer registers it exclusively through `gh-aw-mcpg`. See
+API-proxy-only network. The service is reachable exclusively through a
+compiler-launched, run-labelled `gh-aw-mcpg` gateway on an AWF-owned private
+control network. See
 [Unified Enclave Architecture and Migration](enclaves-architecture.md).
 
 `enclaves.privateRepos` is the single trusted repository list for every
@@ -2501,12 +2502,51 @@ independent behavior until runtime cutover.
 Agent enclaves join only the dedicated `internal` `awf-enclave-agent` network
 (172.31.0.0/24). Its only other member is a dedicated API proxy that also joins
 a separate egress bridge and is the only holder of a real provider credential.
-The MCP server runs `network_mode: none` and is never on that network; neither
-is the primary agent, Squid, the general API proxy, the safe-outputs collector,
-the MCP gateway, or the CLI proxy. The dedicated proxy's credentials are
+The MCP server is never on that network. It joins only the separate `internal`
+`awf-enclave-mcp-control` network with the externally launched MCP gateway; the
+primary agent, Squid, general API proxy, safe-outputs collector, CLI proxy, and
+all enclave executors are excluded. The server publishes no host port. The
+dedicated agent-enclave proxy's credentials are
 minimized to the configured route, its external telemetry export and Actions
 OIDC token-exchange state are removed, and its logs stay in the enclave-private
 root.
+
+### 16.2 Exclusive MCP gateway handoff
+
+Enclaves require a compiler-generated handoff before staging:
+
+| Variable | Contract |
+|----------|----------|
+| `AWF_ENCLAVE_MCP_CAPABILITY` | Fresh 64-character lowercase hexadecimal bearer capability passed only to mcpg and AWF |
+| `AWF_ENCLAVE_MCP_GATEWAY_CONTAINER` | External gateway container name; `awmg-mcpg` by default |
+| `AWF_ENCLAVE_MCP_GATEWAY_IDENTITY` | Run-unique value equal to the gateway's `com.github.gh-aw.mcpg.run` label |
+| `AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT` | Host-reachable gateway route ending in `/mcp/awf-enclave` |
+| `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` | Optional bounded AWF end-to-end readiness window, 1000-600000 ms; default 120000 |
+
+All four names are unconditionally excluded from primary-agent environment
+passthrough. The mcpg upstream is named `awf-enclave`, uses
+`http://awf-enclave-mcp:8080/mcp`, supplies
+`Authorization: Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}`, allowlists exactly the
+enabled enclave tool names, uses at least a 120-second HTTP connection retry
+window, and sets the per-tool timeout to 30 seconds more than the largest enabled
+executor timeout.
+
+The compiler must also enable `network.isolation` and include the configured
+gateway container in `network.topologyAttach`. The enclave server itself is not
+a topology peer: its alias is never added to agent `NO_PROXY`, Squid ACLs, or
+static hosts.
+
+AWF starts Compose infrastructure without the primary agent, attaches only the
+label-matching gateway to `awf-enclave-mcp-control`, verifies the network has
+exactly those two members, then performs `initialize` and `tools/list` through
+the gateway route. The complete static tool contracts must match. Failure,
+timeout, authentication failure, identity mismatch, or tool mismatch aborts
+before Compose starts the agent or sbx creates its sandbox.
+
+On shutdown AWF stops the primary-agent work first, sends the server a bounded
+graceful stop to close admissions and drain calls, disconnects but does not stop
+the externally owned gateway, then lets Compose remove the AWF-owned control
+network and private service.
 
 Each enclave is single-use: immutable seed mounted read-only, `--read-only`
 root, bounded `tmpfs`, fixed non-root uid/gid, `--cap-drop ALL`,

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -2494,8 +2494,10 @@ coexist because they do not activate a runtime.
 The AWF-owned MCP server enforces the unified per-repository ledger for both
 executors: a script call and an agent call debit the same live balance, and
 switching executor kinds never resets or forks it. Both executors also share one
-serialization lane inside the server. Legacy brokers retain their existing
-independent behavior until runtime cutover.
+serialization lane inside the server. The HTTP surface admits only one tool call
+to that lane at a time; concurrent calls receive the same canonical error
+without entering a queue. Legacy brokers retain their existing independent
+behavior until runtime cutover.
 
 ### 16.1 Agent executor topology and disclosure
 
@@ -2523,13 +2525,14 @@ Enclaves require a compiler-generated handoff before staging:
 | `AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT` | Host-reachable gateway route ending in `/mcp/awf-enclave` |
 | `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` | Optional bounded AWF end-to-end readiness window, 1000-600000 ms; default 120000 |
 
-All four names are unconditionally excluded from primary-agent environment
+All five names are unconditionally excluded from primary-agent environment
 passthrough. The mcpg upstream is named `awf-enclave`, uses
 `http://awf-enclave-mcp:8080/mcp`, supplies
 `Authorization: Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}`, allowlists exactly the
 enabled enclave tool names, sets each upstream attempt's `connectTimeout` to 120
-seconds, and sets the per-tool timeout to 30 seconds more than the largest
-enabled executor timeout. `gateway.startupTimeout` is stdio-only and MUST NOT be
+seconds, and sets the per-tool timeout to 630 seconds (the maximum 600-second
+fixed disclosure bucket plus a bounded 30-second gateway allowance).
+`gateway.startupTimeout` is stdio-only and MUST NOT be
 used as the HTTP recovery bound.
 
 The compiler must also enable `network.isolation` and include the configured
@@ -2549,10 +2552,15 @@ release after v0.4.8 containing github/gh-aw-mcpg#10784. Until the upstream is
 available, mcpg returns retryable HTTP 503 `backend_unavailable`; AWF retries
 `initialize` with a bounded 500 ms backoff until
 `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` expires. AWF does not log the 503 response
-body, request headers, bearer capability, or other secret material.
+body, request headers, bearer capability, or other secret material. Any other
+HTTP response, malformed recovery response, authentication failure, protocol
+failure, or tool-contract mismatch fails immediately. Every readiness request is
+capped by the remaining AWF readiness budget, so the configured deadline is a
+hard upper bound for the complete handshake.
 
-On shutdown AWF stops the primary-agent work first, sends the server a bounded
-graceful stop to close admissions and drain calls, disconnects but does not stop
+On shutdown AWF stops the primary-agent work first, sends the server a
+630-second bounded graceful stop covering the maximum fixed disclosure bucket
+plus the stop allowance to close admissions and drain calls, disconnects but does not stop
 the externally owned gateway, then lets Compose remove the AWF-owned control
 network and private service.
 

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -1105,7 +1105,7 @@
     },
     "enclaves": {
       "type": "object",
-      "description": "Unified private-repository enclaves. Repositories and sensitivities are shared by the script and agent executors, and every invocation debits one live per-repository information budget regardless of executor kind. AWF exposes the enabled executors through one AWF-owned, no-egress MCP server; that server is not yet attached to the primary agent.",
+      "description": "Unified private-repository enclaves. Repositories and sensitivities are shared by the script and agent executors, and every invocation debits one live per-repository information budget regardless of executor kind. AWF exposes enabled executors only through an AWF-owned MCP server and the compiler-launched trusted mcpg gateway.",
       "additionalProperties": false,
       "properties": {
         "enabled": {

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -102,7 +102,9 @@ repositories, sensitivity, remaining budget, invocation counts, runtime, engine,
 profile, or model configuration. Admitted executions debit the *same* live
 per-repository ledger under executor kind `script` or `agent`; both executors
 also share one serialization lane, so at most one enclave holds private
-repository content at a time.
+repository content at a time. The HTTP surface admits at most one tool call into
+that lane; a concurrent call receives the canonical error immediately rather
+than creating an unbounded queue of fixed timing buckets.
 
 ### Agent executor isolation
 
@@ -143,8 +145,10 @@ applies only to stdio process startup and does not extend HTTP attempts. While
 the HTTP upstream is unavailable, mcpg returns retryable HTTP 503
 `backend_unavailable`. AWF retries the complete `initialize` handshake with a
 bounded 500 ms backoff until `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` expires.
-Neither component may silently downgrade or bypass the gateway while waiting,
-and readiness errors never log response bodies, headers, or capabilities.
+Each request is capped by the remaining readiness budget. All other HTTP,
+authentication, protocol, and tool-contract failures are terminal. Neither
+component may silently downgrade or bypass the gateway while waiting, and
+readiness errors never log response bodies, headers, or capabilities.
 
 The primary agent must not start until AWF has proved readiness end to end:
 
@@ -175,14 +179,14 @@ The compiler must generate this upstream entry before starting `awmg-mcpg`:
     },
     "tools": ["enclave_run_script", "enclave_run_agent"],
     "connectTimeout": 120,
-    "toolTimeout": 150
+    "toolTimeout": 630
   }
 }
 ```
 
-The `tools` array must contain only enabled executor tools. `toolTimeout` is 30
-seconds greater than the largest enabled executor timeout (150 in the example).
-The compiler must
+The `tools` array must contain only enabled executor tools. `toolTimeout` is 630
+seconds: the maximum 600-second fixed disclosure bucket plus a bounded 30-second
+gateway transport allowance. The compiler must
 generate a fresh 64-character lowercase hexadecimal
 `AWF_ENCLAVE_MCP_CAPABILITY`, pass it to mcpg for header substitution and to the
 AWF host process, and never pass it to the primary agent. It must also:
@@ -222,9 +226,10 @@ alternate path to the enclave server.
 
 ### Shutdown
 
-After primary-agent work stops, AWF sends the enclave server `SIGTERM`. The
-server closes admissions, drains the single execution lane within Docker's
-bounded stop grace, reconciles labelled enclaves, and exits. AWF then disconnects
+After primary-agent work stops, AWF sends the enclave server `SIGTERM` with a
+630-second bounded stop grace: the maximum 600-second fixed disclosure bucket
+plus a 30-second stop allowance. The server closes admissions, drains the single execution lane,
+reconciles labelled enclaves, and exits. AWF then disconnects
 the external gateway from `awf-enclave-mcp-control`; Compose removes the
 AWF-owned server and network, and host cleanup removes the private roots. AWF
 never stops or removes `awmg-mcpg`.

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -137,10 +137,14 @@ Executor outcomes return successful JSON-RPC tool results whose
 `{"status":"error"}`. Secret-dependent failures never use JSON-RPC errors or
 `isError`. Cleanup remains inside the fixed timing bucket.
 
-`gh-aw-mcpg` startup may precede AWF's enclave server startup. The compiler must
-configure the HTTP upstream before launching mcpg and give it sufficient
-connection timeout/retry behavior for AWF staging and startup. Neither component
-may silently downgrade or bypass the gateway while waiting.
+`gh-aw-mcpg` startup may precede AWF's enclave server startup. Each upstream
+attempt is bounded by the server's `connectTimeout`; `gateway.startupTimeout`
+applies only to stdio process startup and does not extend HTTP attempts. While
+the HTTP upstream is unavailable, mcpg returns retryable HTTP 503
+`backend_unavailable`. AWF retries the complete `initialize` handshake with a
+bounded 500 ms backoff until `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` expires.
+Neither component may silently downgrade or bypass the gateway while waiting,
+and readiness errors never log response bodies, headers, or capabilities.
 
 The primary agent must not start until AWF has proved readiness end to end:
 
@@ -191,8 +195,8 @@ AWF host process, and never pass it to the primary agent. It must also:
   ending in `/mcp/awf-enclave`;
 - optionally set `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` to a bounded
   1000-600000 ms value (default 120000);
-- configure gateway HTTP-upstream startup timeout/retry semantics for at least
-  120 seconds.
+- configure the upstream `connectTimeout` to 120 seconds; do not rely on the
+  stdio-only `gateway.startupTimeout` for HTTP recovery.
 - enable AWF network isolation and include `awmg-mcpg` in `topologyAttach`, so
   Compose agents reach only the gateway on `awf-net` while AWF separately
   attaches the same verified container to the enclave control network.
@@ -201,7 +205,9 @@ AWF host process, and never pass it to the primary agent. It must also:
 for the static entry and handoff names. AWF excludes all handoff variables from
 agent environment passthrough, including `--env-all`.
 
-The current gh-aw compiler does not yet emit this enclave upstream, capability,
+This contract requires MCP Gateway specification 1.15.0 and the first mcpg
+release after v0.4.8 containing github/gh-aw-mcpg#10784. The current gh-aw
+compiler does not yet emit this enclave upstream, capability,
 identity label, or readiness endpoint. It requires a companion change in
 `pkg/workflow/mcp_setup_gateway.go`, `mcp_gateway_config.go`,
 `mcp_renderer.go`, and `awf_config.go`. Current mcpg releases must also support

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -2,11 +2,10 @@
 
 ## Status
 
-Layer 3 of the staged migration adds the **agent executor** to the same
-AWF-owned MCP server, behind the same authenticated private socket and the same
-shared per-repository ledger. The subsystem remains deliberately disconnected
-from the primary agent until the `gh-aw-mcpg` attachment layer. Both legacy
-runtimes remain unchanged.
+Layer 4 of the staged migration connects the AWF-owned MCP server exclusively
+through `gh-aw-mcpg`. The primary agent receives no enclave socket, capability,
+direct URL, repository list, control root, ledger, or private state. Both legacy
+runtimes remain unchanged for the final cutover layer.
 
 ## Decision
 
@@ -58,10 +57,15 @@ primary agent learns; it does not bound what the provider sees.
 
 The script service is an offline Compose service. AWF stages immutable seeds and
 creates a run-unique private root before Compose generation. Compose pre-pulls or
-builds the script image, then starts the MCP server with `network_mode: none`.
+builds the script image, then starts the MCP server only on the internal control
+network.
 The server owns the Docker socket, seed map, shared ledger, protected audit
-state, and a private Unix socket plus capability token. Neither the socket nor
-the token is mounted into the primary agent in this layer.
+state and a run-scoped capability token. The server joins only the dedicated
+`internal` `awf-enclave-mcp-control` network under the stable
+`awf-enclave-mcp:8080` identity. There is no published host port. AWF attaches
+only the compiler-labelled external gateway to that network after verifying its
+run identity. Neither the capability nor any direct transport is mounted into or
+exported to the primary agent.
 
 When the agent executor is enabled, AWF additionally pre-pulls or builds the
 `enclave-agent` image, creates the dedicated `internal` `awf-enclave-agent`
@@ -133,19 +137,91 @@ Executor outcomes return successful JSON-RPC tool results whose
 `{"status":"error"}`. Secret-dependent failures never use JSON-RPC errors or
 `isError`. Cleanup remains inside the fixed timing bucket.
 
-`gh-aw-mcpg` startup may precede AWF's enclave server startup. The configured MCP
-server connection timeout and retry policy are the synchronization mechanism;
-neither component may silently downgrade or bypass the gateway while waiting.
+`gh-aw-mcpg` startup may precede AWF's enclave server startup. The compiler must
+configure the HTTP upstream before launching mcpg and give it sufficient
+connection timeout/retry behavior for AWF staging and startup. Neither component
+may silently downgrade or bypass the gateway while waiting.
 
 The primary agent must not start until AWF has proved readiness end to end:
 
-1. the AWF-owned enclave MCP server is healthy;
-2. `gh-aw-mcpg` has connected to that exact configured server;
-3. a guarded readiness call has traversed `gh-aw-mcpg` to the server and returned
-   the expected proof.
+1. the AWF-owned enclave MCP server is healthy on its private control network;
+2. the running gateway name and `com.github.gh-aw.mcpg.run` label match the
+   compiler handoff;
+3. AWF attaches that gateway to the control network and proves it is the only
+   member besides the server;
+4. `initialize`, `notifications/initialized`, and `tools/list` traverse the
+   gateway's published route;
+5. the returned server identity and complete tool contracts exactly match the
+   enabled executor set.
 
 A timeout, identity mismatch, failed proof, or unavailable executor capability
 fails the run before repository staging is exposed or the primary agent starts.
+
+### Compiler-generated mcpg handoff
+
+The compiler must generate this upstream entry before starting `awmg-mcpg`:
+
+```json
+{
+  "awf-enclave": {
+    "type": "http",
+    "url": "http://awf-enclave-mcp:8080/mcp",
+    "headers": {
+      "Authorization": "Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}"
+    },
+    "tools": ["enclave_run_script", "enclave_run_agent"],
+    "connectTimeout": 120,
+    "toolTimeout": 150
+  }
+}
+```
+
+The `tools` array must contain only enabled executor tools. `toolTimeout` is 30
+seconds greater than the largest enabled executor timeout (150 in the example).
+The compiler must
+generate a fresh 64-character lowercase hexadecimal
+`AWF_ENCLAVE_MCP_CAPABILITY`, pass it to mcpg for header substitution and to the
+AWF host process, and never pass it to the primary agent. It must also:
+
+- launch the externally owned gateway as `awmg-mcpg`;
+- label it `com.github.gh-aw.mcpg.run=<run-unique identity>`;
+- set `AWF_ENCLAVE_MCP_GATEWAY_IDENTITY` to that exact identity for AWF;
+- set `AWF_ENCLAVE_MCP_GATEWAY_CONTAINER=awmg-mcpg`;
+- set `AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT` to the host-reachable gateway route
+  ending in `/mcp/awf-enclave`;
+- optionally set `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` to a bounded
+  1000-600000 ms value (default 120000);
+- configure gateway HTTP-upstream startup timeout/retry semantics for at least
+  120 seconds.
+- enable AWF network isolation and include `awmg-mcpg` in `topologyAttach`, so
+  Compose agents reach only the gateway on `awf-net` while AWF separately
+  attaches the same verified container to the enclave control network.
+
+`buildEnclaveMcpgUpstreamContract()` is the machine-readable AWF source of truth
+for the static entry and handoff names. AWF excludes all handoff variables from
+agent environment passthrough, including `--env-all`.
+
+The current gh-aw compiler does not yet emit this enclave upstream, capability,
+identity label, or readiness endpoint. It requires a companion change in
+`pkg/workflow/mcp_setup_gateway.go`, `mcp_gateway_config.go`,
+`mcp_renderer.go`, and `awf_config.go`. Current mcpg releases must also support
+retrying an initially unavailable HTTP upstream without permanently omitting its
+tools; otherwise the compiler must delay/restart mcpg after AWF infrastructure
+readiness. AWF does not restart or take ownership of mcpg.
+
+The enclave server alias never enters the primary agent's `NO_PROXY`, Squid ACL,
+static hosts, mounts, or environment. Only `awmg-mcpg` remains an agent-visible
+topology peer. Thus proxy-aware and proxy-ignoring clients cannot use Squid as an
+alternate path to the enclave server.
+
+### Shutdown
+
+After primary-agent work stops, AWF sends the enclave server `SIGTERM`. The
+server closes admissions, drains the single execution lane within Docker's
+bounded stop grace, reconciles labelled enclaves, and exits. AWF then disconnects
+the external gateway from `awf-enclave-mcp-control`; Compose removes the
+AWF-owned server and network, and host cleanup removes the private roots. AWF
+never stops or removes `awmg-mcpg`.
 
 ## Migration sequence
 
@@ -156,24 +232,23 @@ fails the run before repository staging is exposed or the primary agent starts.
 2. **AWF-owned script MCP server.** Implement the authenticated, offline local
    server and hardened script executor over the shared contracts; do not expose
    its private transport to the primary agent.
-3. **Agent executor (this layer).** Add the fixed model loop, the dedicated
+3. **Agent executor.** Add the fixed model loop, the dedicated
    API-proxy-only enclave network, and the `enclave_run_agent` tool behind the
-   same MCP server, the same private socket, and the same shared ledger. The
-   private transport still is not exposed to the primary agent.
-4. **`gh-aw-mcpg` integration.** Register and guard the AWF-owned server, wire
+   same MCP server, authenticated private transport, and shared ledger. The
+   private transport is not exposed to the primary agent.
+4. **`gh-aw-mcpg` integration (this layer).** Register and guard the AWF-owned server, wire
    startup retry/timeouts, require end-to-end readiness before primary-agent
    startup, and route both executor tools exclusively through the gateway.
-5. **Runtime cutover.** Move all callers to the unified MCP surface and
-   the unified server. Remove direct `bounded-query` and `bounded-agent` agent
-   surfaces after parity tests demonstrate canonical response and isolation
-   equivalence.
-6. **Legacy removal.** Remove `boundedQueries`, `boundedAgents`, their brokers,
-   compatibility exports, images, docs, and tests only after the unified path is
+5. **Runtime cutover and legacy removal.** Move all callers to the unified MCP
+   surface, prove canonical-response and isolation parity, then remove
+   `boundedQueries`, `boundedAgents`, their direct agent surfaces, brokers,
+   compatibility exports, images, docs, and tests. The unified mcpg path becomes
    the sole supported runtime.
 
 ## Compatibility
 
-This layer does not change primary-agent mounts or environment and does not
-alter legacy protocol bytes. Existing `boundedQueries` and `boundedAgents`
-configurations continue to run as before. Unified and legacy configurations
-remain mutually exclusive and fail closed before staging.
+This layer adds no primary-agent enclave mount, environment variable, wrapper,
+skill, direct URL, or fallback and does not alter legacy protocol bytes.
+Existing `boundedQueries` and `boundedAgents` configurations continue to run as
+before. Unified and legacy configurations remain mutually exclusive and fail
+closed before staging.

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -1105,7 +1105,7 @@
     },
     "enclaves": {
       "type": "object",
-      "description": "Unified private-repository enclaves. Repositories and sensitivities are shared by the script and agent executors, and every invocation debits one live per-repository information budget regardless of executor kind. AWF exposes the enabled executors through one AWF-owned, no-egress MCP server; that server is not yet attached to the primary agent.",
+      "description": "Unified private-repository enclaves. Repositories and sensitivities are shared by the script and agent executors, and every invocation debits one live per-repository information budget regardless of executor kind. AWF exposes enabled executors only through an AWF-owned MCP server and the compiler-launched trusted mcpg gateway.",
       "additionalProperties": false,
       "properties": {
         "enabled": {

--- a/src/cli-workflow.test.ts
+++ b/src/cli-workflow.test.ts
@@ -1,6 +1,7 @@
 import { runMainWorkflow } from './cli-workflow';
 import { WrapperConfig } from './types';
 import { HostAccessConfig } from './host-iptables';
+import { normalizeEnclavesConfig } from './parsers/enclave-parser';
 
 jest.mock('./topology', () => ({
   TOPOLOGY_NETWORK_NAME: 'awf-net',
@@ -26,6 +27,17 @@ const baseConfig: WrapperConfig = {
   imageRegistry: 'registry',
   imageTag: 'latest',
   buildLocal: false,
+};
+
+const enclaveConfig: WrapperConfig = {
+  ...baseConfig,
+  networkIsolation: true,
+  topologyAttach: ['awmg-mcpg'],
+  enclaves: normalizeEnclavesConfig({
+    enabled: true,
+    privateRepos: [{ repo: 'octo/private', sensitivity: 'internal' }],
+    executors: { script: { enabled: true } },
+  }),
 };
 
 const createLogger = () => ({
@@ -352,6 +364,73 @@ describe('runMainWorkflow', () => {
 
     expect(connectTopologyContainers).not.toHaveBeenCalled();
     expect(exitCode).toBe(0);
+  });
+
+  it('proves the enclave server through mcpg before primary-agent startup', async () => {
+    const order: string[] = [];
+    const prepareEnclaves = jest.fn().mockImplementation(async () => order.push('stage'));
+    const connectEnclaveGateway = jest.fn().mockImplementation(async () => order.push('connect'));
+    const assertEnclaveGatewayReady = jest.fn().mockImplementation(async () => order.push('ready'));
+    const startContainers = jest.fn().mockImplementation(
+      async (
+        _workDir: string,
+        _allowedDomains: string[],
+        _proxyLogsDir?: string,
+        _skipPull?: boolean,
+        _onNetworkReady?: () => Promise<void>,
+        onInfrastructureReady?: () => Promise<void>,
+      ) => {
+        order.push('infrastructure');
+        await onInfrastructureReady?.();
+        order.push('agent-started');
+      },
+    );
+    const runAgentCommand = jest.fn().mockImplementation(async () => {
+      order.push('agent-run');
+      return { exitCode: 0 };
+    });
+
+    await runMainWorkflow(enclaveConfig, createWorkflowDependencies({
+      prepareEnclaves,
+      connectEnclaveGateway,
+      assertEnclaveGatewayReady,
+      startContainers,
+      runAgentCommand,
+    }), createWorkflowOptions());
+
+    expect(order).toEqual([
+      'stage',
+      'infrastructure',
+      'connect',
+      'ready',
+      'agent-started',
+      'agent-run',
+    ]);
+  });
+
+  it('aborts before primary-agent startup when gateway readiness fails', async () => {
+    const runAgentCommand = jest.fn();
+    const startContainers = jest.fn().mockImplementation(
+      async (
+        _workDir: string,
+        _allowedDomains: string[],
+        _proxyLogsDir?: string,
+        _skipPull?: boolean,
+        _onNetworkReady?: () => Promise<void>,
+        onInfrastructureReady?: () => Promise<void>,
+      ) => {
+        await onInfrastructureReady?.();
+        throw new Error('agent must not be started');
+      },
+    );
+    await expect(runMainWorkflow(enclaveConfig, createWorkflowDependencies({
+      prepareEnclaves: jest.fn(),
+      connectEnclaveGateway: jest.fn(),
+      assertEnclaveGatewayReady: jest.fn().mockRejectedValue(new Error('tool mismatch')),
+      startContainers,
+      runAgentCommand,
+    }), createWorkflowOptions())).rejects.toThrow(/tool mismatch/);
+    expect(runAgentCommand).not.toHaveBeenCalled();
   });
 
   it('passes agentTimeout to runAgentCommand', async () => {

--- a/src/cli-workflow.ts
+++ b/src/cli-workflow.ts
@@ -23,7 +23,14 @@ interface WorkflowDependencies {
   ensureFirewallNetwork: () => Promise<{ squidIp: string; agentIp: string; proxyIp: string; subnet: string }>;
   setupHostIptables: (squidIp: string, port: number, dnsServers: string[], apiProxyIp?: string, dohProxyIp?: string, hostAccess?: HostAccessConfig, cliProxyConfig?: CliProxyHostConfig) => Promise<void>;
   writeConfigs: (config: WrapperConfig) => Promise<void>;
-  startContainers: (workDir: string, allowedDomains: string[], proxyLogsDir?: string, skipPull?: boolean, onNetworkReady?: () => Promise<void>) => Promise<void>;
+  startContainers: (
+    workDir: string,
+    allowedDomains: string[],
+    proxyLogsDir?: string,
+    skipPull?: boolean,
+    onNetworkReady?: () => Promise<void>,
+    onInfrastructureReady?: () => Promise<void>,
+  ) => Promise<void>;
   runAgentCommand: (
     workDir: string,
     allowedDomains: string[],
@@ -60,6 +67,10 @@ interface WorkflowDependencies {
    * network after the AWF containers have started.
    */
   connectTopologyContainers?: (networkName: string, containerNames: string[]) => Promise<void>;
+  /** Attaches and verifies the externally owned gateway on the private enclave control path. */
+  connectEnclaveGateway?: (config: WrapperConfig) => Promise<void>;
+  /** Proves initialize and the exact enabled tool contracts through mcpg. */
+  assertEnclaveGatewayReady?: (config: WrapperConfig) => Promise<void>;
 }
 
 interface WorkflowCallbacks {
@@ -236,8 +247,27 @@ export async function runMainWorkflow(
         }
       : undefined;
 
+  const onInfrastructureReady = config.enclaves?.enabled
+    ? async () => {
+        if (!dependencies.connectEnclaveGateway || !dependencies.assertEnclaveGatewayReady) {
+          throw new Error('Enclaves require an exclusive MCP gateway readiness implementation');
+        }
+        logger.info('Attaching the trusted MCP gateway to the private enclave control path...');
+        await dependencies.connectEnclaveGateway(config);
+        logger.info('Proving enclave tools end to end through the MCP gateway...');
+        await dependencies.assertEnclaveGatewayReady(config);
+      }
+    : undefined;
+
   try {
-    await dependencies.startContainers(config.workDir, config.allowedDomains, config.proxyLogsDir, config.skipPull, onNetworkReady);
+    await dependencies.startContainers(
+      config.workDir,
+      config.allowedDomains,
+      config.proxyLogsDir,
+      config.skipPull,
+      onNetworkReady,
+      onInfrastructureReady,
+    );
   } catch (startError) {
     // Signal that containers may have been partially created so the caller's
     // cleanup (stopContainers / docker compose down -v) will tear them down

--- a/src/commands/main-action.test.ts
+++ b/src/commands/main-action.test.ts
@@ -20,6 +20,7 @@ jest.mock('./validate-options');
 jest.mock('../sbx-manager');
 jest.mock('../bounded-query/ingress');
 jest.mock('../bounded-agent/ingress');
+jest.mock('../enclave/gateway');
 
 import { logger } from '../logger';
 import * as dockerManager from '../docker-manager';
@@ -35,6 +36,7 @@ import * as validateOptions from './validate-options';
 import * as sbxManager from '../sbx-manager';
 import * as boundedQueryIngress from '../bounded-query/ingress';
 import * as boundedAgentIngress from '../bounded-agent/ingress';
+import * as enclaveGateway from '../enclave/gateway';
 import { MAIN_ACTION_STUB_CONFIG, setupMainActionTestHarness } from './main-action.test-utils';
 
 const {
@@ -59,6 +61,7 @@ const mockedValidateOptions = validateOptions as jest.Mocked<typeof validateOpti
 const mockedSbxManager = sbxManager as jest.Mocked<typeof sbxManager>;
 const mockedBoundedQueryIngress = boundedQueryIngress as jest.Mocked<typeof boundedQueryIngress>;
 const mockedBoundedAgentIngress = boundedAgentIngress as jest.Mocked<typeof boundedAgentIngress>;
+const mockedEnclaveGateway = enclaveGateway as jest.Mocked<typeof enclaveGateway>;
 
 describe('createMainAction', () => {
   let processExitSpy: jest.SpyInstance;
@@ -894,12 +897,40 @@ describe('createMainAction', () => {
         MAIN_ACTION_STUB_CONFIG.workDir,
         MAIN_ACTION_STUB_CONFIG.auditDir
       );
+      expect(mockedEnclaveGateway.shutdownEnclaveGateway).toHaveBeenCalledWith(
+        MAIN_ACTION_STUB_CONFIG
+      );
+      expect(
+        mockedEnclaveGateway.shutdownEnclaveGateway.mock.invocationCallOrder[0]
+      ).toBeLessThan(
+        mockedDockerManager.preserveIptablesAudit.mock.invocationCallOrder[0]
+      );
       expect(mockedDockerManager.stopContainers).toHaveBeenCalledWith(
         MAIN_ACTION_STUB_CONFIG.workDir,
         MAIN_ACTION_STUB_CONFIG.keepContainers
       );
       expect(mockedHostIptables.cleanupHostIptables).toHaveBeenCalled();
       expect(mockedDockerManager.cleanup).toHaveBeenCalled();
+    });
+
+    it('preserves audits after an enclave drain failure', async () => {
+      mockedEnclaveGateway.shutdownEnclaveGateway.mockRejectedValueOnce(
+        new Error('drain failed')
+      );
+      const performCleanup = testHelpers.buildCleanupFn(
+        MAIN_ACTION_STUB_CONFIG,
+        () => true,
+        () => false,
+      );
+
+      await performCleanup();
+
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        'Failed to stop the enclave gateway control path; continuing cleanup.',
+        expect.any(Error)
+      );
+      expect(mockedDockerManager.preserveIptablesAudit).toHaveBeenCalled();
+      expect(mockedDockerManager.stopContainers).toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/main-action.ts
+++ b/src/commands/main-action.ts
@@ -40,6 +40,11 @@ import {
 import { prepareBoundedQueries, teardownBoundedQueries } from '../bounded-query/manager';
 import { prepareEnclaves, teardownEnclaves } from '../enclave/manager';
 import {
+  assertEnclaveGatewayReady,
+  connectEnclaveGateway,
+  shutdownEnclaveGateway,
+} from '../enclave/gateway';
+import {
   prepareBoundedAgents,
   reportBoundedAgentSbxIngressResult,
   teardownBoundedAgents,
@@ -143,6 +148,11 @@ function buildCleanupFn(
     // Copy iptables audit BEFORE stopping containers (volumes are destroyed by `docker compose down -v`)
     if (getContainersStarted()) {
       preserveIptablesAudit(config.workDir, config.auditDir);
+      try {
+        await shutdownEnclaveGateway(config);
+      } catch (error) {
+        logger.warn('Failed to stop the enclave gateway control path; continuing cleanup.', error);
+      }
       await stopContainers(config.workDir, config.keepContainers);
     }
 
@@ -311,9 +321,23 @@ export function createMainAction(getOptionValueSource: OptionSourceResolver) {
     let sbxEnvironment: Record<string, string> | undefined;
 
     const sbxStartContainers = useSbx
-      ? async (workDir: string, allowedDomains: string[], proxyLogsDir?: string, skipPull?: boolean, onNetworkReady?: () => Promise<void>) => {
+      ? async (
+          workDir: string,
+          allowedDomains: string[],
+          proxyLogsDir?: string,
+          skipPull?: boolean,
+          onNetworkReady?: () => Promise<void>,
+          onInfrastructureReady?: () => Promise<void>,
+        ) => {
           // Start infra-only compose (squid, api-proxy — no agent service)
-          await startContainers(workDir, allowedDomains, proxyLogsDir, skipPull, onNetworkReady);
+          await startContainers(
+            workDir,
+            allowedDomains,
+            proxyLogsDir,
+            skipPull,
+            onNetworkReady,
+            onInfrastructureReady,
+          );
 
           // Verify sbx is available
           if (!await isSbxAvailable()) {
@@ -578,6 +602,8 @@ export function createMainAction(getOptionValueSource: OptionSourceResolver) {
         collectDiagnosticLogs,
         assertTopologySupported,
         connectTopologyContainers,
+        connectEnclaveGateway,
+        assertEnclaveGatewayReady,
         prepareBoundedQueries,
         prepareBoundedAgents,
         prepareEnclaves,

--- a/src/commands/main-action.ts
+++ b/src/commands/main-action.ts
@@ -145,14 +145,14 @@ function buildCleanupFn(
       }
     }
 
-    // Copy iptables audit BEFORE stopping containers (volumes are destroyed by `docker compose down -v`)
+    // Drain enclave calls first, then preserve all audit artifacts before Compose removes volumes.
     if (getContainersStarted()) {
-      preserveIptablesAudit(config.workDir, config.auditDir);
       try {
         await shutdownEnclaveGateway(config);
       } catch (error) {
         logger.warn('Failed to stop the enclave gateway control path; continuing cleanup.', error);
       }
+      preserveIptablesAudit(config.workDir, config.auditDir);
       await stopContainers(config.workDir, config.keepContainers);
     }
 

--- a/src/compose-generator.ts
+++ b/src/compose-generator.ts
@@ -24,6 +24,7 @@ import {
   ENCLAVE_AGENT_EGRESS_NETWORK,
   ENCLAVE_AGENT_NETWORK,
   ENCLAVE_AGENT_SUBNET,
+  ENCLAVE_MCP_CONTROL_NETWORK,
 } from './enclave/network';
 import { buildInternalServiceHosts } from './services/internal-service-hosts';
 
@@ -256,6 +257,13 @@ export function generateDockerCompose(
     compose.networks[ENCLAVE_AGENT_EGRESS_NETWORK] = {
       name: ENCLAVE_AGENT_EGRESS_NETWORK,
       driver: 'bridge',
+    };
+  }
+  if (config.enclaves?.enabled) {
+    compose.networks[ENCLAVE_MCP_CONTROL_NETWORK] = {
+      name: ENCLAVE_MCP_CONTROL_NETWORK,
+      driver: 'bridge',
+      internal: true,
     };
   }
   return compose;

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -216,10 +216,7 @@ export interface AwfFileConfig {
     maxModelRequests?: number;
     maxModelTokens?: number;
   };
-  /**
-   * Unified enclave configuration. This foundation is parsed and validated but
-   * does not expose a primary-agent runtime surface yet.
-   */
+  /** Unified enclave configuration exposed only through the trusted MCP gateway. */
   enclaves?: RawEnclavesConfig;
 }
 

--- a/src/container-lifecycle.ts
+++ b/src/container-lifecycle.ts
@@ -10,6 +10,8 @@ import {
   BOUNDED_AGENT_API_PROXY_CONTAINER_NAME,
   BOUNDED_AGENT_BROKER_CONTAINER_NAME,
   BOUNDED_QUERY_BROKER_CONTAINER_NAME,
+  ENCLAVE_AGENT_API_PROXY_CONTAINER_NAME,
+  ENCLAVE_MCP_SERVER_CONTAINER_NAME,
 } from './constants';
 import { getLocalDockerEnv } from './docker-host';
 import { isAgentExternallyKilled, markAgentExternallyKilled } from './container-lifecycle-state';
@@ -28,6 +30,9 @@ const MAX_GVISOR_AGENT_RETRIES = 1;
 // Containers that exit within this window are assumed to have crashed during
 // Node/V8 initialisation (before any agent work began) and are safe to restart.
 const GVISOR_STARTUP_CRASH_WINDOW_MS = 30_000;
+
+class InfrastructureReadinessError extends Error {}
+class PostReadinessAgentStartupError extends Error {}
 
 function getComposeUpArgs(skipPull?: boolean): string[] {
   const composeArgs = ['compose', 'up', '-d'];
@@ -58,6 +63,7 @@ async function attemptContainerStartup(
   composeArgs: string[],
   skipPull?: boolean,
   onNetworkReady?: () => Promise<void>,
+  onInfrastructureReady?: () => Promise<void>,
 ): Promise<Error | undefined> {
   // Phase 1 (topology mode only): start squid-proxy alone so the compose-managed
   // awf-net is created before any health-gated dependents (cli-proxy, agent) start.
@@ -84,6 +90,41 @@ async function attemptContainerStartup(
   }
 
   try {
+    if (onInfrastructureReady) {
+      const listed = await execa('docker', ['compose', 'config', '--services'], {
+        cwd: workDir,
+        env: getLocalDockerEnv(),
+      });
+      const services = listed.stdout
+        .split('\n')
+        .map((service) => service.trim())
+        .filter(Boolean);
+      const infrastructure = services.filter(
+        (service) => service !== 'agent' && service !== 'iptables-init',
+      );
+      if (infrastructure.length === 0) {
+        throw new Error('No infrastructure services were generated for enclave gateway startup');
+      }
+      await runDockerComposeUp(workDir, [...composeArgs, ...infrastructure]);
+      try {
+        await onInfrastructureReady();
+      } catch (error) {
+        throw new InfrastructureReadinessError(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      if (!services.includes('agent')) {
+        return undefined;
+      }
+      try {
+        await runDockerComposeUp(workDir, composeArgs);
+      } catch (error) {
+        throw new PostReadinessAgentStartupError(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      return undefined;
+    }
     await runDockerComposeUp(workDir, composeArgs);
     return undefined;
   } catch (error) {
@@ -243,8 +284,19 @@ async function handleStartupFailure(
  *        now resolve the peer, so the health gate succeeds.
  *
  *   When this callback is omitted the existing single-`up` path is used unchanged.
+ * @param onInfrastructureReady - Optional fail-closed gate invoked after every
+ *   non-agent Compose service starts and before the compose agent starts. For
+ *   infrastructure-only runtimes such as sbx, it runs before startContainers
+ *   returns and therefore before the sandbox is created.
  */
-export async function startContainers(workDir: string, allowedDomains: string[], proxyLogsDir?: string, skipPull?: boolean, onNetworkReady?: () => Promise<void>): Promise<void> {
+export async function startContainers(
+  workDir: string,
+  allowedDomains: string[],
+  proxyLogsDir?: string,
+  skipPull?: boolean,
+  onNetworkReady?: () => Promise<void>,
+  onInfrastructureReady?: () => Promise<void>,
+): Promise<void> {
   logger.info('Starting containers...');
 
   // Force remove any existing containers with these names to avoid conflicts
@@ -262,6 +314,8 @@ export async function startContainers(workDir: string, allowedDomains: string[],
       BOUNDED_QUERY_BROKER_CONTAINER_NAME,
       BOUNDED_AGENT_BROKER_CONTAINER_NAME,
       BOUNDED_AGENT_API_PROXY_CONTAINER_NAME,
+      ENCLAVE_MCP_SERVER_CONTAINER_NAME,
+      ENCLAVE_AGENT_API_PROXY_CONTAINER_NAME,
     ], {
       reject: false,
       env: getLocalDockerEnv(),
@@ -272,9 +326,32 @@ export async function startContainers(workDir: string, allowedDomains: string[],
   }
 
   const composeArgs = getComposeUpArgs(skipPull);
-  const runComposeUp = () => runDockerComposeUp(workDir, composeArgs);
-  const startupError = await attemptContainerStartup(workDir, composeArgs, skipPull, onNetworkReady);
+  const runComposeUp = onInfrastructureReady
+    ? async () => {
+        const error = await attemptContainerStartup(
+          workDir,
+          composeArgs,
+          skipPull,
+          onNetworkReady,
+          onInfrastructureReady,
+        );
+        if (error) throw error;
+      }
+    : () => runDockerComposeUp(workDir, composeArgs);
+  const startupError = await attemptContainerStartup(
+    workDir,
+    composeArgs,
+    skipPull,
+    onNetworkReady,
+    onInfrastructureReady,
+  );
   if (startupError) {
+    if (
+      startupError instanceof InfrastructureReadinessError
+      || startupError instanceof PostReadinessAgentStartupError
+    ) {
+      throw startupError;
+    }
     await handleStartupFailure(startupError, workDir, proxyLogsDir, allowedDomains, runComposeUp);
     return;
   }

--- a/src/container-start.test.ts
+++ b/src/container-start.test.ts
@@ -31,6 +31,8 @@ describe('startContainers', () => {
         'awf-bounded-query-broker',
         'awf-bounded-agent-broker',
         'awf-bounded-agent-api-proxy',
+        'awf-enclave-mcp-server',
+        'awf-enclave-agent-api-proxy',
       ],
       expect.objectContaining({ reject: false })
     );

--- a/src/container-start.test.ts
+++ b/src/container-start.test.ts
@@ -549,5 +549,94 @@ describe('startContainers', () => {
       );
       expect(fullUpCalls).toHaveLength(2);
     });
+
+    describe('enclave gateway readiness phase', () => {
+      it('starts infrastructure, runs readiness, and only then starts the compose agent', async () => {
+        const order: string[] = [];
+        const onInfrastructureReady = jest.fn().mockImplementation(async () => {
+          order.push('readiness');
+        });
+        mockExecaFn.mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any);
+        mockExecaFn.mockResolvedValueOnce({
+          stdout: 'squid-proxy\nenclave-script-image\nenclave-mcp-server\nagent\niptables-init\n',
+          stderr: '',
+          exitCode: 0,
+        } as any);
+        mockExecaFn.mockImplementationOnce(async () => {
+          order.push('infrastructure');
+          return { stdout: '', stderr: '', exitCode: 0 };
+        });
+        mockExecaFn.mockImplementationOnce(async () => {
+          order.push('agent');
+          return { stdout: '', stderr: '', exitCode: 0 };
+        });
+
+        await startContainers(
+          getDir(),
+          ['github.com'],
+          undefined,
+          undefined,
+          undefined,
+          onInfrastructureReady,
+        );
+
+        expect(order).toEqual(['infrastructure', 'readiness', 'agent']);
+        expect(mockExecaFn.mock.calls[2][1]).toEqual([
+          'compose',
+          'up',
+          '-d',
+          'squid-proxy',
+          'enclave-script-image',
+          'enclave-mcp-server',
+        ]);
+      });
+
+      it('does not start a compose agent when readiness fails', async () => {
+        mockExecaFn.mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any);
+        mockExecaFn.mockResolvedValueOnce({
+          stdout: 'squid-proxy\nenclave-mcp-server\nagent\n',
+          stderr: '',
+          exitCode: 0,
+        } as any);
+        mockExecaFn.mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any);
+
+        await expect(startContainers(
+          getDir(),
+          ['github.com'],
+          undefined,
+          undefined,
+          undefined,
+          jest.fn().mockRejectedValue(new Error('gateway timeout')),
+        )).rejects.toThrow(/gateway timeout/);
+
+        const fullAgentStart = mockExecaFn.mock.calls.some(
+          (call: any[]) => Array.isArray(call[1]) && call[1].includes('agent'),
+        );
+        expect(fullAgentStart).toBe(false);
+      });
+
+      it('runs the same readiness gate for an sbx infrastructure-only compose file', async () => {
+        const onInfrastructureReady = jest.fn().mockResolvedValue(undefined);
+        mockExecaFn.mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any);
+        mockExecaFn.mockResolvedValueOnce({
+          stdout: 'squid-proxy\nenclave-mcp-server\n',
+          stderr: '',
+          exitCode: 0,
+        } as any);
+        mockExecaFn.mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any);
+
+        await startContainers(
+          getDir(),
+          ['github.com'],
+          undefined,
+          undefined,
+          undefined,
+          onInfrastructureReady,
+        );
+
+        expect(onInfrastructureReady).toHaveBeenCalledTimes(1);
+        expect(mockExecaFn).toHaveBeenCalledTimes(3);
+      });
+    });
   });
 });

--- a/src/enclave/agent-runner-spec.test.ts
+++ b/src/enclave/agent-runner-spec.test.ts
@@ -232,7 +232,8 @@ describe('unified enclave agent server configuration', () => {
     );
     expect(loadServerConfig({ readFileSync: () => 'a'.repeat(64) })).toMatchObject({
       primaryBackend: 'docker',
-      socketPath: '/run/awf-enclave-mcp/server.sock',
+      listenHost: '0.0.0.0',
+      listenPort: 8080,
       auditDir: '/var/log/awf-enclave',
     });
   });

--- a/src/enclave/gateway.test.ts
+++ b/src/enclave/gateway.test.ts
@@ -13,6 +13,7 @@ import {
   shutdownEnclaveGateway,
 } from './gateway';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const enclaveProtocol = require(path.join(
   __dirname,
   '../../containers/bounded-query/enclave-mcp/mcp-protocol.js',

--- a/src/enclave/gateway.test.ts
+++ b/src/enclave/gateway.test.ts
@@ -47,8 +47,14 @@ function env(endpoint = 'http://127.0.0.1:8080/mcp/awf-enclave'): NodeJS.Process
 
 function listen(
   tools: unknown[],
-): Promise<{ endpoint: string; close: () => Promise<void> }> {
+  unavailableInitializations = 0,
+): Promise<{
+  endpoint: string;
+  initializeAttempts: () => number;
+  close: () => Promise<void>;
+}> {
   return new Promise((resolve) => {
+    let initializeAttempts = 0;
     const server = http.createServer((request, response) => {
       const chunks: Buffer[] = [];
       request.on('data', (chunk: Buffer) => chunks.push(chunk));
@@ -59,6 +65,18 @@ function listen(
         };
         response.setHeader('content-type', 'application/json');
         response.setHeader('mcp-session-id', 'session-1');
+        if (message.method === 'initialize') {
+          initializeAttempts += 1;
+          if (initializeAttempts <= unavailableInitializations) {
+            response.statusCode = 503;
+            response.end(JSON.stringify({
+              error: 'backend_unavailable',
+              message: 'Backend MCP server is not ready; retry initialization',
+              retryable: true,
+            }));
+            return;
+          }
+        }
         if (message.method === 'notifications/initialized') {
           response.statusCode = 202;
           response.end();
@@ -79,6 +97,7 @@ function listen(
       if (!address || typeof address === 'string') throw new Error('test server did not bind');
       resolve({
         endpoint: `http://127.0.0.1:${address.port}/mcp/awf-enclave`,
+        initializeAttempts: () => initializeAttempts,
         close: () => new Promise<void>((done) => server.close(() => done())),
       });
     });
@@ -198,6 +217,22 @@ describe('enclave mcpg handoff', () => {
       await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
         .resolves.toBeUndefined();
       expect(contract.server.tools).toEqual(['enclave_run_script']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('retries mcpg backend_unavailable responses until initialize succeeds', async () => {
+    const server = await listen([enclaveProtocol.TOOL], 1);
+    try {
+      await expect(assertEnclaveGatewayReady(
+        config(),
+        {
+          ...env(server.endpoint),
+          AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS: '2000',
+        },
+      )).resolves.toBeUndefined();
+      expect(server.initializeAttempts()).toBe(2);
     } finally {
       await server.close();
     }

--- a/src/enclave/gateway.test.ts
+++ b/src/enclave/gateway.test.ts
@@ -47,7 +47,16 @@ function env(endpoint = 'http://127.0.0.1:8080/mcp/awf-enclave'): NodeJS.Process
 
 function listen(
   tools: unknown[],
-  unavailableInitializations = 0,
+  options: {
+    unavailableInitializations?: number;
+    initializationStatus?: number;
+    initializationBody?: string;
+    initializationRpcError?: boolean;
+    oversizedInitialization?: boolean;
+    hangInitialization?: boolean;
+    trickleInitialization?: boolean;
+    sse?: boolean;
+  } = {},
 ): Promise<{
   endpoint: string;
   initializeAttempts: () => number;
@@ -63,17 +72,49 @@ function listen(
           id?: number;
           method: string;
         };
-        response.setHeader('content-type', 'application/json');
+        response.setHeader(
+          'content-type',
+          options.sse ? 'text/event-stream' : 'application/json',
+        );
         response.setHeader('mcp-session-id', 'session-1');
         if (message.method === 'initialize') {
           initializeAttempts += 1;
-          if (initializeAttempts <= unavailableInitializations) {
+          if (options.hangInitialization) return;
+          if (options.trickleInitialization) {
+            const interval = setInterval(() => response.write(' '), 5);
+            response.on('close', () => clearInterval(interval));
+            return;
+          }
+          if (
+            options.unavailableInitializations
+            && initializeAttempts <= options.unavailableInitializations
+          ) {
             response.statusCode = 503;
             response.end(JSON.stringify({
               error: 'backend_unavailable',
               message: 'Backend MCP server is not ready; retry initialization',
               retryable: true,
             }));
+            return;
+          }
+          if (options.initializationStatus) {
+            response.statusCode = options.initializationStatus;
+            response.end(options.initializationBody ?? JSON.stringify({
+              error: 'permanent_failure',
+              retryable: false,
+            }));
+            return;
+          }
+          if (options.initializationRpcError) {
+            response.end(JSON.stringify({
+              jsonrpc: '2.0',
+              id: message.id,
+              error: { code: -32000, message: 'permanent failure' },
+            }));
+            return;
+          }
+          if (options.oversizedInitialization) {
+            response.end('x'.repeat(256 * 1024 + 1));
             return;
           }
         }
@@ -89,7 +130,8 @@ function listen(
               serverInfo: { name: 'awf-enclave', version: '1.0.0' },
             }
           : { tools };
-        response.end(JSON.stringify({ jsonrpc: '2.0', id: message.id, result }));
+        const payload = JSON.stringify({ jsonrpc: '2.0', id: message.id, result });
+        response.end(options.sse ? `data: ${payload}\n\n` : payload);
       });
     });
     server.listen(0, '127.0.0.1', () => {
@@ -116,7 +158,7 @@ describe('enclave mcpg handoff', () => {
         headers: { Authorization: 'Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}' },
         tools: ['enclave_run_script', 'enclave_run_agent'],
         connectTimeout: 120,
-        toolTimeout: 150,
+        toolTimeout: 630,
       },
       handoff: {
         capabilityEnv: 'AWF_ENCLAVE_MCP_CAPABILITY',
@@ -145,6 +187,47 @@ describe('enclave mcpg handoff', () => {
       config(),
       env('http://127.0.0.1:8080/health'),
     )).toThrow(/must address the gateway route/);
+  });
+
+  it.each([
+    [config(), { ...env(), AWF_ENCLAVE_MCP_GATEWAY_IDENTITY: 'short' }, /IDENTITY/],
+    [config(), { ...env(), AWF_ENCLAVE_MCP_GATEWAY_CONTAINER: 'bad/name' }, /CONTAINER/],
+    [config(), { ...env(), AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS: '999' }, /READINESS_TIMEOUT/],
+    [config(), { ...env(), AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT: 'not-a-url' }, /ENDPOINT/],
+  ])('rejects invalid compiler handoff values', (wrapperConfig, handoff, expected) => {
+    expect(() => resolveEnclaveGatewayContract(
+      wrapperConfig,
+      handoff as NodeJS.ProcessEnv,
+    )).toThrow(expected as RegExp);
+  });
+
+  it('rejects compiler contract generation while enclaves are disabled', () => {
+    expect(() => buildEnclaveMcpgUpstreamContract({
+      ...config(),
+      enclaves: undefined,
+    })).toThrow(/disabled/);
+  });
+
+  it('rejects gateway resolution while enclaves are disabled', () => {
+    expect(() => resolveEnclaveGatewayContract({
+      ...config(),
+      enclaves: undefined,
+    }, env())).toThrow(/disabled/);
+  });
+
+  it('builds an agent-only timeout and tool allowlist', () => {
+    const wrapperConfig = {
+      ...config(),
+      enclaves: normalizeEnclavesConfig({
+        enabled: true,
+        privateRepos: [{ repo: 'octo/private', sensitivity: 'internal' }],
+        executors: { agent: { enabled: true, model: 'gpt-test', timeout: 45 } },
+      }),
+    };
+    expect(buildEnclaveMcpgUpstreamContract(wrapperConfig).server).toMatchObject({
+      tools: ['enclave_run_agent'],
+      toolTimeout: 630,
+    });
   });
 
   it('attaches only the expected labelled gateway to the private control network', async () => {
@@ -188,6 +271,57 @@ describe('enclave mcpg handoff', () => {
     await expect(connectEnclaveGateway(config(), env())).rejects.toThrow(/identity did not match/);
   });
 
+  it.each([
+    [{ exitCode: 1, stdout: '', stderr: '' }, /container is unavailable/],
+    [{ exitCode: 0, stdout: '{', stderr: '' }, /identity could not be inspected/],
+  ])('fails closed when the gateway cannot be inspected', async (result, expected) => {
+    mockExeca.mockResolvedValueOnce(result);
+    await expect(connectEnclaveGateway(config(), env())).rejects.toThrow(expected);
+  });
+
+  it('fails closed when the gateway cannot attach to the control network', async () => {
+    mockExeca
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          Name: '/awmg-mcpg',
+          State: { Running: true },
+          HostConfig: { NetworkMode: 'bridge' },
+          Config: { Labels: { [ENCLAVE_MCP_GATEWAY_RUN_LABEL]: 'test-run-identity' } },
+        }),
+      })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'denied' });
+    await expect(connectEnclaveGateway(config(), env())).rejects.toThrow(/Failed to attach/);
+  });
+
+  it.each([
+    [{ exitCode: 1, stdout: '', stderr: '' }, /network is unavailable/],
+    [{ exitCode: 0, stdout: '{', stderr: '' }, /membership could not be inspected/],
+    [{
+      exitCode: 0,
+      stdout: JSON.stringify({
+        first: { Name: 'awf-enclave-mcp-server' },
+        second: { Name: 'awmg-mcpg' },
+        third: { Name: 'unexpected' },
+      }),
+      stderr: '',
+    }, /unexpected member/],
+  ])('fails closed on invalid control-network membership', async (networkResult, expected) => {
+    mockExeca
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          Name: '/awmg-mcpg',
+          State: { Running: true },
+          HostConfig: { NetworkMode: 'bridge' },
+          Config: { Labels: { [ENCLAVE_MCP_GATEWAY_RUN_LABEL]: 'test-run-identity' } },
+        }),
+      })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce(networkResult);
+    await expect(connectEnclaveGateway(config(), env())).rejects.toThrow(expected);
+  });
+
   it('proves initialize and the exact tool contracts through the gateway', async () => {
     const contract = buildEnclaveMcpgUpstreamContract(config());
     const server = await listen([{
@@ -222,8 +356,21 @@ describe('enclave mcpg handoff', () => {
     }
   });
 
+  it('accepts bounded SSE responses from the gateway', async () => {
+    const server = await listen([enclaveProtocol.TOOL], { sse: true });
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
+        .resolves.toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  });
+
   it('retries mcpg backend_unavailable responses until initialize succeeds', async () => {
-    const server = await listen([enclaveProtocol.TOOL], 1);
+    const server = await listen(
+      [enclaveProtocol.TOOL],
+      { unavailableInitializations: 1 },
+    );
     try {
       await expect(assertEnclaveGatewayReady(
         config(),
@@ -238,14 +385,117 @@ describe('enclave mcpg handoff', () => {
     }
   });
 
-  it('times out before agent startup when the gateway publishes a mismatched tool contract', async () => {
+  it('fails immediately when the gateway publishes a mismatched tool contract', async () => {
     const server = await listen([{ name: 'unexpected_tool' }]);
     try {
-      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 10))
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
         .rejects.toThrow(/tool contract did not exactly match/);
+      expect(server.initializeAttempts()).toBe(1);
     } finally {
       await server.close();
     }
+  });
+
+  it('does not retry permanent HTTP failures', async () => {
+    const server = await listen([], { initializationStatus: 401 });
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
+        .rejects.toThrow(/readiness request failed/);
+      expect(server.initializeAttempts()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('does not retry a malformed backend-unavailable response', async () => {
+    const server = await listen([], {
+      initializationStatus: 503,
+      initializationBody: '{',
+    });
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
+        .rejects.toThrow(/readiness request failed/);
+      expect(server.initializeAttempts()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('fails immediately on initialize JSON-RPC errors', async () => {
+    const server = await listen([], { initializationRpcError: true });
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
+        .rejects.toThrow(/initialize proof/);
+      expect(server.initializeAttempts()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects readiness responses above the framing bound', async () => {
+    const server = await listen([], { oversizedInitialization: true });
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
+        .rejects.toThrow(/framing bound/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('caps each request by the remaining readiness deadline', async () => {
+    const server = await listen([], { hangInitialization: true });
+    const started = Date.now();
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 30))
+        .rejects.toThrow(/request timed out/);
+      expect(Date.now() - started).toBeLessThan(500);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('enforces the deadline while a gateway slowly streams response bytes', async () => {
+    const server = await listen([], { trickleInitialization: true });
+    const started = Date.now();
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 30))
+        .rejects.toThrow(/request timed out/);
+      expect(Date.now() - started).toBeLessThan(500);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('times out after retryable backend-unavailable responses exhaust the deadline', async () => {
+    const server = await listen([], { unavailableInitializations: 100 });
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 30))
+        .rejects.toThrow(/readiness timed out/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('covers canonical tool validation and an expired request budget', () => {
+    expect(enclaveGatewayTestHelpers.canonicalToolSet('invalid')).toBe('invalid');
+    expect(enclaveGatewayTestHelpers.canonicalJson(undefined)).toBe('undefined');
+    expect(enclaveGatewayTestHelpers.canonicalToolSet([null])).toBe('invalid');
+    expect(enclaveGatewayTestHelpers.canonicalToolSet([
+      { name: 'duplicate' },
+      { name: 'duplicate' },
+    ])).toBe('invalid');
+    expect(enclaveGatewayTestHelpers.canonicalToolSet([
+      { name: 'z' },
+      { name: 'a' },
+    ])).toContain('"name":"a"');
+    expect(() => enclaveGatewayTestHelpers.remainingRequestBudget(Date.now() - 1))
+      .toThrow(/deadline expired/);
+  });
+
+  it('does not stop or disconnect anything when enclave cleanup is retained', async () => {
+    await shutdownEnclaveGateway({ ...config(), enclaves: undefined }, env());
+    await shutdownEnclaveGateway({ ...config(), keepContainers: true }, env());
+    expect(mockExeca).not.toHaveBeenCalled();
   });
 
   it('drains the AWF server and disconnects mcpg without stopping the external container', async () => {
@@ -254,8 +504,8 @@ describe('enclave mcpg handoff', () => {
     expect(mockExeca).toHaveBeenNthCalledWith(
       1,
       'docker',
-      ['compose', 'stop', '-t', '10', 'enclave-mcp-server'],
-      expect.objectContaining({ cwd: '/tmp/awf-test' }),
+      ['compose', 'stop', '-t', '630', 'enclave-mcp-server'],
+      expect.objectContaining({ cwd: '/tmp/awf-test', timeout: 645_000 }),
     );
     expect(mockExeca).toHaveBeenNthCalledWith(
       2,
@@ -264,5 +514,11 @@ describe('enclave mcpg handoff', () => {
       expect.anything(),
     );
     expect(mockExeca.mock.calls.flat().join(' ')).not.toMatch(/docker (?:stop|rm).*awmg-mcpg/);
+  });
+
+  it('does not disconnect mcpg when the enclave server fails to drain', async () => {
+    mockExeca.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'failed' });
+    await expect(shutdownEnclaveGateway(config(), env())).rejects.toThrow(/Failed to drain/);
+    expect(mockExeca).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/enclave/gateway.test.ts
+++ b/src/enclave/gateway.test.ts
@@ -1,0 +1,232 @@
+import * as http from 'http';
+import * as path from 'path';
+import execa from 'execa';
+import { normalizeEnclavesConfig } from '../parsers/enclave-parser';
+import type { WrapperConfig } from '../types';
+import {
+  ENCLAVE_MCP_GATEWAY_RUN_LABEL,
+  assertEnclaveGatewayReady,
+  buildEnclaveMcpgUpstreamContract,
+  connectEnclaveGateway,
+  enclaveGatewayTestHelpers,
+  resolveEnclaveGatewayContract,
+  shutdownEnclaveGateway,
+} from './gateway';
+
+const enclaveProtocol = require(path.join(
+  __dirname,
+  '../../containers/bounded-query/enclave-mcp/mcp-protocol.js',
+));
+
+jest.mock('execa', () => ({ __esModule: true, default: jest.fn() }));
+const mockExeca = execa as unknown as jest.Mock;
+
+function config(agent = false): WrapperConfig {
+  return {
+    workDir: '/tmp/awf-test',
+    enclaves: normalizeEnclavesConfig({
+      enabled: true,
+      privateRepos: [{ repo: 'octo/private', sensitivity: 'internal' }],
+      executors: {
+        script: { enabled: true },
+        agent: agent ? { enabled: true, model: 'gpt-test' } : undefined,
+      },
+    }),
+  } as WrapperConfig;
+}
+
+function env(endpoint = 'http://127.0.0.1:8080/mcp/awf-enclave'): NodeJS.ProcessEnv {
+  return {
+    AWF_ENCLAVE_MCP_CAPABILITY: 'a'.repeat(64),
+    AWF_ENCLAVE_MCP_GATEWAY_IDENTITY: 'test-run-identity',
+    AWF_ENCLAVE_MCP_GATEWAY_CONTAINER: 'awmg-mcpg',
+    AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT: endpoint,
+  };
+}
+
+function listen(
+  tools: unknown[],
+): Promise<{ endpoint: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on('data', (chunk: Buffer) => chunks.push(chunk));
+      request.on('end', () => {
+        const message = JSON.parse(Buffer.concat(chunks).toString('utf8')) as {
+          id?: number;
+          method: string;
+        };
+        response.setHeader('content-type', 'application/json');
+        response.setHeader('mcp-session-id', 'session-1');
+        if (message.method === 'notifications/initialized') {
+          response.statusCode = 202;
+          response.end();
+          return;
+        }
+        const result = message.method === 'initialize'
+          ? {
+              protocolVersion: '2025-06-18',
+              capabilities: { tools: { listChanged: false } },
+              serverInfo: { name: 'awf-enclave', version: '1.0.0' },
+            }
+          : { tools };
+        response.end(JSON.stringify({ jsonrpc: '2.0', id: message.id, result }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('test server did not bind');
+      resolve({
+        endpoint: `http://127.0.0.1:${address.port}/mcp/awf-enclave`,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+describe('enclave mcpg handoff', () => {
+  beforeEach(() => mockExeca.mockReset());
+
+  it('generates the exact static compiler upstream without secret material', () => {
+    expect(buildEnclaveMcpgUpstreamContract(config(true))).toEqual({
+      name: 'awf-enclave',
+      server: {
+        type: 'http',
+        url: 'http://awf-enclave-mcp:8080/mcp',
+        headers: { Authorization: 'Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}' },
+        tools: ['enclave_run_script', 'enclave_run_agent'],
+        connectTimeout: 120,
+        toolTimeout: 150,
+      },
+      handoff: {
+        capabilityEnv: 'AWF_ENCLAVE_MCP_CAPABILITY',
+        gatewayContainerEnv: 'AWF_ENCLAVE_MCP_GATEWAY_CONTAINER',
+        gatewayEndpointEnv: 'AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT',
+        gatewayIdentityEnv: 'AWF_ENCLAVE_MCP_GATEWAY_IDENTITY',
+        readinessTimeoutEnv: 'AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS',
+        gatewayRunLabel: ENCLAVE_MCP_GATEWAY_RUN_LABEL,
+      },
+    });
+  });
+
+  it('keeps readiness contracts byte-equivalent to the server tool definitions', () => {
+    expect(enclaveGatewayTestHelpers.expectedTools(config(true))).toEqual([
+      enclaveProtocol.TOOL,
+      enclaveProtocol.AGENT_TOOL,
+    ]);
+  });
+
+  it('rejects missing capability and non-gateway readiness routes', () => {
+    expect(() => resolveEnclaveGatewayContract(config(), {
+      ...env(),
+      AWF_ENCLAVE_MCP_CAPABILITY: undefined,
+    })).toThrow(/CAPABILITY/);
+    expect(() => resolveEnclaveGatewayContract(
+      config(),
+      env('http://127.0.0.1:8080/health'),
+    )).toThrow(/must address the gateway route/);
+  });
+
+  it('attaches only the expected labelled gateway to the private control network', async () => {
+    mockExeca
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          Name: '/awmg-mcpg',
+          State: { Running: true },
+          HostConfig: { NetworkMode: 'bridge' },
+          Config: { Labels: { [ENCLAVE_MCP_GATEWAY_RUN_LABEL]: 'test-run-identity' } },
+        }),
+      })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          first: { Name: 'awf-enclave-mcp-server' },
+          second: { Name: 'awmg-mcpg' },
+        }),
+      });
+    await connectEnclaveGateway(config(), env());
+    expect(mockExeca).toHaveBeenNthCalledWith(
+      2,
+      'docker',
+      ['network', 'connect', 'awf-enclave-mcp-control', 'awmg-mcpg'],
+      expect.objectContaining({ reject: false }),
+    );
+  });
+
+  it('fails closed on gateway identity mismatch', async () => {
+    mockExeca.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        Name: '/awmg-mcpg',
+        State: { Running: true },
+        HostConfig: { NetworkMode: 'bridge' },
+        Config: { Labels: { [ENCLAVE_MCP_GATEWAY_RUN_LABEL]: 'wrong-run' } },
+      }),
+    });
+    await expect(connectEnclaveGateway(config(), env())).rejects.toThrow(/identity did not match/);
+  });
+
+  it('proves initialize and the exact tool contracts through the gateway', async () => {
+    const contract = buildEnclaveMcpgUpstreamContract(config());
+    const server = await listen([{
+      name: 'enclave_run_script',
+      description: 'Run a bounded script against one configured private repository and return one finite value.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          privateRepo: { type: 'string', description: 'Bare configured owner/repository selector.' },
+          schema: {
+            type: 'object',
+            description: 'An AWF finite-disclosure schema (const, boolean, enum, integer, object, tuple, array, or union).',
+          },
+          script: { type: 'string', description: 'Bounded UTF-8 Python source.' },
+        },
+        required: ['privateRepo', 'schema', 'script'],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: { status: { enum: ['ok', 'error'] }, result: {} },
+        required: ['status'],
+        additionalProperties: false,
+      },
+    }]);
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 1000))
+        .resolves.toBeUndefined();
+      expect(contract.server.tools).toEqual(['enclave_run_script']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('times out before agent startup when the gateway publishes a mismatched tool contract', async () => {
+    const server = await listen([{ name: 'unexpected_tool' }]);
+    try {
+      await expect(assertEnclaveGatewayReady(config(), env(server.endpoint), 10))
+        .rejects.toThrow(/tool contract did not exactly match/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('drains the AWF server and disconnects mcpg without stopping the external container', async () => {
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    await shutdownEnclaveGateway(config(), env());
+    expect(mockExeca).toHaveBeenNthCalledWith(
+      1,
+      'docker',
+      ['compose', 'stop', '-t', '10', 'enclave-mcp-server'],
+      expect.objectContaining({ cwd: '/tmp/awf-test' }),
+    );
+    expect(mockExeca).toHaveBeenNthCalledWith(
+      2,
+      'docker',
+      ['network', 'disconnect', '-f', 'awf-enclave-mcp-control', 'awmg-mcpg'],
+      expect.anything(),
+    );
+    expect(mockExeca.mock.calls.flat().join(' ')).not.toMatch(/docker (?:stop|rm).*awmg-mcpg/);
+  });
+});

--- a/src/enclave/gateway.ts
+++ b/src/enclave/gateway.ts
@@ -1,0 +1,455 @@
+import * as http from 'http';
+import * as https from 'https';
+import execa from 'execa';
+import { ENCLAVE_MCP_SERVER_CONTAINER_NAME } from '../constants';
+import { getLocalDockerEnv } from '../docker-host';
+import type { WrapperConfig } from '../types';
+import {
+  ENCLAVE_MCP_CONTROL_NETWORK,
+} from './network';
+
+export const ENCLAVE_MCP_CAPABILITY_ENV = 'AWF_ENCLAVE_MCP_CAPABILITY';
+export const ENCLAVE_MCP_GATEWAY_CONTAINER_ENV = 'AWF_ENCLAVE_MCP_GATEWAY_CONTAINER';
+export const ENCLAVE_MCP_GATEWAY_ENDPOINT_ENV = 'AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT';
+export const ENCLAVE_MCP_GATEWAY_IDENTITY_ENV = 'AWF_ENCLAVE_MCP_GATEWAY_IDENTITY';
+export const ENCLAVE_MCP_READINESS_TIMEOUT_ENV = 'AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS';
+export const ENCLAVE_MCP_GATEWAY_RUN_LABEL = 'com.github.gh-aw.mcpg.run';
+export const ENCLAVE_MCP_SERVER_NAME = 'awf-enclave';
+export const ENCLAVE_MCP_UPSTREAM_URL = 'http://awf-enclave-mcp:8080/mcp';
+
+const DEFAULT_GATEWAY_CONTAINER = 'awmg-mcpg';
+const DEFAULT_READINESS_TIMEOUT_MS = 120_000;
+const REQUEST_TIMEOUT_MS = 5_000;
+const RETRY_DELAY_MS = 500;
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+interface EnclaveGatewayContract {
+  capability: string;
+  containerName: string;
+  endpoint: URL;
+  identity: string;
+  expectedTools: ReadonlyArray<Record<string, unknown>>;
+  readinessTimeoutMs: number;
+}
+
+export interface EnclaveMcpgUpstreamContract {
+  name: typeof ENCLAVE_MCP_SERVER_NAME;
+  server: {
+    type: 'http';
+    url: typeof ENCLAVE_MCP_UPSTREAM_URL;
+    headers: { Authorization: string };
+    tools: string[];
+    connectTimeout: number;
+    toolTimeout: number;
+  };
+  handoff: {
+    capabilityEnv: typeof ENCLAVE_MCP_CAPABILITY_ENV;
+    gatewayContainerEnv: typeof ENCLAVE_MCP_GATEWAY_CONTAINER_ENV;
+    gatewayEndpointEnv: typeof ENCLAVE_MCP_GATEWAY_ENDPOINT_ENV;
+    gatewayIdentityEnv: typeof ENCLAVE_MCP_GATEWAY_IDENTITY_ENV;
+    readinessTimeoutEnv: typeof ENCLAVE_MCP_READINESS_TIMEOUT_ENV;
+    gatewayRunLabel: typeof ENCLAVE_MCP_GATEWAY_RUN_LABEL;
+  };
+}
+
+interface JsonRpcResponse {
+  jsonrpc?: unknown;
+  id?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+const finiteSchemaInput = {
+  type: 'object',
+  description: 'An AWF finite-disclosure schema (const, boolean, enum, integer, object, tuple, array, or union).',
+};
+
+const outputSchema = {
+  type: 'object',
+  properties: {
+    status: { enum: ['ok', 'error'] },
+    result: {},
+  },
+  required: ['status'],
+  additionalProperties: false,
+};
+
+const scriptTool = {
+  name: 'enclave_run_script',
+  description: 'Run a bounded script against one configured private repository and return one finite value.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      privateRepo: { type: 'string', description: 'Bare configured owner/repository selector.' },
+      schema: finiteSchemaInput,
+      script: { type: 'string', description: 'Bounded UTF-8 Python source.' },
+    },
+    required: ['privateRepo', 'schema', 'script'],
+    additionalProperties: false,
+  },
+  outputSchema,
+};
+
+const agentTool = {
+  name: 'enclave_run_agent',
+  description:
+    'Run a bounded, single-use agent enclave against one configured private repository and return one finite value.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      privateRepo: { type: 'string', description: 'Bare configured owner/repository selector.' },
+      schema: finiteSchemaInput,
+      prompt: { type: 'string', description: 'Bounded UTF-8 task prompt.' },
+    },
+    required: ['privateRepo', 'schema', 'prompt'],
+    additionalProperties: false,
+  },
+  outputSchema,
+};
+
+function expectedTools(config: WrapperConfig): ReadonlyArray<Record<string, unknown>> {
+  const tools: Record<string, unknown>[] = [];
+  if (config.enclaves?.executors.script.enabled) tools.push(scriptTool);
+  if (config.enclaves?.executors.agent.enabled) tools.push(agentTool);
+  return tools;
+}
+
+/**
+ * Machine-readable compiler handoff. This intentionally contains only the
+ * static upstream route and environment-variable names, never the capability.
+ */
+export function buildEnclaveMcpgUpstreamContract(config: WrapperConfig): EnclaveMcpgUpstreamContract {
+  if (!config.enclaves?.enabled) {
+    throw new Error('Cannot build an mcpg upstream contract while enclaves are disabled');
+  }
+  return {
+    name: ENCLAVE_MCP_SERVER_NAME,
+    server: {
+      type: 'http',
+      url: ENCLAVE_MCP_UPSTREAM_URL,
+      headers: { Authorization: 'Bearer ' + '$' + `{${ENCLAVE_MCP_CAPABILITY_ENV}}` },
+      tools: expectedTools(config).map((tool) => String(tool.name)),
+      connectTimeout: 120,
+      toolTimeout: Math.max(
+        config.enclaves.executors.script.enabled ? config.enclaves.executors.script.timeout : 0,
+        config.enclaves.executors.agent.enabled ? config.enclaves.executors.agent.timeout : 0,
+      ) + 30,
+    },
+    handoff: {
+      capabilityEnv: ENCLAVE_MCP_CAPABILITY_ENV,
+      gatewayContainerEnv: ENCLAVE_MCP_GATEWAY_CONTAINER_ENV,
+      gatewayEndpointEnv: ENCLAVE_MCP_GATEWAY_ENDPOINT_ENV,
+      gatewayIdentityEnv: ENCLAVE_MCP_GATEWAY_IDENTITY_ENV,
+      readinessTimeoutEnv: ENCLAVE_MCP_READINESS_TIMEOUT_ENV,
+      gatewayRunLabel: ENCLAVE_MCP_GATEWAY_RUN_LABEL,
+    },
+  };
+}
+
+export function resolveEnclaveGatewayContract(
+  config: WrapperConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): EnclaveGatewayContract {
+  if (!config.enclaves?.enabled) {
+    throw new Error('Enclave gateway contract requested while enclaves are disabled');
+  }
+  const capability = env[ENCLAVE_MCP_CAPABILITY_ENV] ?? '';
+  const identity = env[ENCLAVE_MCP_GATEWAY_IDENTITY_ENV] ?? '';
+  const containerName = env[ENCLAVE_MCP_GATEWAY_CONTAINER_ENV] || DEFAULT_GATEWAY_CONTAINER;
+  const endpointRaw = env[ENCLAVE_MCP_GATEWAY_ENDPOINT_ENV] ?? '';
+  const timeoutRaw = env[ENCLAVE_MCP_READINESS_TIMEOUT_ENV];
+
+  if (!/^[0-9a-f]{64}$/.test(capability)) {
+    throw new Error(`${ENCLAVE_MCP_CAPABILITY_ENV} must contain a run-scoped 256-bit lowercase hex capability`);
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{7,127}$/.test(identity)) {
+    throw new Error(`${ENCLAVE_MCP_GATEWAY_IDENTITY_ENV} is missing or invalid`);
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/.test(containerName)) {
+    throw new Error(`${ENCLAVE_MCP_GATEWAY_CONTAINER_ENV} is invalid`);
+  }
+  const readinessTimeoutMs = timeoutRaw === undefined
+    ? DEFAULT_READINESS_TIMEOUT_MS
+    : Number(timeoutRaw);
+  if (
+    !Number.isSafeInteger(readinessTimeoutMs)
+    || readinessTimeoutMs < 1_000
+    || readinessTimeoutMs > 600_000
+  ) {
+    throw new Error(`${ENCLAVE_MCP_READINESS_TIMEOUT_ENV} must be between 1000 and 600000`);
+  }
+
+  let endpoint: URL;
+  try {
+    endpoint = new URL(endpointRaw);
+  } catch {
+    throw new Error(`${ENCLAVE_MCP_GATEWAY_ENDPOINT_ENV} must be an absolute HTTP readiness URL`);
+  }
+  if (
+    !['http:', 'https:'].includes(endpoint.protocol)
+    || !endpoint.pathname.endsWith(`/mcp/${ENCLAVE_MCP_SERVER_NAME}`)
+    || endpoint.username
+    || endpoint.password
+  ) {
+    throw new Error(
+      `${ENCLAVE_MCP_GATEWAY_ENDPOINT_ENV} must address the gateway route /mcp/${ENCLAVE_MCP_SERVER_NAME}`,
+    );
+  }
+
+  return {
+    capability,
+    containerName,
+    endpoint,
+    identity,
+    expectedTools: expectedTools(config),
+    readinessTimeoutMs,
+  };
+}
+
+async function inspectGateway(contract: EnclaveGatewayContract): Promise<void> {
+  const result = await execa(
+    'docker',
+    ['inspect', '--format', '{{json .}}', contract.containerName],
+    { env: getLocalDockerEnv(), reject: false, timeout: 10_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error('Trusted enclave MCP gateway container is unavailable');
+  }
+  let inspected: {
+    Name?: string;
+    State?: { Running?: boolean };
+    Config?: { Labels?: Record<string, string> };
+    HostConfig?: { NetworkMode?: string };
+  };
+  try {
+    inspected = JSON.parse(result.stdout);
+  } catch {
+    throw new Error('Trusted enclave MCP gateway identity could not be inspected');
+  }
+  if (
+    inspected.Name !== `/${contract.containerName}`
+    || inspected.State?.Running !== true
+    || inspected.Config?.Labels?.[ENCLAVE_MCP_GATEWAY_RUN_LABEL] !== contract.identity
+    || inspected.HostConfig?.NetworkMode !== 'bridge'
+  ) {
+    throw new Error('Trusted enclave MCP gateway identity did not match the compiler handoff');
+  }
+}
+
+async function assertControlNetworkMembership(contract: EnclaveGatewayContract): Promise<void> {
+  const result = await execa(
+    'docker',
+    ['network', 'inspect', '--format', '{{json .Containers}}', ENCLAVE_MCP_CONTROL_NETWORK],
+    { env: getLocalDockerEnv(), reject: false, timeout: 10_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error('Enclave MCP control network is unavailable');
+  }
+  let containers: Record<string, { Name?: string }>;
+  try {
+    containers = JSON.parse(result.stdout);
+  } catch {
+    throw new Error('Enclave MCP control network membership could not be inspected');
+  }
+  const names = Object.values(containers).map((entry) => entry.Name).filter(Boolean).sort();
+  const expected = [ENCLAVE_MCP_SERVER_CONTAINER_NAME, contract.containerName].sort();
+  if (JSON.stringify(names) !== JSON.stringify(expected)) {
+    throw new Error('Enclave MCP control network contains an unexpected member');
+  }
+}
+
+export async function connectEnclaveGateway(
+  config: WrapperConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const contract = resolveEnclaveGatewayContract(config, env);
+  await inspectGateway(contract);
+  const connected = await execa(
+    'docker',
+    ['network', 'connect', ENCLAVE_MCP_CONTROL_NETWORK, contract.containerName],
+    { env: getLocalDockerEnv(), reject: false, timeout: 10_000 },
+  );
+  if (
+    connected.exitCode !== 0
+    && !/already exists in network|is already attached|already connected/i.test(connected.stderr || '')
+  ) {
+    throw new Error('Failed to attach the trusted enclave MCP gateway to its private control network');
+  }
+  await assertControlNetworkMembership(contract);
+}
+
+function postJsonRpc(
+  endpoint: URL,
+  body: Record<string, unknown>,
+  sessionId?: string,
+): Promise<{ response: JsonRpcResponse; sessionId?: string }> {
+  return new Promise((resolve, reject) => {
+    const payload = Buffer.from(JSON.stringify(body), 'utf8');
+    const transport = endpoint.protocol === 'https:' ? https : http;
+    const request = transport.request(endpoint, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+        'content-length': String(payload.length),
+        ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+      },
+      timeout: REQUEST_TIMEOUT_MS,
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      response.on('data', (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > 256 * 1024) {
+          request.destroy(new Error('Gateway readiness response exceeded its framing bound'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on('end', () => {
+        try {
+          if (response.statusCode !== 200 && response.statusCode !== 202) {
+            reject(new Error('Gateway readiness request failed'));
+            return;
+          }
+          const raw = Buffer.concat(chunks).toString('utf8');
+          const contentType = String(response.headers['content-type'] ?? '');
+          const events = raw
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith('data:'))
+            .map((line) => line.slice(5).trim())
+            .filter((line) => line !== '' && line !== '[DONE]');
+          const jsonText = contentType.includes('text/event-stream')
+            ? events[events.length - 1]
+            : raw;
+          const parsed = !jsonText ? {} : JSON.parse(jsonText) as JsonRpcResponse;
+          const returnedSession = response.headers['mcp-session-id'];
+          resolve({
+            response: parsed,
+            sessionId: typeof returnedSession === 'string' ? returnedSession : sessionId,
+          });
+        } catch {
+          reject(new Error('Gateway readiness response was not bounded JSON'));
+        }
+      });
+    });
+    request.on('timeout', () => request.destroy(new Error('Gateway readiness request timed out')));
+    request.on('error', reject);
+    request.end(payload);
+  });
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+function canonicalToolSet(value: unknown): string {
+  if (!Array.isArray(value)) return 'invalid';
+  const names = value.map((tool) => (
+    tool && typeof tool === 'object' ? (tool as Record<string, unknown>).name : undefined
+  ));
+  if (
+    names.some((name) => typeof name !== 'string')
+    || new Set(names).size !== names.length
+  ) {
+    return 'invalid';
+  }
+  return canonicalJson([...value].sort((left, right) => (
+    String((left as Record<string, unknown>).name)
+      .localeCompare(String((right as Record<string, unknown>).name))
+  )));
+}
+
+async function proveGatewayReadiness(contract: EnclaveGatewayContract): Promise<void> {
+  const initialized = await postJsonRpc(contract.endpoint, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'awf-readiness', version: '1.0.0' },
+    },
+  });
+  const result = initialized.response.result as { serverInfo?: { name?: string } } | undefined;
+  if (initialized.response.error || result?.serverInfo?.name !== 'awf-enclave') {
+    throw new Error('Gateway initialize proof did not reach the AWF enclave server');
+  }
+  await postJsonRpc(contract.endpoint, {
+    jsonrpc: '2.0',
+    method: 'notifications/initialized',
+  }, initialized.sessionId);
+  const listed = await postJsonRpc(contract.endpoint, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/list',
+    params: {},
+  }, initialized.sessionId);
+  const tools = (listed.response.result as { tools?: unknown })?.tools;
+  if (canonicalToolSet(tools) !== canonicalToolSet(contract.expectedTools)) {
+    throw new Error('Gateway enclave tool contract did not exactly match the enabled executors');
+  }
+}
+
+export async function assertEnclaveGatewayReady(
+  config: WrapperConfig,
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs?: number,
+): Promise<void> {
+  const contract = resolveEnclaveGatewayContract(config, env);
+  const deadline = Date.now() + (timeoutMs ?? contract.readinessTimeoutMs);
+  let lastError: unknown;
+  do {
+    try {
+      await proveGatewayReadiness(contract);
+      return;
+    } catch (error) {
+      lastError = error;
+      const remaining = deadline - Date.now();
+      if (remaining > 0) {
+        await new Promise((resolve) => setTimeout(resolve, Math.min(RETRY_DELAY_MS, remaining)));
+      }
+    }
+  } while (Date.now() < deadline);
+  throw new Error(
+    `Enclave MCP gateway readiness timed out before primary-agent startup: ${
+      lastError instanceof Error ? lastError.message : 'unknown readiness failure'
+    }`,
+  );
+}
+
+export async function shutdownEnclaveGateway(
+  config: WrapperConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (!config.enclaves?.enabled || config.keepContainers) return;
+  const contract = resolveEnclaveGatewayContract(config, env);
+  await execa(
+    'docker',
+    ['compose', 'stop', '-t', '10', 'enclave-mcp-server'],
+    { cwd: config.workDir, env: getLocalDockerEnv(), reject: false, timeout: 15_000 },
+  );
+  await execa(
+    'docker',
+    ['network', 'disconnect', '-f', ENCLAVE_MCP_CONTROL_NETWORK, contract.containerName],
+    { env: getLocalDockerEnv(), reject: false, timeout: 10_000 },
+  );
+}
+
+export const enclaveGatewayTestHelpers = {
+  agentTool,
+  canonicalJson,
+  canonicalToolSet,
+  expectedTools,
+  inspectGateway,
+  proveGatewayReadiness,
+  scriptTool,
+};

--- a/src/enclave/gateway.ts
+++ b/src/enclave/gateway.ts
@@ -1,6 +1,7 @@
 import * as http from 'http';
 import * as https from 'https';
 import execa from 'execa';
+import { TIMING_BUCKETS_MS } from '../bounded-execution';
 import { ENCLAVE_MCP_SERVER_CONTAINER_NAME } from '../constants';
 import { getLocalDockerEnv } from '../docker-host';
 import type { WrapperConfig } from '../types';
@@ -22,6 +23,7 @@ const DEFAULT_READINESS_TIMEOUT_MS = 120_000;
 const REQUEST_TIMEOUT_MS = 5_000;
 const RETRY_DELAY_MS = 500;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
+const ENCLAVE_MCP_OPERATION_TIMEOUT_SECONDS = Math.max(...TIMING_BUCKETS_MS) / 1_000 + 30;
 
 interface EnclaveGatewayContract {
   capability: string;
@@ -57,6 +59,13 @@ interface JsonRpcResponse {
   id?: unknown;
   result?: unknown;
   error?: unknown;
+}
+
+class GatewayReadinessError extends Error {
+  constructor(message: string, readonly retryable = false) {
+    super(message);
+    this.name = 'GatewayReadinessError';
+  }
 }
 
 const finiteSchemaInput = {
@@ -130,10 +139,7 @@ export function buildEnclaveMcpgUpstreamContract(config: WrapperConfig): Enclave
       headers: { Authorization: 'Bearer ' + '$' + `{${ENCLAVE_MCP_CAPABILITY_ENV}}` },
       tools: expectedTools(config).map((tool) => String(tool.name)),
       connectTimeout: 120,
-      toolTimeout: Math.max(
-        config.enclaves.executors.script.enabled ? config.enclaves.executors.script.timeout : 0,
-        config.enclaves.executors.agent.enabled ? config.enclaves.executors.agent.timeout : 0,
-      ) + 30,
+      toolTimeout: ENCLAVE_MCP_OPERATION_TIMEOUT_SECONDS,
     },
     handoff: {
       capabilityEnv: ENCLAVE_MCP_CAPABILITY_ENV,
@@ -281,9 +287,18 @@ export async function connectEnclaveGateway(
 function postJsonRpc(
   endpoint: URL,
   body: Record<string, unknown>,
+  timeoutMs: number,
   sessionId?: string,
 ): Promise<{ response: JsonRpcResponse; sessionId?: string }> {
   return new Promise((resolve, reject) => {
+    const resolveBounded = (value: { response: JsonRpcResponse; sessionId?: string }): void => {
+      clearTimeout(deadlineTimer);
+      resolve(value);
+    };
+    const rejectBounded = (error: Error): void => {
+      clearTimeout(deadlineTimer);
+      reject(error);
+    };
     const payload = Buffer.from(JSON.stringify(body), 'utf8');
     const transport = endpoint.protocol === 'https:' ? https : http;
     const request = transport.request(endpoint, {
@@ -294,7 +309,7 @@ function postJsonRpc(
         'content-length': String(payload.length),
         ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
       },
-      timeout: REQUEST_TIMEOUT_MS,
+      timeout: timeoutMs,
     }, (response) => {
       const chunks: Buffer[] = [];
       let total = 0;
@@ -308,11 +323,31 @@ function postJsonRpc(
       });
       response.on('end', () => {
         try {
+          const raw = Buffer.concat(chunks).toString('utf8');
           if (response.statusCode !== 200 && response.statusCode !== 202) {
-            reject(new Error('Gateway readiness request failed'));
+            if (response.statusCode === 503) {
+              try {
+                const unavailable = JSON.parse(raw) as {
+                  error?: unknown;
+                  retryable?: unknown;
+                };
+                if (
+                  unavailable.error === 'backend_unavailable'
+                  && unavailable.retryable === true
+                ) {
+                  rejectBounded(new GatewayReadinessError(
+                    'Gateway backend is not yet available',
+                    true,
+                  ));
+                  return;
+                }
+              } catch {
+                // The response is permanent unless it matches the documented recovery shape.
+              }
+            }
+            rejectBounded(new GatewayReadinessError('Gateway readiness request failed'));
             return;
           }
-          const raw = Buffer.concat(chunks).toString('utf8');
           const contentType = String(response.headers['content-type'] ?? '');
           const events = raw
             .split(/\r?\n/)
@@ -324,17 +359,24 @@ function postJsonRpc(
             : raw;
           const parsed = !jsonText ? {} : JSON.parse(jsonText) as JsonRpcResponse;
           const returnedSession = response.headers['mcp-session-id'];
-          resolve({
+          resolveBounded({
             response: parsed,
             sessionId: typeof returnedSession === 'string' ? returnedSession : sessionId,
           });
         } catch {
-          reject(new Error('Gateway readiness response was not bounded JSON'));
+          rejectBounded(new GatewayReadinessError(
+            'Gateway readiness response was not bounded JSON',
+          ));
         }
       });
     });
-    request.on('timeout', () => request.destroy(new Error('Gateway readiness request timed out')));
-    request.on('error', reject);
+    request.on('timeout', () => request.destroy(
+      new GatewayReadinessError('Gateway readiness request timed out'),
+    ));
+    request.on('error', rejectBounded);
+    const deadlineTimer = setTimeout(() => request.destroy(
+      new GatewayReadinessError('Gateway readiness request timed out'),
+    ), timeoutMs);
     request.end(payload);
   });
 }
@@ -368,7 +410,18 @@ function canonicalToolSet(value: unknown): string {
   )));
 }
 
-async function proveGatewayReadiness(contract: EnclaveGatewayContract): Promise<void> {
+function remainingRequestBudget(deadline: number): number {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    throw new GatewayReadinessError('Gateway readiness deadline expired');
+  }
+  return Math.min(REQUEST_TIMEOUT_MS, remaining);
+}
+
+async function proveGatewayReadiness(
+  contract: EnclaveGatewayContract,
+  deadline: number,
+): Promise<void> {
   const initialized = await postJsonRpc(contract.endpoint, {
     jsonrpc: '2.0',
     id: 1,
@@ -378,7 +431,7 @@ async function proveGatewayReadiness(contract: EnclaveGatewayContract): Promise<
       capabilities: {},
       clientInfo: { name: 'awf-readiness', version: '1.0.0' },
     },
-  });
+  }, remainingRequestBudget(deadline));
   const result = initialized.response.result as { serverInfo?: { name?: string } } | undefined;
   if (initialized.response.error || result?.serverInfo?.name !== 'awf-enclave') {
     throw new Error('Gateway initialize proof did not reach the AWF enclave server');
@@ -386,13 +439,13 @@ async function proveGatewayReadiness(contract: EnclaveGatewayContract): Promise<
   await postJsonRpc(contract.endpoint, {
     jsonrpc: '2.0',
     method: 'notifications/initialized',
-  }, initialized.sessionId);
+  }, remainingRequestBudget(deadline), initialized.sessionId);
   const listed = await postJsonRpc(contract.endpoint, {
     jsonrpc: '2.0',
     id: 2,
     method: 'tools/list',
     params: {},
-  }, initialized.sessionId);
+  }, remainingRequestBudget(deadline), initialized.sessionId);
   const tools = (listed.response.result as { tools?: unknown })?.tools;
   if (canonicalToolSet(tools) !== canonicalToolSet(contract.expectedTools)) {
     throw new Error('Gateway enclave tool contract did not exactly match the enabled executors');
@@ -409,9 +462,12 @@ export async function assertEnclaveGatewayReady(
   let lastError: unknown;
   do {
     try {
-      await proveGatewayReadiness(contract);
+      await proveGatewayReadiness(contract, deadline);
       return;
     } catch (error) {
+      if (!(error instanceof GatewayReadinessError) || !error.retryable) {
+        throw error;
+      }
       lastError = error;
       const remaining = deadline - Date.now();
       if (remaining > 0) {
@@ -432,11 +488,20 @@ export async function shutdownEnclaveGateway(
 ): Promise<void> {
   if (!config.enclaves?.enabled || config.keepContainers) return;
   const contract = resolveEnclaveGatewayContract(config, env);
-  await execa(
+  const drainTimeoutSeconds = ENCLAVE_MCP_OPERATION_TIMEOUT_SECONDS;
+  const stopped = await execa(
     'docker',
-    ['compose', 'stop', '-t', '10', 'enclave-mcp-server'],
-    { cwd: config.workDir, env: getLocalDockerEnv(), reject: false, timeout: 15_000 },
+    ['compose', 'stop', '-t', String(drainTimeoutSeconds), 'enclave-mcp-server'],
+    {
+      cwd: config.workDir,
+      env: getLocalDockerEnv(),
+      reject: false,
+      timeout: (drainTimeoutSeconds + 15) * 1_000,
+    },
   );
+  if (stopped.exitCode !== 0) {
+    throw new Error('Failed to drain the enclave MCP server before audit preservation');
+  }
   await execa(
     'docker',
     ['network', 'disconnect', '-f', ENCLAVE_MCP_CONTROL_NETWORK, contract.containerName],
@@ -451,5 +516,6 @@ export const enclaveGatewayTestHelpers = {
   expectedTools,
   inspectGateway,
   proveGatewayReadiness,
+  remainingRequestBudget,
   scriptTool,
 };

--- a/src/enclave/manager.test.ts
+++ b/src/enclave/manager.test.ts
@@ -23,9 +23,21 @@ const gitRunner: GitRunner = async (args) => {
 jest.mock('execa', () => ({ __esModule: true, default: jest.fn() }));
 const mockExeca = execa as unknown as jest.Mock;
 
+function enclaveEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    GH_TOKEN: 'secret',
+    AWF_ENCLAVE_MCP_CAPABILITY: 'a'.repeat(64),
+    AWF_ENCLAVE_MCP_GATEWAY_IDENTITY: 'test-run-identity',
+    AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT: 'http://127.0.0.1:8080/mcp/awf-enclave',
+    ...overrides,
+  };
+}
+
 function config(workDir: string, overrides: Parameters<typeof normalizeEnclavesConfig>[0] = {}): WrapperConfig {
   return {
     workDir,
+    networkIsolation: true,
+    topologyAttach: ['awmg-mcpg'],
     enclaves: normalizeEnclavesConfig({
       enabled: true,
       privateRepos: [{ repo: 'octo/private', sensitivity: 'internal' }],
@@ -82,10 +94,31 @@ describe('prepareEnclaves fail-closed preflight', () => {
 
   it('rejects a network Docker daemon before staging', async () => {
     await expect(prepareEnclaves(config(workDir), {
-      env: { GH_TOKEN: 'secret', DOCKER_HOST: 'tcp://daemon:2375' },
+      env: enclaveEnv({ DOCKER_HOST: 'tcp://daemon:2375' }),
       assertPrimaryAvailable: jest.fn(),
       assertScriptRuntimeAvailable: jest.fn(),
     })).rejects.toThrow(/Unix-socket Docker host/);
+  });
+
+  it('requires the compiler topology handoff before staging', async () => {
+    const wrapperConfig = config(workDir);
+    wrapperConfig.networkIsolation = false;
+    wrapperConfig.topologyAttach = [];
+    await expect(prepareEnclaves(wrapperConfig, {
+      env: enclaveEnv(),
+      assertPrimaryAvailable: jest.fn(),
+      assertScriptRuntimeAvailable: jest.fn(),
+    })).rejects.toThrow(/require networkIsolation/);
+  });
+
+  it('rejects a gateway container omitted from topologyAttach', async () => {
+    const wrapperConfig = config(workDir);
+    wrapperConfig.topologyAttach = ['another-peer'];
+    await expect(prepareEnclaves(wrapperConfig, {
+      env: enclaveEnv(),
+      assertPrimaryAvailable: jest.fn(),
+      assertScriptRuntimeAvailable: jest.fn(),
+    })).rejects.toThrow(/topologyAttach to include/);
   });
 
   it('proves both executor runtimes before staging when both are enabled', async () => {
@@ -97,7 +130,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
         agent: { enabled: true, model: 'gpt-test' },
       },
     }), {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       gitRunner,
       assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
       assertScriptRuntimeAvailable,
@@ -115,7 +148,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
     await prepareToleratingPrivateRootIo(agentConfig(workDir, {
       executors: { agent: { enabled: true, model: 'gpt-test' } },
     }), {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       gitRunner,
       assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
       assertScriptRuntimeAvailable,
@@ -130,7 +163,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
     await expect(prepareEnclaves(agentConfig(workDir, {
       executors: { agent: { enabled: true, model: 'gpt-test', runtime: 'sbx' } },
     }), {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       assertPrimaryAvailable: jest.fn(),
       assertScriptRuntimeAvailable: jest.fn(),
       assertAgentRuntimeAvailable,
@@ -145,7 +178,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
       }),
       enableApiProxy: false,
     } as WrapperConfig, {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       assertPrimaryAvailable: jest.fn(),
       assertAgentRuntimeAvailable: jest.fn(),
     })).rejects.toThrow(/agent executor requires the AWF API proxy/);
@@ -155,7 +188,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
     await expect(prepareEnclaves(config(workDir, {
       executors: { script: { enabled: true, runtime: 'sbx' } },
     }), {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       assertPrimaryAvailable: jest.fn(),
       assertScriptRuntimeAvailable: jest.fn(),
     })).rejects.toThrow(/runtime "sbx" is not implemented/);
@@ -164,7 +197,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
   it('requires a staging credential before runtime probes', async () => {
     const assertPrimaryAvailable = jest.fn();
     await expect(prepareEnclaves(config(workDir), {
-      env: {},
+      env: enclaveEnv({ GH_TOKEN: undefined }),
       assertPrimaryAvailable,
       assertScriptRuntimeAvailable: jest.fn(),
     })).rejects.toThrow(/staging credential/);
@@ -173,7 +206,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
 
   it('stages immutable seeds and a private MCP capability before Compose starts', async () => {
     await prepareEnclaves(config(workDir), {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       gitRunner,
       assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
       assertScriptRuntimeAvailable: jest.fn().mockResolvedValue(undefined),
@@ -189,7 +222,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
         sensitivity: 'internal',
       }],
     });
-    expect(fs.readFileSync(paths.capabilityPath, 'utf8').trim()).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.readFileSync(paths.capabilityPath, 'utf8').trim()).toBe('a'.repeat(64));
     expect(fs.statSync(paths.capabilityPath).mode & 0o777).toBe(0o600);
     expect(paths.root.startsWith(workDir)).toBe(false);
     expect(paths.ingressRoot.startsWith(workDir)).toBe(false);
@@ -198,7 +231,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
   it('removes labelled orphan containers and both private roots on teardown', async () => {
     const wrapperConfig = config(workDir);
     await prepareEnclaves(wrapperConfig, {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       gitRunner,
       assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
       assertScriptRuntimeAvailable: jest.fn().mockResolvedValue(undefined),
@@ -228,7 +261,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
   it('preserves private state and fails loudly when orphan cleanup fails', async () => {
     const wrapperConfig = config(workDir);
     await prepareEnclaves(wrapperConfig, {
-      env: { GH_TOKEN: 'secret' },
+      env: enclaveEnv(),
       gitRunner,
       assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
       assertScriptRuntimeAvailable: jest.fn().mockResolvedValue(undefined),

--- a/src/enclave/manager.test.ts
+++ b/src/enclave/manager.test.ts
@@ -4,9 +4,16 @@ import * as path from 'path';
 import execa from 'execa';
 import { normalizeEnclavesConfig } from '../parsers/enclave-parser';
 import type { WrapperConfig } from '../types';
-import { prepareEnclaves, teardownEnclaves } from './manager';
+import {
+  isEnclaveAgentEnabled,
+  isEnclaveScriptEnabled,
+  prepareEnclaves,
+  teardownEnclaves,
+} from './manager';
 import { releaseSeedPermissions, type GitRunner } from '../bounded-query/staging';
 import { resolveEnclavePaths } from './paths';
+import * as boundedQueryPreflight from '../bounded-query/preflight';
+import * as boundedAgentPreflight from '../bounded-agent/preflight';
 
 const gitRunner: GitRunner = async (args) => {
   if (args.includes('clone')) {
@@ -136,10 +143,38 @@ describe('prepareEnclaves fail-closed preflight', () => {
       assertScriptRuntimeAvailable,
       assertAgentRuntimeAvailable,
     });
+
     expect(assertScriptRuntimeAvailable).toHaveBeenCalledTimes(1);
     expect(assertAgentRuntimeAvailable).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true, runtime: 'docker', model: 'gpt-test' }),
     );
+  });
+
+  it('uses the default runtime proofs for enabled executors', async () => {
+    const scriptProof = jest.spyOn(boundedQueryPreflight, 'assertQueryRuntimeAvailable')
+      .mockResolvedValueOnce(undefined);
+    const agentProof = jest.spyOn(boundedAgentPreflight, 'assertEnclaveRuntimeAvailable')
+      .mockResolvedValueOnce(undefined);
+    const wrapperConfig = agentConfig(workDir, {
+      executors: {
+        script: { enabled: true },
+        agent: { enabled: true, model: 'gpt-test' },
+      },
+    });
+    try {
+      await prepareToleratingPrivateRootIo(wrapperConfig, {
+        env: enclaveEnv(),
+        gitRunner,
+        assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
+      });
+      expect(scriptProof).toHaveBeenCalledTimes(1);
+      expect(agentProof).toHaveBeenCalledTimes(1);
+      expect(isEnclaveScriptEnabled(wrapperConfig)).toBe(true);
+      expect(isEnclaveAgentEnabled(wrapperConfig)).toBe(true);
+    } finally {
+      scriptProof.mockRestore();
+      agentProof.mockRestore();
+    }
   });
 
   it('never probes a disabled executor runtime', async () => {

--- a/src/enclave/manager.ts
+++ b/src/enclave/manager.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import execa from 'execa';
 import { fixArtifactPermissionsForRootless } from '../artifact-permissions';
@@ -22,6 +21,10 @@ import type { BoundedAgentsConfig } from '../types';
 import { assertPrivateRootIsolated } from '../bounded-query/mount-policy';
 import { validateEnclavesConfig } from './preflight';
 import { generateEnclaveRunId, resolveEnclavePaths, type EnclavePaths } from './paths';
+import {
+  ENCLAVE_MCP_CAPABILITY_ENV,
+  resolveEnclaveGatewayContract,
+} from './gateway';
 
 export const ENCLAVE_RUN_LABEL = 'awf.enclave.run';
 
@@ -92,6 +95,19 @@ export async function prepareEnclaves(
   const enclaves = config.enclaves!;
   const env = deps.env ?? process.env;
   const errors = validateEnclavesConfig(config);
+  try {
+    const gateway = resolveEnclaveGatewayContract(config, env);
+    if (!config.networkIsolation) {
+      errors.push('enclaves require networkIsolation so the externally launched gateway is attachable');
+    }
+    if (!config.topologyAttach?.includes(gateway.containerName)) {
+      errors.push(
+        `enclaves require topologyAttach to include the trusted gateway container "${gateway.containerName}"`,
+      );
+    }
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'enclave gateway handoff is invalid');
+  }
   if (enclaves.executors.script.enabled && enclaves.executors.script.runtime === 'sbx') {
     errors.push('enclaves.executors.script.runtime "sbx" is not implemented and never falls back');
   }
@@ -176,7 +192,7 @@ export async function prepareEnclaves(
     })),
   };
   writeExclusive(paths.seedMapPath, serializePrivateRepositorySeedMap(seedMap), 0o600);
-  writeExclusive(paths.capabilityPath, `${crypto.randomBytes(32).toString('hex')}\n`, 0o600);
+  writeExclusive(paths.capabilityPath, `${env[ENCLAVE_MCP_CAPABILITY_ENV]}\n`, 0o600);
   logger.info(`Enclaves: staged ${staging.seeds.length} immutable seed(s); staging credential discarded.`);
 }
 

--- a/src/enclave/mcp-server.test.ts
+++ b/src/enclave/mcp-server.test.ts
@@ -10,6 +10,7 @@ const {
 } = require(path.join(root, 'enclave-mcp', 'mcp-protocol.js'));
 const {
   createMcpServer,
+  createSingleToolAdmission,
   safeCapabilityEquals,
 } = require(path.join(root, 'enclave-mcp', 'server.js'));
 const { createBroker } = require(path.join(root, 'broker', 'broker.js'));
@@ -141,9 +142,46 @@ describe('AWF enclave MCP protocol', () => {
     await expect(dispatchJsonRpc(rpc('unknown'), deps)).resolves.toMatchObject({
       error: { code: -32601 },
     });
+
     await expect(dispatchJsonRpc(rpc('tools/call', { name: 'other', arguments: {} }), deps))
       .resolves.toMatchObject({ error: { code: -32602 } });
     expect(parseJsonRpcBody(Buffer.from('{"jsonrpc":"2.0","id":1,"id":2}'))).toBeUndefined();
+  });
+
+  it('admits only one unified enclave tool call at a time', async () => {
+    const tryAcquireToolCall = createSingleToolAdmission();
+    let finishFirst: (() => void) | undefined;
+    const broker = {
+      handle: (_request: unknown, respond: (value: string) => void) => new Promise<void>((resolve) => {
+        finishFirst = () => {
+          respond('{"status":"ok","result":true}');
+          resolve();
+        };
+      }),
+    };
+    const deps = { broker, maxScriptBytes: 65536, tryAcquireToolCall };
+    const first = dispatchJsonRpc(rpc('tools/call', {
+      name: TOOL_NAME,
+      arguments: validArguments,
+    }), deps);
+    await Promise.resolve();
+    const busy = await dispatchJsonRpc(rpc('tools/call', {
+      name: TOOL_NAME,
+      arguments: validArguments,
+    }), deps);
+
+    expect(busy.result).toEqual({
+      content: [{ type: 'text', text: '{"status":"error"}' }],
+      structuredContent: { status: 'error' },
+    });
+    finishFirst!();
+    await expect(first).resolves.toMatchObject({
+      result: { structuredContent: { status: 'ok', result: true } },
+    });
+
+    const release = tryAcquireToolCall();
+    expect(release).toEqual(expect.any(Function));
+    release();
   });
 
   it('authenticates a private bearer capability in constant-length comparisons', () => {

--- a/src/enclave/network.ts
+++ b/src/enclave/network.ts
@@ -10,8 +10,8 @@
  * metrics, and quota state are private to this subsystem.
  *
  * The enclave MCP server that *launches* these enclaves never joins this
- * network: it runs `network_mode: none` and reaches the Docker daemon only
- * through a bind-mounted Unix socket.
+ * network. It joins only the separate internal MCP control network and reaches
+ * the Docker daemon through a bind-mounted Unix socket.
  *
  * The network is created by Compose with an explicit `name:` so the server —
  * which launches enclaves with a fixed `docker run --network <name>` argument
@@ -23,6 +23,18 @@ export const ENCLAVE_AGENT_NETWORK = 'awf-enclave-agent';
 
 /** Egress bridge joined only by the dedicated agent-enclave API proxy. */
 export const ENCLAVE_AGENT_EGRESS_NETWORK = 'awf-enclave-agent-egress';
+
+/**
+ * Private control network shared only by the AWF-owned enclave MCP server and
+ * the externally launched trusted MCP gateway.
+ */
+export const ENCLAVE_MCP_CONTROL_NETWORK = 'awf-enclave-mcp-control';
+
+/** Stable upstream identity used in compiler-generated mcpg configuration. */
+export const ENCLAVE_MCP_CONTROL_ALIAS = 'awf-enclave-mcp';
+
+/** Streamable HTTP port reachable only on {@link ENCLAVE_MCP_CONTROL_NETWORK}. */
+export const ENCLAVE_MCP_CONTROL_PORT = 8080;
 
 /**
  * Fixed subnet for the agent-enclave network.

--- a/src/enclave/paths.test.ts
+++ b/src/enclave/paths.test.ts
@@ -2,12 +2,11 @@ import * as path from 'path';
 import { resolveEnclavePaths } from './paths';
 
 describe('resolveEnclavePaths', () => {
-  it('keeps private state and the future mcpg control endpoint disjoint', () => {
+  it('keeps private state and the gateway capability handoff disjoint', () => {
     const paths = resolveEnclavePaths('/tmp/awf-test', '/private');
     expect(paths.root).toMatch(/^\/private\/awf-enclave-private-/);
     expect(paths.ingressRoot).toMatch(/^\/private\/awf-enclave-control-/);
     expect(paths.ingressRoot).not.toContain(paths.root);
-    expect(paths.socketPath).toBe(path.join(paths.runDir, 'server.sock'));
     expect(paths.capabilityPath).toBe(path.join(paths.runDir, 'auth-token'));
     expect(paths.auditDir.startsWith(paths.root)).toBe(true);
   });

--- a/src/enclave/paths.ts
+++ b/src/enclave/paths.ts
@@ -12,20 +12,17 @@ export interface EnclavePaths {
   seedMapPath: string;
   ingressRoot: string;
   runDir: string;
-  socketPath: string;
   capabilityPath: string;
 }
 
 export const ENCLAVE_PRIVATE_BASE_DIR = '/var/tmp';
-export const ENCLAVE_SOCKET_FILENAME = 'server.sock';
 export const ENCLAVE_CAPABILITY_FILENAME = 'auth-token';
 
 export const ENCLAVE_BROKER_SEEDS_DIR = '/srv/awf/seeds';
 export const ENCLAVE_BROKER_WORK_DIR = '/srv/awf/work';
 export const ENCLAVE_BROKER_SEED_MAP_PATH = '/srv/awf/seed-map.json';
-export const ENCLAVE_BROKER_SOCKET_DIR = '/run/awf-enclave-mcp';
-export const ENCLAVE_BROKER_SOCKET_PATH = `${ENCLAVE_BROKER_SOCKET_DIR}/${ENCLAVE_SOCKET_FILENAME}`;
-export const ENCLAVE_BROKER_CAPABILITY_PATH = `${ENCLAVE_BROKER_SOCKET_DIR}/${ENCLAVE_CAPABILITY_FILENAME}`;
+export const ENCLAVE_BROKER_CAPABILITY_DIR = '/run/awf-enclave-mcp';
+export const ENCLAVE_BROKER_CAPABILITY_PATH = `${ENCLAVE_BROKER_CAPABILITY_DIR}/${ENCLAVE_CAPABILITY_FILENAME}`;
 export const ENCLAVE_BROKER_CONTROL_DIR = '/run/awf-enclave-mcp-control';
 export const ENCLAVE_BROKER_AUDIT_DIR = '/var/log/awf-enclave';
 export const ENCLAVE_BROKER_DOCKER_SOCKET_PATH = '/var/run/docker.sock';
@@ -54,7 +51,6 @@ export function resolveEnclavePaths(
     seedMapPath: path.join(root, 'seed-map.json'),
     ingressRoot,
     runDir,
-    socketPath: path.join(runDir, ENCLAVE_SOCKET_FILENAME),
     capabilityPath: path.join(runDir, ENCLAVE_CAPABILITY_FILENAME),
   };
 }

--- a/src/enclave/preflight.test.ts
+++ b/src/enclave/preflight.test.ts
@@ -207,6 +207,12 @@ describe('validateEnclavesConfig', () => {
     })).join('\n')).toMatch(/enclaves cannot be combined with enableDind/);
   });
 
+  it('rejects script-only enclaves when the primary agent receives the Docker socket', () => {
+    expect(validateEnclavesConfig(config({ enableDind: true }))).toEqual(
+      expect.arrayContaining([expect.stringContaining('cannot be combined with enableDind')]),
+    );
+  });
+
   it('rejects an agent executor that cannot reach a model or drops its network', () => {
     const enclaves = normalizeEnclavesConfig({
       enabled: true,

--- a/src/enclave/preflight.ts
+++ b/src/enclave/preflight.ts
@@ -78,9 +78,9 @@ export function validateEnclavesConfig(config: WrapperConfig): string[] {
   }
   if (config.enableDind) {
     errors.push(
-      'enclaves cannot be combined with enableDind: exposing the Docker socket to the primary agent ' +
-      'would allow it to inspect private seed mounts, join enclave networks, and bypass the ' +
-      'finite-disclosure ledger',
+      'enclaves cannot be combined with enableDind: exposing the Docker socket to the primary ' +
+      'agent would allow it to inspect the gateway capability, private seeds, control network, ' +
+      'and ledger state',
     );
   }
 

--- a/src/services/agent-environment/excluded-vars.test.ts
+++ b/src/services/agent-environment/excluded-vars.test.ts
@@ -17,6 +17,19 @@ describe('buildExclusionSet', () => {
       expect(set.has('PATH')).toBe(true);
     });
 
+    it('never passes enclave gateway handoff material to the primary agent', () => {
+      const excluded = buildExclusionSet(makeConfig({ envAll: true }));
+      for (const name of [
+        'AWF_ENCLAVE_MCP_CAPABILITY',
+        'AWF_ENCLAVE_MCP_GATEWAY_IDENTITY',
+        'AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT',
+        'AWF_ENCLAVE_MCP_GATEWAY_CONTAINER',
+        'AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS',
+      ]) {
+        expect(excluded.has(name)).toBe(true);
+      }
+    });
+
     it('should always exclude shell state variables', () => {
       const set = buildExclusionSet(makeConfig());
       expect(set.has('PWD')).toBe(true);

--- a/src/services/agent-environment/excluded-vars.ts
+++ b/src/services/agent-environment/excluded-vars.ts
@@ -21,6 +21,11 @@ export function buildExclusionSet(config: WrapperConfig): Set<string> {
     'AWF_STAGED_RUNNER_BINARY_NAME',
     'AWF_GEMINI_ENABLED',
     'MCP_GATEWAY_HOST_DOMAIN',
+    'AWF_ENCLAVE_MCP_CAPABILITY',
+    'AWF_ENCLAVE_MCP_GATEWAY_IDENTITY',
+    'AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT',
+    'AWF_ENCLAVE_MCP_GATEWAY_CONTAINER',
+    'AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS',
   ]);
 
   if (config.enableApiProxy) {

--- a/src/services/enclave-agent-service.test.ts
+++ b/src/services/enclave-agent-service.test.ts
@@ -94,10 +94,12 @@ describe('unified enclave agent executor compose assembly', () => {
     });
   });
 
-  it('keeps the MCP server networkless and free of provider credentials', () => {
+  it('keeps the MCP server on only the private control network and free of provider credentials', () => {
     const result = build();
-    expect(result.service.network_mode).toBe('none');
-    expect(result.service).not.toHaveProperty('networks');
+    expect(result.service).not.toHaveProperty('network_mode');
+    expect(result.service.networks).toEqual({
+      'awf-enclave-mcp-control': { aliases: ['awf-enclave-mcp'] },
+    });
     expect(result.service).not.toHaveProperty('ports');
     const environment = result.service.environment as Record<string, string>;
     for (const key of [
@@ -308,8 +310,8 @@ describe('unified enclave compose topology', () => {
       })
       .map(([name]) => name);
     expect(members).toEqual(['enclave-agent-api-proxy']);
-    expect((compose.services['enclave-mcp-server'] as Record<string, any>).network_mode)
-      .toBe('none');
+    expect((compose.services['enclave-mcp-server'] as Record<string, any>).networks)
+      .toEqual({ 'awf-enclave-mcp-control': { aliases: ['awf-enclave-mcp'] } });
     expect((compose.services['enclave-agent-image'] as Record<string, any>).network_mode)
       .toBe('none');
   });

--- a/src/services/enclave-mcp-service.test.ts
+++ b/src/services/enclave-mcp-service.test.ts
@@ -34,7 +34,7 @@ const ghcr = {
 describe('buildEnclaveMcpService', () => {
   afterAll(() => fs.rmSync(workDir, { recursive: true, force: true }));
 
-  it('builds a no-egress server without exposing it to the primary agent', () => {
+  it('builds a gateway-only no-egress server without exposing it to the primary agent', () => {
     const result = buildEnclaveMcpService({ config: config(), imageConfig: ghcr });
     expect(result.scriptImageService!).toMatchObject({
       image: 'ghcr.io/github/gh-aw-firewall/enclave-script:v1',
@@ -44,12 +44,16 @@ describe('buildEnclaveMcpService', () => {
     expect(result.service).toMatchObject({
       container_name: 'awf-enclave-mcp-server',
       image: 'ghcr.io/github/gh-aw-firewall/enclave-mcp-server:v1',
-      network_mode: 'none',
       depends_on: {
         'enclave-script-image': { condition: 'service_completed_successfully' },
       },
+      networks: {
+        'awf-enclave-mcp-control': {
+          aliases: ['awf-enclave-mcp'],
+        },
+      },
     });
-    expect(result.service).not.toHaveProperty('networks');
+    expect(result.service).not.toHaveProperty('network_mode');
     expect(result.service).not.toHaveProperty('ports');
     const environment = result.service.environment as Record<string, string>;
     expect(environment.AWF_ENCLAVE_MAX_SCRIPT_BYTES).toBe('65536');
@@ -123,9 +127,17 @@ describe('buildEnclaveMcpService', () => {
     }
     expect(compose.services['enclave-script-image']).toBeDefined();
     expect(compose.services['enclave-mcp-server']).toBeDefined();
+    expect(compose.networks['awf-enclave-mcp-control']).toMatchObject({
+      name: 'awf-enclave-mcp-control',
+      internal: true,
+    });
     const agent = compose.services.agent as unknown as Record<string, unknown>;
     expect((agent.depends_on as Record<string, unknown>)['enclave-mcp-server']).toBeUndefined();
     expect(JSON.stringify(agent.volumes)).not.toContain('awf-enclave-control');
     expect(JSON.stringify(agent.environment)).not.toContain('AWF_ENCLAVE');
+    expect(JSON.stringify(agent)).not.toContain('awf-enclave-mcp');
+    expect(JSON.stringify((agent as { networks?: unknown }).networks)).not.toContain(
+      'awf-enclave-mcp-control',
+    );
   });
 });

--- a/src/services/enclave-mcp-service.ts
+++ b/src/services/enclave-mcp-service.ts
@@ -1,5 +1,4 @@
 import { buildRuntimeImageRef } from '../image-tag';
-import { getSafeHostGid, getSafeHostUid } from '../host-identity';
 import {
   ENCLAVE_AGENT_API_PROXY_CONTAINER_NAME,
   ENCLAVE_MCP_SERVER_CONTAINER_NAME,
@@ -14,7 +13,7 @@ import {
   ENCLAVE_BROKER_DOCKER_SOCKET_PATH,
   ENCLAVE_BROKER_SEED_MAP_PATH,
   ENCLAVE_BROKER_SEEDS_DIR,
-  ENCLAVE_BROKER_SOCKET_DIR,
+  ENCLAVE_BROKER_CAPABILITY_DIR,
   ENCLAVE_BROKER_WORK_DIR,
   resolveEnclavePaths,
 } from '../enclave/paths';
@@ -23,6 +22,8 @@ import {
   ENCLAVE_AGENT_API_PROXY_IP,
   ENCLAVE_AGENT_EGRESS_NETWORK,
   ENCLAVE_AGENT_NETWORK,
+  ENCLAVE_MCP_CONTROL_ALIAS,
+  ENCLAVE_MCP_CONTROL_NETWORK,
 } from '../enclave/network';
 import { resolveBoundedQueryPrimaryBackend } from '../bounded-query/runtime-matrix';
 import { resolveDockerSocketPath } from './agent-volumes/docker-socket';
@@ -44,8 +45,9 @@ import {
  *
  * Topology, which is the whole point of the feature:
  *
- * - the **MCP server** runs with `network_mode: none` — no `awf-net`, no
- *   `awf-ext`, no agent-enclave network, no DNS, no Squid, no host gateway.
+ * - the **MCP server** joins only the dedicated internal enclave control
+ *   network — no `awf-net`, no `awf-ext`, no agent-enclave network, no Squid,
+ *   no host gateway.
  *   It holds the Docker socket and the private seed/work/audit mounts, and it
  *   never holds a provider credential.
  * - **script enclaves** run with `--network none`.
@@ -55,8 +57,9 @@ import {
  *   this subsystem. No primary agent, Squid, general proxy, MCP server, safe
  *   outputs, MCP gateway, or CLI proxy is on that network, and the API proxy
  *   is the only holder of a real credential.
- * - the **primary agent** receives nothing at all in this migration layer:
- *   gh-aw-mcpg owns attaching the private socket in a later layer.
+ * - the **primary agent** receives no socket, capability, direct URL, private
+ *   mount, repository list, ledger state, or control metadata. It reaches the
+ *   tools only through the externally launched trusted MCP gateway.
  */
 
 const LOCAL_ENCLAVE_SCRIPT_IMAGE = 'awf-enclave-script:local';
@@ -262,9 +265,8 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
   const environment: Record<string, string> = {
     AWF_ENCLAVE_PRIMARY_BACKEND: primaryBackend,
     AWF_ENCLAVE_HOST_WORK_DIR: toDaemonVisiblePath(paths.workDir, config.dockerHostPathPrefix),
-    AWF_ENCLAVE_SOCKET_UID: getSafeHostUid(),
-    AWF_ENCLAVE_SOCKET_GID: getSafeHostGid(),
     AWF_ENCLAVE_CAPABILITY_PATH: ENCLAVE_BROKER_CAPABILITY_PATH,
+    AWF_ENCLAVE_LISTEN_HOST: '0.0.0.0',
     AWF_ENCLAVE_SCRIPT_ENABLED: String(script?.enabled === true),
     AWF_ENCLAVE_AGENT_ENABLED: String(agent?.enabled === true),
   };
@@ -348,12 +350,16 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
   result.service = {
     container_name: ENCLAVE_MCP_SERVER_CONTAINER_NAME,
     ...resolveServerImage(imageConfig),
-    network_mode: 'none',
+    networks: {
+      [ENCLAVE_MCP_CONTROL_NETWORK]: {
+        aliases: [ENCLAVE_MCP_CONTROL_ALIAS],
+      },
+    },
     volumes: applyHostPathPrefixToVolumes(
       [
         `${paths.seedsDir}:${ENCLAVE_BROKER_SEEDS_DIR}:ro`,
         `${paths.workDir}:${ENCLAVE_BROKER_WORK_DIR}:rw`,
-        `${paths.runDir}:${ENCLAVE_BROKER_SOCKET_DIR}:rw`,
+        `${paths.runDir}:${ENCLAVE_BROKER_CAPABILITY_DIR}:rw`,
         `${paths.controlDir}:${ENCLAVE_BROKER_CONTROL_DIR}:rw`,
         `${paths.auditDir}:${ENCLAVE_BROKER_AUDIT_DIR}:rw`,
         `${paths.seedMapPath}:${ENCLAVE_BROKER_SEED_MAP_PATH}:ro`,

--- a/src/services/optional-services.ts
+++ b/src/services/optional-services.ts
@@ -323,9 +323,8 @@ function assembleEnclaveMcpService(params: AssembleOptionalServicesParams): void
   if (agentImageService) services['enclave-agent-image'] = agentImageService;
   if (agentApiProxyService) services['enclave-agent-api-proxy'] = agentApiProxyService;
   services['enclave-mcp-server'] = service;
-  // This migration layer intentionally does not mount the MCP socket/capability
-  // into the primary agent or make agent startup depend on this service.
-  // gh-aw-mcpg owns that attachment in a later layer.
+  // The gateway readiness gate is host-orchestrated before agent startup. There
+  // is deliberately no agent dependency, mount, environment, or direct URL.
 }
 
 function finalizeSysrootVolumes(

--- a/src/types/enclave-options.ts
+++ b/src/types/enclave-options.ts
@@ -1,9 +1,9 @@
 /**
  * Unified trusted configuration for private-repository enclaves.
  *
- * This is a foundation-only surface: later layers will expose the configured
- * executors through an AWF-owned MCP server. Executor controls are trusted AWF
- * configuration and are never accepted from an invocation request.
+ * Executors are exposed only through an AWF-owned MCP server behind the trusted
+ * gateway. Executor controls are trusted AWF configuration and are never
+ * accepted from an invocation request.
  */
 
 export type EnclaveSensitivity = 'public' | 'internal' | 'confidential' | 'sealed';


### PR DESCRIPTION
## Stack

Layer 4 of the greenfield enclave migration.

Depends on:
- #6986 — unified enclave foundation
- #6988 — AWF-owned script MCP server
- #6990 — enclave agent executor
- github/gh-aw-mcpg#10784 — late HTTP backend recovery; requires MCP Gateway spec 1.15.0 and the first mcpg release after v0.4.8 containing that change

Base branch: `lpcox-enclave-agent-executor`

## Summary

- puts the AWF-owned enclave MCP server on a dedicated internal `awf-enclave-mcp-control` network with no published port, Squid path, `awf-net` membership, agent mount, direct URL, wrapper, or skill fallback
- validates the externally owned `awmg-mcpg` container by run-scoped label, attaches only it to the control network, and rejects unexpected members
- uses a run-scoped bearer capability shared only between AWF and mcpg and excluded from all primary-agent environment passthrough
- starts infrastructure without the primary agent, then proves `initialize` and the complete enabled `tools/list` contracts through mcpg before starting either a Compose agent or sbx sandbox
- retries the complete initialize handshake when mcpg returns retryable HTTP 503 `backend_unavailable`, with bounded 500 ms backoff until `AWF_ENCLAVE_MCP_READINESS_TIMEOUT_MS` expires; the first 503 is not terminal and response bodies/headers/capabilities are not logged
- stops admissions and drains the AWF server within a bound, disconnects but never stops/removes mcpg, then removes AWF-owned state/network
- keeps legacy `boundedQueries` and `boundedAgents` functional for the final layer-5 cutover
- documents and exports a machine-readable compiler handoff contract

## Compiler handoff required

The gh-aw compiler must add an `awf-enclave` HTTP upstream at `http://awf-enclave-mcp:8080/mcp`, substitute the run-scoped capability into its bearer authorization header, allowlist only enabled enclave tools, set per-server `connectTimeout: 120` and the derived tool timeout, label `awmg-mcpg` with `com.github.gh-aw.mcpg.run=<identity>`, and pass the gateway identity/container/readiness endpoint handoff variables to AWF but never the primary agent.

`connectTimeout` governs each HTTP upstream attempt. `gateway.startupTimeout` is stdio-only and must not be used as the HTTP recovery bound. The compiler must pin the first mcpg release after v0.4.8 containing #10784/spec 1.15.0. The current compiler does not yet emit this contract, so a gh-aw follow-up is required.

## Validation

- mcpg recovery contract: first HTTP 503 `backend_unavailable` followed by successful initialize and exact tools/list discovery
- focused recovery/startup suite: 3 suites and 75 tests passed
- full unit suite: 324 suites passed; 5,571 tests passed; 1 skipped
- focused enclave/mcpg suite: 10 suites and 197 tests passed
- TypeScript type-check passed
- TypeScript build passed
- all changed TypeScript files passed focused ESLint
- changed JavaScript passed `node --check`
- both generated config schemas parsed successfully
- direct MCP HTTP exercise proved bearer rejection, initialize identity, and static tool discovery
- two focused code-review passes completed with findings resolved

The exact locked `typescript-eslint` package remains unavailable from the configured feed, so repository-wide lint could not use the lockfile toolchain. An isolated compatible lint toolchain found one pre-existing error outside this change; every changed TypeScript file passes lint.