### PR TITLE
feat: complete Firecracker preview rollout coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ permissions:
   contents: write   # Required for creating releases, pushing version commits and tags
   packages: write   # Required for pushing to GHCR
   id-token: write   # Required for cosign keyless signing
+  attestations: write # Required for Firecracker test artifact provenance
 
 jobs:
   bump-version:
@@ -720,7 +721,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [bump-version, build-squid, build-agent, build-api-proxy, build-cli-proxy, build-agent-act, build-build-tools, build-enclaves, build-gh-aw-node]
+    needs: [bump-version, build-squid, build-agent, build-api-proxy, build-cli-proxy, build-agent-act, build-build-tools, build-enclaves, build-gh-aw-node, build-firecracker-test-artifacts]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
@@ -810,6 +811,23 @@ jobs:
         run: |
           npm pack
           mv *.tgz release/awf.tgz
+
+      - name: Download Firecracker preview test artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-firecracker-test-x86_64
+          path: firecracker-release-assets
+
+      - name: Stage Firecracker preview test assets
+        run: |
+          cp firecracker-release-assets/awf-firecracker-test-x86_64.tar.gz \
+            release/firecracker-test-x86_64.tar.gz
+          cp firecracker-release-assets/SHA256SUMS \
+            release/firecracker-test-x86_64.SHA256SUMS
+          cp firecracker-release-assets/manifest.json \
+            release/firecracker-test-x86_64.manifest.json
+          cp firecracker-release-assets/sbom.spdx.json \
+            release/firecracker-test-x86_64.sbom.spdx.json
 
       - name: Generate containers list
         run: |
@@ -966,6 +984,10 @@ jobs:
             release/awf-darwin-arm64
             release/awf-bundle.js
             release/awf.tgz
+            release/firecracker-test-x86_64.tar.gz
+            release/firecracker-test-x86_64.SHA256SUMS
+            release/firecracker-test-x86_64.manifest.json
+            release/firecracker-test-x86_64.sbom.spdx.json
             release/containers.txt
             release/awf-config.schema.json
             release/awf-config.v1.schema.json
@@ -981,4 +1003,48 @@ jobs:
         with:
           name: release-artifacts
           path: release/
+          retention-days: 7
+
+  build-firecracker-test-artifacts:
+    name: Build Firecracker Preview Test Artifacts
+    runs-on: ubuntu-24.04
+    needs: bump-version
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          ref: ${{ needs.bump-version.outputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.0'
+          cache-dependency-path: guest/firecracker-supervisor/go.mod
+
+      - name: Install guest build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            bc binutils bison build-essential ca-certificates cpio e2fsprogs \
+            file flex libelf-dev libssl-dev rsync xz-utils
+
+      - name: Build and verify pinned test artifacts
+        run: |
+          VERSION="${{ needs.bump-version.outputs.version }}" \
+            ./guest/firecracker/build-test-artifacts.sh
+          ./guest/firecracker/verify-test-artifacts.sh \
+            release/firecracker-test-x86_64
+
+      - name: Attest guest artifact provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release/firecracker-test-x86_64/awf-firecracker-test-x86_64.tar.gz
+
+      - name: Upload Firecracker test artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: release-firecracker-test-x86_64
+          path: release/firecracker-test-x86_64/
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -9,7 +9,7 @@ on:
         type: boolean
         default: true
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build-test-artifacts:
     name: Build deterministic test guest
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'firecracker-kvm'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -78,7 +78,8 @@ jobs:
     needs: build-test-artifacts
     if: >-
       (github.event_name == 'workflow_dispatch' && inputs.run_live_kvm) ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'firecracker-kvm')
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'firecracker-kvm'))
     runs-on: [self-hosted, linux, x64, kvm, awf-firecracker]
     timeout-minutes: 45
     steps:
@@ -140,6 +141,7 @@ jobs:
             -F 'awf-firecracker-real-secret-do-not-expose' \
             "$destination"; then
             echo "::error::Secret sentinel found in diagnostic artifacts"
+            rm -rf "$destination"
             exit 1
           fi
 

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -1,0 +1,167 @@
+name: Firecracker Preview Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_live_kvm:
+        description: Run the explicitly labeled self-hosted Linux/KVM job
+        required: true
+        type: boolean
+        default: true
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: firecracker-preview-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-test-artifacts:
+    name: Build deterministic test guest
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'firecracker-kvm'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.0'
+          cache-dependency-path: guest/firecracker-supervisor/go.mod
+
+      - name: Install deterministic guest build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            bc \
+            binutils \
+            bison \
+            build-essential \
+            ca-certificates \
+            cpio \
+            e2fsprogs \
+            file \
+            flex \
+            libelf-dev \
+            libssl-dev \
+            rsync \
+            xz-utils
+
+      - name: Build and verify pinned artifacts
+        run: |
+          ./guest/firecracker/build-test-artifacts.sh
+          ./guest/firecracker/verify-test-artifacts.sh \
+            release/firecracker-test-x86_64
+
+      - name: Attest guest artifact provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release/firecracker-test-x86_64/awf-firecracker-test-x86_64.tar.gz
+
+      - name: Upload guest artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: firecracker-test-x86_64
+          path: release/firecracker-test-x86_64/
+          if-no-files-found: error
+          retention-days: 7
+
+  live-kvm:
+    name: Live Firecracker KVM smoke/security
+    needs: build-test-artifacts
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.run_live_kvm) ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'firecracker-kvm')
+    runs-on: [self-hosted, linux, x64, kvm, awf-firecracker]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Download verified guest artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: firecracker-test-x86_64
+          path: ${{ runner.temp }}/firecracker-test-x86_64
+
+      - name: Verify capable host and artifact digests
+        run: |
+          ./scripts/ci/firecracker-host-preflight.sh \
+            "$RUNNER_TEMP/firecracker-test-x86_64"
+
+      - name: Install, build, and prepare infrastructure images
+        run: |
+          npm ci
+          npm run build
+          docker build -t ghcr.io/github/gh-aw-firewall/squid:latest containers/squid
+          docker build -t ghcr.io/github/gh-aw-firewall/api-proxy:latest containers/api-proxy
+
+      - name: Run live fail-closed smoke/security coverage
+        run: |
+          ./scripts/ci/firecracker-live-smoke.sh \
+            "$RUNNER_TEMP/firecracker-test-x86_64"
+
+      - name: Collect redacted diagnostics
+        if: always()
+        run: |
+          set -euo pipefail
+          source_root="$RUNNER_TEMP/awf-firecracker-live"
+          destination="$RUNNER_TEMP/firecracker-diagnostics-safe"
+          rm -rf "$destination"
+          mkdir -p "$destination"
+          if [ -d "$source_root" ]; then
+            while IFS= read -r -d '' file; do
+              relative=${file#"$source_root/"}
+              mkdir -p "$destination/$(dirname "$relative")"
+              cp "$file" "$destination/$relative"
+            done < <(
+              find "$source_root" -type f \
+                \( -path '*/audit/*' \
+                -o -path '*/proxy-logs/*' \
+                -o -name 'stdout.log' \
+                -o -name 'stderr.log' \) \
+                -print0
+            )
+          fi
+          if grep -R --binary-files=without-match \
+            -F 'awf-firecracker-real-secret-do-not-expose' \
+            "$destination"; then
+            echo "::error::Secret sentinel found in diagnostic artifacts"
+            exit 1
+          fi
+
+      - name: Upload actionable diagnostics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: firecracker-live-diagnostics
+          path: ${{ runner.temp }}/firecracker-diagnostics-safe/
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Enforce final residue cleanup
+        if: always()
+        run: |
+          set -euo pipefail
+          while read -r namespace _; do
+            case "$namespace" in
+              awffc-*) sudo ip netns delete "$namespace" ;;
+            esac
+          done < <(sudo ip netns list)
+          if sudo ip netns list | grep -q '^awffc-'; then
+            echo "::error::Firecracker namespace residue remains after cleanup"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See [GitHub Actions](docs/github_actions.md) for advanced setup and `awf logs su
 - [Diagnosing AWF failures](docs/diagnosing-awf-failures.md) — use the Self-Hosted Runner Doctor agent to triage self-hosted/ARC/GHES/GHEC failures
 - [Auth Doctor Updater workflow](.github/workflows/auth-doctor-updater.md) — daily/manual audit that opens bounded PRs with evidence-backed authentication and API-proxy documentation corrections
 - [Image verification](docs/image-verification.md) — cosign signature verification
+- [Firecracker integration (preview)](docs/firecracker-integration.md) — Firecracker v1.16.1 microVM backend: explicit opt-in, Linux/KVM only, macOS/Windows unsupported, operator-managed artifacts with mandatory SHA-256 digests, fail-closed egress, mandatory API proxy credential isolation
 
 ## Development
 

--- a/docs/INTEGRATION-TESTS.md
+++ b/docs/INTEGRATION-TESTS.md
@@ -192,3 +192,44 @@ Each document provides per-test-case analysis with plain-language descriptions, 
 - **[Container & Operations Tests](test-analysis/container-ops.md)** — Workdir, volumes, git, env vars, logging, Docker availability
 - **[CI & Smoke Tests](test-analysis/ci-smoke.md)** — All 27 CI/smoke/build-test workflows analyzed
 - **[Test Infrastructure](test-analysis/test-infra.md)** — Runner architecture, batch pattern, cleanup strategy, limitations
+
+## Firecracker preview integration tests
+
+The Firecracker backend has its own separate CI workflow (`test-firecracker.yml`)
+that is distinct from the standard integration test suite above.
+
+**Trigger:** `workflow_dispatch` or PR label `firecracker-kvm`. A manual
+dispatch can set `run_live_kvm: false` for a hosted artifact-build-only check.
+It does **not** run on push or schedule.
+
+**Build job** (`ubuntu-24.04`): Builds deterministic guest artifacts — Firecracker
+v1.16.1 binaries, Linux 6.1.141 kernel, BusyBox 1.36.1 rootfs, and AWF guest
+supervisor — from pinned, SHA-256 verified sources. Attests provenance. Uploads
+as a 7-day workflow artifact.
+
+**Live job** (`[self-hosted, linux, x64, kvm, awf-firecracker]`): Downloads the
+build artifact, verifies all five SHA-256 digests, and runs the live smoke/security
+suite. This job **never** lands on a GitHub-hosted runner; it requires an
+explicitly labeled self-hosted runner with KVM access.
+
+Live assertions (see `scripts/ci/firecracker-live-smoke.sh`):
+
+| Case | What it proves |
+|------|---------------|
+| `allowed-https` | Allowed domains reach the internet through Squid |
+| `blocked-domain` | Non-allowlisted domains are blocked |
+| `direct-egress` | Bypassing proxy env vars does not enable direct egress |
+| `arbitrary-tcp` | Raw TCP to arbitrary IPs is blocked |
+| `dns-denial` | Direct DNS (8.8.8.8:53) is blocked from the guest |
+| `metadata-denial` | EC2/GCP/Azure instance metadata IP (`169.254.169.254`) is unreachable |
+| `api-proxy-reflect` | API proxy `/reflect` reachable; secret sentinel not present in output |
+| `workspace-copyback` | Guest file writes, permission changes, and symlinks survive copy-back |
+| `exit-code` | Agent exit code propagates faithfully (37 → 37) |
+| `timeout-124` | Timed-out agent exits 124 |
+| `partial-start-cleanup` | Corrupt rootfs causes clean failure; no namespace residue |
+| `cancellation` | `SIGTERM` cleans up network namespace; exits 143 |
+| `keep` | `--keep-containers` preserves jail/namespace/images; all diagnostics ≤1 MiB |
+
+After every case, the suite asserts no `awffc-*` namespaces or Firecracker
+interface residue remain. See [Firecracker integration (preview)](../docs/firecracker-integration.md#part-14--ci-workflow)
+for the full CI workflow specification.

--- a/docs/INTEGRATION-TESTS.md
+++ b/docs/INTEGRATION-TESTS.md
@@ -198,9 +198,11 @@ Each document provides per-test-case analysis with plain-language descriptions, 
 The Firecracker backend has its own separate CI workflow (`test-firecracker.yml`)
 that is distinct from the standard integration test suite above.
 
-**Trigger:** `workflow_dispatch` or PR label `firecracker-kvm`. A manual
-dispatch can set `run_live_kvm: false` for a hosted artifact-build-only check.
-It does **not** run on push or schedule.
+**Trigger:** `workflow_dispatch` or pull request open/synchronize/reopen/label.
+Pull requests always run the hosted deterministic artifact build; only label
+`firecracker-kvm` enables the live job. A manual dispatch can set
+`run_live_kvm: false` for an artifact-build-only check. It does **not** run on
+push or schedule.
 
 **Build job** (`ubuntu-24.04`): Builds deterministic guest artifacts — Firecracker
 v1.16.1 binaries, Linux 6.1.141 kernel, BusyBox 1.36.1 rootfs, and AWF guest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,3 +239,27 @@ Use `--keep-containers` to preserve containers and files after execution for deb
 - `execa`: Subprocess execution (docker-compose commands)
 - `js-yaml`: YAML generation for Docker Compose config
 - TypeScript 5.x, compiled to ES2020 CommonJS
+
+## Firecracker microVM runtime (preview)
+
+When `--container-runtime firecracker --firecracker-preview` is supplied, AWF
+uses a substantially different execution architecture:
+
+- The **agent container is replaced** by a Firecracker microVM — a hardware-isolated
+  virtual machine with its own Linux kernel.
+- The Squid proxy and API proxy **remain as Docker Compose containers** on the host.
+- The workspace is **not bind-mounted**; it is copied into a bounded ext4 image
+  (`workspace.ext4`) before boot and copied back after the agent exits.
+  There is no live filesystem passthrough (no virtiofs).
+- A **dedicated network namespace** (`awffc-<runId>`) isolates the VM's network.
+  nftables rules inside the namespace allow only Squid and the API proxy; all
+  other guest outbound connections are denied.
+- The **API proxy is mandatory**; provider credentials are never passed as guest
+  environment variables and an explicit assertion enforces this.
+- **TTY, Docker-in-Docker, topology peers, enclaves, extra volume mounts, and
+  remote Docker hosts all fail closed** in this preview.
+- **Linux/KVM only** — macOS and Windows are permanently unsupported.
+  GitHub-hosted runners are not supported (no `/dev/kvm`).
+
+See [Firecracker integration (preview)](./firecracker-integration.md) for the
+full architecture, trust model, and operator guide.

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -272,6 +272,16 @@ microVM to the proven internal bridge, and executes through vsock. Host access,
 DinD, extra mounts, TTY, topology peers, and enclaves fail closed in this
 preview. Selecting `firecracker` never falls back to another runtime.
 
+**macOS and Windows are permanently unsupported.** GitHub-hosted runners are not
+supported (no `/dev/kvm`). The API proxy is mandatory; provider credentials are
+never passed as guest environment variables. No auto-download of artifacts; all
+five artifact paths and their SHA-256 digests are required on every invocation.
+Release test artifacts (`firecracker-test-x86_64`) are x86_64 test/preview
+artifacts built by `test-firecracker.yml` and are not production defaults and
+not auto-downloaded. See [Firecracker integration (preview)](./firecracker-integration.md)
+for the complete operator guide, trust model, workspace semantics, CI workflow
+specification, and troubleshooting reference.
+
 When DinD is detected, AWF preserves the detected `DOCKER_HOST` value for the agent environment (including MCP servers) so DinD-aware tooling can reach the correct daemon without manual workflow env overrides.
 
 The following CLI flag has no config-file equivalent by design:

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -277,9 +277,11 @@ supported (no `/dev/kvm`). The API proxy is mandatory; provider credentials are
 never passed as guest environment variables. No auto-download of artifacts; all
 five artifact paths and their SHA-256 digests are required on every invocation.
 Release test artifacts (`firecracker-test-x86_64`) are x86_64 test/preview
-artifacts built by `test-firecracker.yml` and are not production defaults and
-not auto-downloaded. See [Firecracker integration (preview)](./firecracker-integration.md)
-for the complete operator guide, trust model, workspace semantics, CI workflow
+artifacts built by both the release workflow and `test-firecracker.yml`. They
+are published as explicitly named release/workflow assets, but are not
+production defaults and are never auto-downloaded. See
+[Firecracker integration (preview)](./firecracker-integration.md) for the
+complete operator guide, trust model, workspace semantics, CI workflow
 specification, and troubleshooting reference.
 
 When DinD is detected, AWF preserves the detected `DOCKER_HOST` value for the agent environment (including MCP servers) so DinD-aware tooling can reach the correct daemon without manual workflow env overrides.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -123,6 +123,27 @@ sudo systemctl start docker
 sudo systemctl enable docker
 ```
 
+## Firecracker preview host requirements
+
+The Firecracker microVM backend is an **explicit opt-in preview** available only on a
+subset of host configurations. It is **not** the default and does **not** fall back to
+any other runtime.
+
+| Requirement | Value |
+|-------------|-------|
+| Operating system | **Linux only** — macOS and Windows fail preflight immediately |
+| Architecture | x86_64 primary (aarch64 accepted by preflight code; no pre-built aarch64 test artifact) |
+| KVM device | `/dev/kvm` must exist and be readable + writable by the workflow user |
+| GitHub-hosted runners | **Not supported** — `/dev/kvm` is not exposed; nested virtualization on GitHub-hosted runners is experimental and **not a supported target** |
+| Recommended runner labels | `self-hosted, linux, x64, kvm, awf-firecracker` |
+| Firecracker version | **v1.16.1 exactly** — enforced at preflight; any other version fails |
+| Jailer | Mandatory — the jailer binary must match the Firecracker binary version |
+| Docker | Local Unix-socket Docker Engine required; remote Docker hosts rejected |
+| Required tools | `ip`, `sysctl`, `nft`, `mke2fs`, `debugfs`, `e2fsck`, `rsync`, `sha256sum`, `timeout`, `docker`, `docker compose` v2, passwordless `sudo` |
+
+See [Firecracker integration (preview)](./firecracker-integration.md) for the complete
+prerequisites, artifact policy, and CLI reference.
+
 ## Reporting Compatibility Issues
 
 If you encounter compatibility issues with a supported configuration, please:

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -901,10 +901,13 @@ The Firecracker CI workflow (`test-firecracker.yml`) triggers **only** on:
 - `workflow_dispatch` — manual trigger from the Actions UI or `gh workflow run`;
   `run_live_kvm: false` validates the deterministic artifact build without
   queueing the KVM job
-- A pull request being **labeled** with `firecracker-kvm`
+- Any pull request open, synchronize, or reopen event builds and verifies the
+  deterministic guest artifacts on `ubuntu-24.04`
+- A pull request being **labeled** with `firecracker-kvm` additionally enables
+  the live KVM job
 
-It does **not** run on push, on scheduled triggers, or on unlabeled pull request
-events. This ensures the live KVM job never silently runs on GitHub-hosted
+It does **not** run on push or schedule. Unlabeled pull requests run only the
+hosted artifact build; the live KVM job never silently runs on GitHub-hosted
 runners.
 
 ### Jobs

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -421,6 +421,8 @@ Firecracker binary that boots it.
 
 Before boot, AWF creates a writable ext4 image (`workspace.ext4`) sized to hold
 the workspace with 128 MiB headroom (minimum 256 MiB, maximum 8 GiB). The image
+file is created exclusively with host mode `0600`, so a pre-existing path cannot
+be reused and only the operator can read or modify the staged workspace image. It
 contains:
 
 - The entire `$GITHUB_WORKSPACE` (or `cwd()` if the variable is unset) directory,
@@ -442,11 +444,11 @@ After the agent command exits, AWF extracts the workspace image content via
 `debugfs` and compares it to the pre-run manifest:
 
 - **New or modified files** — written back to the host workspace
