### PR TITLE
ci: run Firecracker live smoke on hosted Ubuntu

### DIFF
--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_live_kvm:
-        description: Run the explicitly labeled self-hosted Linux/KVM job
+        description: Run the live KVM job on GitHub-hosted x64 Ubuntu 24.04
         required: true
         type: boolean
         default: true
@@ -80,7 +80,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.run_live_kvm) ||
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'firecracker-kvm'))
-    runs-on: [self-hosted, linux, x64, kvm, awf-firecracker]
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -98,6 +98,12 @@ jobs:
           name: firecracker-test-x86_64
           path: ${{ runner.temp }}/firecracker-test-x86_64
 
+      - name: Grant workflow user access to KVM
+        run: |
+          if [ -e /dev/kvm ]; then
+            sudo chmod 666 /dev/kvm
+          fi
+
       - name: Verify capable host and artifact digests
         run: |
           ./scripts/ci/firecracker-host-preflight.sh \

--- a/docs/INTEGRATION-TESTS.md
+++ b/docs/INTEGRATION-TESTS.md
@@ -209,10 +209,10 @@ v1.16.1 binaries, Linux 6.1.141 kernel, BusyBox 1.36.1 rootfs, and AWF guest
 supervisor — from pinned, SHA-256 verified sources. Attests provenance. Uploads
 as a 7-day workflow artifact.
 
-**Live job** (`[self-hosted, linux, x64, kvm, awf-firecracker]`): Downloads the
-build artifact, verifies all five SHA-256 digests, and runs the live smoke/security
-suite. This job **never** lands on a GitHub-hosted runner; it requires an
-explicitly labeled self-hosted runner with KVM access.
+**Live job** (`ubuntu-24.04`): Runs on a GitHub-hosted x64 runner, downloads the
+build artifact, verifies all five SHA-256 digests, and runs the live
+smoke/security suite. The preflight requires usable KVM and fails closed if
+`/dev/kvm` or another required host capability is unavailable.
 
 Live assertions (see `scripts/ci/firecracker-live-smoke.sh`):
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,7 +259,8 @@ uses a substantially different execution architecture:
 - **TTY, Docker-in-Docker, topology peers, enclaves, extra volume mounts, and
   remote Docker hosts all fail closed** in this preview.
 - **Linux/KVM only** — macOS and Windows are permanently unsupported.
-  GitHub-hosted runners are not supported (no `/dev/kvm`).
+  CI specifically supports GitHub-hosted x64 `ubuntu-24.04`; KVM remains
+  mandatory, and hosts without usable `/dev/kvm` access fail closed.
 
 See [Firecracker integration (preview)](./firecracker-integration.md) for the
 full architecture, trust model, and operator guide.

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -272,10 +272,11 @@ microVM to the proven internal bridge, and executes through vsock. Host access,
 DinD, extra mounts, TTY, topology peers, and enclaves fail closed in this
 preview. Selecting `firecracker` never falls back to another runtime.
 
-**macOS and Windows are permanently unsupported.** GitHub-hosted runners are not
-supported (no `/dev/kvm`). The API proxy is mandatory; provider credentials are
-never passed as guest environment variables. No auto-download of artifacts; all
-five artifact paths and their SHA-256 digests are required on every invocation.
+**macOS and Windows are permanently unsupported.** CI specifically supports
+GitHub-hosted x64 `ubuntu-24.04`; KVM remains mandatory, and hosts without usable
+`/dev/kvm` access fail closed. The API proxy is mandatory; provider credentials
+are never passed as guest environment variables. No auto-download of artifacts;
+all five artifact paths and their SHA-256 digests are required on every invocation.
 Release test artifacts (`firecracker-test-x86_64`) are x86_64 test/preview
 artifacts built by both the release workflow and `test-firecracker.yml`. They
 are published as explicitly named release/workflow assets, but are not

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -134,8 +134,7 @@ any other runtime.
 | Operating system | **Linux only** — macOS and Windows fail preflight immediately |
 | Architecture | x86_64 primary (aarch64 accepted by preflight code; no pre-built aarch64 test artifact) |
 | KVM device | `/dev/kvm` must exist and be readable + writable by the workflow user |