-- **Deleted files** — recorded in the manifest but not re-deleted from the host
-  workspace (the guest deletes inside the image only)
-- **Conflict detection** — if a file the guest modified was also modified on the
-  host between boot and copy-back (unusual in CI; more likely in development),
-  AWF logs a warning and preserves the guest version
+- **Deleted files** — removed from the host workspace by the authoritative
+  `rsync --delete` copy-back
+- **Conflict detection** — any concurrent host-only or divergent host/guest
+  change aborts copy-back rather than overwriting host work; AWF preserves the
+  changed raw workspace image for recovery
 
 ### Recovery image
 

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -121,7 +121,7 @@ and topology completeness, is a prerequisite for promotion to non-preview.
 │           │              │  │  Firecracker VMM (pid inside     ││   │
 │  ┌──────────────────┐   │  │  netns awffc-<runId>)            ││   │
 │  │  API Proxy       │   │  │  Kernel: vmlinux.bin             ││   │
-│  │  (Docker)        │   │  │  Rootfs: rootfs.ext4 (read-only) ││   │
+│  │  (Docker)        │   │  │  Rootfs: rootfs.ext4 (priv copy) ││   │
 │  │  172.30.0.30     │   │  │  Workspace: workspace.ext4 (rw)  ││   │
 │  └──────────────────┘   │  │  Supervisor: vsock port 52       ││   │
 │                          │  └──────────────────────────────────┘│   │
@@ -169,8 +169,8 @@ at `/workspace` inside the VM. It is not part of the shared rootfs.
    `<workDir>/firecracker-jailer/<runId>/root/` and drops to a non-root uid/gid
 6. **API configuration** — AWF configures the VMM via its Unix socket:
    kernel boot params, vcpu count, memory, TAP network interface, rootfs block
-   device (read-only), workspace block device (read-write), vsock device (CID 3,
-   port 52)
+   device (private writable copy), workspace block device (read-write), vsock
+   device (CID 3, port 52)
 7. **Boot** — the VM boots; the supervisor starts and waits on vsock port 52
 8. **Connectivity probe** — host confirms Squid reachability and API proxy
    `/reflect` endpoint from inside the guest before the agent is started
@@ -332,7 +332,7 @@ retry.
 | Firecracker binary | `--firecracker-binary` | `--firecracker-binary-sha256` | Firecracker VMM binary, **must be v1.16.1** |
 | Jailer binary | `--firecracker-jailer-binary` | `--firecracker-jailer-sha256` | Jailer binary, same version as Firecracker binary |
 | Guest kernel | `--firecracker-kernel` | `--firecracker-kernel-sha256` | A KVM-compatible Linux bzImage |
-| Guest rootfs | `--firecracker-rootfs` | `--firecracker-rootfs-sha256` | Read-only ext4 base image |
+| Guest rootfs | `--firecracker-rootfs` | `--firecracker-rootfs-sha256` | Ext4 base image; staged as a private writable copy per run |
 | Guest supervisor | `--firecracker-supervisor` | `--firecracker-supervisor-sha256` | AWF vsock supervisor binary |
 
 All five digests are required. Supplying any subset causes a hard pre-boot
@@ -568,14 +568,18 @@ This is a hard failure before the VM boots. The check covers:
 ### How credentials flow
 
 Provider API calls made by the agent:
-1. Agent makes an HTTPS request to a provider endpoint (e.g., `api.anthropic.com`)
-2. Request is transparently intercepted by Squid (HTTP CONNECT proxy)
-3. Request traverses to the API proxy on the host
-4. API proxy injects the real `Authorization` / `x-api-key` header
-5. Request continues to the provider
+1. Guest provider base URLs point directly at the API proxy's IP:port (e.g.,
+   `http://172.30.0.30:10001`); that IP is also listed in `NO_PROXY`, so the
+   request goes straight to the API proxy without traversing Squid
+2. API proxy injects the real `Authorization` / `x-api-key` header
+3. API proxy's own upstream request to the real provider goes through Squid
+   (domain-ACL enforced)
+4. Response is relayed back to the agent
 
 The guest never sees the real credential value; it sees only the API proxy
-endpoint, which is accessible only from inside the AWF network.
+endpoint, which is accessible only from inside the AWF network. Squid enforces
+egress policy on the API proxy's outbound request, not on the guest's request
+to the API proxy.
 
 ### API proxy connectivity probe
 

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -1,0 +1,1136 @@
+---
+title: Firecracker microVM integration (preview)
+description: Architecture, threat model, prerequisites, workspace semantics, networking, API proxy, lifecycle, diagnostics, and CLI reference for the Firecracker v1.16.1 microVM preview backend.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+:::danger[Explicit preview opt-in required — not a production default]
+The Firecracker backend is a **preview** that requires every flag described in
+this document. It is **not** enabled by default, does **not** auto-activate, and
+is **never** a fallback for any other runtime. You must supply
+`--container-runtime firecracker --firecracker-preview` together with all
+artifact paths and their SHA-256 digests on every invocation. Omitting any
+required input is a hard failure.
+
+**Linux/KVM only.** macOS and Windows are unsupported and will never silently
+pass; the preflight fails immediately on non-Linux hosts. GitHub-hosted runners
+do not expose `/dev/kvm`; nested virtualization on GitHub-hosted runners is
+experimental and **not a supported target** for this preview.
+:::
+
+This document covers the AWF Firecracker v1.16.1 microVM preview. It is
+structured for two audiences:
+
+1. **Operators** who want to set up and run the preview on a capable self-hosted
+   runner.
+2. **Engineers** who want to understand the implementation design and trust model.
+
+For the Docker-compose defaults see [Architecture](./architecture.md). For
+gVisor (OCI runtime, no separate kernel) see [gVisor integration](./gvisor-integration.md).
+For Docker Sandboxes (sbx) see [sbx integration](./sbx-integration.md). For
+sandbox design rationale see [Sandbox design](./sandbox-design.md).
+
+---
+
+## Part 1 — What Firecracker adds and why it is a preview
+
+### What Firecracker is
+
+[Firecracker](https://firecracker-microvm.github.io/) is a minimal virtual
+machine monitor (VMM) built by AWS for serverless/container workloads. It uses
+Linux's KVM subsystem to boot a separate Linux kernel inside a hardware-isolated
+virtual machine. The guest is completely isolated from the host kernel; the only
+communication surfaces are the Firecracker control API socket, a vsock channel,
+and explicit network interfaces.
+
+AWF's Firecracker preview runs the **agent command** inside the microVM while
+keeping the host-side egress filtering infrastructure (Squid proxy, API proxy,
+iptables/nftables rules) on the host. The guest kernel never touches host memory;
+the agent can only reach host-side services through explicit permitted
+network endpoints.
+
+### Why it is a preview
+
+The Firecracker backend adds meaningful defense-in-depth but also imposes
+requirements that make it unsuitable as a universal default:
+
+- **Hard host requirements** — Linux kernel with KVM, specific system tools,
+  cgroup v1 or v2, passwordless sudo for the operator account.
+- **Operator-managed artifacts** — there is no auto-download. Every artifact
+  (Firecracker binary, jailer binary, guest kernel, rootfs, guest supervisor)
+  must be supplied by the operator with an exact SHA-256 digest.
+- **Pinned to Firecracker v1.16.1** — the version pin is enforced at runtime;
+  any other version fails preflight.
+- **x86_64 only for test artifacts** — the released test artifact set targets
+  x86_64. aarch64 is supported at the code level (preflight will accept it) but
+  no pre-built aarch64 test artifact is shipped.
+- **Topology restrictions** — topology peers, enclaves, Docker-in-Docker,
+  extra volume mounts, TTY, host access, and DNS-over-HTTPS all fail closed.
+
+These constraints are intentional. Relaxing them, especially artifact management
+and topology completeness, is a prerequisite for promotion to non-preview.
+
+### Comparison with the other isolation backends
+
+| Property | Docker (default) | gVisor | sbx | Firecracker |
+|----------|-----------------|--------|-----|-------------|
+| Isolation mechanism | Linux namespaces/cgroups | Userspace application kernel | Docker Sandboxes microVM (KVM) | Firecracker microVM (KVM) |
+| Separate Linux kernel | No | No (own syscall surface) | Yes | Yes |
+| Requires KVM | No | No (systrap platform) | macOS/Win: platform hypervisor; Linux: KVM | Yes — hard requirement |
+| Works on GitHub-hosted runners | Yes | Yes | macOS only | No (no `/dev/kvm`) |
+| Workspace delivery | bind mount | bind mount | virtiofs passthrough | ext4 image copy-in / copy-back |
+| Virtiofs / live bind mounts | N/A | N/A | Yes (default) | **No** |
+| Docker-in-Docker | Supported | Supported | Yes (in-VM engine) | **Not supported** |
+| Topology peers / enclaves | Supported | Supported | Supported | **Not supported (preview)** |
+| TTY | Supported | Supported | Supported | **Not supported (preview)** |
+| Credential isolation | API proxy (optional/required in strict) | API proxy | API proxy (host-side injection) | API proxy — **mandatory** |
+| Auto-download artifacts | N/A | N/A | Yes (sbx binary) | **No — operator-managed** |
+| Version pin | N/A | N/A | N/A | v1.16.1 — hard enforcement |
+
+---
+
+## Part 2 — Architecture
+
+### Host-side components
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Host (Linux, KVM-capable, self-hosted runner)                      │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │  AWF CLI (runs as root via sudo from the non-root operator)  │  │
+│  │  - Validates all artifacts and digests (preflight)           │  │
+│  │  - Starts Docker Compose: Squid + API proxy containers       │  │
+│  │  - Creates dedicated network namespace (awffc-<runId>)       │  │
+│  │  - Sets up TAP device + nftables rules inside namespace      │  │
+│  │  - Creates ext4 workspace image, copies workspace in         │  │
+│  │  - Launches Firecracker via jailer in the namespace          │  │
+│  │  - Waits for vsock supervisor handshake                      │  │
+│  │  - Executes agent command via vsock protocol                 │  │
+│  │  - Copies changed workspace files back after completion      │  │
+│  │  - Cleans up namespace, jail, images                        │  │
+│  └──────────────────────────────────────────────────────────────┘  │
+│           │                       │                                 │
+│           ▼                       ▼                                 │
+│  ┌──────────────────┐   ┌──────────────────────────────────────┐   │
+│  │  Squid Proxy     │   │  Firecracker jailer chroot           │   │
+│  │  (Docker)        │   │  (/tmp/awf-.../firecracker-jailer/   │   │
+│  │  172.30.0.10:3128│   │   <runId>/root/)                     │   │
+│  └──────────────────┘   │  ┌──────────────────────────────────┐│   │
+│           │              │  │  Firecracker VMM (pid inside     ││   │
+│  ┌──────────────────┐   │  │  netns awffc-<runId>)            ││   │
+│  │  API Proxy       │   │  │  Kernel: vmlinux.bin             ││   │
+│  │  (Docker)        │   │  │  Rootfs: rootfs.ext4 (read-only) ││   │
+│  │  172.30.0.30     │   │  │  Workspace: workspace.ext4 (rw)  ││   │
+│  └──────────────────┘   │  │  Supervisor: vsock port 52       ││   │
+│                          │  └──────────────────────────────────┘│   │
+│                          └──────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+                   ↕ nftables-enforced per-namespace egress
+                   (only Squid port 3128 and API proxy reachable from guest)
+```
+
+### Guest contents
+
+The guest rootfs (`rootfs.ext4`) is a minimal ext4 image containing:
+
+- **BusyBox** — static binary providing `/bin/sh`, `wget`, `nc`, `nslookup`,
+  `ip`, `timeout`, and other standard utilities
+- **AWF guest supervisor** (`/sbin/awf-supervisor`) — a statically compiled Go
+  binary that listens on vsock port 52, receives execution requests from the
+  host, runs the agent command, and streams stdin/stdout/stderr back
+- **CA bundle** — a pinned Mozilla CA bundle (date-stamped, SHA-256 verified)
+  at `/etc/ssl/certs/ca-certificates.crt`
+- **Minimal /etc/passwd, /etc/group** — defines `root`, `awf` (uid/gid 1000),
+  and `nobody`
+- **Empty /etc/resolv.conf** — direct DNS is intentionally absent; the comment
+  states this explicitly (see §Networking)
+
+The workspace is a **separate** writable ext4 image (`workspace.ext4`) mounted
+at `/workspace` inside the VM. It is not part of the shared rootfs.
+
+### Control flow
+
+1. **Preflight** — validate host (Linux, x86_64 or arm64, `/dev/kvm` r/w,
+   required tools, cgroup hierarchy, Docker, passwordless sudo), validate all
+   five artifact files (type, permissions, ownership, digest)
+2. **Infrastructure start** — Docker Compose brings up Squid and the API proxy
+   in the same network as usual; the host bridge is discovered
+3. **Network namespace** — a dedicated namespace `awffc-<runId>` is created with
+   a veth pair (host side joins the infrastructure bridge; namespace side is
+   wired to a TAP device for the VM) and nftables rules that allow only the
+   Squid port and the API proxy from the guest
+4. **Workspace image** — `mke2fs` creates `workspace.ext4`; the host workspace
+   and a `.awf-home` directory are copied in via `rsync` then `debugfs`; a
+   pre-run manifest is recorded
+5. **Jailer launch** — Firecracker is launched by the jailer inside the network
+   namespace; the jailer establishes a chroot under
+   `<workDir>/firecracker-jailer/<runId>/root/` and drops to a non-root uid/gid
+6. **API configuration** — AWF configures the VMM via its Unix socket:
+   kernel boot params, vcpu count, memory, TAP network interface, rootfs block
+   device (read-only), workspace block device (read-write), vsock device (CID 3,
+   port 52)
+7. **Boot** — the VM boots; the supervisor starts and waits on vsock port 52
+8. **Connectivity probe** — host confirms Squid reachability and API proxy
+   `/reflect` endpoint from inside the guest before the agent is started
+9. **Agent execution** — host sends the execution request over vsock; supervisor
+   forks the agent command, forwards stdin/stdout/stderr; exit code returned
+10. **Copy-back** — workspace.ext4 is read back via `debugfs`; files changed
+    relative to the pre-run manifest are extracted and conflict-checked against
+    the host workspace before writing back
+11. **Cleanup** — network namespace, veth pair, TAP device, and jail directory
+    are removed; images are deleted unless `--keep-containers` was given
+
+---
+
+## Part 3 — Threat model and trust boundaries
+
+### What the microVM boundary enforces
+
+- **Host kernel isolation** — agent processes are inside a separate kernel with
+  hardware memory isolation. A memory corruption exploit in the agent cannot
+  directly access host memory.
+- **No direct host filesystem access** — the only data path between guest and
+  host is the workspace ext4 image (explicit, bounded, copy-in/copy-back with
+  conflict checking) and the vsock protocol (explicit RPC).
+- **No virtiofs / live bind mounts** — the preview does not expose any live
+  filesystem passthrough. Guest filesystem writes are bounded to `workspace.ext4`
+  and are checked on copy-back.
+- **No host daemon access** — the guest cannot reach the host Docker socket,
+  the host Docker Engine, or any host Unix sockets.
+- **Egress fully mediated** — guest direct egress is blocked at the nftables
+  level inside the network namespace. The guest can reach only Squid (port 3128)
+  and the API proxy. Direct IP connections, arbitrary TCP/UDP, and raw DNS are
+  all denied.
+- **Credential isolation** — real API credentials (OpenAI, Anthropic, Copilot,
+  Gemini, GitHub token) are **never** passed as guest environment variables. An
+  explicit assertion at boot time verifies none of the configured secret values
+  appear in any guest environment variable. The API proxy on the host side
+  injects credentials into provider calls at the HTTP layer.
+- **No metadata reachability** — the EC2/GCP/Azure instance metadata IP
+  (`169.254.169.254`) and link-local range are blocked in the guest network
+  namespace.
+
+### What the microVM boundary does NOT protect
+
+- **Agent trust** — the agent command runs as the configured uid/gid (default:
+  the operator's uid from `SUDO_UID`). A malicious agent can read and modify
+  all files in the workspace image and communicate with Squid.
+- **Workload secrets passed explicitly** — any environment variable the operator
+  explicitly passes to the guest (not the credential set above) is in-scope for
+  the guest agent.
+- **CPU side-channels** — Firecracker does not mitigate Spectre/Meltdown-class
+  attacks beyond what the host kernel provides. Multi-tenant use on the same
+  physical core requires additional host-level mitigations.
+- **Jailer uid/gid** — the jailer drops to a non-root uid, but this uid must
+  exist on the host. The jailer process itself runs in the operator's sudo
+  session.
+
+### Trust boundaries summary
+
+| Boundary | Enforced by | Notes |
+|----------|------------|-------|
+| Guest ↔ host kernel | KVM hardware isolation | Hard boundary; VM escape requires VMM/KVM vulnerability |
+| Guest filesystem ↔ host filesystem | Explicit ext4 image + copy-back | No live mounts; changes are conflict-checked |
+| Guest ↔ host network | nftables rules in dedicated network namespace | Only Squid + API proxy reachable from guest |
+| Agent credentials ↔ guest env | Explicit assertion at boot | Fails hard if any secret would enter guest env |
+| Guest DNS | DNS-over-Squid only | Direct DNS denied; resolv.conf empty |
+| Guest direct egress | nftables DENY | All outbound except proxy ports blocked |
+
+---
+
+## Part 4 — Prerequisites and supported hosts
+
+### Supported host configurations
+
+| Requirement | Value |
+|-------------|-------|
+| Operating system | **Linux only** — macOS and Windows are unsupported and fail preflight immediately |
+| Architecture | x86_64 (primary) — aarch64 accepted by preflight code but no pre-built test artifacts are released |
+| KVM device | `/dev/kvm` must exist and be readable + writable by the workflow user |
+| GitHub-hosted runners | **Not supported** — no `/dev/kvm`; GitHub-hosted nested virtualization is experimental and not a supported target |
+| Recommended runner labels | `self-hosted, linux, x64, kvm, awf-firecracker` (matches the CI live-kvm job) |
+
+:::caution[Self-hosted runner requirement]
+GitHub-hosted runners (`ubuntu-latest`, etc.) do not expose `/dev/kvm`. The
+Firecracker backend will always fail preflight on those runners. Use an
+**explicitly labeled self-hosted runner** with confirmed KVM access.
+
+GitHub-hosted runners with experimental nested virtualization are **not** a
+supported target for this preview. The preflight does not check for nested
+virtualization specifically; it checks for a real, accessible `/dev/kvm`.
+:::
+
+### Required host tools
+
+The following tools must be present on `PATH` and executable:
+
+| Tool | Purpose |
+|------|---------|
+| `ip` | Network namespace and veth management |
+| `nft` | nftables rules inside the network namespace |
+| `mke2fs` | Create the workspace ext4 image |
+| `debugfs` | Populate and extract workspace image content |
+| `e2fsck` | Verify the workspace image after creation |
+| `rsync` | Stage workspace content for `debugfs` import |
+| `sha256sum` | Artifact digest verification in CI scripts |
+| `timeout` | Bounded tool invocations in CI scripts |
+| `docker` | Docker Engine (host-visible, local Unix socket) |
+| `docker compose` v2 | Compose v2 for Squid/API proxy infrastructure |
+| `sudo` | Passwordless sudo for jailer and netns setup |
+
+:::note
+The Docker daemon must be reachable via a local Unix socket. A remote Docker
+host (e.g., `DOCKER_HOST=tcp://...`) is rejected at preflight because the
+infrastructure bridge created by Docker Compose must be directly visible on the
+host's network stack.
+:::
+
+### Required kernel controls
+
+The following host kernel paths must be readable:
+
+- `/proc/sys/net/ipv4/ip_forward`
+- `/proc/sys/net/ipv6/conf/all/disable_ipv6`
+- `/proc/sys/kernel/seccomp/actions_avail`
+
+One of the following cgroup hierarchies must be available:
+
+- `/sys/fs/cgroup/cgroup.controllers` (cgroup v2)
+- `/sys/fs/cgroup` writable (cgroup v1)
+
+### Operator account
+
+AWF must be invoked through `sudo` from a **non-root** account. The jailer
+specifically rejects a root `SUDO_UID`/`SUDO_GID` (the actual uid inside the
+jail must be non-root). The `SUDO_UID` and `SUDO_GID` environment variables set
+by sudo are used to determine the jailer uid/gid and the guest execution identity.
+
+---
+
+## Part 5 — Artifact policy
+
+### Why artifacts are operator-managed
+
+The Firecracker preview does **not** auto-download any artifacts. There is no
+"latest" mode, no demo asset, and no unverified download path. Every artifact
+must be:
+
+1. Obtained by the operator from a trusted source
+2. Supplied by absolute path on the CLI or in the config file
+3. Accompanied by its exact SHA-256 digest
+
+At runtime, AWF computes the SHA-256 of every artifact file and compares it to
+the supplied digest before the VM boots. A mismatch is a hard failure with no
+retry.
+
+### Required artifacts
+
+| Artifact | CLI flag | Digest flag | Description |
+|----------|---------|-------------|-------------|
+| Firecracker binary | `--firecracker-binary` | `--firecracker-binary-sha256` | Firecracker VMM binary, **must be v1.16.1** |
+| Jailer binary | `--firecracker-jailer-binary` | `--firecracker-jailer-sha256` | Jailer binary, same version as Firecracker binary |
+| Guest kernel | `--firecracker-kernel` | `--firecracker-kernel-sha256` | A KVM-compatible Linux bzImage |
+| Guest rootfs | `--firecracker-rootfs` | `--firecracker-rootfs-sha256` | Read-only ext4 base image |
+| Guest supervisor | `--firecracker-supervisor` | `--firecracker-supervisor-sha256` | AWF vsock supervisor binary |
+
+All five digests are required. Supplying any subset causes a hard pre-boot
+validation failure.
+
+### Version pin
+
+The Firecracker binary and jailer binary are both pinned to **v1.16.1**. The
+preflight:
+
+1. Runs `firecracker --version` and `jailer --version`
+2. Parses the version strings
+3. Requires both to report exactly `1.16.1`
+4. Requires both to match each other
+
+Any version mismatch — including a newer Firecracker release — fails preflight.
+
+### Artifact file security requirements
+
+Each artifact file is validated for:
+
+- **Absolute path** — relative paths are rejected
+- **Regular file** — symbolic links are rejected
+- **Not group- or world-writable** — mode bits `o022` must not be set
+- **Owned by root or the operator uid** — other owners are rejected
+- **Correct access mode** — Firecracker/jailer binaries must be executable; kernel/rootfs/supervisor must be readable
+
+### Releasing test artifacts
+
+The CI workflow `test-firecracker.yml` (see §CI workflow) builds a
+reproducible artifact set:
+`release/firecracker-test-x86_64/awf-firecracker-test-x86_64.tar.gz`.
+
+This tarball contains:
+
+| File | Description |
+|------|-------------|
+| `firecracker` | Firecracker v1.16.1 binary (extracted from upstream release, SHA-256 verified) |
+| `jailer` | Jailer v1.16.1 binary |
+| `vmlinux.bin` | Linux 6.1.141 bzImage built from upstream source with a pinned kernel config |
+| `rootfs.ext4` | Minimal BusyBox + supervisor rootfs image |
+| `awf-firecracker-supervisor` | AWF guest supervisor binary |
+| `SHA256SUMS` | SHA-256 digests for all five files |
+| `manifest.json` | Human-readable manifest of versions and build inputs |
+| `sbom.spdx.json` | SPDX 2.3 software bill of materials |
+
+:::danger[Test artifacts — not production defaults]
+The release artifact set is an **x86_64 test/preview artifact set**. It is
+purpose-built for integration testing and preview evaluation. It is:
+
+- **Not** an auto-downloaded default
+- **Not** a production-ready distribution
+- **Not** intended for use as a stable base for production workloads without
+  independent review
+- **Not** distributed as a standalone GitHub Release asset of the main AWF
+  release process (the main release workflow does not publish Firecracker
+  artifacts)
+
+Production use requires operators to obtain, verify, and manage their own
+kernel and rootfs images appropriate to their workload security requirements.
+:::
+
+### Guest kernel requirements
+
+Operators who want to supply their own guest kernel (recommended for production
+evaluation) must use a Linux kernel built with a KVM-microVM-compatible
+configuration. The Firecracker project publishes reference kernel configs at
+`resources/guest_configs/` in the Firecracker repository. The kernel pin in the
+test artifact set is **Linux 6.1.141** with the upstream Firecracker CI config
+`microvm-kernel-ci-x86_64-6.1.config`.
+
+Operators are responsible for ensuring their guest kernel is:
+
+- A KVM guest kernel (not a full machine kernel)
+- Compatible with Firecracker v1.16.1
+- Sourced from a trusted build and verified by digest
+
+AWF does not impose a specific kernel version beyond the version of the
+Firecracker binary that boots it.
+
+---
+
+## Part 6 — Workspace image semantics
+
+### What gets copied into the VM
+
+Before boot, AWF creates a writable ext4 image (`workspace.ext4`) sized to hold
+the workspace with 128 MiB headroom (minimum 256 MiB, maximum 8 GiB). The image
+contains:
+
+- The entire `$GITHUB_WORKSPACE` (or `cwd()` if the variable is unset) directory,
+  copied via `rsync` then loaded into the image via `debugfs`
+- A `.awf-home` subdirectory at the workspace root, used as `$HOME` inside the
+  guest (`/workspace/.awf-home`)
+
+:::caution[No virtiofs, no live bind mounts]
+The Firecracker preview does **not** use virtiofs or any live filesystem
+passthrough. The host workspace is snapshotted at boot time into a bounded ext4
+image. Changes the host makes to the workspace directory after the VM boots are
+not visible to the guest, and changes the guest makes are not visible to the
+host until copy-back completes after the agent exits.
+:::
+
+### Copy-back and conflict detection
+
+After the agent command exits, AWF extracts the workspace image content via
+`debugfs` and compares it to the pre-run manifest:
+
+- **New or modified files** — written back to the host workspace
+- **Deleted files** — recorded in the manifest but not re-deleted from the host
+  workspace (the guest deletes inside the image only)
+- **Conflict detection** — if a file the guest modified was also modified on the
+  host between boot and copy-back (unusual in CI; more likely in development),
+  AWF logs a warning and preserves the guest version
+
+### Recovery image
+
+If copy-back fails partway through, AWF writes the raw `workspace.ext4` to a
+recovery path (`<workDir>/firecracker-recovery/<runId>-workspace.ext4`) before
+cleanup. This allows manual recovery using standard `debugfs` or `mount` tools.
+The recovery path is logged at `warn` level so it is visible even if the overall
+command exits non-zero.
+
+### Bounded image size
+
+The workspace image is bounded to a maximum of **8 GiB** by default
+(`FIRECRACKER_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES`). If the workspace content
+exceeds this bound (after accounting for the 128 MiB headroom), preflight fails
+with an explicit size error before the VM is launched.
+
+---
+
+## Part 7 — Networking and egress guarantees
+
+### Network topology
+
+Each Firecracker run gets a **dedicated network namespace** named `awffc-<runId>`.
+Inside the namespace:
+
+- A **veth pair** connects the namespace to the host infrastructure bridge
+  (the same bridge used by the Docker Compose Squid/API-proxy services)
+- A **TAP device** connects the namespace to the Firecracker VMM
+- **nftables rules** are installed that:
+  - Allow guest → Squid (`172.30.0.10:3128`)
+  - Allow guest → API proxy (if enabled)
+  - Drop all other guest-initiated outbound connections
+
+### Guest IP addressing
+
+Guest VMs are assigned IPs from the `100.64.0.0/10` range (IANA shared address
+space), using `/30` subnets. Each run gets a unique `/30` subnet derived from
+a 20-bit hash of the run ID, providing up to ~1 million distinct slots.
+
+### What the guest cannot reach
+
+| Target | Status |
+|--------|--------|
+| Arbitrary internet hosts (direct) | **Blocked** — all direct egress denied |
+| Arbitrary TCP/UDP (not via Squid) | **Blocked** |
+| Raw DNS (port 53, including 8.8.8.8) | **Blocked** — `/etc/resolv.conf` is empty; direct DNS denied |
+| EC2/GCP/Azure metadata (`169.254.169.254`) | **Blocked** — link-local range blocked |
+| Multicast (`224.0.0.0/4`) | **Blocked** |
+| Host Docker socket | **Not accessible** — no socket mount |
+| Host network | **Not accessible** — isolated namespace |
+| Squid proxy | **Allowed** — all HTTP/HTTPS goes through Squid; Squid enforces `--allow-domains` ACL |
+| API proxy | **Allowed** (mandatory in Firecracker) — credential injection only |
+
+### DNS in the guest
+
+The guest rootfs has an intentionally empty `/etc/resolv.conf`. The comment in
+the file states: _"Direct DNS is intentionally unavailable in the Firecracker
+preview."_
+
+Hostname resolution for allowed domains goes through the Squid proxy's own DNS
+resolution on the host. The guest does not perform independent DNS lookups. This
+design means the guest cannot bypass the Squid domain ACL by resolving allowed
+domain IPs and connecting to them directly — any direct IP connection is blocked
+at the nftables layer.
+
+### Egress is proxy-mandatory
+
+All outbound HTTP/HTTPS traffic from the guest must go through the Squid proxy.
+AWF sets `HTTP_PROXY`, `HTTPS_PROXY`, and related variables in the guest
+environment pointing to Squid. Tools that ignore these variables (or that make
+direct TCP connections) will fail because the nftables rules block direct
+outbound connections.
+
+---
+
+## Part 8 — API proxy and credential isolation
+
+### Why the API proxy is mandatory
+
+Unlike older Docker and gVisor configurations where the API proxy could be optional in
+non-strict mode), the Firecracker preview **requires** the API proxy. The
+runtime validation enforces this:
+
+```
+Firecracker preview requires API proxy credential isolation
+```
+
+The rationale is that the API proxy is the only path by which provider
+credentials (OpenAI, Anthropic, Copilot, Gemini, GitHub) can reach their
+destinations. Real credential values are explicitly **never** placed in guest
+environment variables.
+
+### Credential isolation enforcement
+
+At the moment the guest environment is assembled, AWF runs an explicit assertion
+(`assertNoProviderSecrets`) that scans every guest environment variable value
+for any substring matching a configured provider credential. If a match is found,
+AWF throws:
+
+```
+Refusing to pass a real provider credential through Firecracker guest variable <name>
+```
+
+This is a hard failure before the VM boots. The check covers:
+- `openaiApiKey`
+- `anthropicApiKey`
+- `copilotGithubToken`
+- `copilotProviderApiKey`
+- `geminiApiKey`
+- `googleApiKey`
+- `githubToken`
+
+### How credentials flow
+
+Provider API calls made by the agent:
+1. Agent makes an HTTPS request to a provider endpoint (e.g., `api.anthropic.com`)
+2. Request is transparently intercepted by Squid (HTTP CONNECT proxy)
+3. Request traverses to the API proxy on the host
+4. API proxy injects the real `Authorization` / `x-api-key` header
+5. Request continues to the provider
+
+The guest never sees the real credential value; it sees only the API proxy
+endpoint, which is accessible only from inside the AWF network.
+
+### API proxy connectivity probe
+
+After the VM boots but before the agent command is sent, AWF probes the API
+proxy's `/reflect` endpoint from inside the guest:
+
+```sh
+curl --fail --silent --show-error --max-time 5 --noproxy '*' \
+    --output /dev/null http://<apiProxyIp>:10000/reflect
+```
+
+If this probe fails, the agent command is never started and the VM is shut down.
+The probe timeout is bounded at 15 seconds total (shared with the Squid probe).
+
+---
+
+## Part 9 — Lifecycle, signals, and partial-start cleanup
+
+### Normal lifecycle
+
+```
+preflight → infrastructure start → network namespace create →
+workspace image create → jailer launch → VM boot → supervisor handshake →
+connectivity probe → agent execution → copy-back → cleanup
+```
+
+### Signal handling and cancellation
+
+When the AWF process receives `SIGTERM` or is cancelled:
+
+1. AWF calls `manager.cancel()` with reason `"AWF cleanup"`, which sends a
+   cancellation message over vsock to the supervisor
+2. AWF waits up to **3 seconds** (`FIRECRACKER_CANCEL_GRACE_MS`) for the active
+   execution to finish
+3. AWF calls `manager.stop()` which terminates the Firecracker process and
+   removes the jail
+4. The network namespace and all associated interfaces are cleaned up
+5. The workspace image and staging directories are removed (unless
+   `--keep-containers` was given)
+
+The CI live-smoke test verifies this: it sends `SIGTERM` after the namespace
+appears, waits for the process to exit, and asserts no namespace residue remains.
+Expected exit code after `SIGTERM` is **143** (128 + 15).
+
+### Partial-start cleanup
+
+If the VM fails to start after the jailer has been launched (e.g., a bad rootfs,
+an API timeout, or a vsock handshake failure), AWF performs the same cleanup
+sequence as normal stop. Workspace images, the jail directory, and the network
+namespace are all removed. The cleanup result is logged; if cleanup itself fails,
+the combined error (startup failure + cleanup failure) is reported with both
+causes.
+
+### Keep mode (`--keep-containers`)
+
+When `--keep-containers` is set:
+
+- The network namespace `awffc-<runId>` is **not** deleted
+- The jail directory `<workDir>/firecracker-jailer/<runId>/` is **not** deleted
+- The workspace image directory `<workDir>/firecracker-images/<runId>/` is **not** deleted
+- AWF logs the jail root path, the image directory, and the network namespace name
+
+On successful `--keep-containers` completion, the live-smoke test verifies:
+
+```
+sudo ip netns list | grep -q '^awffc-'  # namespace preserved
+test -d "$keep_work/firecracker-jailer"  # jail preserved
+```
+
+Preserved resources must be cleaned up manually. See §Troubleshooting for
+manual cleanup commands.
+
+### Resource residue policy
+
+Any network namespace matching `awffc-*` that persists after a run is considered
+residue. The CI workflow's final step enforces this:
+
+```bash
+while read -r namespace _; do
+  case "$namespace" in
+    awffc-*) sudo ip netns delete "$namespace" ;;
+  esac
+done < <(sudo ip netns list)
+if sudo ip netns list | grep -q '^awffc-'; then
+  echo "::error::Firecracker namespace residue remains after cleanup"
+  exit 1
+fi
+```
+
+Operators should include a similar cleanup step in any runner maintenance workflow.
+
+---
+
+## Part 10 — CPU and memory controls
+
+### Virtual CPUs
+
+Default: **2 vCPUs**. Configure with `--firecracker-vcpus <count>`.
+
+The guest vCPU count maps directly to Firecracker's vCPU configuration. The host
+kernel schedules these as regular Linux threads inside the jailer process. There
+is no CPU pinning by default; operators who need it should apply host-side cgroup
+CPU sets to the jailer cgroup.
+
+### Memory
+
+Default: **512 MiB**. Configure with `--firecracker-memory-mib <mib>`.
+
+The memory limit is enforced by Firecracker's VMM; the guest cannot exceed the
+configured allocation. The host-side cgroup enforced by the jailer also applies
+the allocation. Memory is not overcommitted within a single run.
+
+### Jailer cgroup enforcement
+
+The Firecracker jailer places the VMM process in a cgroup. AWF's preflight
+detects whether cgroup v1 or v2 is available and passes the version to the
+jailer. The jailer creates its own cgroup hierarchy under its assigned uid/gid
+group. Operators can apply additional cgroup controls (memory limits, CPU shares)
+at the runner level by configuring the jailer's parent cgroup.
+
+---
+
+## Part 11 — Bounded diagnostics, logging, and metrics
+
+### What is collected
+
+When `--keep-containers` is used or when `collectDiagnostics()` is called (e.g.,
+on workflow failure), AWF writes the following to `<auditDir>/firecracker/`:
+
+| File | Content | Size bound |
+|------|---------|-----------|
+| `network-plan.json` | Full network plan including namespace name, veth names, TAP name, IP assignments, allowed endpoints | Small (JSON) |
+| `firecracker.log` | Firecracker VMM log (passed via the Firecracker API) | **1 MiB total** (truncated by AWF capture) |
+| `firecracker.metrics.jsonl` | Firecracker metrics JSONL stream | **1 MiB total** (truncated by AWF capture) |
+| `jailer-stdout.log` | Jailer process stdout capture | **1 MiB total** |
+| `jailer-stderr.log` | Jailer process stderr capture | **1 MiB total** |
+
+All captured diagnostic files are individually bounded at **1 MiB**
+(`FIRECRACKER_CAPTURE_LIMIT_BYTES = 1024 * 1024`). Files that exceed the capture
+limit are truncated; the truncation is silent (no error thrown).
+
+The CI live-smoke test asserts this bound:
+
+```bash
+find "$keep_audit/firecracker" -type f -size +1048576c -print -quit \
+  | grep -q . && {
+    echo "Firecracker diagnostic artifact exceeded the 1 MiB bound" >&2
+    exit 1
+  }
+```
+
+### What the CI diagnostic collection step gathers
+
+The CI workflow's "Collect redacted diagnostics" step gathers only:
+
+- Files under `*/audit/*`
+- Files under `*/proxy-logs/*`
+- `stdout.log` and `stderr.log` for each test case
+
+Before uploading, the step scans all collected files for the secret sentinel
+string (`awf-firecracker-real-secret-do-not-expose`). If found, the step fails
+the workflow with an error annotation.
+
+### Proxy logs
+
+Squid access logs (`proxy-logs/`) are collected as in all other AWF runs. These
+contain the Squid access log with per-request domain decisions (`TCP_TUNNEL`,
+`TCP_DENIED`, etc.). Since the Firecracker guest always proxies through Squid,
+the proxy logs are the definitive record of what the agent accessed.
+
+### Structured logging
+
+AWF emits structured JSON logs at the host level (not inside the guest). Key
+Firecracker-specific log entries include:
+
+- `[firecracker] Agent command exited with code <N>` — normal agent exit
+- `[firecracker] Guest supervisor, Squid, and API proxy connectivity verified` — successful probe
+- `[firecracker] Preserved jail: <path>` — keep-mode notification
+- `[firecracker] Preserved images: <path>` — keep-mode notification
+- `[firecracker] Preserved network namespace: <name>` — keep-mode notification
+
+---
+
+## Part 12 — Topology and feature restrictions
+
+The following features are **fail-closed** in the Firecracker preview: requesting
+any of them produces a hard validation failure before the VM is launched.
+
+| Feature | Status | Error |
+|---------|--------|-------|
+| Topology peers (`--topology-attach`) | **Rejected** | "topology peers and enclaves are disabled" |
+| Enclaves (`enclaves.enabled`) | **Rejected** | Same as above |
+| Docker-in-Docker (`--enable-dind`) | **Rejected** | "does not support Docker-in-Docker or split filesystems" |
+| Split Docker host path prefix | **Rejected** | Same as above |
+| ARC DinD runner topology | **Rejected** | Same as above |
+| Host access (`--enable-host-access`) | **Rejected** | "does not support host access" |
+| Host ports (`--allow-host-ports`) | **Rejected** | Same as above |
+| Host service ports | **Rejected** | Same as above |
+| Extra volume mounts (`--volume-mount`) | **Rejected** | "does not support additional host volume mounts" |
+| DNS-over-HTTPS (`--dns-over-https`) | **Rejected** | "does not support DNS-over-HTTPS" |
+| TTY (`--tty`) | **Rejected** | "guest supervisor does not support TTY execution" |
+| Remote Docker host (non-Unix socket) | **Rejected** | "requires a local Unix-socket Docker daemon" |
+| Disabled API proxy (`--no-enable-api-proxy`) | **Rejected** | "requires API proxy credential isolation" |
+| Legacy security mode (`--legacy-security`) | **Rejected** | "requires strict --network-isolation security" |
+
+:::caution[Enclaves never fall back]
+If enclaves are enabled in the config and `--container-runtime firecracker` is
+selected, the validation failure is immediate and hard. There is no fallback to
+a non-Firecracker runtime. If you need enclaves, use a different runtime.
+:::
+
+### Primary agent only
+
+The Firecracker backend supports **only the primary agent** execution path. It
+does not participate in the enclave executor stack (script executor or agent
+executor). Enclave executors that select `firecracker` as their runtime will
+fail validation.
+
+---
+
+## Part 13 — CLI reference
+
+### Minimal invocation
+
+```bash
+sudo -E awf \
+  --container-runtime firecracker \
+  --firecracker-preview \
+  --firecracker-binary /path/to/firecracker \
+  --firecracker-jailer-binary /path/to/jailer \
+  --firecracker-kernel /path/to/vmlinux.bin \
+  --firecracker-rootfs /path/to/rootfs.ext4 \
+  --firecracker-supervisor /path/to/awf-firecracker-supervisor \
+  --firecracker-binary-sha256 <64-hex-chars> \
+  --firecracker-jailer-sha256 <64-hex-chars> \
+  --firecracker-kernel-sha256 <64-hex-chars> \
+  --firecracker-rootfs-sha256 <64-hex-chars> \
+  --firecracker-supervisor-sha256 <64-hex-chars> \
+  --allow-domains example.com \
+  -- my-agent-command
+```
+
+:::note
+`sudo -E` is required. The `-E` flag preserves environment variables (including
+`GITHUB_WORKSPACE` and provider token variables). The jailer requires root.
+Firecracker options derive the non-root jail identity from `SUDO_UID`/`SUDO_GID`.
+:::
+
+### Full CLI option reference
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--container-runtime firecracker` | string | — | **Required.** Selects the Firecracker backend. |
+| `--firecracker-preview` | boolean | false | **Required.** Explicit opt-in gate. Artifact flags do not bypass this gate; the runtime refuses to start without it. |
+| `--firecracker-binary <path>` | string | `/usr/local/bin/firecracker` | Absolute path to the Firecracker v1.16.1 binary. |
+| `--firecracker-jailer-binary <path>` | string | `/usr/local/bin/jailer` | Absolute path to the matching jailer binary. |
+| `--firecracker-kernel <path>` | string | — | **Required.** Absolute path to the guest Linux kernel image. |
+| `--firecracker-rootfs <path>` | string | — | **Required.** Absolute path to the guest rootfs ext4 image. |
+| `--firecracker-supervisor <path>` | string | — | **Required.** Absolute path to the AWF guest supervisor binary. |
+| `--firecracker-vcpus <count>` | integer | 2 | Guest virtual CPU count. |
+| `--firecracker-memory-mib <mib>` | integer | 512 | Guest memory in MiB. |
+| `--firecracker-api-timeout-ms <ms>` | integer | 5000 | Bounded Firecracker API socket readiness timeout in milliseconds. |
+| `--firecracker-binary-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the Firecracker binary. |
+| `--firecracker-jailer-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the jailer binary. |
+| `--firecracker-kernel-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the guest kernel. |
+| `--firecracker-rootfs-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the guest rootfs. |
+| `--firecracker-supervisor-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the AWF guest supervisor. |
+
+### Using test artifacts
+
+If you have unpacked `awf-firecracker-test-x86_64.tar.gz` to `$ARTIFACTS`:
+
+```bash
+# Read digests from SHA256SUMS
+ARTIFACTS=/path/to/firecracker-test-x86_64
+digest() { awk -v f="$1" '$2==f{print $1;exit}' "$ARTIFACTS/SHA256SUMS"; }
+
+sudo -E awf \
+  --container-runtime firecracker \
+  --firecracker-preview \
+  --firecracker-binary   "$ARTIFACTS/firecracker" \
+  --firecracker-jailer-binary "$ARTIFACTS/jailer" \
+  --firecracker-kernel   "$ARTIFACTS/vmlinux.bin" \
+  --firecracker-rootfs   "$ARTIFACTS/rootfs.ext4" \
+  --firecracker-supervisor "$ARTIFACTS/awf-firecracker-supervisor" \
+  --firecracker-binary-sha256   "$(digest firecracker)" \
+  --firecracker-jailer-sha256   "$(digest jailer)" \
+  --firecracker-kernel-sha256   "$(digest vmlinux.bin)" \
+  --firecracker-rootfs-sha256   "$(digest rootfs.ext4)" \
+  --firecracker-supervisor-sha256 "$(digest awf-firecracker-supervisor)" \
+  --allow-domains example.com \
+  -- curl -s https://example.com
+```
+
+### Config file equivalent
+
+```json
+{
+  "containerRuntime": "firecracker",
+  "firecracker": {
+    "previewEnabled": true,
+    "firecrackerBinary": "/path/to/firecracker",
+    "jailerBinary": "/path/to/jailer",
+    "kernelPath": "/path/to/vmlinux.bin",
+    "rootfsPath": "/path/to/rootfs.ext4",
+    "supervisorPath": "/path/to/awf-firecracker-supervisor",
+    "vcpuCount": 2,
+    "memoryMib": 512,
+    "apiTimeoutMs": 5000,
+    "sha256": {
+      "firecracker": "<64-hex-chars>",
+      "jailer": "<64-hex-chars>",
+      "kernel": "<64-hex-chars>",
+      "rootfs": "<64-hex-chars>",
+      "supervisor": "<64-hex-chars>"
+    }
+  }
+}
+```
+
+---
+
+## Part 14 — CI workflow
+
+### Trigger conditions
+
+The Firecracker CI workflow (`test-firecracker.yml`) triggers **only** on:
+
+- `workflow_dispatch` — manual trigger from the Actions UI or `gh workflow run`;
+  `run_live_kvm: false` validates the deterministic artifact build without
+  queueing the KVM job
+- A pull request being **labeled** with `firecracker-kvm`
+
+It does **not** run on push, on scheduled triggers, or on unlabeled pull request
+events. This ensures the live KVM job never silently runs on GitHub-hosted
+runners.
+
+### Jobs
+
+#### `build-test-artifacts` (runs on `ubuntu-24.04`)
+
+This job runs on a GitHub-hosted `ubuntu-24.04` runner. It does **not** require
+KVM. It:
+
+1. Checks out the repository
+2. Sets up Go 1.25.0
+3. Installs deterministic build prerequisites (`bc`, `binutils`, `bison`,
+   `build-essential`, `cpio`, `e2fsprogs`, `file`, `flex`, `libelf-dev`,
+   `libssl-dev`, `rsync`, `xz-utils`)
+4. Runs `guest/firecracker/build-test-artifacts.sh` — downloads Firecracker
+   v1.16.1 (SHA-256 verified), Linux 6.1.141 (SHA-256 verified), BusyBox 1.36.1
+   (SHA-256 verified), and a pinned CA bundle; builds kernel, BusyBox, and
+   supervisor; creates rootfs; produces `SHA256SUMS`, `manifest.json`, and
+   `sbom.spdx.json`; archives everything as
+   `release/firecracker-test-x86_64/awf-firecracker-test-x86_64.tar.gz`
+5. Runs `guest/firecracker/verify-test-artifacts.sh` against the output
+6. Attests artifact provenance via `actions/attest-build-provenance`
+7. Uploads `release/firecracker-test-x86_64/` as artifact `firecracker-test-x86_64`
+   with 7-day retention
+
+#### `live-kvm` (runs on `[self-hosted, linux, x64, kvm, awf-firecracker]`)
+
+This job runs on a **self-hosted runner** with the exact label set
+`[self-hosted, linux, x64, kvm, awf-firecracker]`. It will never land on a
+GitHub-hosted runner because GitHub-hosted runners do not carry these labels.
+
+It:
+
+1. Downloads the `firecracker-test-x86_64` artifact from the build job
+2. Runs `scripts/ci/firecracker-host-preflight.sh` — verifies Linux, x86_64,
+   `/dev/kvm`, required tools, Firecracker/jailer version strings, and all five
+   SHA-256 digests via `sha256sum --check --strict SHA256SUMS`
+3. Installs NPM dependencies, builds the AWF distribution, and builds the
+   Squid and API proxy container images locally
+4. Runs `scripts/ci/firecracker-live-smoke.sh` — the live test suite
+5. Collects redacted diagnostics (audit, proxy-logs, stdout/stderr) and scans
+   for the secret sentinel before uploading
+6. Enforces final residue cleanup of all `awffc-*` network namespaces
+
+### Live smoke test assertions
+
+The live smoke test (`firecracker-live-smoke.sh`) runs these named cases:
+
+| Case | Expected exit | Assertion |
+|------|--------------|-----------|
+| `allowed-https` | 0 | `wget https://example.com` succeeds and returns "Example Domain" |
+| `blocked-domain` | 0 | `wget https://github.com` fails (not in `--allow-domains`) |
+| `direct-egress` | 0 | Unsets `HTTP_PROXY`/`HTTPS_PROXY`; direct `wget https://example.com` fails |
+| `arbitrary-tcp` | 0 | `nc -z 1.1.1.1 443` fails (direct TCP blocked) |
+| `dns-denial` | 0 | `nslookup example.com 8.8.8.8` fails (direct DNS blocked) |
+| `metadata-denial` | 0 | Unsets proxy vars; `wget http://169.254.169.254/latest/meta-data/` fails |
+| `api-proxy-reflect` | 0 | API proxy `/reflect` endpoint reachable from guest; response contains "providers"; `env` does not contain the secret sentinel |
+| `workspace-copyback` | 0 | Guest writes `.hidden`, `bin/run` (chmod 755), `run-link` (symlink); all appear on host after run |
+| `exit-code` | 37 | `exit 37` inside guest propagates as AWF exit code 37 |
+| `timeout-124` | 124 | `sleep 90` with `--agent-timeout 1` exits with code 124 |
+| `partial-start-cleanup` | 1 | Corrupt rootfs (valid digest, invalid content) causes startup failure; no namespace residue |
+| `cancellation` | 143 | `SIGTERM` after namespace appears; no namespace residue |
+| `keep` (keep mode) | 0 | `--keep-containers`; namespace preserved; jail preserved; diagnostic files present; all bounded ≤1 MiB |
+
+After every case (except `keep`), the test asserts:
+
+- No `awffc-*` network namespaces remain
+- No `fch*`, `fcn*`, or `fct*` veth/TAP interfaces remain
+
+### Secret sentinel check
+
+All smoke test cases set `OPENAI_API_KEY=awf-firecracker-real-secret-do-not-expose`.
+After each run, the test scans `stdout.log`, `audit/`, and `proxy-logs/` for
+this sentinel string. Finding it means a real credential would have leaked into
+guest-visible or diagnostic output, which is a test failure.
+
+---
+
+## Part 15 — Troubleshooting
+
+### Preflight failures
+
+**`Firecracker requires Linux with KVM; found darwin`**
+
+You are running on macOS. Firecracker is Linux/KVM only. macOS and Windows are
+permanently unsupported. This development session cannot perform a live KVM boot.
+
+**`Firecracker requires readable and writable /dev/kvm`**
+
+The runner either lacks `/dev/kvm` (not a KVM-capable host, or a GitHub-hosted
+runner) or the operator account lacks read/write access.
+
+Check: `ls -la /dev/kvm` — if the device does not exist, the host lacks KVM
+support. If it exists but is not accessible, add the user to the `kvm` group:
+`sudo usermod -aG kvm $USER` (requires re-login).
+
+**`Firecracker is pinned to v1.16.1; found v<other>`**
+
+The Firecracker binary on the supplied path is not v1.16.1. Obtain the correct
+version. Do not attempt to bypass the version check.
+
+**`<artifact> SHA-256 mismatch: expected <A>, got <B>`**
+
+The artifact file does not match the supplied digest. Either the wrong digest
+was provided, the file was modified after download, or the file is corrupt.
+Re-obtain the artifact from a trusted source and recompute the digest.
+
+**`Firecracker jailer requires a non-root target uid/gid`**
+
+The operator account is root (uid 0), or `SUDO_UID`/`SUDO_GID` were not set
+(i.e., `sudo -E` was not used correctly). The jailer requires a non-root jail
+identity. Run as a non-root user through `sudo`.
+
+**`required host tool "<tool>" was not found on PATH`**
+
+Install the missing tool. Common package names:
+- `ip`, `sysctl`, `nft` — `iproute2`, `procps`, `nftables`
+- `mke2fs`, `debugfs`, `e2fsck` — `e2fsprogs`
+- `rsync` — `rsync`
+
+**`Firecracker and Docker-in-Docker are mutually exclusive`**
+
+The config or CLI has both Firecracker and DinD/ARC-DinD selected. Remove the
+DinD-related flags. The Firecracker backend does not support Docker-in-Docker
+in this preview.
+
+### Boot failures
+
+**`Firecracker guest connectivity probe failed with exit code <N>`**
+
+The VM booted but the guest could not reach Squid or the API proxy within the
+15-second probe timeout. Possible causes:
+
+1. The infrastructure bridge is not ready — check `docker inspect <bridgeName>`
+2. The nftables rules were not installed correctly — check with
+   `sudo ip netns exec awffc-<runId> nft list ruleset`
+3. The guest IP was not assigned — check the network plan in
+   `<auditDir>/firecracker/network-plan.json`
+
+Enable `--log-level debug` to see detailed network setup steps.
+
+**`Firecracker manager did not expose the configured guest IP`**
+
+The VM started but the guest supervisor did not report a guest IP via vsock
+handshake. Check `<auditDir>/firecracker/jailer-stderr.log` for VMM errors
+and `<auditDir>/firecracker/firecracker.log` for boot errors.
+
+**API timeout (startup)**
+
+If the Firecracker API socket does not become ready within `--firecracker-api-timeout-ms`
+(default 5000 ms), startup fails. On slow hosts or under memory pressure, try
+increasing to 10000 ms.
+
+### Cleanup / residue
+
+**Namespace residue after a failed run:**
+
+```bash
+# List residue
+sudo ip netns list | grep awffc
+
+# Remove specific namespace
+sudo ip netns delete awffc-<runId>
+
+# Remove all AWF Firecracker namespaces
+sudo ip netns list | awk '/^awffc-/{print $1}' | \
+  xargs -r -I{} sudo ip netns delete {}
+```
+
+**Jailer directory residue (only if stop failed):**
+
+```bash
+# Find residue
+ls /tmp/awf-*/firecracker-jailer/ 2>/dev/null
+
+# Remove (be certain this is AWF residue before removing)
+sudo rm -rf /tmp/awf-<timestamp>/firecracker-jailer/<runId>
+```
+
+**Docker infrastructure (Squid/API proxy) not cleaned up:**
+
+```bash
+sudo docker compose -f /tmp/awf-<timestamp>/docker-compose.yml down --volumes --remove-orphans
+```
+
+### Workspace copy-back recovery
+
+If copy-back fails and a recovery image was preserved:
+
+```bash
+# Mount the recovery image (requires root or loop mount capability)
+sudo mkdir -p /mnt/awf-recovery
+sudo mount -o loop <workDir>/firecracker-recovery/<runId>-workspace.ext4 /mnt/awf-recovery
+
+# Browse or extract files
+ls /mnt/awf-recovery/workspace/
+
+# Unmount when done
+sudo umount /mnt/awf-recovery
+```
+
+Alternatively, use `debugfs` directly:
+
+```bash
+debugfs -R 'ls /workspace' <path-to-recovery.ext4>
+debugfs -R 'dump /workspace/output.txt /tmp/recovered-output.txt' <path-to-recovery.ext4>
+```
+
+---
+
+## Part 16 — Known limitations
+
+This section documents known gaps in the current preview. Items here are expected
+to be addressed before promotion out of preview.
+
+| Limitation | Details |
+|-----------|---------|
+| **x86_64 test artifacts only** | No pre-built aarch64 test artifact is released. aarch64 is accepted by preflight code but must be built by the operator. |
+| **No topology peers or enclaves** | The MCP gateway path is not proved in the Firecracker network model. Topology attachment and enclave execution are disabled. |
+| **No TTY** | The guest supervisor does not implement a PTY multiplexer. Interactive agents requiring TTY cannot run. |
+| **No virtiofs / live bind mounts** | Workspace is snapshotted at boot. Files created on the host after VM start are not visible to the guest. |
+| **No Docker-in-Docker** | The guest has no Docker daemon. Agents that build or run containers cannot use Docker inside the VM. |
+| **Single agent only** | The Firecracker path supports one agent execution per VM. Multi-agent or parallel executor models are not supported. |
+| **GitHub-hosted runners unsupported** | GitHub-hosted runners do not expose `/dev/kvm`. Experimental nested virtualization is not a supported target. |
+| **macOS/Windows unsupported** | Firecracker requires Linux KVM; the preview fails preflight on these hosts. |
+| **No unverified latest/demo assets** | There is no "just try it" path. Operators must manage and verify all artifacts. |
+| **8 GiB workspace image ceiling** | Workspaces larger than 8 GiB cannot be used with Firecracker. |
+| **Workspace copy-back is authoritative** | Guest deletions are applied with `rsync --delete`. Any concurrent host-only or divergent change fails copy-back and preserves the changed image for recovery instead of overwriting host work. |
+| **No DNS-over-HTTPS in guest** | The DoH proxy is a host-side service; the guest does not participate. |

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -362,9 +362,12 @@ Each artifact file is validated for:
 
 ### Releasing test artifacts
 