-| GitHub-hosted runners | **Not supported** — `/dev/kvm` is not exposed; nested virtualization on GitHub-hosted runners is experimental and **not a supported target** |
-| Recommended runner labels | `self-hosted, linux, x64, kvm, awf-firecracker` |
+| CI runner | GitHub-hosted x64 `ubuntu-24.04` with readable + writable `/dev/kvm` |
 | Firecracker version | **v1.16.1 exactly** — enforced at preflight; any other version fails |
 | Jailer | Mandatory — the jailer binary must match the Firecracker binary version |
 | Docker | Local Unix-socket Docker Engine required; remote Docker hosts rejected |

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -14,16 +14,16 @@ artifact paths and their SHA-256 digests on every invocation. Omitting any
 required input is a hard failure.
 
 **Linux/KVM only.** macOS and Windows are unsupported and will never silently
-pass; the preflight fails immediately on non-Linux hosts. GitHub-hosted runners
-do not expose `/dev/kvm`; nested virtualization on GitHub-hosted runners is
-experimental and **not a supported target** for this preview.
+pass; the preflight fails immediately on non-Linux hosts. CI specifically
+supports GitHub-hosted x64 `ubuntu-24.04`, which exposes `/dev/kvm`. KVM remains
+mandatory, and any host without a readable and writable `/dev/kvm` fails closed.
 :::
 
 This document covers the AWF Firecracker v1.16.1 microVM preview. It is
 structured for two audiences:
 
-1. **Operators** who want to set up and run the preview on a capable self-hosted
-   runner.
+1. **Operators** who want to set up and run the preview on a capable Linux/KVM
+   host.
 2. **Engineers** who want to understand the implementation design and trust model.
 
 For the Docker-compose defaults see [Architecture](./architecture.md). For
@@ -78,7 +78,7 @@ and topology completeness, is a prerequisite for promotion to non-preview.
 | Isolation mechanism | Linux namespaces/cgroups | Userspace application kernel | Docker Sandboxes microVM (KVM) | Firecracker microVM (KVM) |
 | Separate Linux kernel | No | No (own syscall surface) | Yes | Yes |
 | Requires KVM | No | No (systrap platform) | macOS/Win: platform hypervisor; Linux: KVM | Yes — hard requirement |
-| Works on GitHub-hosted runners | Yes | Yes | macOS only | No (no `/dev/kvm`) |
+| Works on GitHub-hosted runners | Yes | Yes | macOS only | Yes — x64 `ubuntu-24.04` with KVM |
 | Workspace delivery | bind mount | bind mount | virtiofs passthrough | ext4 image copy-in / copy-back |
 | Virtiofs / live bind mounts | N/A | N/A | Yes (default) | **No** |
 | Docker-in-Docker | Supported | Supported | Yes (in-VM engine) | **Not supported** |
@@ -96,7 +96,7 @@ and topology completeness, is a prerequisite for promotion to non-preview.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  Host (Linux, KVM-capable, self-hosted runner)                      │
+│  Host (Linux, x86_64, KVM-capable)                                  │
 │                                                                     │
 │  ┌──────────────────────────────────────────────────────────────┐  │
 │  │  AWF CLI (runs as root via sudo from the non-root operator)  │  │
@@ -249,17 +249,13 @@ at `/workspace` inside the VM. It is not part of the shared rootfs.
 | Operating system | **Linux only** — macOS and Windows are unsupported and fail preflight immediately |
 | Architecture | x86_64 (primary) — aarch64 accepted by preflight code but no pre-built test artifacts are released |
 | KVM device | `/dev/kvm` must exist and be readable + writable by the workflow user |
-| GitHub-hosted runners | **Not supported** — no `/dev/kvm`; GitHub-hosted nested virtualization is experimental and not a supported target |
-| Recommended runner labels | `self-hosted, linux, x64, kvm, awf-firecracker` (matches the CI live-kvm job) |
+| CI runner | GitHub-hosted x64 `ubuntu-24.04` with readable + writable `/dev/kvm` |
 
-:::caution[Self-hosted runner requirement]
-GitHub-hosted runners (`ubuntu-latest`, etc.) do not expose `/dev/kvm`. The
-Firecracker backend will always fail preflight on those runners. Use an
-**explicitly labeled self-hosted runner** with confirmed KVM access.
-
-GitHub-hosted runners with experimental nested virtualization are **not** a
-supported target for this preview. The preflight does not check for nested
-virtualization specifically; it checks for a real, accessible `/dev/kvm`.
+:::caution[KVM requirement]
+The CI-supported host is GitHub-hosted x64 `ubuntu-24.04`. Do not infer support
+for other GitHub-hosted images or architectures. The preflight checks the actual
+host capabilities, including a readable and writable `/dev/kvm`, and fails
+closed when any requirement is absent.
 :::
 
 ### Required host tools