-The CI workflow `test-firecracker.yml` (see §CI workflow) builds a
-reproducible artifact set:
+The release workflow and `test-firecracker.yml` (see §CI workflow) build the
+same reproducible artifact set:
 `release/firecracker-test-x86_64/awf-firecracker-test-x86_64.tar.gz`.
+The release workflow publishes the tarball, checksum manifest, build manifest,
+and SPDX SBOM as versioned GitHub Release assets. CI uploads the unpacked set as
+a 7-day workflow artifact for validation.
 
 This tarball contains:
 
@@ -387,12 +390,13 @@ purpose-built for integration testing and preview evaluation. It is:
 - **Not** a production-ready distribution
 - **Not** intended for use as a stable base for production workloads without
   independent review
-- **Not** distributed as a standalone GitHub Release asset of the main AWF
-  release process (the main release workflow does not publish Firecracker
-  artifacts)
+- **Distributed only as an explicitly named test/preview GitHub Release asset**,
+  never selected or downloaded automatically by AWF
 
 Production use requires operators to obtain, verify, and manage their own
 kernel and rootfs images appropriate to their workload security requirements.
+The published `firecracker-test-x86_64.SHA256SUMS` covers the five extracted
+runtime files, not the tarball itself; extract the bundle before checking it.
 :::
 
 ### Guest kernel requirements

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -114,10 +114,10 @@ The `agent-act` image is used when running with `--agent-image act` for workflow
 
 ### Firecracker preview test artifacts
 
-The main release workflow does **not** publish Firecracker guest artifacts.
-Firecracker test artifacts (`firecracker-test-x86_64`) are built and attested
-separately by the `test-firecracker.yml` CI workflow and uploaded as
-**7-day workflow artifacts**, not as GitHub Release assets.
+The main release workflow builds, attests, and publishes the versioned
+`firecracker-test-x86_64` preview bundle as GitHub Release assets. Pull request
+and manual validation through `test-firecracker.yml` also uploads the unpacked
+artifact set with **7-day workflow-artifact retention**.
 
 These artifacts are:
 
@@ -129,6 +129,8 @@ These artifacts are:
 - **Not a production default** — operators who want to evaluate Firecracker for
   production must obtain, verify, and manage their own guest kernel and rootfs
   appropriate to their workload security requirements.