@@ -917,8 +913,8 @@ The Firecracker CI workflow (`test-firecracker.yml`) triggers **only** on:
   the live KVM job
 
 It does **not** run on push or schedule. Unlabeled pull requests run only the
-hosted artifact build; the live KVM job never silently runs on GitHub-hosted
-runners.
+artifact build; the live KVM job runs only when explicitly requested by manual
+dispatch or the `firecracker-kvm` label.
 
 ### Jobs
 
@@ -943,11 +939,12 @@ KVM. It:
 7. Uploads `release/firecracker-test-x86_64/` as artifact `firecracker-test-x86_64`
    with 7-day retention
 
-#### `live-kvm` (runs on `[self-hosted, linux, x64, kvm, awf-firecracker]`)
+#### `live-kvm` (runs on `ubuntu-24.04`)
 
-This job runs on a **self-hosted runner** with the exact label set
-`[self-hosted, linux, x64, kvm, awf-firecracker]`. It will never land on a
-GitHub-hosted runner because GitHub-hosted runners do not carry these labels.
+This job runs on a GitHub-hosted x64 `ubuntu-24.04` runner. Its preflight
+requires a readable and writable `/dev/kvm` and fails closed rather than
+silently skipping the live suite if the runner lacks KVM or another required
+host capability.
 
 It:
 
@@ -1141,7 +1138,7 @@ to be addressed before promotion out of preview.
 | **No virtiofs / live bind mounts** | Workspace is snapshotted at boot. Files created on the host after VM start are not visible to the guest. |
 | **No Docker-in-Docker** | The guest has no Docker daemon. Agents that build or run containers cannot use Docker inside the VM. |
 | **Single agent only** | The Firecracker path supports one agent execution per VM. Multi-agent or parallel executor models are not supported. |
-| **GitHub-hosted runners unsupported** | GitHub-hosted runners do not expose `/dev/kvm`. Experimental nested virtualization is not a supported target. |
+| **Narrow CI host support** | CI specifically supports GitHub-hosted x64 `ubuntu-24.04`; other hosts must satisfy every preflight requirement and fail closed otherwise. |
 | **macOS/Windows unsupported** | Firecracker requires Linux KVM; the preview fails preflight on these hosts. |
 | **No unverified latest/demo assets** | There is no "just try it" path. Operators must manage and verify all artifacts. |
 | **8 GiB workspace image ceiling** | Workspaces larger than 8 GiB cannot be used with Firecracker. |

--- a/scripts/ci/firecracker-host-preflight.sh
+++ b/scripts/ci/firecracker-host-preflight.sh
@@ -9,8 +9,8 @@ fail() {
 }
 
 [ "$(uname -s)" = Linux ] || fail "Linux is required; macOS and Windows are unsupported."
-[ "$(uname -m)" = x86_64 ] || fail "This CI artifact set requires an x86_64 self-hosted runner."
-[ -c /dev/kvm ] || fail "/dev/kvm is missing; use an explicitly KVM-capable self-hosted runner."
+[ "$(uname -m)" = x86_64 ] || fail "This CI artifact set requires an x86_64 host."
+[ -c /dev/kvm ] || fail "/dev/kvm is missing; use a KVM-capable host."
 [ -r /dev/kvm ] && [ -w /dev/kvm ] \
   || fail "/dev/kvm must be readable and writable by the workflow user."
 
@@ -40,4 +40,4 @@ docker compose version >/dev/null || fail "Docker Compose v2 is required."
   sha256sum --check --strict SHA256SUMS
 ) || fail "Artifact digest verification failed."
 
-echo "Firecracker host preflight passed on explicitly labeled self-hosted Linux/KVM runner."
+echo "Firecracker host preflight passed on Linux/x86_64 with accessible KVM."


### PR DESCRIPTION
## Summary
- run the live Firecracker KVM job on GitHub-hosted x64 `ubuntu-24.04`
- make host preflight diagnostics runner-neutral while preserving fail-closed KVM checks
- align Firecracker integration, compatibility, and test documentation with the supported CI host

## Validation
- `bash -n scripts/ci/firecracker-host-preflight.sh`
- YAML parse of `.github/workflows/test-firecracker.yml`
- `git diff --check`

Local Markdown/Prettier execution was unavailable because the configured npm feed could not serve a locked dependency and direct npm registry access is blocked. The live workflow will validate the hosted runner end to end.