+- **Explicitly verified** — `firecracker-test-x86_64.SHA256SUMS` covers the five
+  files inside the tarball; extract the tarball before running `sha256sum -c`.
 
 See [Firecracker integration (preview) — Artifact policy](./firecracker-integration.md#part-5--artifact-policy)
 for the complete artifact specification and digest requirements.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -112,6 +112,27 @@ These images are automatically pulled by the CLI when running commands.
 
 The `agent-act` image is used when running with `--agent-image act` for workflows that need closer parity with GitHub Actions runner environments.
 
+### Firecracker preview test artifacts
+
+The main release workflow does **not** publish Firecracker guest artifacts.
+Firecracker test artifacts (`firecracker-test-x86_64`) are built and attested
+separately by the `test-firecracker.yml` CI workflow and uploaded as
+**7-day workflow artifacts**, not as GitHub Release assets.
+
+These artifacts are:
+
+- **x86_64 only** — no aarch64 test artifact is published.
+- **Preview / testing purpose only** — `manifest.json` inside the tarball states:
+  `"purpose": "AWF Firecracker preview test artifacts; not production defaults"`.
+- **Not auto-downloaded** — there is no mechanism in AWF to fetch them
+  automatically; operators must download, verify, and supply them explicitly.
+- **Not a production default** — operators who want to evaluate Firecracker for
+  production must obtain, verify, and manage their own guest kernel and rootfs
+  appropriate to their workload security requirements.
+
+See [Firecracker integration (preview) — Artifact policy](./firecracker-integration.md#part-5--artifact-policy)
+for the complete artifact specification and digest requirements.
+
 ## Testing a Release Locally
 
 Before releasing, you can test the build process locally:

--- a/guest/firecracker/build-test-artifacts.sh
+++ b/guest/firecracker/build-test-artifacts.sh
@@ -137,7 +137,7 @@ disable_busybox_option TC
 make -C "$busybox_dir" -j"$JOBS"
 
 supervisor="$OUTPUT/awf-firecracker-supervisor"
-VERSION="v${FIRECRACKER_VERSION}" \
+VERSION="${VERSION:-v${FIRECRACKER_VERSION}}" \
   OUTPUT="$supervisor" \
   "$ROOT/guest/firecracker-supervisor/build.sh"
 
@@ -244,7 +244,9 @@ cat >"$OUTPUT/sbom.spdx.json" <<EOF
       "versionInfo": "${FIRECRACKER_VERSION}",
       "downloadLocation": "https://github.com/firecracker-microvm/firecracker/releases/tag/v${FIRECRACKER_VERSION}",
       "filesAnalyzed": false,
-      "licenseConcluded": "Apache-2.0"
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION"
     },
     {
       "name": "linux",
@@ -252,7 +254,9 @@ cat >"$OUTPUT/sbom.spdx.json" <<EOF
       "versionInfo": "${LINUX_VERSION}",
       "downloadLocation": "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${LINUX_VERSION}.tar.xz",
       "filesAnalyzed": false,
-      "licenseConcluded": "GPL-2.0-only"
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION"
     },
     {
       "name": "busybox",
@@ -260,8 +264,15 @@ cat >"$OUTPUT/sbom.spdx.json" <<EOF
       "versionInfo": "${BUSYBOX_VERSION}",
       "downloadLocation": "https://busybox.net/downloads/busybox-${BUSYBOX_VERSION}.tar.bz2",
       "filesAnalyzed": false,
-      "licenseConcluded": "GPL-2.0-only"
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "copyrightText": "NOASSERTION"
     }
+  ],
+  "relationships": [
+    { "spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-Firecracker" },
+    { "spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-Linux" },
+    { "spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-BusyBox" }
   ]
 }
 EOF

--- a/guest/firecracker/build-test-artifacts.sh
+++ b/guest/firecracker/build-test-artifacts.sh
@@ -99,19 +99,30 @@ download_verified \
 tar --extract --bzip2 --file "$busybox_tar" --directory "$BUILD"
 busybox_dir="$BUILD/busybox-${BUSYBOX_VERSION}"
 make -C "$busybox_dir" defconfig
-"$busybox_dir/scripts/config" --file "$busybox_dir/.config" \
-  --enable STATIC \
-  --enable WGET \
-  --enable FEATURE_WGET_HTTPS \
-  --enable TLS \
-  --enable IP \
-  --enable IPADDR \
-  --enable IPLINK \
-  --enable IPROUTE \
-  --enable NC \
-  --enable NSLOOKUP \
-  --enable TIMEOUT
-make -C "$busybox_dir" oldconfig </dev/null >/dev/null
+enable_busybox_option() {
+  local option=$1
+  if grep -q "^CONFIG_${option}=" "$busybox_dir/.config"; then
+    sed -i "s/^CONFIG_${option}=.*/CONFIG_${option}=y/" "$busybox_dir/.config"
+  elif grep -q "^# CONFIG_${option} is not set$" "$busybox_dir/.config"; then
+    sed -i "s/^# CONFIG_${option} is not set$/CONFIG_${option}=y/" "$busybox_dir/.config"
+  else
+    printf 'CONFIG_%s=y\n' "$option" >>"$busybox_dir/.config"
+  fi
+}
+for option in \
+  STATIC \
+  WGET \
+  FEATURE_WGET_HTTPS \
+  TLS \
+  IP \
+  IPADDR \
+  IPLINK \
+  IPROUTE \
+  NC \
+  NSLOOKUP \
+  TIMEOUT; do
+  enable_busybox_option "$option"
+done
 make -C "$busybox_dir" -j"$JOBS"
 
 supervisor="$OUTPUT/awf-firecracker-supervisor"

--- a/guest/firecracker/build-test-artifacts.sh
+++ b/guest/firecracker/build-test-artifacts.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+FIRECRACKER_VERSION=1.16.1
+FIRECRACKER_ARCHIVE_SHA256=382a02a869e4d6d5cb14c40577f9545e8458021ea8b0b2d3fc10ec14d9c242e6
+LINUX_VERSION=6.1.141
+LINUX_SHA256=bc3c45faf6f5f0450666c75fa9dad9bc7c0cf7c7cba0dbd94e5cfdc58229c116
+KERNEL_CONFIG_SHA256=adbc70ab5e89213ba00594b12d25e09bdf8bb1ed3c252d7449326bb14c22963b
+BUSYBOX_VERSION=1.36.1
+BUSYBOX_SHA256=b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
+CA_BUNDLE_DATE=2025-02-25
+CA_BUNDLE_SHA256=50a6277ec69113f00c5fd45f09e8b97a4b3e32daa35d3a95ab30137a55386cef
+SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-1767225600}
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+OUTPUT=${OUTPUT:-"$ROOT/release/firecracker-test-x86_64"}
+BUILD=${BUILD:-"$ROOT/.build/firecracker-test-x86_64"}
+JOBS=${JOBS:-$(getconf _NPROCESSORS_ONLN)}
+
+if [ "$(uname -s)" != Linux ] || [ "$(uname -m)" != x86_64 ]; then
+  echo "Firecracker test artifacts must be built on Linux x86_64" >&2
+  exit 1
+fi
+
+for tool in curl sha256sum tar make gcc ld mke2fs e2fsck go; do
+  command -v "$tool" >/dev/null || {
+    echo "required build tool not found: $tool" >&2
+    exit 1
+  }
+done
+
+rm -rf "$BUILD" "$OUTPUT"
+mkdir -p "$BUILD/downloads" "$OUTPUT"
+
+download_verified() {
+  local url=$1
+  local expected=$2
+  local destination=$3
+  curl --fail --location --proto '=https' --tlsv1.2 "$url" --output "$destination"
+  printf '%s  %s\n' "$expected" "$destination" | sha256sum --check --status
+}
+
+archive="$BUILD/downloads/firecracker-v${FIRECRACKER_VERSION}-x86_64.tgz"
+download_verified \
+  "https://github.com/firecracker-microvm/firecracker/releases/download/v${FIRECRACKER_VERSION}/firecracker-v${FIRECRACKER_VERSION}-x86_64.tgz" \
+  "$FIRECRACKER_ARCHIVE_SHA256" \
+  "$archive"
+tar --extract --gzip --file "$archive" --directory "$BUILD"
+release_dir="$BUILD/release-v${FIRECRACKER_VERSION}-x86_64"
+(
+  cd "$release_dir"
+  sha256sum --check --ignore-missing SHA256SUMS
+)
+install -m 0755 \
+  "$release_dir/firecracker-v${FIRECRACKER_VERSION}-x86_64" \
+  "$OUTPUT/firecracker"
+install -m 0755 \
+  "$release_dir/jailer-v${FIRECRACKER_VERSION}-x86_64" \
+  "$OUTPUT/jailer"
+
+linux_tar="$BUILD/downloads/linux-${LINUX_VERSION}.tar.xz"
+kernel_config="$BUILD/downloads/firecracker-kernel.config"
+download_verified \
+  "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${LINUX_VERSION}.tar.xz" \
+  "$LINUX_SHA256" \
+  "$linux_tar"
+download_verified \
+  "https://raw.githubusercontent.com/firecracker-microvm/firecracker/v${FIRECRACKER_VERSION}/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config" \
+  "$KERNEL_CONFIG_SHA256" \
+  "$kernel_config"
+tar --extract --xz --file "$linux_tar" --directory "$BUILD"
+cp "$kernel_config" "$BUILD/linux-${LINUX_VERSION}/.config"
+make -C "$BUILD/linux-${LINUX_VERSION}" \
+  ARCH=x86_64 \
+  KBUILD_BUILD_TIMESTAMP="@${SOURCE_DATE_EPOCH}" \
+  KBUILD_BUILD_USER=awf \
+  KBUILD_BUILD_HOST=github \
+  LOCALVERSION=-awf-firecracker \
+  olddefconfig
+make -C "$BUILD/linux-${LINUX_VERSION}" \
+  -j"$JOBS" \
+  ARCH=x86_64 \
+  KBUILD_BUILD_TIMESTAMP="@${SOURCE_DATE_EPOCH}" \
+  KBUILD_BUILD_USER=awf \
+  KBUILD_BUILD_HOST=github \
+  LOCALVERSION=-awf-firecracker \
+  bzImage
+install -m 0644 \
+  "$BUILD/linux-${LINUX_VERSION}/arch/x86/boot/bzImage" \
+  "$OUTPUT/vmlinux.bin"
+
+busybox_tar="$BUILD/downloads/busybox-${BUSYBOX_VERSION}.tar.bz2"
+download_verified \
+  "https://busybox.net/downloads/busybox-${BUSYBOX_VERSION}.tar.bz2" \
+  "$BUSYBOX_SHA256" \
+  "$busybox_tar"
+tar --extract --bzip2 --file "$busybox_tar" --directory "$BUILD"
+busybox_dir="$BUILD/busybox-${BUSYBOX_VERSION}"
+make -C "$busybox_dir" defconfig
+"$busybox_dir/scripts/config" --file "$busybox_dir/.config" \
+  --enable STATIC \
+  --enable WGET \
+  --enable FEATURE_WGET_HTTPS \
+  --enable TLS \
+  --enable IP \
+  --enable IPADDR \
+  --enable IPLINK \
+  --enable IPROUTE \
+  --enable NC \
+  --enable NSLOOKUP \
+  --enable TIMEOUT
+make -C "$busybox_dir" oldconfig </dev/null >/dev/null
+make -C "$busybox_dir" -j"$JOBS"
+
+supervisor="$OUTPUT/awf-firecracker-supervisor"
+VERSION="v${FIRECRACKER_VERSION}" \
+  OUTPUT="$supervisor" \
+  "$ROOT/guest/firecracker-supervisor/build.sh"
+
+rootfs_tree="$BUILD/rootfs"
+mkdir -p \
+  "$rootfs_tree/bin" \
+  "$rootfs_tree/dev" \
+  "$rootfs_tree/etc/ssl/certs" \
+  "$rootfs_tree/proc" \
+  "$rootfs_tree/root" \
+  "$rootfs_tree/sbin" \
+  "$rootfs_tree/sys" \
+  "$rootfs_tree/tmp" \
+  "$rootfs_tree/usr/bin" \
+  "$rootfs_tree/usr/sbin" \
+  "$rootfs_tree/workspace"
+make -C "$busybox_dir" CONFIG_PREFIX="$rootfs_tree" install
+install -m 0755 "$supervisor" "$rootfs_tree/sbin/awf-supervisor"
+cat >"$rootfs_tree/etc/passwd" <<'EOF'
+root:x:0:0:root:/root:/bin/sh
+awf:x:1000:1000:AWF guest:/workspace:/bin/sh
+nobody:x:65534:65534:nobody:/:/bin/false
+EOF
+cat >"$rootfs_tree/etc/group" <<'EOF'
+root:x:0:
+awf:x:1000:
+nogroup:x:65534:
+EOF
+cat >"$rootfs_tree/etc/resolv.conf" <<'EOF'
+# Direct DNS is intentionally unavailable in the Firecracker preview.
+EOF
+ca_bundle="$BUILD/downloads/cacert-${CA_BUNDLE_DATE}.pem"
+download_verified \
+  "https://curl.se/ca/cacert-${CA_BUNDLE_DATE}.pem" \
+  "$CA_BUNDLE_SHA256" \
+  "$ca_bundle"
+install -m 0644 "$ca_bundle" "$rootfs_tree/etc/ssl/certs/ca-certificates.crt"
+chmod 01777 "$rootfs_tree/tmp"
+find "$rootfs_tree" -print0 | xargs -0 touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
+
+rootfs="$OUTPUT/rootfs.ext4"
+E2FSPROGS_FAKE_TIME="$SOURCE_DATE_EPOCH" mke2fs \
+  -t ext4 \
+  -F \
+  -q \
+  -b 4096 \
+  -d "$rootfs_tree" \
+  -U 7b6680c1-1e8c-4aac-a04e-95b8f36ff8ee \
+  -E lazy_itable_init=0,lazy_journal_init=0 \
+  "$rootfs" \
+  32768
+E2FSPROGS_FAKE_TIME="$SOURCE_DATE_EPOCH" e2fsck -f -y "$rootfs" >/dev/null
+
+(
+  cd "$OUTPUT"
+  sha256sum \
+    firecracker \
+    jailer \
+    vmlinux.bin \
+    rootfs.ext4 \
+    awf-firecracker-supervisor \
+    > SHA256SUMS
+)
+
+cat >"$OUTPUT/manifest.json" <<EOF
+{
+  "schemaVersion": 1,
+  "purpose": "AWF Firecracker preview test artifacts; not production defaults",
+  "architecture": "x86_64",
+  "sourceDateEpoch": ${SOURCE_DATE_EPOCH},
+  "firecracker": {
+    "version": "${FIRECRACKER_VERSION}",
+    "archiveSha256": "${FIRECRACKER_ARCHIVE_SHA256}"
+  },
+  "kernel": {
+    "version": "${LINUX_VERSION}",
+    "sourceSha256": "${LINUX_SHA256}",
+    "configSha256": "${KERNEL_CONFIG_SHA256}"
+  },
+  "userspace": {
+    "busyboxVersion": "${BUSYBOX_VERSION}",
+    "busyboxSourceSha256": "${BUSYBOX_SHA256}",
+    "caBundleDate": "${CA_BUNDLE_DATE}",
+    "caBundleSha256": "${CA_BUNDLE_SHA256}"
+  }
+}
+EOF
+
+cat >"$OUTPUT/sbom.spdx.json" <<EOF
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "awf-firecracker-test-x86_64",
+  "documentNamespace": "https://github.com/github/gh-aw-firewall/firecracker-test/${SOURCE_DATE_EPOCH}",
+  "creationInfo": {
+    "created": "2026-01-01T00:00:00Z",
+    "creators": ["Tool: guest/firecracker/build-test-artifacts.sh"]
+  },
+  "packages": [
+    {
+      "name": "firecracker",
+      "SPDXID": "SPDXRef-Firecracker",
+      "versionInfo": "${FIRECRACKER_VERSION}",
+      "downloadLocation": "https://github.com/firecracker-microvm/firecracker/releases/tag/v${FIRECRACKER_VERSION}",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0"
+    },
+    {
+      "name": "linux",
+      "SPDXID": "SPDXRef-Linux",
+      "versionInfo": "${LINUX_VERSION}",
+      "downloadLocation": "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${LINUX_VERSION}.tar.xz",
+      "filesAnalyzed": false,
+      "licenseConcluded": "GPL-2.0-only"
+    },
+    {
+      "name": "busybox",
+      "SPDXID": "SPDXRef-BusyBox",
+      "versionInfo": "${BUSYBOX_VERSION}",
+      "downloadLocation": "https://busybox.net/downloads/busybox-${BUSYBOX_VERSION}.tar.bz2",
+      "filesAnalyzed": false,
+      "licenseConcluded": "GPL-2.0-only"
+    }
+  ]
+}
+EOF
+
+tar \
+  --sort=name \
+  --mtime="@${SOURCE_DATE_EPOCH}" \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  --create \
+  --gzip \
+  --file "$OUTPUT/awf-firecracker-test-x86_64.tar.gz" \
+  --directory "$OUTPUT" \
+  firecracker \
+  jailer \
+  vmlinux.bin \
+  rootfs.ext4 \
+  awf-firecracker-supervisor \
+  SHA256SUMS \
+  manifest.json \
+  sbom.spdx.json

--- a/guest/firecracker/build-test-artifacts.sh
+++ b/guest/firecracker/build-test-artifacts.sh
@@ -109,6 +109,14 @@ enable_busybox_option() {
     printf 'CONFIG_%s=y\n' "$option" >>"$busybox_dir/.config"
   fi
 }
+disable_busybox_option() {
+  local option=$1
+  if grep -q "^CONFIG_${option}=" "$busybox_dir/.config"; then
+    sed -i "s/^CONFIG_${option}=.*/# CONFIG_${option} is not set/" "$busybox_dir/.config"
+  elif ! grep -q "^# CONFIG_${option} is not set$" "$busybox_dir/.config"; then
+    printf '# CONFIG_%s is not set\n' "$option" >>"$busybox_dir/.config"
+  fi
+}
 for option in \
   STATIC \
   WGET \
@@ -123,6 +131,9 @@ for option in \
   TIMEOUT; do
   enable_busybox_option "$option"
 done
+# BusyBox 1.36.1 tc depends on CBQ UAPI definitions removed from newer build hosts.
+# The minimal guest never uses traffic control; AWF enforces policy in the host netns.
+disable_busybox_option TC
 make -C "$busybox_dir" -j"$JOBS"
 
 supervisor="$OUTPUT/awf-firecracker-supervisor"

--- a/guest/firecracker/verify-test-artifacts.sh
+++ b/guest/firecracker/verify-test-artifacts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${1:?usage: verify-test-artifacts.sh ARTIFACT_DIR}
+
+for file in \
+  firecracker \
+  jailer \
+  vmlinux.bin \
+  rootfs.ext4 \
+  awf-firecracker-supervisor \
+  SHA256SUMS \
+  manifest.json \
+  sbom.spdx.json; do
+  test -f "$ARTIFACT_DIR/$file" || {
+    echo "missing Firecracker artifact: $file" >&2
+    exit 1
+  }
+done
+
+(
+  cd "$ARTIFACT_DIR"
+  sha256sum --check SHA256SUMS
+)
+
+"$ARTIFACT_DIR/firecracker" --version | grep -F '1.16.1'
+"$ARTIFACT_DIR/jailer" --version | grep -F '1.16.1'
+file "$ARTIFACT_DIR/vmlinux.bin" | grep -E 'Linux kernel|boot executable'
+e2fsck -f -n "$ARTIFACT_DIR/rootfs.ext4"
+debugfs -R 'stat /sbin/awf-supervisor' "$ARTIFACT_DIR/rootfs.ext4" 2>&1 \
+  | grep -F 'Type: regular'
+grep -F '"purpose": "AWF Firecracker preview test artifacts; not production defaults"' \
+  "$ARTIFACT_DIR/manifest.json"
+grep -F '"spdxVersion": "SPDX-2.3"' "$ARTIFACT_DIR/sbom.spdx.json"

--- a/scripts/ci/firecracker-host-preflight.sh
+++ b/scripts/ci/firecracker-host-preflight.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${1:?usage: firecracker-host-preflight.sh ARTIFACT_DIR}
+
+fail() {
+  echo "::error title=Firecracker host preflight::$*" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = Linux ] || fail "Linux is required; macOS and Windows are unsupported."
+[ "$(uname -m)" = x86_64 ] || fail "This CI artifact set requires an x86_64 self-hosted runner."
+[ -c /dev/kvm ] || fail "/dev/kvm is missing; use an explicitly KVM-capable self-hosted runner."
+[ -r /dev/kvm ] && [ -w /dev/kvm ] \
+  || fail "/dev/kvm must be readable and writable by the workflow user."
+
+for control in \
+  /proc/sys/net/ipv4/ip_forward \
+  /proc/sys/net/ipv6/conf/all/disable_ipv6 \
+  /proc/sys/kernel/seccomp/actions_avail; do
+  [ -r "$control" ] || fail "Required host kernel control is unavailable: $control"
+done
+[ -r /sys/fs/cgroup/cgroup.controllers ] || [ -w /sys/fs/cgroup ] \
+  || fail "A usable cgroup v1 or v2 hierarchy is required by jailer."
+
+for tool in nft ip sysctl mke2fs debugfs e2fsck rsync docker sha256sum timeout; do
+  command -v "$tool" >/dev/null || fail "Required host tool is missing: $tool"
+done
+command -v sudo >/dev/null || fail "Passwordless sudo is required for jailer and netns setup."
+sudo -n true || fail "Passwordless sudo is required for jailer and netns setup."
+docker info >/dev/null || fail "A host-visible Docker Engine is required."
+docker compose version >/dev/null || fail "Docker Compose v2 is required."
+
+"$ARTIFACT_DIR/firecracker" --version | grep -Fq '1.16.1' \
+  || fail "Firecracker v1.16.1 is required."
+"$ARTIFACT_DIR/jailer" --version | grep -Fq '1.16.1' \
+  || fail "jailer v1.16.1 is required."
+(
+  cd "$ARTIFACT_DIR"
+  sha256sum --check --strict SHA256SUMS
+) || fail "Artifact digest verification failed."
+
+echo "Firecracker host preflight passed on explicitly labeled self-hosted Linux/KVM runner."

--- a/scripts/ci/firecracker-live-smoke.sh
+++ b/scripts/ci/firecracker-live-smoke.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${1:?usage: firecracker-live-smoke.sh ARTIFACT_DIR}
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+RUN_ROOT=${RUNNER_TEMP:-/tmp}/awf-firecracker-live
+SECRET_SENTINEL=awf-firecracker-real-secret-do-not-expose
+
+ARTIFACT_DIR=$(cd "$ARTIFACT_DIR" && pwd)
+rm -rf "$RUN_ROOT"
+mkdir -p "$RUN_ROOT"
+
+digest() {
+  awk -v file="$1" '$2 == file { print $1; exit }' "$ARTIFACT_DIR/SHA256SUMS"
+}
+
+COMMON=(
+  --container-runtime firecracker
+  --firecracker-preview
+  --firecracker-binary "$ARTIFACT_DIR/firecracker"
+  --firecracker-jailer-binary "$ARTIFACT_DIR/jailer"
+  --firecracker-kernel "$ARTIFACT_DIR/vmlinux.bin"
+  --firecracker-rootfs "$ARTIFACT_DIR/rootfs.ext4"
+  --firecracker-supervisor "$ARTIFACT_DIR/awf-firecracker-supervisor"
+  --firecracker-binary-sha256 "$(digest firecracker)"
+  --firecracker-jailer-sha256 "$(digest jailer)"
+  --firecracker-kernel-sha256 "$(digest vmlinux.bin)"
+  --firecracker-rootfs-sha256 "$(digest rootfs.ext4)"
+  --firecracker-supervisor-sha256 "$(digest awf-firecracker-supervisor)"
+  --allow-domains example.com
+  --skip-pull
+  --diagnostic-logs
+)
+
+assert_no_residue() {
+  if sudo ip netns list | grep -q '^awffc-'; then
+    sudo ip netns list >&2
+    echo "Firecracker network namespace residue detected" >&2
+    return 1
+  fi
+  if sudo ip -o link show | grep -Eq ' (fch|fcn|fct)[0-9a-f]{12}[:@]'; then
+    sudo ip -o link show >&2
+    echo "Firecracker veth/TAP residue detected" >&2
+    return 1
+  fi
+}
+
+run_case() {
+  local name=$1
+  local expected=$2
+  local command=$3
+  shift 3
+  local work="$RUN_ROOT/$name/work"
+  local workspace="$RUN_ROOT/$name/workspace"
+  local audit="$RUN_ROOT/$name/audit"
+  local proxy_logs="$RUN_ROOT/$name/proxy-logs"
+  mkdir -p "$work" "$workspace" "$audit" "$proxy_logs"
+  printf 'host-input\n' >"$workspace/input.txt"
+
+  set +e
+  (
+    export GITHUB_WORKSPACE="$workspace"
+    export OPENAI_API_KEY="$SECRET_SENTINEL"
+    sudo -E node "$ROOT/dist/cli.js" \
+      "${COMMON[@]}" \
+      --work-dir "$work" \
+      --audit-dir "$audit" \
+      --proxy-logs-dir "$proxy_logs" \
+      "$@" \
+      -- "$command"
+  ) >"$RUN_ROOT/$name/stdout.log" 2>"$RUN_ROOT/$name/stderr.log"
+  local status=$?
+  set -e
+
+  if [ "$status" -ne "$expected" ]; then
+    echo "case $name: expected exit $expected, got $status" >&2
+    tail -200 "$RUN_ROOT/$name/stderr.log" >&2
+    return 1
+  fi
+  if grep -R --binary-files=without-match -F "$SECRET_SENTINEL" \
+    "$RUN_ROOT/$name/stdout.log" \
+    "$audit" \
+    "$proxy_logs" >/dev/null 2>&1; then
+    echo "case $name: secret sentinel leaked into guest-visible or diagnostic output" >&2
+    return 1
+  fi
+  assert_no_residue
+}
+
+assert_no_residue
+
+run_case allowed-https 0 \
+  'wget -qO- https://example.com | grep -q "Example Domain"'
+run_case blocked-domain 0 \
+  '! wget -qO- https://github.com'
+run_case direct-egress 0 \
+  'unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ! wget -qO- https://example.com'
+run_case arbitrary-tcp 0 \
+  '! nc -z -w 3 1.1.1.1 443'
+run_case dns-denial 0 \
+  '! nslookup example.com 8.8.8.8'
+run_case metadata-denial 0 \
+  'unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ! wget -T 3 -qO- http://169.254.169.254/latest/meta-data/'
+run_case api-proxy-reflect 0 \
+  'wget -qO /tmp/reflect http://172.30.0.30:10000/reflect && grep -q "providers" /tmp/reflect && ! env | grep -F "awf-firecracker-real-secret-do-not-expose"'
+
+run_case workspace-copyback 0 \
+  'printf changed > .hidden && mkdir -p bin && printf "#!/bin/sh\necho ok\n" > bin/run && chmod 755 bin/run && ln -s bin/run run-link'
+test "$(cat "$RUN_ROOT/workspace-copyback/workspace/.hidden")" = changed
+test -x "$RUN_ROOT/workspace-copyback/workspace/bin/run"
+test "$(readlink "$RUN_ROOT/workspace-copyback/workspace/run-link")" = bin/run
+
+run_case exit-code 37 'exit 37'
+run_case timeout-124 124 'sleep 90' --agent-timeout 1
+
+corrupt="$RUN_ROOT/corrupt-rootfs.ext4"
+printf 'not-an-ext4-image\n' >"$corrupt"
+corrupt_digest=$(sha256sum "$corrupt" | awk '{print $1}')
+run_case partial-start-cleanup 1 'true' \
+  --firecracker-rootfs "$corrupt" \
+  --firecracker-rootfs-sha256 "$corrupt_digest" \
+  --firecracker-api-timeout-ms 3000
+
+cancel_work="$RUN_ROOT/cancellation/work"
+cancel_workspace="$RUN_ROOT/cancellation/workspace"
+cancel_audit="$RUN_ROOT/cancellation/audit"
+mkdir -p "$cancel_work" "$cancel_workspace" "$cancel_audit"
+(
+  export GITHUB_WORKSPACE="$cancel_workspace"
+  export OPENAI_API_KEY="$SECRET_SENTINEL"
+  exec sudo -E node "$ROOT/dist/cli.js" \
+    "${COMMON[@]}" \
+    --work-dir "$cancel_work" \
+    --audit-dir "$cancel_audit" \
+    -- 'sleep 300'
+) >"$RUN_ROOT/cancellation/stdout.log" 2>"$RUN_ROOT/cancellation/stderr.log" &
+cancel_pid=$!
+for _ in $(seq 1 60); do
+  sudo ip netns list | grep -q '^awffc-' && break
+  sleep 1
+done
+kill -TERM "$cancel_pid"
+set +e
+wait "$cancel_pid"
+cancel_status=$?
+set -e
+[ "$cancel_status" -eq 143 ] || {
+  echo "cancellation: expected exit 143, got $cancel_status" >&2
+  exit 1
+}
+assert_no_residue
+
+keep_work="$RUN_ROOT/keep/work"
+keep_workspace="$RUN_ROOT/keep/workspace"
+keep_audit="$RUN_ROOT/keep/audit"
+mkdir -p "$keep_work" "$keep_workspace" "$keep_audit"
+(
+  export GITHUB_WORKSPACE="$keep_workspace"
+  export OPENAI_API_KEY="$SECRET_SENTINEL"
+  sudo -E node "$ROOT/dist/cli.js" \
+    "${COMMON[@]}" \
+    --keep-containers \
+    --work-dir "$keep_work" \
+    --audit-dir "$keep_audit" \
+    -- 'true'
+) >"$RUN_ROOT/keep/stdout.log" 2>"$RUN_ROOT/keep/stderr.log"
+sudo ip netns list | grep -q '^awffc-' || {
+  echo "keep mode did not preserve the run network namespace" >&2
+  exit 1
+}
+test -d "$keep_work/firecracker-jailer"
+test -f "$keep_audit/firecracker/network-plan.json"
+test -f "$keep_audit/firecracker/firecracker.log"
+test -f "$keep_audit/firecracker/firecracker.metrics.jsonl"
+find "$keep_audit/firecracker" -type f -size +1048576c -print -quit \
+  | grep -q . && {
+    echo "Firecracker diagnostic artifact exceeded the 1 MiB bound" >&2
+    exit 1
+  }
+
+while read -r namespace _; do
+  case "$namespace" in
+    awffc-*) sudo ip netns delete "$namespace" ;;
+  esac
+done < <(sudo ip netns list)
+sudo docker compose -f "$keep_work/docker-compose.yml" down --volumes --remove-orphans
+assert_no_residue
+
+echo "Firecracker live smoke/security suite passed."

--- a/src/commands/main-action.test.ts
+++ b/src/commands/main-action.test.ts
@@ -470,7 +470,11 @@ describe('createMainAction', () => {
         preserve,
       };
       const cleanup = testHelpers.buildCleanupFn(
-        { ...MAIN_ACTION_STUB_CONFIG, keepContainers: true },
+        {
+          ...MAIN_ACTION_STUB_CONFIG,
+          keepContainers: true,
+          diagnosticLogs: true,
+        },
         () => false,
         () => false,
         backend,
@@ -478,6 +482,7 @@ describe('createMainAction', () => {
 
       await cleanup();
 
+      expect(backend.collectDiagnostics).toHaveBeenCalledTimes(1);
       expect(preserve).toHaveBeenCalledTimes(1);
       expect(backend.stop).not.toHaveBeenCalled();
     });
@@ -495,17 +500,61 @@ describe('createMainAction', () => {
         stop: jest.fn().mockRejectedValue(runtimeError),
       };
       const cleanup = testHelpers.buildCleanupFn(
-        { ...MAIN_ACTION_STUB_CONFIG, keepContainers: false },
+        {
+          ...MAIN_ACTION_STUB_CONFIG,
+          keepContainers: false,
+          diagnosticLogs: true,
+        },
         () => false,
         () => false,
         backend,
       );
 
       await expect(cleanup()).rejects.toBe(runtimeError);
+      expect(backend.collectDiagnostics).toHaveBeenCalledTimes(1);
       expect(mockedDockerManager.cleanup).toHaveBeenCalled();
       expect(mockedLogger.warn).toHaveBeenCalledWith(
         'External runtime cleanup failed; continuing with infrastructure teardown.',
         runtimeError,
+      );
+    });
+  });
+
+  describe('external runtime diagnostics', () => {
+    it('aggregates backend and Docker diagnostics with explicit failures', async () => {
+      const backend = {
+        runtime: 'firecracker',
+        preflight: jest.fn().mockResolvedValue(undefined),
+        start: jest.fn(),
+        exec: jest.fn(),
+        collectDiagnostics: jest.fn().mockResolvedValue(undefined),
+        stop: jest.fn(),
+      };
+      let collectDiagnostics!: (workDir: string) => Promise<void>;
+      mockedExternalRuntimeResolver.resolveExternalRuntimeBackend
+        .mockReturnValueOnce(backend);
+      mockedCliWorkflow.runMainWorkflow.mockImplementationOnce(
+        async (_config, dependencies) => {
+          collectDiagnostics = dependencies.collectDiagnosticLogs!;
+          return 0;
+        },
+      );
+
+      const action = createMainAction(getOptionValueSource);
+      await action(['echo hi'], {});
+      await expect(collectDiagnostics('/tmp/awf')).resolves.toBeUndefined();
+      expect(backend.collectDiagnostics).toHaveBeenCalledTimes(1);
+      expect(mockedDockerManager.collectDiagnosticLogs)
+        .toHaveBeenCalledWith('/tmp/awf');
+
+      backend.collectDiagnostics.mockRejectedValueOnce(
+        new Error('backend diagnostics failed'),
+      );
+      mockedDockerManager.collectDiagnosticLogs.mockRejectedValueOnce(
+        'docker diagnostics failed',
+      );
+      await expect(collectDiagnostics('/tmp/awf')).rejects.toThrow(
+        /backend diagnostics failed; docker diagnostics failed/,
       );
     });
   });

--- a/src/commands/main-action.ts
+++ b/src/commands/main-action.ts
@@ -106,6 +106,9 @@ function buildCleanupFn(
 
     if (externalRuntimeBackend) {
       try {
+        if (config.diagnosticLogs) {
+          await externalRuntimeBackend.collectDiagnostics();
+        }
         if (config.keepContainers && externalRuntimeBackend.preserve) {
           await externalRuntimeBackend.preserve();
         } else if (!config.keepContainers) {
@@ -336,6 +339,26 @@ export function createMainAction(getOptionValueSource: OptionSourceResolver) {
     const workflowRunAgentCommand = externalWorkflowDependencies?.runAgentCommand
       ?? ((workDir: string, allowedDomains: string[], proxyLogsDir?: string, agentTimeoutMinutes?: number) =>
         runAgentCommand(workDir, allowedDomains, proxyLogsDir, agentTimeoutMinutes, config.containerRuntime));
+    const workflowCollectDiagnosticLogs = externalRuntimeBackend
+      ? async (workDir: string): Promise<void> => {
+         const results = await Promise.allSettled([
+           externalRuntimeBackend.collectDiagnostics(),
+           collectDiagnosticLogs(workDir),
+         ]);
+         const failures = results.filter(
+           (result): result is PromiseRejectedResult => result.status === 'rejected',
+         );
+         if (failures.length > 0) {
+           throw new Error(
+             failures.map((failure) => (
+               failure.reason instanceof Error
+                 ? failure.reason.message
+                 : String(failure.reason)
+             )).join('; '),
+           );
+         }
+        }
+      : collectDiagnosticLogs;
 
     exitCode = await runMainWorkflow(
       config,
@@ -345,7 +368,7 @@ export function createMainAction(getOptionValueSource: OptionSourceResolver) {
         writeConfigs,
         startContainers: externalWorkflowDependencies?.startContainers ?? startContainers,
         runAgentCommand: workflowRunAgentCommand,
-        collectDiagnosticLogs,
+        collectDiagnosticLogs: workflowCollectDiagnosticLogs,
         assertTopologySupported,
         connectTopologyContainers,
         connectEnclaveGateway,

--- a/src/firecracker-runtime-backend.test.ts
+++ b/src/firecracker-runtime-backend.test.ts
@@ -75,6 +75,7 @@ const preflightResult = {
   kernelPath: '/opt/kernel',
   rootfsPath: '/opt/rootfs',
   supervisorPath: '/opt/supervisor',
+  cgroupVersion: 2 as const,
   tools: {
     ip: '/usr/bin/ip',
     nft: '/usr/sbin/nft',
@@ -109,6 +110,7 @@ function harness(overrides: Partial<FirecrackerRuntimeBackendDependencies> = {})
     cancel: jest.fn().mockResolvedValue(undefined),
     writeStdin: jest.fn().mockResolvedValue(undefined),
     endStdin: jest.fn().mockResolvedValue(undefined),
+    collectDiagnostics: jest.fn().mockResolvedValue(undefined),
     stop: jest.fn(async () => { order.push('vm-stop'); }),
   };
   const infra = infrastructure();
@@ -187,7 +189,7 @@ describe('Firecracker runtime backend', () => {
       'vm-stop',
     ]);
     expect(manager.execute).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      argv: ['/bin/bash', '-lc', 'printf hello'],
+      argv: ['/bin/sh', '-lc', 'printf hello'],
       cwd: '/workspace',
       uid: 1000,
       gid: 1000,

--- a/src/firecracker-runtime-backend.ts
+++ b/src/firecracker-runtime-backend.ts
@@ -54,6 +54,7 @@ interface FirecrackerManagerAdapter {
   writeStdin(data: Buffer, requestId?: string): Promise<void>;
   endStdin(requestId?: string): Promise<void>;
   stop(options?: { preserve?: boolean }): Promise<void>;
+  collectDiagnostics(directory: string): Promise<void>;
 }
 
 export interface FirecrackerRuntimeBackendDependencies {
@@ -162,33 +163,41 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
     onNetworkReady,
     onInfrastructureReady,
   ) => {
-    await this.preflight();
-    await this.dependencies.startInfrastructure(
-      workDir,
-      allowedDomains,
-      proxyLogsDir,
-      skipPull,
-      onNetworkReady,
-      onInfrastructureReady,
+    let stage = 'preflight';
+    this.dependencies.logger.info(
+      '[firecracker] runtime=firecracker maturity=preview fallback=disabled',
     );
-
-    const firecracker = requireFirecrackerConfig(this.config);
-    const infrastructure = await this.dependencies.resolveInfrastructure(
-      Boolean(this.config.enableApiProxy),
-      this.preflightResult?.tools.ip,
-    );
-    this.identity = this.dependencies.identity();
-    this.manager = this.dependencies.createManager(
-      firecracker,
-      workDir,
-      infrastructure,
-      this.dependencies.workspacePath(),
-      this.dependencies.homePath(),
-      this.identity,
-    );
-
     try {
+      await this.preflight();
+      stage = 'compose-infrastructure';
+      await this.dependencies.startInfrastructure(
+        workDir,
+        allowedDomains,
+        proxyLogsDir,
+        skipPull,
+        onNetworkReady,
+        onInfrastructureReady,
+      );
+
+      stage = 'infrastructure-discovery';
+      const firecracker = requireFirecrackerConfig(this.config);
+      const infrastructure = await this.dependencies.resolveInfrastructure(
+        Boolean(this.config.enableApiProxy),
+        this.preflightResult?.tools.ip,
+      );
+      this.identity = this.dependencies.identity();
+      this.manager = this.dependencies.createManager(
+        firecracker,
+        workDir,
+        infrastructure,
+        this.dependencies.workspacePath(),
+        this.dependencies.homePath(),
+        this.identity,
+      );
+
+      stage = 'topology-revalidation';
       await infrastructure.revalidate();
+      stage = 'jailer-configuration';
       await this.manager.start();
       if (!this.manager.guestIp) {
         throw new Error('Firecracker manager did not expose the configured guest IP');
@@ -198,11 +207,17 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
         infrastructure,
         this.manager.guestIp,
       );
+      stage = 'guest-boot';
       await this.manager.startInstance();
+      stage = 'guest-connectivity';
       await this.probeGuestConnectivity();
+      this.dependencies.logger.info('[firecracker] stage=ready');
     } catch (error) {
+      this.dependencies.logger.warn(
+        `[firecracker] stage=${stage} status=failed: ${formatError(error)}`,
+      );
       try {
-        await this.manager.stop();
+        await this.manager?.stop();
       } catch (cleanupError) {
         const combined = new Error(
           `Firecracker startup failed: ${formatError(error)}; ` +
@@ -240,7 +255,7 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
       : agentTimeoutMinutes * 60_000;
     const execution = manager.execute({
       requestId,
-      argv: ['/bin/bash', '-lc', this.config.agentCommand],
+      argv: ['/bin/sh', '-lc', this.config.agentCommand],
       env: environment,
       cwd: FIRECRACKER_GUEST_WORKSPACE,
       ...identity,
@@ -289,7 +304,13 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
     }
   };
 
-  async collectDiagnostics(): Promise<void> {}
+  async collectDiagnostics(): Promise<void> {
+    if (!this.manager) return;
+    const directory = this.config.auditDir
+      ? `${this.config.auditDir}/firecracker`
+      : `${this.config.workDir}/diagnostics/firecracker`;
+    await this.manager.collectDiagnostics(directory);
+  }
 
   async stop(): Promise<void> {
     if (this.stopped) return;

--- a/src/firecracker/api-client.test.ts
+++ b/src/firecracker/api-client.test.ts
@@ -64,6 +64,15 @@ describe('FirecrackerApiClient', () => {
       host_dev_name: 'fct123456789012',
       guest_mac: '02:00:00:00:00:01',
     });
+    await client.putLogger({
+      log_path: '/run/firecracker.log',
+      level: 'Info',
+      show_level: true,
+    });
+    await client.putMetrics({
+      metrics_path: '/run/firecracker.metrics.jsonl',
+    });
+    await client.putAction('FlushMetrics');
     await client.instanceStart();
 
     expect(received).toEqual([
@@ -90,6 +99,27 @@ describe('FirecrackerApiClient', () => {
           host_dev_name: 'fct123456789012',
           guest_mac: '02:00:00:00:00:01',
         }),
+      },
+      {
+        method: 'PUT',
+        url: '/logger',
+        body: JSON.stringify({
+          log_path: '/run/firecracker.log',
+          level: 'Info',
+          show_level: true,
+        }),
+      },
+      {
+        method: 'PUT',
+        url: '/metrics',
+        body: JSON.stringify({
+          metrics_path: '/run/firecracker.metrics.jsonl',
+        }),
+      },
+      {
+        method: 'PUT',
+        url: '/actions',
+        body: JSON.stringify({ action_type: 'FlushMetrics' }),
       },
       {
         method: 'PUT',

--- a/src/firecracker/api-client.ts
+++ b/src/firecracker/api-client.ts
@@ -41,6 +41,17 @@ export interface FirecrackerNetworkInterface {
   tx_rate_limiter?: FirecrackerRateLimiter;
 }
 
+export interface FirecrackerLoggerConfig {
+  log_path: string;
+  level?: 'Error' | 'Warning' | 'Info' | 'Debug' | 'Trace';
+  show_level?: boolean;
+  show_log_origin?: boolean;
+}
+
+export interface FirecrackerMetricsConfig {
+  metrics_path: string;
+}
+
 export type FirecrackerActionType =
   | 'InstanceStart'
   | 'SendCtrlAltDel'
@@ -109,6 +120,14 @@ export class FirecrackerApiClient {
       `/network-interfaces/${encodeURIComponent(networkInterface.iface_id)}`,
       networkInterface,
     );
+  }
+
+  putLogger(config: FirecrackerLoggerConfig): Promise<void> {
+    return this.request('PUT', '/logger', config);
+  }
+
+  putMetrics(config: FirecrackerMetricsConfig): Promise<void> {
+    return this.request('PUT', '/metrics', config);
   }
 
   instanceStart(): Promise<void> {

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -83,6 +83,9 @@ function dependencies(
     putDrive: jest.fn().mockResolvedValue(undefined),
     putVsock: jest.fn().mockResolvedValue(undefined),
     putNetworkInterface: jest.fn().mockResolvedValue(undefined),
+    putLogger: jest.fn().mockResolvedValue(undefined),
+    putMetrics: jest.fn().mockResolvedValue(undefined),
+    putAction: jest.fn().mockResolvedValue(undefined),
     instanceStart: jest.fn().mockResolvedValue(undefined),
   } as unknown as FirecrackerApiClient;
   return {
@@ -93,12 +96,16 @@ function dependencies(
       kernelPath: '/opt/vmlinux',
       rootfsPath: '/opt/rootfs.ext4',
       tools: hostTools,
+      supervisorPath: '/opt/awf-supervisor',
+      cgroupVersion: 2,
     }),
     launch: jest.fn().mockReturnValue(processMock()),
     mkdir: jest.fn().mockResolvedValue(undefined),
     copyFile: jest.fn().mockResolvedValue(undefined),
     chmod: jest.fn().mockResolvedValue(undefined),
     chown: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    readFile: jest.fn().mockResolvedValue(Buffer.alloc(0)),
     access: jest.fn().mockResolvedValue(undefined),
     rm: jest.fn().mockResolvedValue(undefined),
     sleep: jest.fn().mockResolvedValue(undefined),
@@ -663,6 +670,9 @@ describe('FirecrackerManager', () => {
       putMachineConfig: jest.fn().mockResolvedValue(undefined),
       putBootSource: jest.fn().mockResolvedValue(undefined),
       putDrive: jest.fn().mockResolvedValue(undefined),
+      putLogger: jest.fn().mockResolvedValue(undefined),
+      putMetrics: jest.fn().mockResolvedValue(undefined),
+      putAction: jest.fn().mockResolvedValue(undefined),
       putNetworkInterface: jest.fn().mockRejectedValue(new Error('invalid NIC')),
     } as unknown as FirecrackerApiClient;
     const deps = dependencies({
@@ -705,5 +715,30 @@ describe('FirecrackerManager', () => {
       /exited before API readiness with code null and signal SIGKILL/,
     );
     expect(deps.sleep).not.toHaveBeenCalled();
+  });
+
+  it('flushes metrics and bounds diagnostic files before persistence', async () => {
+    const oversized = Buffer.alloc(1024 * 1024 + 128, 0x61);
+    const deps = dependencies({
+      readFile: jest.fn().mockResolvedValue(oversized),
+    });
+    const manager = new FirecrackerManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'diagnostics',
+      networkConfig(),
+    );
+
+    const client = await manager.start();
+    await manager.startInstance();
+    await manager.collectDiagnostics('/tmp/diagnostics');
+
+    expect(client.putAction).toHaveBeenCalledWith('FlushMetrics');
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/firecracker.metrics.jsonl',
+      expect.objectContaining({ length: 1024 * 1024 }),
+      { mode: 0o600 },
+    );
   });
 });

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -106,7 +106,7 @@ function dependencies(
     chmod: jest.fn().mockResolvedValue(undefined),
     chown: jest.fn().mockResolvedValue(undefined),
     writeFile: jest.fn().mockResolvedValue(undefined),
-    readFile: jest.fn().mockResolvedValue(Buffer.alloc(0)),
+    readFileTail: jest.fn().mockResolvedValue(Buffer.alloc(0)),
     access: jest.fn().mockResolvedValue(undefined),
     rm: jest.fn().mockResolvedValue(undefined),
     sleep: jest.fn().mockResolvedValue(undefined),
@@ -742,7 +742,9 @@ describe('FirecrackerManager', () => {
     Object.assign(child, { stdout, stderr });
     const deps = dependencies({
       launch: jest.fn().mockReturnValue(child),
-      readFile: jest.fn().mockResolvedValue(oversized),
+      readFileTail: jest.fn().mockImplementation((_source: string, maxBytes: number) =>
+        Promise.resolve(oversized.subarray(oversized.length - maxBytes)),
+      ),
     });
     const manager = new FirecrackerManager(
       config(),

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -1,4 +1,5 @@
 import type { ExecaChildProcess } from 'execa';
+import { PassThrough } from 'stream';
 import type { FirecrackerOptions } from '../types/runtime-options';
 import type { FirecrackerApiClient } from './api-client';
 import {
@@ -735,7 +736,12 @@ describe('FirecrackerManager', () => {
 
   it('flushes metrics and bounds diagnostic files before persistence', async () => {
     const oversized = Buffer.alloc(1024 * 1024 + 128, 0x61);
+    const child = processMock();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    Object.assign(child, { stdout, stderr });
     const deps = dependencies({
+      launch: jest.fn().mockReturnValue(child),
       readFile: jest.fn().mockResolvedValue(oversized),
     });
     const manager = new FirecrackerManager(
@@ -747,6 +753,8 @@ describe('FirecrackerManager', () => {
     );
 
     const client = await manager.start();
+    stdout.write(oversized);
+    stderr.write('jailer error');
     await manager.startInstance();
     await manager.collectDiagnostics('/tmp/diagnostics');
 
@@ -754,6 +762,16 @@ describe('FirecrackerManager', () => {
     expect(deps.writeFile).toHaveBeenCalledWith(
       '/tmp/diagnostics/firecracker.metrics.jsonl',
       expect.objectContaining({ length: 1024 * 1024 }),
+      { mode: 0o600 },
+    );
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/jailer-stdout.log',
+      expect.objectContaining({ length: 1024 * 1024 }),
+      { mode: 0o600 },
+    );
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/jailer-stderr.log',
+      Buffer.from('jailer error'),
       { mode: 0o600 },
     );
   });

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -151,6 +151,23 @@ describe('FirecrackerManager', () => {
     });
     delete process.env.SUDO_UID;
     delete process.env.SUDO_GID;
+    const uidSpy = jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const gidSpy = jest.spyOn(process, 'getgid').mockReturnValue(0);
+    const originalSudoUid = process.env.SUDO_UID;
+    const originalSudoGid = process.env.SUDO_GID;
+    delete process.env.SUDO_UID;
+    delete process.env.SUDO_GID;
+    try {
+      expect(firecrackerManagerTestHelpers.resolveJailerIdentity)
+        .toThrow(/non-root target uid\/gid/);
+    } finally {
+      uidSpy.mockRestore();
+      gidSpy.mockRestore();
+      if (originalSudoUid === undefined) delete process.env.SUDO_UID;
+      else process.env.SUDO_UID = originalSudoUid;
+      if (originalSudoGid === undefined) delete process.env.SUDO_GID;
+      else process.env.SUDO_GID = originalSudoGid;
+    }
   });
 
   it('constructs unique, contained jail paths', () => {

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -143,21 +143,20 @@ describe('FirecrackerManager', () => {
     }, hostTools)).toBeDefined();
     expect(defaults.createVsockClient('/tmp/vsock.socket', 52, 100)).toBeDefined();
 
-    process.env.SUDO_UID = '2001';
-    process.env.SUDO_GID = '2002';
-    expect(firecrackerManagerTestHelpers.resolveJailerIdentity()).toEqual({
-      uid: 2001,
-      gid: 2002,
-    });
-    delete process.env.SUDO_UID;
-    delete process.env.SUDO_GID;
-    const uidSpy = jest.spyOn(process, 'getuid').mockReturnValue(0);
-    const gidSpy = jest.spyOn(process, 'getgid').mockReturnValue(0);
     const originalSudoUid = process.env.SUDO_UID;
     const originalSudoGid = process.env.SUDO_GID;
-    delete process.env.SUDO_UID;
-    delete process.env.SUDO_GID;
+    const uidSpy = jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const gidSpy = jest.spyOn(process, 'getgid').mockReturnValue(0);
     try {
+      process.env.SUDO_UID = '2001';
+      process.env.SUDO_GID = '2002';
+      expect(firecrackerManagerTestHelpers.resolveJailerIdentity()).toEqual({
+        uid: 2001,
+        gid: 2002,
+      });
+
+      delete process.env.SUDO_UID;
+      delete process.env.SUDO_GID;
       expect(firecrackerManagerTestHelpers.resolveJailerIdentity)
         .toThrow(/non-root target uid\/gid/);
     } finally {

--- a/src/firecracker/manager.ts
+++ b/src/firecracker/manager.ts
@@ -71,7 +71,7 @@ export interface FirecrackerManagerDependencies {
   chmod(filePath: string, mode: number): Promise<void>;
   chown(filePath: string, uid: number, gid: number): Promise<void>;
   writeFile: typeof fs.writeFile;
-  readFile: typeof fs.readFile;
+  readFileTail(filePath: string, maxBytes: number): Promise<Buffer>;
   access(filePath: string): Promise<void>;
   rm(directory: string, options: { recursive: true; force: true }): Promise<void>;
   sleep(milliseconds: number): Promise<void>;
@@ -98,6 +98,21 @@ export interface FirecrackerManagerGuestConfig {
   readonly identity?: { uid: number; gid: number };
 }
 
+async function readBoundedTail(filePath: string, maxBytes: number): Promise<Buffer> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const { size } = await handle.stat();
+    const length = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(length);
+    if (length > 0) {
+      await handle.read(buffer, 0, length, size - length);
+    }
+    return buffer;
+  } finally {
+    await handle.close();
+  }
+}
+
 const defaultDependencies: FirecrackerManagerDependencies = {
   preflight: runFirecrackerPreflight,
   launch: (command, args, options) => execa(command, args, options),
@@ -106,7 +121,7 @@ const defaultDependencies: FirecrackerManagerDependencies = {
   chmod: fs.chmod,
   chown: fs.chown,
   writeFile: fs.writeFile,
-  readFile: fs.readFile,
+  readFileTail: (filePath, maxBytes) => readBoundedTail(filePath, maxBytes),
   access: fs.access,
   rm: fs.rm,
   sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
@@ -629,10 +644,7 @@ export class FirecrackerManager {
 
   private async copyBoundedDiagnostic(source: string, destination: string): Promise<void> {
     try {
-      const contents = await this.dependencies.readFile(source);
-      const bounded = contents.length <= FIRECRACKER_CAPTURE_LIMIT_BYTES
-        ? contents
-        : contents.subarray(contents.length - FIRECRACKER_CAPTURE_LIMIT_BYTES);
+      const bounded = await this.dependencies.readFileTail(source, FIRECRACKER_CAPTURE_LIMIT_BYTES);
       await this.dependencies.writeFile(destination, bounded, { mode: 0o600 });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;

--- a/src/firecracker/manager.ts
+++ b/src/firecracker/manager.ts
@@ -2,7 +2,11 @@ import { randomBytes } from 'crypto';
 import { constants, promises as fs } from 'fs';
 import * as path from 'path';
 import execa, { type ExecaChildProcess } from 'execa';
-import type { FirecrackerOptions } from '../types/runtime-options';
+import {
+  FIRECRACKER_RELEASE_VERSION,
+  type FirecrackerOptions,
+} from '../types/runtime-options';
+import { getSafeHostGid, getSafeHostUid } from '../host-identity';
 import { FirecrackerApiClient } from './api-client';
 import {
   FirecrackerLinuxNetworkCommands,
@@ -28,6 +32,9 @@ import {
 const API_SOCKET_NAME = 'firecracker.socket';
 const VSOCK_SOCKET_NAME = 'awf-vsock.socket';
 const WORKSPACE_IMAGE_NAME = 'workspace.ext4';
+const FIRECRACKER_LOG_NAME = 'firecracker.log';
+const FIRECRACKER_METRICS_NAME = 'firecracker.metrics.jsonl';
+const FIRECRACKER_CAPTURE_LIMIT_BYTES = 1024 * 1024;
 const KERNEL_JAIL_PATH = '/kernel';
 const ROOTFS_JAIL_PATH = '/rootfs';
 const WORKSPACE_JAIL_PATH = '/workspace.ext4';
@@ -44,6 +51,8 @@ export interface FirecrackerRunPaths {
   rootfsPath: string;
   workspacePath: string;
   vsockSocketPath: string;
+  logPath: string;
+  metricsPath: string;
 }
 
 export interface FirecrackerManagerDependencies {
@@ -61,6 +70,8 @@ export interface FirecrackerManagerDependencies {
   copyFile(source: string, destination: string, flags: number): Promise<void>;
   chmod(filePath: string, mode: number): Promise<void>;
   chown(filePath: string, uid: number, gid: number): Promise<void>;
+  writeFile: typeof fs.writeFile;
+  readFile: typeof fs.readFile;
   access(filePath: string): Promise<void>;
   rm(directory: string, options: { recursive: true; force: true }): Promise<void>;
   sleep(milliseconds: number): Promise<void>;
@@ -94,6 +105,8 @@ const defaultDependencies: FirecrackerManagerDependencies = {
   copyFile: fs.copyFile,
   chmod: fs.chmod,
   chown: fs.chown,
+  writeFile: fs.writeFile,
+  readFile: fs.readFile,
   access: fs.access,
   rm: fs.rm,
   sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
@@ -125,8 +138,8 @@ function parsePositiveIdentity(value: string | undefined): number | undefined {
 }
 
 function resolveJailerIdentity(): { uid: number; gid: number } {
-  const uid = parsePositiveIdentity(process.env.SUDO_UID) ?? process.getuid?.();
-  const gid = parsePositiveIdentity(process.env.SUDO_GID) ?? process.getgid?.();
+  const uid = Number(getSafeHostUid());
+  const gid = Number(getSafeHostGid());
   if (uid === undefined || gid === undefined || uid === 0 || gid === 0) {
     throw new Error(
       'Firecracker jailer requires a non-root target uid/gid; run through sudo from a non-root account',
@@ -157,6 +170,8 @@ export function createFirecrackerRunPaths(
     rootfsPath: path.join(jailRoot, ROOTFS_JAIL_PATH),
     workspacePath: path.join(jailRoot, WORKSPACE_IMAGE_NAME),
     vsockSocketPath: path.join(jailRoot, 'run', VSOCK_SOCKET_NAME),
+    logPath: path.join(jailRoot, 'run', FIRECRACKER_LOG_NAME),
+    metricsPath: path.join(jailRoot, 'run', FIRECRACKER_METRICS_NAME),
   };
 }
 
@@ -172,6 +187,8 @@ export class FirecrackerManager {
   private guestClient: FirecrackerVsockClient | undefined;
   private networkPlan: FirecrackerNetworkPlan | undefined;
   private instanceStarted = false;
+  private readonly stdoutCapture = new BoundedOutputCapture(FIRECRACKER_CAPTURE_LIMIT_BYTES);
+  private readonly stderrCapture = new BoundedOutputCapture(FIRECRACKER_CAPTURE_LIMIT_BYTES);
 
   get guestIp(): string | undefined {
     return this.networkPlan?.guestIp;
@@ -246,6 +263,7 @@ export class FirecrackerManager {
           '--gid', String(identity.gid),
           '--chroot-base-dir', this.paths.chrootBaseDir,
           '--netns', networkPlan.netnsPath,
+          '--cgroup-version', String(artifacts.cgroupVersion),
           '--',
           '--api-sock', `/run/${API_SOCKET_NAME}`,
         ],
@@ -255,6 +273,12 @@ export class FirecrackerManager {
           env: { ...process.env },
         },
       );
+      this.process.stdout?.on('data', (chunk: Buffer | string) => {
+        this.stdoutCapture.append(chunk);
+      });
+      this.process.stderr?.on('data', (chunk: Buffer | string) => {
+        this.stderrCapture.append(chunk);
+      });
 
       await this.waitForApiSocket();
       await this.stageArtifact(artifacts.kernelPath, this.paths.kernelPath, 0o400, identity);
@@ -267,6 +291,17 @@ export class FirecrackerManager {
         this.paths.apiSocketPath,
         this.config.apiTimeoutMs,
       );
+      await this.stageDiagnosticFile(this.paths.logPath, identity);
+      await this.stageDiagnosticFile(this.paths.metricsPath, identity);
+      await this.client.putLogger({
+        log_path: `/run/${FIRECRACKER_LOG_NAME}`,
+        level: 'Info',
+        show_level: true,
+        show_log_origin: true,
+      });
+      await this.client.putMetrics({
+        metrics_path: `/run/${FIRECRACKER_METRICS_NAME}`,
+      });
       await this.client.putMachineConfig({
         vcpu_count: this.config.vcpuCount,
         mem_size_mib: this.config.memoryMib,
@@ -498,6 +533,45 @@ export class FirecrackerManager {
     return child.exitCode !== null || child.signalCode !== null;
   }
 
+  async collectDiagnostics(directory: string): Promise<void> {
+    await this.dependencies.mkdir(directory, { recursive: true, mode: 0o700 });
+    if (this.client && this.instanceStarted) {
+      await this.client.putAction('FlushMetrics');
+      await this.dependencies.sleep(25);
+    }
+    const writeBounded = async (fileName: string, contents: Buffer): Promise<void> => {
+      const destination = path.join(directory, fileName);
+      await this.dependencies.writeFile(destination, contents, { mode: 0o600 });
+    };
+    await writeBounded('jailer-stdout.log', this.stdoutCapture.contents());
+    await writeBounded('jailer-stderr.log', this.stderrCapture.contents());
+    await this.copyBoundedDiagnostic(
+      this.paths.logPath,
+      path.join(directory, FIRECRACKER_LOG_NAME),
+    );
+    await this.copyBoundedDiagnostic(
+      this.paths.metricsPath,
+      path.join(directory, FIRECRACKER_METRICS_NAME),
+    );
+    await this.dependencies.writeFile(
+      path.join(directory, 'network-plan.json'),
+      `${JSON.stringify(this.networkPlan ?? null, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+    await this.dependencies.writeFile(
+      path.join(directory, 'runtime.json'),
+      `${JSON.stringify({
+        runtime: 'firecracker',
+        version: FIRECRACKER_RELEASE_VERSION,
+        runId: this.paths.runId,
+        vcpuCount: this.config.vcpuCount,
+        memoryMib: this.config.memoryMib,
+        instanceStarted: this.instanceStarted,
+      }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+  }
+
   private async waitForApiSocket(): Promise<void> {
     const deadline = Date.now() + this.config.apiTimeoutMs;
     while (Date.now() < deadline) {
@@ -532,6 +606,26 @@ export class FirecrackerManager {
     await this.dependencies.chown(destination, identity.uid, identity.gid);
     await this.dependencies.chmod(destination, mode);
   }
+
+  private async stageDiagnosticFile(
+    destination: string,
+    identity: { uid: number; gid: number },
+  ): Promise<void> {
+    await this.dependencies.writeFile(destination, '', { flag: 'wx', mode: 0o600 });
+    await this.dependencies.chown(destination, identity.uid, identity.gid);
+  }
+
+  private async copyBoundedDiagnostic(source: string, destination: string): Promise<void> {
+    try {
+      const contents = await this.dependencies.readFile(source);
+      const bounded = contents.length <= FIRECRACKER_CAPTURE_LIMIT_BYTES
+        ? contents
+        : contents.subarray(contents.length - FIRECRACKER_CAPTURE_LIMIT_BYTES);
+      await this.dependencies.writeFile(destination, bounded, { mode: 0o600 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
 }
 
 export function buildSupervisorBootArgs(
@@ -560,4 +654,22 @@ export function buildSupervisorBootArgs(
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+class BoundedOutputCapture {
+  private buffer = Buffer.alloc(0);
+
+  constructor(private readonly maximumBytes: number) {}
+
+  append(chunk: Buffer | string): void {
+    const next = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.buffer = Buffer.concat([this.buffer, next]);
+    if (this.buffer.length > this.maximumBytes) {
+      this.buffer = this.buffer.subarray(this.buffer.length - this.maximumBytes);
+    }
+  }
+
+  contents(): Buffer {
+    return this.buffer;
+  }
 }

--- a/src/firecracker/manager.ts
+++ b/src/firecracker/manager.ts
@@ -132,20 +132,32 @@ export const firecrackerManagerTestHelpers = {
   resolveJailerIdentity,
 };
 
-function parsePositiveIdentity(value: string | undefined): number | undefined {
-  if (!value || !/^[1-9]\d*$/.test(value)) return undefined;
-  return Number(value);
-}
-
 function resolveJailerIdentity(): { uid: number; gid: number } {
+  const operatorUid = parsePositiveIdentity(process.env.SUDO_UID) ?? process.getuid?.();
+  const operatorGid = parsePositiveIdentity(process.env.SUDO_GID) ?? process.getgid?.();
+  if (
+    operatorUid === undefined ||
+    operatorGid === undefined ||
+    operatorUid === 0 ||
+    operatorGid === 0
+  ) {
+    throw new Error(
+      'Firecracker jailer requires a non-root target uid/gid; run through sudo from a non-root account',
+    );
+  }
   const uid = Number(getSafeHostUid());
   const gid = Number(getSafeHostGid());
-  if (uid === undefined || gid === undefined || uid === 0 || gid === 0) {
+  if (!Number.isSafeInteger(uid) || !Number.isSafeInteger(gid) || uid < 1 || gid < 1) {
     throw new Error(
       'Firecracker jailer requires a non-root target uid/gid; run through sudo from a non-root account',
     );
   }
   return { uid, gid };
+}
+
+function parsePositiveIdentity(value: string | undefined): number | undefined {
+  if (!value || !/^[1-9]\d*$/.test(value)) return undefined;
+  return Number(value);
 }
 
 export function createFirecrackerRunPaths(

--- a/src/firecracker/preflight.test.ts
+++ b/src/firecracker/preflight.test.ts
@@ -46,6 +46,8 @@ function dependencies(
     runVersion: jest.fn().mockResolvedValue('Firecracker v1.16.1'),
     sha256: jest.fn().mockResolvedValue(digest),
     assertToolAvailable: jest.fn(async (tool: string) => `/usr/bin/${tool}`),
+    assertHostPolicy: jest.fn().mockResolvedValue(2),
+    assertDockerInfrastructure: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -109,6 +111,7 @@ describe('Firecracker preflight', () => {
     }), deps);
 
     expect(result.version).toBe('1.16.1');
+    expect(result.cgroupVersion).toBe(2);
     expect(deps.access).toHaveBeenCalledWith(
       '/dev/kvm',
       constants.R_OK | constants.W_OK,
@@ -124,6 +127,7 @@ describe('Firecracker preflight', () => {
       e2fsck: '/usr/bin/e2fsck',
       rsync: '/usr/bin/rsync',
     });
+    expect(result.cgroupVersion).toBe(2);
   });
 
   it('rejects inaccessible KVM without checking artifacts', async () => {

--- a/src/firecracker/preflight.test.ts
+++ b/src/firecracker/preflight.test.ts
@@ -1,6 +1,7 @@
 import { constants } from 'fs';
 import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
+import execa from 'execa';
 import * as os from 'os';
 import * as path from 'path';
 import type { FirecrackerOptions } from '../types/runtime-options';
@@ -12,7 +13,10 @@ import {
   type FirecrackerPreflightDependencies,
 } from './preflight';
 
+jest.mock('execa');
+
 const digest = 'a'.repeat(64);
+const mockedExeca = execa as jest.MockedFunction<typeof execa>;
 
 function config(overrides: Partial<FirecrackerOptions> = {}): FirecrackerOptions {
   return {
@@ -57,16 +61,29 @@ describe('Firecracker preflight', () => {
 
   beforeEach(() => {
     originalPath = process.env.PATH;
+    mockedExeca.mockReset();
   });
 
   afterEach(() => {
     delete process.env.SUDO_UID;
+    jest.restoreAllMocks();
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
   });
 
   it('runs default version, tool, and digest host probes', async () => {
     const defaults = firecrackerPreflightTestHelpers.defaultDependencies;
+    mockedExeca
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: `node ${process.version.slice(1)}`,
+        stderr: '',
+      } as never)
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'unsupported flag',
+      } as never);
     await expect(defaults.runVersion(process.execPath)).resolves.toContain(
       process.version.slice(1),
     );
@@ -90,6 +107,77 @@ describe('Firecracker preflight', () => {
     } finally {
       await fs.rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it('runs layer-6 host policy and Docker probes through the default helper', async () => {
+    const defaults = firecrackerPreflightTestHelpers.defaultDependencies;
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const access = jest.spyOn(fs, 'access').mockResolvedValue(undefined);
+    await expect(defaults.assertHostPolicy()).resolves.toBe(2);
+    expect(access).toHaveBeenCalledWith(
+      '/proc/sys/kernel/seccomp/actions_avail',
+      constants.R_OK,
+    );
+
+    mockedExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: 'available',
+      stderr: '',
+    } as never);
+    await expect(defaults.assertDockerInfrastructure()).resolves.toBeUndefined();
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'docker',
+      ['compose', 'version'],
+      expect.objectContaining({ timeout: 10_000, reject: false }),
+    );
+  });
+
+  it('reports layer-6 host policy and Docker probe failures', async () => {
+    const defaults = firecrackerPreflightTestHelpers.defaultDependencies;
+    jest.spyOn(process, 'getuid').mockReturnValue(1000);
+    await expect(defaults.assertHostPolicy()).rejects.toThrow(/require root/);
+
+    mockedExeca.mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'daemon unavailable',
+    } as never);
+    await expect(defaults.assertDockerInfrastructure())
+      .rejects.toThrow(/docker info failed.*daemon unavailable/);
+  });
+
+  it('supports cgroup v1 and reports missing kernel or cgroup controls', async () => {
+    const defaults = firecrackerPreflightTestHelpers.defaultDependencies;
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const access = jest.spyOn(fs, 'access');
+    access.mockImplementation(async (filePath) => {
+      if (filePath === '/sys/fs/cgroup/cgroup.controllers') {
+        throw new Error('no cgroup v2');
+      }
+    });
+    await expect(defaults.assertHostPolicy()).resolves.toBe(1);
+
+    access.mockReset().mockRejectedValue(new Error('kernel control denied'));
+    await expect(defaults.assertHostPolicy())
+      .rejects.toThrow(/host kernel policy.*kernel control denied/);
+
+    access.mockReset().mockImplementation(async (filePath) => {
+      if (String(filePath).startsWith('/proc/')) return;
+      throw new Error('no usable cgroup');
+    });
+    await expect(defaults.assertHostPolicy())
+      .rejects.toThrow(/requires a writable cgroup v1 hierarchy.*no usable cgroup/);
+
+    access.mockReset().mockRejectedValue('kernel control string failure');
+    await expect(defaults.assertHostPolicy())
+      .rejects.toThrow(/host kernel policy.*kernel control string failure/);
+
+    access.mockReset().mockImplementation(async (filePath) => {
+      if (String(filePath).startsWith('/proc/')) return;
+      return Promise.reject('cgroup string failure');
+    });
+    await expect(defaults.assertHostPolicy())
+      .rejects.toThrow(/requires a writable cgroup v1 hierarchy.*cgroup string failure/);
   });
 
   it('parses Firecracker and jailer release output', () => {

--- a/src/firecracker/preflight.ts
+++ b/src/firecracker/preflight.ts
@@ -21,6 +21,8 @@ export interface FirecrackerPreflightDependencies {
   runVersion(binaryPath: string): Promise<string>;
   sha256(filePath: string): Promise<string>;
   assertToolAvailable(tool: string): Promise<string>;
+  assertHostPolicy(): Promise<1 | 2>;
+  assertDockerInfrastructure(): Promise<void>;
 }
 
 export type FirecrackerHostToolPaths = Readonly<{
@@ -70,6 +72,51 @@ const defaultDependencies: FirecrackerPreflightDependencies = {
     }
     throw new Error(`required trusted host tool "${tool}" was not found on PATH`);
   },
+  assertHostPolicy: async () => {
+    if (process.getuid?.() !== 0) {
+      throw new Error(
+        'Firecracker jailer and network setup require root; invoke awf through sudo from a non-root account',
+      );
+    }
+    try {
+      await fs.access('/proc/sys/net/ipv4/ip_forward', constants.R_OK);
+      await fs.access('/proc/sys/net/ipv6/conf/all/disable_ipv6', constants.R_OK);
+      await fs.access('/proc/sys/kernel/seccomp/actions_avail', constants.R_OK);
+    } catch (error) {
+      throw new Error(
+        'host kernel policy does not expose required network namespace and seccomp controls: ' +
+        `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    try {
+      await fs.access('/sys/fs/cgroup/cgroup.controllers', constants.R_OK);
+      return 2;
+    } catch {
+      try {
+        await fs.access('/sys/fs/cgroup', constants.R_OK | constants.W_OK);
+        return 1;
+      } catch (error) {
+        throw new Error(
+          'Firecracker jailer requires a writable cgroup v1 hierarchy or cgroup v2 controllers: ' +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  },
+  assertDockerInfrastructure: async () => {
+    for (const args of [['info'], ['compose', 'version']] as const) {
+      const result = await execa('docker', [...args], {
+        reject: false,
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `docker ${args.join(' ')} failed with code ${result.exitCode}: ${result.stderr.trim()}`,
+        );
+      }
+    }
+  },
 };
 
 /** @internal Exposed only for focused host-probe tests. */
@@ -83,6 +130,7 @@ export interface FirecrackerPreflightResult {
   rootfsPath: string;
   supervisorPath: string;
   tools: FirecrackerHostToolPaths;
+  cgroupVersion: 1 | 2;
 }
 
 async function assertTrustedHostTool(label: string, filePath: string): Promise<void> {
@@ -251,6 +299,8 @@ export async function runFirecrackerPreflight(
       `${error instanceof Error ? error.message : String(error)}`,
     );
   }
+  const cgroupVersion = await dependencies.assertHostPolicy();
+  await dependencies.assertDockerInfrastructure();
   await assertTrustedRegularFile(
     'Firecracker binary',
     config.firecrackerBinary,
@@ -350,5 +400,6 @@ export async function runFirecrackerPreflight(
     rootfsPath: config.rootfsPath,
     supervisorPath: config.supervisorPath,
     tools,
+    cgroupVersion,
   };
 }

--- a/src/firecracker/workspace-image.test.ts
+++ b/src/firecracker/workspace-image.test.ts
@@ -59,6 +59,7 @@ describe('Firecracker workspace images', () => {
 
     const prepared = await image.prepare();
     expect(prepared.imageBytes).toBe(FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES);
+    expect((await fs.stat(prepared.workspaceImagePath)).mode & 0o777).toBe(0o600);
     expect(await fs.readFile(
       path.join(image.stagingDirectory, 'workspace', '.hidden'),
       'utf8',

--- a/src/firecracker/workspace-image.test.ts
+++ b/src/firecracker/workspace-image.test.ts
@@ -77,8 +77,9 @@ describe('Firecracker workspace images', () => {
       path.join(image.stagingDirectory, 'workspace', '.awf-home', '.config', 'gh'),
     )).rejects.toThrow();
     expect(commands.map(({ command }) => command)).toEqual([
-      'mke2fs', 'debugfs', 'debugfs', 'e2fsck',
+      'mke2fs', 'debugfs', 'debugfs', 'debugfs', 'e2fsck',
     ]);
+    expect(commands[1].args).toContain('rm /sbin/awf-supervisor');
     expect(commands[0].args).toEqual(expect.arrayContaining(['-b', '4096']));
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -115,6 +116,29 @@ describe('Firecracker workspace images', () => {
       new Map([['file', file('host')]]),
     )).toThrow(/concurrently/);
     expect(() => assertNoWorkspaceConflicts(original, guest, guest)).not.toThrow();
+  });
+
+  it('rejects host-only changes that copy-back would overwrite or delete', () => {
+    const file = (digest: string) => ({
+      type: 'file' as const,
+      mode: 0o644,
+      uid: 1000,
+      gid: 1000,
+      size: 1,
+      digest,
+    });
+    const original = new Map([['existing', file('before')]]);
+    const unchangedGuest = new Map([['existing', file('before')]]);
+    const hostChanged = new Map([
+      ['existing', file('host-change')],
+      ['host-created', file('host-created')],
+    ]);
+
+    expect(() => assertNoWorkspaceConflicts(
+      original,
+      unchangedGuest,
+      hostChanged,
+    )).toThrow(/existing.*host-created/);
   });
 
   it('preserves the changed image when copy-back fails and cleanup remains safe', async () => {

--- a/src/firecracker/workspace-image.ts
+++ b/src/firecracker/workspace-image.ts
@@ -292,6 +292,11 @@ export class FirecrackerWorkspaceImage {
     assertDebugfsOperand(localSupervisor, 'supervisor staging path');
     await this.runTool('debugfs', [
       '-w',
+      '-R', 'rm /sbin/awf-supervisor',
+      this.rootfsImagePath,
+    ]);
+    await this.dependencies.runTool('debugfs', [
+      '-w',
       '-R', `write ${localSupervisor} /sbin/awf-supervisor`,
       this.rootfsImagePath,
     ]);


### PR DESCRIPTION
## Stack

**Layer 6/6** of the Firecracker preview stack. Targets `lpcox-firecracker-runtime-integration` at exact parent `92e9ddb5e342d28705c8c7b2cbc6663e99089e27` after PR #7135 merged.

Previous layer: #7136

Full stack: #7129 → #7133 → #7134 → #7135 → #7136 → this PR.

## Summary

- adds deterministic x86_64 preview/test artifacts: pinned Firecracker + jailer v1.16.1, Linux 6.1.141, static BusyBox rootfs, AWF guest supervisor, SHA-256 manifest, SPDX SBOM, and build provenance
- integrates those test-only artifacts into the release workflow without making them production defaults or auto-downloaded runtime defaults
- adds hosted artifact validation on pull requests and a live KVM smoke/security job restricted to `[self-hosted, linux, x64, kvm, awf-firecracker]`; live execution additionally requires the `firecracker-kvm` PR label or an explicit manual dispatch
- covers allowed/blocked HTTPS, direct/raw egress denial, TCP/UDP/DNS/link-local denial, API-proxy reflection and secret isolation, workspace copy-back and metadata preservation, exit/timeout/signal/partial-start cleanup, residue checks, keep mode, and bounded diagnostics
- captures bounded Firecracker logs/metrics, guest serial/jailer output, network plan, runtime metadata, Squid/API-proxy logs, and redacted config without uploading generated secret-bearing Compose files
- hardens cumulative behavior: trusted host-tool path adapters, one-time safe identity, pure-root rejection, cgroup/Docker/kernel preflight, exclusive `0600` workspace image creation, authoritative supervisor replacement, host-only concurrent workspace conflict detection, bounded child output, and non-sensitive failure-stage observability
- retains only layer-6-owned logger/metrics/API, cgroup/kernel policy, infrastructure diagnostics, bounded jailer capture, pure-root, and rollout-specific coverage; merged layer-4/layer-5 patches are not replayed
- adds the authoritative Firecracker integration guide and updates compatibility, config, architecture, integration-test, README, and release documentation

## Preview limitations

This remains an explicit opt-in preview with no automatic fallback. It supports Linux KVM only; macOS and Windows are unsupported. GitHub-hosted nested virtualization is experimental/unsupported, so explicitly labeled capable self-hosted runners are recommended. Jailer and Firecracker v1.16.1 are mandatory. Operators must supply compatible kernel/rootfs/supervisor artifacts and all five SHA-256 digests. The release artifacts are x86_64 test/preview inputs, not production defaults. There is no virtiofs or live bind mount: workspaces use bounded ext4 copy-in/copy-back. Firecracker is primary-agent-only; DinD, host access, extra mounts, TTY, topology peers, and enclaves fail closed.

## Validation

- complete unit suite: 296 suites / 4,664 tests
- coverage: lines 94.21%, statements 93.14%, functions 94.06%, branches 86.26%
- TypeScript typecheck and build
- ESLint on all changed TypeScript files (0 errors)
- Markdown lint on all changed documentation (0 issues)
- schema regeneration with no drift
- `actionlint` and YAML parsing for release and Firecracker workflows (custom self-hosted labels explicitly allowed)
- shell syntax validation for all new build/preflight/smoke scripts
- guest supervisor `go test ./...`, Go build, deterministic Linux ELF build, and SHA-256 verification
- artifact builder non-Linux fail-closed host gate
- post-restack CI is running on head `f7ebae75d0e73193b32022d447051db2b1afb898`

A live KVM boot was **not** run locally because this child session is on macOS without `/dev/kvm`. The live workflow job remains gated on the explicit `firecracker-kvm` label.