### PR TITLE
feat: add bounded Firecracker runtime staging and agent rootfs

### DIFF
--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -73,6 +73,51 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build-agent-rootfs:
+    name: Build agent-capable guest rootfs
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.0'
+          cache-dependency-path: guest/firecracker-supervisor/go.mod
+
+      - name: Install agent rootfs build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            binutils \
+            ca-certificates \
+            e2fsprogs \
+            file \
+            xz-utils
+
+      - name: Build and verify the agent rootfs
+        run: |
+          sudo env "PATH=$PATH" ./guest/firecracker/build-agent-rootfs.sh
+          sudo ./guest/firecracker/verify-agent-rootfs.sh \
+            release/firecracker-agent-x86_64/rootfs.ext4
+          (cd release/firecracker-agent-x86_64 && sha256sum --check SHA256SUMS)
+
+      - name: Attest agent rootfs provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release/firecracker-agent-x86_64/awf-firecracker-agent-x86_64.tar.gz
+
+      - name: Upload agent rootfs artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: firecracker-agent-x86_64
+          path: release/firecracker-agent-x86_64/
+          if-no-files-found: error
+          retention-days: 7
+
   live-kvm:
     name: Live Firecracker KVM smoke/security
     needs: build-test-artifacts

--- a/docs/INTEGRATION-TESTS.md
+++ b/docs/INTEGRATION-TESTS.md
@@ -209,6 +209,15 @@ v1.16.1 binaries, Linux 6.1.141 kernel, BusyBox 1.36.1 rootfs, and AWF guest
 supervisor — from pinned, SHA-256 verified sources. Attests provenance. Uploads
 as a 7-day workflow artifact.
 
+**Agent rootfs job** (`ubuntu-24.04`): Builds the separate agent-capable guest
+rootfs (`guest/firecracker/build-agent-rootfs.sh`) from a digest-pinned Debian
+base and a frozen package snapshot, verifies the published `rootfs.ext4` against
+the execution contract (`verify-agent-rootfs.sh`), attests provenance, and
+uploads artifact `firecracker-agent-x86_64`. This artifact is distinct from the
+128 MiB BusyBox test rootfs and is the one that can actually run a generated
+gh-aw agent. Contract assertions are unit-tested in
+`scripts/ci/firecracker-agent-rootfs-contract.test.ts`.
+
 **Live job** (`ubuntu-24.04`): Runs on a GitHub-hosted x64 runner, downloads the
 build artifact, verifies all five SHA-256 digests, and runs the live
 smoke/security suite. The preflight requires usable KVM and fails closed if

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -204,6 +204,16 @@ AWF settings MAY be supplied via config files, including stdin (`--config -`).
 - `firecracker.sha256.kernel` → `--firecracker-kernel-sha256`
 - `firecracker.sha256.rootfs` → `--firecracker-rootfs-sha256`
 - `firecracker.sha256.supervisor` → `--firecracker-supervisor-sha256`
+- `firecracker.ghAwRuntime.enabled` → `--firecracker-gh-aw-runtime`
+- `firecracker.ghAwRuntime.runnerTempPath` → `--firecracker-gh-aw-runner-temp`
+- `firecracker.ghAwRuntime.compilerTmpPath` → `--firecracker-gh-aw-compiler-tmp`
+- `firecracker.ghAwRuntime.maxFileBytes` → `--firecracker-gh-aw-max-file-bytes`
+- `firecracker.ghAwRuntime.maxTotalBytes` → `--firecracker-gh-aw-max-total-bytes`
+- `firecracker.ghAwRuntime.maxFileCount` → `--firecracker-gh-aw-max-files`
+- `firecracker.ghAwRuntime.safeOutputs.hostDirectory` → `--firecracker-safe-outputs-dir`
+- `firecracker.ghAwRuntime.safeOutputs.maxFileBytes` → `--firecracker-safe-outputs-max-file-bytes`
+- `firecracker.ghAwRuntime.safeOutputs.maxTotalBytes` → `--firecracker-safe-outputs-max-total-bytes`
+- `firecracker.ghAwRuntime.safeOutputs.maxFileCount` → `--firecracker-safe-outputs-max-files`
 - `chroot.binariesSourcePath` → *(config-only; mounts a runner-side binaries directory at `/tmp/awf-runner-bin` inside chroot mode and prepends it to `PATH`)*
 - `chroot.identity.home` → *(config-only; forwarded as `AWF_CHROOT_IDENTITY_HOME` and applied after chroot pivot)*
 - `chroot.identity.user` → *(config-only; forwarded as `AWF_CHROOT_IDENTITY_USER` and applied to `USER`/`LOGNAME` after chroot pivot)*
@@ -271,6 +281,15 @@ supervisor. AWF starts Compose infrastructure only, attaches the jailed
 microVM to the proven internal bridge, and executes through vsock. Host access,
 DinD, extra mounts, TTY, topology peers, and enclaves fail closed in this
 preview. Selecting `firecracker` never falls back to another runtime.
+
+The optional `firecracker.ghAwRuntime` surface stages generated gh-aw compiler
+assets for the guest. It is **not** a general mount facility: only
+`<RUNNER_TEMP>/gh-aw` and `<compilerTmpPath>/gh-aw` are eligible sources, both
+are staged onto a separate **read-only** block device, and `--volume-mount`
+remains rejected whether or not staging is enabled. Its optional
+`safeOutputs` block adds a bounded writable exchange device that is copied back
+to the host only after the microVM is confirmed stopped. Per-file, total-byte,
+and file-count caps are enforced during the copy in both directions.
 
 **macOS and Windows are permanently unsupported.** CI specifically supports
 GitHub-hosted x64 `ubuntu-24.04`; KVM remains mandatory, and hosts without usable

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -725,6 +725,76 @@
               "$ref": "#/$defs/sha256Digest"
             }
           }
+        },
+        "ghAwRuntime": {
+          "type": "object",
+          "description": "AWF-owned staging contract for generated gh-aw agent runtime assets. Sources are fixed by AWF (canonical RUNNER_TEMP/gh-aw and the compiler tmp gh-aw tree); this is never a general bind-mount facility and never stages credentials.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Stage the fixed gh-aw runtime asset set onto a dedicated read-only guest block device."
+            },
+            "runnerTempPath": {
+              "type": "string",
+              "description": "Absolute host RUNNER_TEMP whose gh-aw subtree is staged. Defaults to $RUNNER_TEMP."
+            },
+            "compilerTmpPath": {
+              "type": "string",
+              "description": "Absolute host tmp root whose gh-aw subtree is staged. Defaults to /tmp."
+            },
+            "maxFileBytes": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 67108864,
+              "description": "Per-file byte cap enforced while staging runtime assets."
+            },
+            "maxTotalBytes": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 536870912,
+              "description": "Total byte cap enforced while staging runtime assets."
+            },
+            "maxFileCount": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 20000,
+              "description": "File count cap enforced while staging runtime assets."
+            },
+            "safeOutputs": {
+              "type": "object",
+              "description": "Bounded safe-output exchange device. Guest writes are copied back to the host only after confirmed VM stop.",
+              "additionalProperties": false,
+              "required": [
+                "hostDirectory"
+              ],
+              "properties": {
+                "hostDirectory": {
+                  "type": "string",
+                  "description": "Absolute host directory that receives a per-run subdirectory of validated safe outputs."
+                },
+                "maxFileBytes": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 16777216,
+                  "description": "Per-file byte cap enforced during copy-back."
+                },
+                "maxTotalBytes": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 67108864,
+                  "description": "Total byte cap enforced during copy-back."
+                },
+                "maxFileCount": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 2000,
+                  "description": "File count cap enforced during copy-back."
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -775,6 +775,14 @@ any of them produces a hard validation failure before the VM is launched.
 | Host ports (`--allow-host-ports`) | **Rejected** | Same as above |
 | Host service ports | **Rejected** | Same as above |
 | Extra volume mounts (`--volume-mount`) | **Rejected** | "does not support additional host volume mounts" |
+
+:::note[gh-aw staging is not a volume mount]
+`--firecracker-gh-aw-runtime` does **not** relax the rule above. It stages a
+fixed, AWF-owned source contract onto a separate read-only block device; it
+accepts no user-supplied source or destination paths, and `--volume-mount`
+remains rejected whether or not staging is enabled. See
+[Part 17](#part-17--gh-aw-agent-runtime-staging).
+:::
 | DNS-over-HTTPS (`--dns-over-https`) | **Rejected** | "does not support DNS-over-HTTPS" |
 | TTY (`--tty`) | **Rejected** | "guest supervisor does not support TTY execution" |
 | Remote Docker host (non-Unix socket) | **Rejected** | "requires a local Unix-socket Docker daemon" |
@@ -843,6 +851,16 @@ Firecracker options derive the non-root jail identity from `SUDO_UID`/`SUDO_GID`
 | `--firecracker-kernel-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the guest kernel. |
 | `--firecracker-rootfs-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the guest rootfs. |
 | `--firecracker-supervisor-sha256 <digest>` | string | — | **Required.** 64-character hex SHA-256 of the AWF guest supervisor. |
+| `--firecracker-gh-aw-runtime` | boolean | false | Stages gh-aw compiler assets onto a **read-only** guest device. See [Part 17](#part-17--gh-aw-agent-runtime-staging). |
+| `--firecracker-gh-aw-runner-temp <path>` | string | `$RUNNER_TEMP` | Absolute canonical host `RUNNER_TEMP`; only its `gh-aw` subtree is staged. |
+| `--firecracker-gh-aw-compiler-tmp <path>` | string | `/tmp` | Absolute canonical host directory holding the compiler's `gh-aw` output. |
+| `--firecracker-gh-aw-max-file-bytes <bytes>` | integer | 67108864 | Per-file staging cap. |
+| `--firecracker-gh-aw-max-total-bytes <bytes>` | integer | 536870912 | Total staging byte cap. |
+| `--firecracker-gh-aw-max-files <count>` | integer | 20000 | Total staged entry cap. |
+| `--firecracker-safe-outputs-dir <path>` | string | — | Absolute host directory that receives safe outputs **after** the VM stops. Enables the bounded exchange device. |
+| `--firecracker-safe-outputs-max-file-bytes <bytes>` | integer | 16777216 | Per-file copy-back cap. |
+| `--firecracker-safe-outputs-max-total-bytes <bytes>` | integer | 67108864 | Total copy-back byte cap. |
+| `--firecracker-safe-outputs-max-files <count>` | integer | 2000 | Copy-back entry cap. |
 
 ### Using test artifacts
 
@@ -891,10 +909,27 @@ sudo -E awf \
       "kernel": "<64-hex-chars>",
       "rootfs": "<64-hex-chars>",
       "supervisor": "<64-hex-chars>"
+    },
+    "ghAwRuntime": {
+      "enabled": true,
+      "runnerTempPath": "/home/runner/work/_temp",
+      "compilerTmpPath": "/tmp",
+      "maxFileBytes": 67108864,
+      "maxTotalBytes": 536870912,
+      "maxFileCount": 20000,
+      "safeOutputs": {
+        "hostDirectory": "/home/runner/work/_temp/awf-safe-outputs",
+        "maxFileBytes": 16777216,
+        "maxTotalBytes": 67108864,
+        "maxFileCount": 2000
+      }
     }
   }
 }
 ```
+
+`ghAwRuntime` is optional. Omit it entirely and the runtime behaves exactly as
+before: the workspace snapshot is the only staged filesystem.
 
 ---
 
@@ -938,6 +973,31 @@ KVM. It:
 6. Attests artifact provenance via `actions/attest-build-provenance`
 7. Uploads `release/firecracker-test-x86_64/` as artifact `firecracker-test-x86_64`
    with 7-day retention
+
+#### `build-agent-rootfs` (runs on `ubuntu-24.04`)
+
+This job also runs without KVM, in parallel with `build-test-artifacts`. It
+builds the *separate* agent-capable rootfs described in
+[Part 17](#part-17--gh-aw-agent-runtime-staging). It:
+
+1. Checks out the repository and sets up Go 1.25.0
+2. Installs the agent rootfs prerequisites (`binutils`, `ca-certificates`,
+   `e2fsprogs`, `file`, `xz-utils`)
+3. Runs `guest/firecracker/build-agent-rootfs.sh` as root — pulls the
+   digest-pinned `debian:bookworm-slim`, installs packages from the frozen
+   `snapshot.debian.org` index, adds SHA-256-verified Node.js and CA bundle,
+   builds the supervisor, strips setuid/setgid bits and credential material,
+   and produces `rootfs.ext4`, `SHA256SUMS`, `manifest.json`, `packages.tsv`,
+   `sbom.spdx.json`, and `awf-firecracker-agent-x86_64.tar.gz`
+4. Runs `guest/firecracker/verify-agent-rootfs.sh` against the published
+   `rootfs.ext4` (read-only `debugfs` dump; never mutates the artifact)
+5. Re-checks `SHA256SUMS`
+6. Attests artifact provenance via `actions/attest-build-provenance`
+7. Uploads `release/firecracker-agent-x86_64/` as artifact
+   `firecracker-agent-x86_64` with 7-day retention
+
+The two builders are independent: `build-test-artifacts` continues to produce
+the 128 MiB BusyBox image used by `live-kvm`, and this job never modifies it.
 
 #### `live-kvm` (runs on `ubuntu-24.04`)
 
@@ -1136,6 +1196,9 @@ to be addressed before promotion out of preview.
 | **No topology peers or enclaves** | The MCP gateway path is not proved in the Firecracker network model. Topology attachment and enclave execution are disabled. |
 | **No TTY** | The guest supervisor does not implement a PTY multiplexer. Interactive agents requiring TTY cannot run. |
 | **No virtiofs / live bind mounts** | Workspace is snapshotted at boot. Files created on the host after VM start are not visible to the guest. |
+| **gh-aw staging is a fixed contract** | Only `<RUNNER_TEMP>/gh-aw` and `<compilerTmp>/gh-aw` can be staged, always read-only. Arbitrary mounts remain rejected. See [Part 17](#part-17--gh-aw-agent-runtime-staging). |
+| **Hardlinks are never staged** | A staged file with `nlink > 1` fails the run, because a hardlink can reference a file outside the staged tree undetectably. |
+| **Agent rootfs must be operator-built** | `build-agent-rootfs.sh` requires Linux x86_64, root, and Docker. No pre-built agent rootfs is published outside CI artifacts. |
 | **No Docker-in-Docker** | The guest has no Docker daemon. Agents that build or run containers cannot use Docker inside the VM. |
 | **Single agent only** | The Firecracker path supports one agent execution per VM. Multi-agent or parallel executor models are not supported. |
 | **Narrow CI host support** | CI specifically supports GitHub-hosted x64 `ubuntu-24.04`; other hosts must satisfy every preflight requirement and fail closed otherwise. |
@@ -1144,3 +1207,244 @@ to be addressed before promotion out of preview.
 | **8 GiB workspace image ceiling** | Workspaces larger than 8 GiB cannot be used with Firecracker. |
 | **Workspace copy-back is authoritative** | Guest deletions are applied with `rsync --delete`. Any concurrent host-only or divergent change fails copy-back and preserves the changed image for recovery instead of overwriting host work. |
 | **No DNS-over-HTTPS in guest** | The DoH proxy is a host-side service; the guest does not participate. |
+
+---
+
+## Part 17 — gh-aw agent runtime staging
+
+Generated gh-aw agents do not run from the workspace alone. The gh-aw compiler
+writes lockfiles, prompts, engine shims, and MCP server configuration under
+`$RUNNER_TEMP/gh-aw` and `/tmp/gh-aw`, and the generated agent reads them at
+runtime. The Firecracker workspace snapshot covers only `GITHUB_WORKSPACE`, so
+without staging those assets a generated agent cannot start inside the guest.
+
+`--firecracker-gh-aw-runtime` closes that gap with a **fixed, AWF-owned
+contract**. It is deliberately *not* a general mount facility.
+
+### What staging is, and what it is not
+
+| Property | gh-aw runtime staging | A general `--volume-mount` |
+|----------|----------------------|----------------------------|
+| Source paths | Fixed contract, AWF-owned | Caller supplied |
+| Destination paths | Fixed contract, AWF-owned | Caller supplied |
+| Guest writability | Read-only device | Typically writable |
+| Copy-back | Never | Often |
+| Status in Firecracker | Supported | **Rejected** (unchanged) |
+
+`--volume-mount` remains rejected by `assertFirecrackerPreSecurityCompatibility`
+whether or not staging is enabled. Enabling staging cannot introduce a new
+source, retarget a destination, or make the runtime device writable.
+
+### The source contract
+
+Only two sources are eligible, and both are resolved from canonical roots:
+
+| ID | Host source | Guest destination |
+|----|-------------|-------------------|
+| `gh-aw-runner-temp` | `<RUNNER_TEMP>/gh-aw` | `/awf/runner-temp/gh-aw` |
+| `gh-aw-tmp` | `<compilerTmp>/gh-aw` | `/tmp/gh-aw` |
+
+`RUNNER_TEMP` defaults to the `RUNNER_TEMP` environment variable and
+`compilerTmp` defaults to `/tmp`; both may be overridden, but only with an
+absolute, canonical, traversal-free path. A root that is configured explicitly
+and does not exist is a hard error (it is almost always a typo); a root that was
+merely defaulted and does not exist is skipped with a warning.
+
+An absent `gh-aw` subtree under a present root is also skipped — a repository
+that does not use gh-aw stages nothing and boots normally.
+
+### Guest layout
+
+```
+/awf/runtime          read-only ext4 device (vdc), contains the staged tree
+  ├── .awf-runtime-assets   marker the supervisor verifies before binding
+  ├── gh-aw-runner-temp/
+  └── gh-aw-tmp/
+/awf/runner-temp/gh-aw  read-only bind of gh-aw-runner-temp   (RUNNER_TEMP=/awf/runner-temp)
+/tmp/gh-aw              read-only bind of gh-aw-tmp
+/awf/exchange         bounded writable ext4 device (vdc or vdd), safe outputs only
+  └── safe-outputs/outputs.jsonl
+/workspace            the only writable filesystem that is copied back to the host
+```
+
+The supervisor mounts the runtime device `ro,nosuid,nodev,noexec` and re-applies
+`MS_RDONLY` to each bind so a read-write remount inside the guest cannot make it
+writable. Device letters are computed host-side from drive-registration order;
+each device carries a marker file, and the supervisor fails closed if the marker
+does not match the device it was told to mount.
+
+Guest variables set when staging is active:
+
+| Variable | Value | Meaning |
+|----------|-------|---------|
+| `RUNNER_TEMP` | `/awf/runner-temp` | Guest-local runner temp (host value is never exported) |
+| `AWF_GH_AW_RUNTIME_MOUNT` | `/awf/runtime` | AWF-owned pointer to the read-only device |
+| `AWF_SAFE_OUTPUTS_DIR` | `/awf/exchange/safe-outputs` | AWF-owned safe-output directory |
+| `GITHUB_AW_SAFE_OUTPUTS` | `/awf/exchange/safe-outputs/outputs.jsonl` | gh-aw safe-output collector file |
+
+`AWF_SAFE_OUTPUTS_DIR` is the AWF-owned name and is authoritative for this
+runtime; `GITHUB_AW_SAFE_OUTPUTS` is set for gh-aw compatibility. Both are only
+present when `--firecracker-safe-outputs-dir` is supplied.
+
+### Copy semantics and caps
+
+Every staged and copied-back byte passes through one bounded copier:
+
+- Directory traversal opens each component with `O_NOFOLLOW`; a symlink
+  encountered as a path component is a hard failure, not a silent skip.
+- Regular files are copied with an exclusive `O_CREAT|O_EXCL` `0600` create
+  (directories `0700`), so an attacker cannot pre-create the destination.
+- The source is `fstat`-ed before and after the copy; a size, inode, device, or
+  mtime change fails the copy (TOCTOU / swapped-file defence).
+- Symlinks are preserved only when their target resolves inside the same staged
+  subtree; escaping targets, absolute targets, and traversal targets fail.
+- Sockets, FIFOs, device nodes, and any file with `setuid`/`setgid` bits fail.
+- Files with `nlink > 1` fail. A hardlink inside `RUNNER_TEMP/gh-aw` to, say,
+  `/etc/shadow` is invisible to path and `realpath` checks, so hardlinks are
+  rejected outright. This is intentionally strict.
+- Per-file bytes, total bytes, and total entry count are enforced *during* the
+  walk, so an oversized tree fails early rather than after filling a device.
+- Duplicate, overlapping, absolute-outside, or reserved guest destinations are
+  rejected before any I/O happens.
+
+Defaults: 64 MiB per file, 512 MiB total, 20 000 entries for staging;
+16 MiB / 64 MiB / 2 000 for safe-output copy-back. A per-file cap larger than
+the total cap is a configuration error.
+
+### Credentials are never staged
+
+Real provider, GitHub, OIDC, and Docker credentials are never placed on any
+guest device:
+
+- The staging walk rejects credential-bearing basenames
+  (`.netrc`, `.git-credentials`, `credentials.json`, `.dockercfg`,
+  `id_rsa`, `id_ed25519`, `.npmrc`, and the credential dot-directories AWF
+  already knows about, excluding the benign `.config`, `.local`, `.cache`,
+  and `.npm`).
+- Staged file *contents* are scanned for the process's real credential values;
+  a match fails the run rather than shipping the secret.
+- The guest environment continues to receive only synthetic API-proxy
+  credentials. `assertNoProviderSecrets` still runs with staging enabled.
+- Network policy is unchanged: egress remains proxy-mandatory and fail-closed.
+
+### Safe-output copy-back happens only after the VM has stopped
+
+The exchange device is a separate, bounded ext4 image. AWF never reads it while
+the VM is running. In `stop()`, extraction runs inside the same
+`terminationConfirmed && instanceWasStarted` gate that guards workspace
+copy-back, immediately after the workspace extraction:
+
+1. Guest shutdown is requested over vsock.
+2. The VM process is confirmed terminated (natural exit, then `SIGTERM`).
+3. The workspace image is extracted and copied back.
+4. The exchange image is extracted and copied back.
+5. Only then is cleanup allowed to remove the images.
+
+Copy-back applies the same bounded copier, plus a destination directory created
+`0700` and owned by the invoking user. Host safe outputs and host config are
+never exposed on writable guest storage — the guest writes into the exchange
+device and nothing else.
+
+If the instance never started, or termination was not confirmed, no copy-back
+occurs. With `--keep-containers` the images are preserved for inspection.
+
+### Agent-capable rootfs
+
+The 128 MiB BusyBox rootfs produced by `guest/firecracker/build-test-artifacts.sh`
+is unchanged and remains the low-level boot/protocol smoke artifact. It cannot
+run a generated gh-aw agent — there is no `bash`, no `node`, no `git`.
+
+`guest/firecracker/build-agent-rootfs.sh` is a **separate builder producing a
+separate artifact**:
+
+| | Test rootfs | Agent rootfs |
+|---|---|---|
+| Builder | `build-test-artifacts.sh` | `build-agent-rootfs.sh` |
+| Output directory | `release/firecracker-test-x86_64/` | `release/firecracker-agent-x86_64/` |
+| Tarball | `awf-firecracker-test-x86_64.tar.gz` | `awf-firecracker-agent-x86_64.tar.gz` |
+| CI artifact | `firecracker-test-x86_64` | `firecracker-agent-x86_64` |
+| Base | static BusyBox | Debian bookworm (digest-pinned) |
+| Size | 128 MiB | 2 GiB |
+| Contents | BusyBox + supervisor | bash, coreutils, git, curl, iproute2, CA certs, Node.js, supervisor |
+
+Every external input is pinned; no `latest` tag or unverified asset is used:
+
+| Input | Pin |
+|-------|-----|
+| Base image | `debian@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241` |
+| Debian packages | `snapshot.debian.org` archive `20251101T000000Z` (`check-valid-until=no`) |
+| Node.js | `22.22.0`, tarball SHA-256 verified |
+| CA bundle | `2025-02-25` snapshot, SHA-256 verified |
+| Timestamps | `SOURCE_DATE_EPOCH` pinned for reproducibility |
+
+Published artifacts:
+
+```
+release/firecracker-agent-x86_64/
+├── rootfs.ext4                          # the guest image
+├── awf-firecracker-supervisor           # matching supervisor binary
+├── SHA256SUMS                           # digests for the two files above
+├── manifest.json                        # pins, sizes, build inputs
+├── packages.tsv                         # exact package/version/arch list
+├── sbom.spdx.json                       # SPDX SBOM
+└── awf-firecracker-agent-x86_64.tar.gz  # everything above, archived
+```
+
+Consume the digests exactly as with the test artifacts — `--firecracker-rootfs`
+and `--firecracker-rootfs-sha256` are still mandatory and still verified.
+
+`guest/firecracker/verify-agent-rootfs.sh` proves the contract and runs twice in
+the build: once against the staging tree and once against the finished
+`rootfs.ext4`. Given an image it dumps it through `debugfs` in read-only mode,
+so verification can never mutate the artifact it attests. It checks that every
+required executable exists, is executable, resolves inside the tree, and that
+its ELF interpreter and every `NEEDED` shared library (or its shebang
+interpreter) is present in-guest — a binary whose loader is missing is a broken
+guest, not a working one. It also re-asserts that no setuid/setgid binaries and
+no credential-bearing paths shipped.
+
+Generated Copilot/Claude/Codex/MCP tooling is **staged**, not baked in; the
+rootfs guarantees only the interpreters and libraries those tools need.
+
+### CI use
+
+`.github/workflows/test-firecracker.yml` gains a `build-agent-rootfs` job that
+runs alongside `build-test-artifacts` on `ubuntu-24.04`, builds the rootfs as
+root, verifies the published image, checks `SHA256SUMS`, attests provenance, and
+uploads the `firecracker-agent-x86_64` artifact. It does not require KVM.
+
+Local build (Linux x86_64, root, Docker required):
+
+```bash
+sudo ./guest/firecracker/build-agent-rootfs.sh
+./guest/firecracker/verify-agent-rootfs.sh release/firecracker-agent-x86_64/rootfs.ext4
+```
+
+### Example
+
+```bash
+ARTIFACTS=/path/to/firecracker-agent-x86_64
+digest() { awk -v f="$1" '$2==f{print $1;exit}' "$ARTIFACTS/SHA256SUMS"; }
+
+sudo -E awf \
+  --container-runtime firecracker \
+  --firecracker-preview \
+  --firecracker-kernel     /path/to/vmlinux.bin \
+  --firecracker-rootfs     "$ARTIFACTS/rootfs.ext4" \
+  --firecracker-supervisor "$ARTIFACTS/awf-firecracker-supervisor" \
+  --firecracker-rootfs-sha256     "$(digest rootfs.ext4)" \
+  --firecracker-supervisor-sha256 "$(digest awf-firecracker-supervisor)" \
+  --firecracker-binary-sha256 "$FC_SHA" \
+  --firecracker-jailer-sha256 "$JAILER_SHA" \
+  --firecracker-kernel-sha256 "$KERNEL_SHA" \
+  --firecracker-gh-aw-runtime \
+  --firecracker-safe-outputs-dir "$RUNNER_TEMP/awf-safe-outputs" \
+  --allow-domains github.com \
+  -- bash /awf/runner-temp/gh-aw/aw_prompts/run.sh
+```
+
+Inside the guest the agent reads its compiler assets from
+`/awf/runner-temp/gh-aw` and `/tmp/gh-aw` (read-only), writes safe outputs to
+`$GITHUB_AW_SAFE_OUTPUTS`, and does all other work in `/workspace`. After the VM
+stops, `/workspace` is copied back to the host workspace and the safe outputs
+appear in `$RUNNER_TEMP/awf-safe-outputs`.

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -1250,6 +1250,13 @@ absolute, canonical, traversal-free path. A root that is configured explicitly
 and does not exist is a hard error (it is almost always a typo); a root that was
 merely defaulted and does not exist is skipped with a warning.
 
+Roots are additionally denylisted. Only `<root>/gh-aw` is ever staged, so no
+tree is copied wholesale, but a root may not be *pointed at* the home directory,
+`RUNNER_TOOL_CACHE`, `/opt/hostedtoolcache`, `/`, or a system directory — that
+would quietly widen the contract into host state. A `RUNNER_TEMP` nested inside
+the home directory (the normal `/home/runner/work/_temp` layout) remains legal;
+the home directory itself does not. A symlinked root is refused outright.
+
 An absent `gh-aw` subtree under a present root is skipped. If *no* root yields a
 `gh-aw` subtree the run fails instead of booting: staging was asked for
 explicitly, so an empty result means the caller would otherwise get a guest that
@@ -1319,6 +1326,11 @@ Every staged and copied-back byte passes through one bounded copier:
 Defaults: 64 MiB per file, 512 MiB total, 20 000 entries for staging;
 16 MiB / 64 MiB / 2 000 for safe-output copy-back. A per-file cap larger than
 the total cap is a configuration error.
+
+The agent rootfs is built the same way: its userspace comes from the
+digest-pinned Debian snapshot and a checksum-verified Node release tarball, never
+from the host's runtimes or `RUNNER_TOOL_CACHE`, and setuid/setgid bits are
+stripped from the staged tree and re-verified in the published image.
 
 ### Credentials are never staged
 

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -453,10 +453,17 @@ After the agent command exits, AWF extracts the workspace image content via
 ### Recovery image
 
 If copy-back fails partway through, AWF writes the raw `workspace.ext4` to a
-recovery path (`<workDir>/firecracker-recovery/<runId>-workspace.ext4`) before
-cleanup. This allows manual recovery using standard `debugfs` or `mount` tools.
-The recovery path is logged at `warn` level so it is visible even if the overall
-command exits non-zero.
+recovery path (`$TMPDIR/awf-firecracker-recovery/<runId>-workspace.ext4`, mode
+`0700`) before cleanup. This allows manual recovery using standard `debugfs` or
+`mount` tools. The recovery path is logged at `warn` level so it is visible even
+if the overall command exits non-zero.
+
+The recovery directory deliberately sits **outside both the workspace and the
+per-run control directories**. The workspace holds guest-controlled content, so
+writing a root-owned image into it would let the guest pre-place a symlink at the
+recovery path and redirect the write; the run directory is deleted by cleanup, so
+it cannot hold the one copy of unrecovered work. AWF refuses to start if the
+recovery directory is nested inside either.
 
 ### Bounded image size
 
@@ -1167,7 +1174,7 @@ If copy-back fails and a recovery image was preserved:
 ```bash
 # Mount the recovery image (requires root or loop mount capability)
 sudo mkdir -p /mnt/awf-recovery
-sudo mount -o loop <workDir>/firecracker-recovery/<runId>-workspace.ext4 /mnt/awf-recovery
+sudo mount -o loop "$TMPDIR/awf-firecracker-recovery/<runId>-workspace.ext4" /mnt/awf-recovery
 
 # Browse or extract files
 ls /mnt/awf-recovery/workspace/
@@ -1369,6 +1376,58 @@ device and nothing else.
 If the instance never started, or termination was not confirmed, no copy-back
 occurs. With `--keep-containers` the images are preserved for inspection.
 
+### Extraction integrity: `debugfs` exits 0 on subcommand failure
+
+`debugfs -R <subcommand>` returns exit status 0 even when the subcommand did no
+work. A missing `rdump` destination, a missing `rdump` source, and a `write`
+whose source cannot be opened all report success to the shell. Only an unknown
+subcommand *name* produces a non-zero status. Left unchecked, a silently failed
+`rdump` would produce an empty extraction directory, and the workspace copy-back
+would then `rsync -a --delete` that emptiness over the merge tree.
+
+AWF therefore treats `debugfs` output, not its exit status, as the result:
+
+- **Silence is success.** Mutating and dumping subcommands may print only the
+  version banner and (for `write`) `Allocated inode: N`. Any other line fails the
+  run, naming every diagnostic `debugfs` emitted.
+- **Extraction sentinels.** A successful `rdump /` always materialises the
+  `lost+found` directory that `mke2fs` creates. The workspace extraction requires
+  it; the exchange extraction requires it plus the AWF-written `.awf-exchange`
+  marker. A missing sentinel fails the run instead of being reported as "the
+  guest produced no output".
+- **Non-empty invariant.** If the staged workspace manifest had entries but the
+  extraction has none, copy-back aborts rather than deleting host work. The
+  changed image is preserved for recovery.
+- **Supervisor read-back.** After the guest supervisor is written into the rootfs
+  image, AWF dumps it back out, re-hashes it against the expected SHA-256, and
+  confirms `debugfs stat` reports mode `0755`. A `write` or `sif` that silently
+  did nothing fails the run before the VM is ever booted.
+
+### Guest writable state
+
+With the read-only runtime device in place, the guest's writable surface is:
+
+| Guest path | Backing | Flags | Copied back |
+| --- | --- | --- | --- |
+| `/` | per-run rootfs image (`vda`) | writable | **No** — discarded with the run |
+| `/workspace` | workspace image (`vdb`) | `nosuid,nodev` | Yes, after confirmed stop |
+| `/awf/runtime` | runtime asset image (`vdc`) | `ro,nosuid,nodev` | No |
+| `/awf/runner-temp/gh-aw`, `/tmp/gh-aw` | binds of `/awf/runtime` | `ro,nosuid,nodev` | No |
+| `/awf/exchange` | exchange image (`vdd`) | `nosuid,nodev,noexec` | Yes, `safe-outputs/` only |
+| `/proc` | procfs | — | No |
+
+`/workspace` is the only writable filesystem whose contents reach the host, and
+`/awf/exchange` is the only other writable device — bounded, `noexec`, and read
+exclusively after the VM has stopped. Writes to the rootfs are intentionally
+permitted (package managers, caches, and the supervisor's own scratch state need
+them) but are discarded: nothing on `vda` is ever copied back.
+
+`/workspace` is mounted `MS_NOSUID | MS_NODEV`, so a setuid binary or device node
+smuggled into the workspace cannot confer privilege inside the guest. `MS_NOEXEC`
+is deliberately **not** set, because builds and tests legitimately execute
+binaries from the workspace. The runtime device is likewise not `noexec`: staged
+gh-aw engine and MCP executables must run from it.
+
 ### Agent-capable rootfs
 
 The 128 MiB BusyBox rootfs produced by `guest/firecracker/build-test-artifacts.sh`
@@ -1423,6 +1482,19 @@ its ELF interpreter and every `NEEDED` shared library (or its shebang
 interpreter) is present in-guest — a binary whose loader is missing is a broken
 guest, not a working one. It also re-asserts that no setuid/setgid binaries and
 no credential-bearing paths shipped.
+
+The verifier additionally proves the **C library family**. gh-aw engines ship
+prebuilt glibc binaries, so a musl-based rootfs would fail at agent run time
+rather than at build time. Verification requires a glibc dynamic loader
+(`ld-linux-*.so`) and `libc.so.6`, rejects any `ld-musl-*`/`libc.musl-*`, and
+confirms the pinned Node build's ELF interpreter is the glibc loader. Debian is
+glibc-based, which is why it is the pinned base.
+
+Host runner state is never baked into the guest: the verifier fails if
+`opt/hostedtoolcache`, `opt/actions-runner`, `home/runner`, or
+`usr/local/share/hostedtoolcache` exist in the image, and the builder never reads
+`RUNNER_TOOL_CACHE`. The guest's Node.js is the pinned, checksum-verified build —
+not a copy of whatever the host runner happened to have.
 
 Generated Copilot/Claude/Codex/MCP tooling is **staged**, not baked in; the
 rootfs guarantees only the interpreters and libraries those tools need.

--- a/docs/firecracker-integration.md
+++ b/docs/firecracker-integration.md
@@ -1250,8 +1250,10 @@ absolute, canonical, traversal-free path. A root that is configured explicitly
 and does not exist is a hard error (it is almost always a typo); a root that was
 merely defaulted and does not exist is skipped with a warning.
 
-An absent `gh-aw` subtree under a present root is also skipped — a repository
-that does not use gh-aw stages nothing and boots normally.
+An absent `gh-aw` subtree under a present root is skipped. If *no* root yields a
+`gh-aw` subtree the run fails instead of booting: staging was asked for
+explicitly, so an empty result means the caller would otherwise get a guest that
+fails mysteriously partway through the agent rather than at configuration time.
 
 ### Guest layout
 
@@ -1267,7 +1269,7 @@ that does not use gh-aw stages nothing and boots normally.
 /workspace            the only writable filesystem that is copied back to the host
 ```
 
-The supervisor mounts the runtime device `ro,nosuid,nodev,noexec` and re-applies
+The supervisor mounts the runtime device `ro,nosuid,nodev` and re-applies
 `MS_RDONLY` to each bind so a read-write remount inside the guest cannot make it
 writable. Device letters are computed host-side from drive-registration order;
 each device carries a marker file, and the supervisor fails closed if the marker
@@ -1290,8 +1292,15 @@ present when `--firecracker-safe-outputs-dir` is supplied.
 
 Every staged and copied-back byte passes through one bounded copier:
 
-- Directory traversal opens each component with `O_NOFOLLOW`; a symlink
-  encountered as a path component is a hard failure, not a silent skip.
+- Traversal is descriptor-pinned: each directory is opened `O_DIRECTORY|O_NOFOLLOW`
+  and its children are reached through that open descriptor, never by
+  re-resolving a pathname. `O_NOFOLLOW` alone would only protect the final
+  component, so swapping an intermediate directory for a symlink mid-walk could
+  otherwise redirect the copy outside the approved tree. A symlink encountered
+  as a path component is a hard failure, not a silent skip.
+- Destination roots must be exclusively created, mode `0700`, and owned by AWF
+  or the target user; a group- or world-writable root is refused so it cannot be
+  substituted after creation.
 - Regular files are copied with an exclusive `O_CREAT|O_EXCL` `0600` create
   (directories `0700`), so an attacker cannot pre-create the destination.
 - The source is `fstat`-ed before and after the copy; a size, inode, device, or
@@ -1447,4 +1456,11 @@ Inside the guest the agent reads its compiler assets from
 `/awf/runner-temp/gh-aw` and `/tmp/gh-aw` (read-only), writes safe outputs to
 `$GITHUB_AW_SAFE_OUTPUTS`, and does all other work in `/workspace`. After the VM
 stops, `/workspace` is copied back to the host workspace and the safe outputs
-appear in `$RUNNER_TEMP/awf-safe-outputs`.
+appear in a per-run subdirectory, `$RUNNER_TEMP/awf-safe-outputs/<runId>`, which
+is created exclusively so one run can never merge into or overwrite another's
+results.
+
+If the copy-back fails — a cap breach, for example — nothing is published under
+that subdirectory, and the exchange image is deliberately left in the jail so
+the run's results can still be recovered by hand. The error names the retained
+path.

--- a/guest/firecracker-supervisor/config.go
+++ b/guest/firecracker-supervisor/config.go
@@ -16,7 +16,22 @@ type bootConfig struct {
 	GuestPrefix     int
 	Gateway         net.IP
 	Interface       string
+	// Optional AWF-owned gh-aw runtime asset device. Read-only for the guest.
+	RuntimeDevice string
+	RuntimeMount  string
+	RuntimeBinds  []runtimeBind
+	// Optional bounded safe-output exchange device.
+	ExchangeDevice string
+	ExchangeMount  string
 }
+
+// runtimeBind maps one staged runtime asset subdirectory to a read-only guest path.
+type runtimeBind struct {
+	ID     string
+	Target string
+}
+
+const maxRuntimeBinds = 8
 
 func parseBootConfig(cmdline string) (bootConfig, error) {
 	values := make(map[string]string)
@@ -64,10 +79,141 @@ func parseBootConfig(cmdline string) (bootConfig, error) {
 	if !validInterface(iface) {
 		return bootConfig{}, fmt.Errorf("invalid awf.guest-interface")
 	}
-	return bootConfig{
+	config := bootConfig{
 		WorkspaceDevice: device, WorkspaceMount: mount, VsockPort: uint32(port),
 		GuestIP: ip, GuestPrefix: prefix, Gateway: gateway, Interface: iface,
-	}, nil
+	}
+	if err := parseOptionalDevices(values, &config); err != nil {
+		return bootConfig{}, err
+	}
+	return config, nil
+}
+
+// parseOptionalDevices validates the optional runtime asset and exchange
+// devices. They are optional so the existing minimal test rootfs, which never
+// receives them, keeps booting unchanged.
+func parseOptionalDevices(values map[string]string, config *bootConfig) error {
+	occupied := []string{config.WorkspaceMount}
+
+	runtimeDevice, runtimeMount := values["awf.runtime-device"], values["awf.runtime-mount"]
+	binds := values["awf.runtime-bind"]
+	if (runtimeDevice == "") != (runtimeMount == "") {
+		return fmt.Errorf("awf.runtime-device and awf.runtime-mount must be set together")
+	}
+	if runtimeDevice == "" && binds != "" {
+		return fmt.Errorf("awf.runtime-bind requires awf.runtime-device")
+	}
+	if runtimeDevice != "" {
+		if err := validDevice(runtimeDevice, "awf.runtime-device"); err != nil {
+			return err
+		}
+		if runtimeDevice == config.WorkspaceDevice {
+			return fmt.Errorf("awf.runtime-device must differ from awf.workspace-device")
+		}
+		if err := validMountTarget(runtimeMount, "awf.runtime-mount", occupied); err != nil {
+			return err
+		}
+		occupied = append(occupied, runtimeMount)
+		config.RuntimeDevice, config.RuntimeMount = runtimeDevice, runtimeMount
+	}
+	if binds != "" {
+		parsed, err := parseRuntimeBinds(binds, occupied)
+		if err != nil {
+			return err
+		}
+		config.RuntimeBinds = parsed
+		for _, bind := range parsed {
+			occupied = append(occupied, bind.Target)
+		}
+	}
+
+	exchangeDevice, exchangeMount := values["awf.exchange-device"], values["awf.exchange-mount"]
+	if (exchangeDevice == "") != (exchangeMount == "") {
+		return fmt.Errorf("awf.exchange-device and awf.exchange-mount must be set together")
+	}
+	if exchangeDevice == "" {
+		return nil
+	}
+	if err := validDevice(exchangeDevice, "awf.exchange-device"); err != nil {
+		return err
+	}
+	if exchangeDevice == config.WorkspaceDevice || exchangeDevice == config.RuntimeDevice {
+		return fmt.Errorf("awf.exchange-device must be a distinct block device")
+	}
+	if err := validMountTarget(exchangeMount, "awf.exchange-mount", occupied); err != nil {
+		return err
+	}
+	config.ExchangeDevice, config.ExchangeMount = exchangeDevice, exchangeMount
+	return nil
+}
+
+func parseRuntimeBinds(raw string, occupied []string) ([]runtimeBind, error) {
+	fields := strings.Split(raw, ",")
+	if len(fields) > maxRuntimeBinds {
+		return nil, fmt.Errorf("awf.runtime-bind exceeds %d entries", maxRuntimeBinds)
+	}
+	seenIDs := make(map[string]struct{}, len(fields))
+	binds := make([]runtimeBind, 0, len(fields))
+	for _, field := range fields {
+		id, target, ok := strings.Cut(field, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid awf.runtime-bind entry %q", field)
+		}
+		if !validBindID(id) {
+			return nil, fmt.Errorf("invalid awf.runtime-bind id %q", id)
+		}
+		if _, duplicate := seenIDs[id]; duplicate {
+			return nil, fmt.Errorf("duplicate awf.runtime-bind id %q", id)
+		}
+		seenIDs[id] = struct{}{}
+		if err := validMountTarget(target, "awf.runtime-bind", occupied); err != nil {
+			return nil, err
+		}
+		occupied = append(occupied, target)
+		binds = append(binds, runtimeBind{ID: id, Target: target})
+	}
+	return binds, nil
+}
+
+func validDevice(device, name string) error {
+	if !strings.HasPrefix(device, "/dev/") || filepath.Clean(device) != device ||
+		strings.Contains(device, "..") {
+		return fmt.Errorf("invalid %s", name)
+	}
+	return nil
+}
+
+// validMountTarget rejects non-canonical targets and any path that would nest
+// inside (or contain) an already-claimed mount point.
+func validMountTarget(target, name string, occupied []string) error {
+	if !filepath.IsAbs(target) || filepath.Clean(target) != target || target == "/" {
+		return fmt.Errorf("invalid %s target %q", name, target)
+	}
+	for _, existing := range occupied {
+		if target == existing || isWithin(target, existing) || isWithin(existing, target) {
+			return fmt.Errorf("%s target %q overlaps mount %q", name, target, existing)
+		}
+	}
+	return nil
+}
+
+func isWithin(child, parent string) bool {
+	return strings.HasPrefix(child, strings.TrimSuffix(parent, "/")+"/")
+}
+
+func validBindID(id string) bool {
+	if id == "" || len(id) > 63 {
+		return false
+	}
+	for i, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case r == '-' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func validInterface(name string) bool {

--- a/guest/firecracker-supervisor/config_test.go
+++ b/guest/firecracker-supervisor/config_test.go
@@ -33,3 +33,93 @@ func TestParseBootConfigRejectsDuplicateArguments(t *testing.T) {
 		t.Fatal("duplicate argument accepted")
 	}
 }
+
+const validOptionalDevices = " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+	" awf.runtime-bind=gh-aw-runner-temp:/awf/runner-temp/gh-aw,gh-aw-tmp:/tmp/gh-aw" +
+	" awf.exchange-device=/dev/vdd awf.exchange-mount=/awf/exchange"
+
+func TestParseBootConfigOptionalDevicesAbsentByDefault(t *testing.T) {
+	config, err := parseBootConfig(validCmdline)
+	if err != nil {
+		t.Fatalf("parseBootConfig: %v", err)
+	}
+	if config.RuntimeDevice != "" || config.RuntimeMount != "" || len(config.RuntimeBinds) != 0 {
+		t.Fatalf("runtime device unexpectedly set: %#v", config)
+	}
+	if config.ExchangeDevice != "" || config.ExchangeMount != "" {
+		t.Fatalf("exchange device unexpectedly set: %#v", config)
+	}
+}
+
+func TestParseBootConfigParsesOptionalDevices(t *testing.T) {
+	config, err := parseBootConfig(validCmdline + validOptionalDevices)
+	if err != nil {
+		t.Fatalf("parseBootConfig: %v", err)
+	}
+	if config.RuntimeDevice != "/dev/vdc" || config.RuntimeMount != "/awf/runtime" {
+		t.Fatalf("unexpected runtime config: %#v", config)
+	}
+	if len(config.RuntimeBinds) != 2 {
+		t.Fatalf("unexpected bind count: %#v", config.RuntimeBinds)
+	}
+	if config.RuntimeBinds[0].ID != "gh-aw-runner-temp" ||
+		config.RuntimeBinds[0].Target != "/awf/runner-temp/gh-aw" {
+		t.Fatalf("unexpected first bind: %#v", config.RuntimeBinds[0])
+	}
+	if config.RuntimeBinds[1].Target != "/tmp/gh-aw" {
+		t.Fatalf("unexpected second bind: %#v", config.RuntimeBinds[1])
+	}
+	if config.ExchangeDevice != "/dev/vdd" || config.ExchangeMount != "/awf/exchange" {
+		t.Fatalf("unexpected exchange config: %#v", config)
+	}
+}
+
+func TestParseBootConfigRejectsUnsafeOptionalDevices(t *testing.T) {
+	cases := map[string]string{
+		"runtime device without mount":     " awf.runtime-device=/dev/vdc",
+		"runtime mount without device":     " awf.runtime-mount=/awf/runtime",
+		"bind without device":              " awf.runtime-bind=gh-aw-tmp:/tmp/gh-aw",
+		"runtime device path traversal":    " awf.runtime-device=/dev/../etc/shadow awf.runtime-mount=/awf/runtime",
+		"runtime device aliases workspace": " awf.runtime-device=/dev/vdb awf.runtime-mount=/awf/runtime",
+		"runtime mount is root":            " awf.runtime-device=/dev/vdc awf.runtime-mount=/",
+		"runtime mount overlaps workspace": " awf.runtime-device=/dev/vdc awf.runtime-mount=/workspace/runtime",
+		"bind escapes into workspace": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp:/workspace/gh-aw",
+		"bind is relative": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp:tmp/gh-aw",
+		"bind traverses": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp:/tmp/../etc",
+		"bind id invalid": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=../evil:/tmp/gh-aw",
+		"bind id uppercase": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=GhAw:/tmp/gh-aw",
+		"bind missing target": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp",
+		"duplicate bind ids": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp:/tmp/gh-aw,gh-aw-tmp:/tmp/other",
+		"duplicate bind targets": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp:/tmp/gh-aw,gh-aw-other:/tmp/gh-aw",
+		"nested bind targets": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=gh-aw-tmp:/tmp/gh-aw,gh-aw-other:/tmp/gh-aw/nested",
+		"too many binds": " awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+			" awf.runtime-bind=a:/tmp/a,b:/tmp/b,c:/tmp/c,d:/tmp/d,e:/tmp/e,f:/tmp/f,g:/tmp/g,h:/tmp/h,i:/tmp/i",
+		"exchange device without mount":     " awf.exchange-device=/dev/vdd",
+		"exchange mount without device":     " awf.exchange-mount=/awf/exchange",
+		"exchange aliases workspace device": " awf.exchange-device=/dev/vdb awf.exchange-mount=/awf/exchange",
+		"exchange overlaps workspace mount": " awf.exchange-device=/dev/vdd awf.exchange-mount=/workspace",
+	}
+	for name, suffix := range cases {
+		if _, err := parseBootConfig(validCmdline + suffix); err == nil {
+			t.Errorf("%s: unsafe command line accepted", name)
+		}
+	}
+}
+
+func TestParseBootConfigRejectsExchangeAliasingRuntimeDevice(t *testing.T) {
+	cmdline := validCmdline +
+		" awf.runtime-device=/dev/vdc awf.runtime-mount=/awf/runtime" +
+		" awf.exchange-device=/dev/vdc awf.exchange-mount=/awf/exchange"
+	if _, err := parseBootConfig(cmdline); err == nil {
+		t.Fatal("aliased runtime and exchange devices accepted")
+	}
+}

--- a/guest/firecracker-supervisor/runtime_linux.go
+++ b/guest/firecracker-supervisor/runtime_linux.go
@@ -81,6 +81,12 @@ func runSupervisor() error {
 	if err := mountWorkspace(config); err != nil {
 		return err
 	}
+	if err := mountRuntimeAssets(config); err != nil {
+		return err
+	}
+	if err := mountExchange(config); err != nil {
+		return err
+	}
 	if err := configureNetwork(config); err != nil {
 		return err
 	}
@@ -117,13 +123,129 @@ func mountProc() error {
 
 func shutdownGuest(config bootConfig) error {
 	syscall.Sync()
+	// Unmount in reverse dependency order so every device is flushed and
+	// detached before the host is allowed to read any of them back.
+	for i := len(config.RuntimeBinds) - 1; i >= 0; i-- {
+		if err := syscall.Unmount(config.RuntimeBinds[i].Target, 0); err != nil {
+			return fmt.Errorf("unmount runtime bind %s: %w", config.RuntimeBinds[i].Target, err)
+		}
+	}
+	if config.RuntimeMount != "" {
+		if err := syscall.Unmount(config.RuntimeMount, 0); err != nil {
+			return fmt.Errorf("unmount runtime assets: %w", err)
+		}
+	}
+	if config.ExchangeMount != "" {
+		if err := syscall.Unmount(config.ExchangeMount, 0); err != nil {
+			return fmt.Errorf("unmount exchange: %w", err)
+		}
+	}
 	if err := syscall.Unmount(config.WorkspaceMount, 0); err != nil {
 		return fmt.Errorf("unmount workspace: %w", err)
 	}
+	syscall.Sync()
 	if err := syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
 		return fmt.Errorf("power off guest: %w", err)
 	}
 	return nil
+}
+
+const (
+	runtimeAssetsMarker = ".awf-runtime-assets"
+	exchangeMarker      = ".awf-exchange"
+	exchangeOutputDir   = "safe-outputs"
+)
+
+// mountRuntimeAssets mounts the AWF-owned gh-aw runtime device read-only and
+// binds each staged subdirectory to its declared guest path, also read-only.
+func mountRuntimeAssets(config bootConfig) error {
+	if config.RuntimeMount == "" {
+		return nil
+	}
+	const flags = syscall.MS_RDONLY | syscall.MS_NOSUID | syscall.MS_NODEV
+	if err := mountBlockDevice(config.RuntimeDevice, config.RuntimeMount, flags, 0555); err != nil {
+		return fmt.Errorf("mount runtime assets: %w", err)
+	}
+	if err := assertMarker(filepath.Join(config.RuntimeMount, runtimeAssetsMarker)); err != nil {
+		return fmt.Errorf("verify runtime asset device: %w", err)
+	}
+	for _, bind := range config.RuntimeBinds {
+		source := filepath.Join(config.RuntimeMount, bind.ID)
+		info, err := os.Stat(source)
+		if err != nil {
+			return fmt.Errorf("stat runtime asset %s: %w", bind.ID, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("runtime asset %s is not a directory", bind.ID)
+		}
+		if err := os.MkdirAll(bind.Target, 0755); err != nil {
+			return fmt.Errorf("create runtime bind %s: %w", bind.Target, err)
+		}
+		if err := syscall.Mount(source, bind.Target, "", syscall.MS_BIND, ""); err != nil {
+			return fmt.Errorf("bind runtime asset %s: %w", bind.ID, err)
+		}
+		remount := uintptr(syscall.MS_REMOUNT | syscall.MS_BIND | flags)
+		if err := syscall.Mount("", bind.Target, "", remount, ""); err != nil {
+			return fmt.Errorf("seal runtime bind %s read-only: %w", bind.Target, err)
+		}
+	}
+	return nil
+}
+
+// mountExchange mounts the bounded writable safe-output device. It is never
+// executable and never carries device nodes or setuid bits.
+func mountExchange(config bootConfig) error {
+	if config.ExchangeMount == "" {
+		return nil
+	}
+	const flags = syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC
+	if err := mountBlockDevice(config.ExchangeDevice, config.ExchangeMount, flags, 0755); err != nil {
+		return fmt.Errorf("mount exchange: %w", err)
+	}
+	if err := assertMarker(filepath.Join(config.ExchangeMount, exchangeMarker)); err != nil {
+		return fmt.Errorf("verify exchange device: %w", err)
+	}
+	outputs := filepath.Join(config.ExchangeMount, exchangeOutputDir)
+	info, err := os.Stat(outputs)
+	if err != nil {
+		return fmt.Errorf("stat exchange output directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("exchange output path is not a directory")
+	}
+	return nil
+}
+
+// assertMarker fails closed when a device is missing its AWF marker, which
+// would mean guest block device ordering did not match the host's plan.
+func assertMarker(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("marker %s is not a regular file", path)
+	}
+	return nil
+}
+
+func mountBlockDevice(device, target string, flags uintptr, mode os.FileMode) error {
+	info, err := os.Stat(device)
+	if err != nil {
+		return fmt.Errorf("stat device: %w", err)
+	}
+	if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+		return fmt.Errorf("%s is not a block device", device)
+	}
+	if err := os.MkdirAll(target, mode); err != nil {
+		return fmt.Errorf("create mount point: %w", err)
+	}
+	if err := syscall.Mount(device, target, "ext4", flags, ""); err == nil {
+		return nil
+	} else if !errors.Is(err, syscall.ENODEV) {
+		return err
+	}
+	return syscall.Mount(device, target, "", flags, "")
 }
 
 func mountWorkspace(config bootConfig) error {

--- a/guest/firecracker-supervisor/runtime_linux.go
+++ b/guest/firecracker-supervisor/runtime_linux.go
@@ -123,31 +123,54 @@ func mountProc() error {
 
 func shutdownGuest(config bootConfig) error {
 	syscall.Sync()
-	// Unmount in reverse dependency order so every device is flushed and
-	// detached before the host is allowed to read any of them back.
-	for i := len(config.RuntimeBinds) - 1; i >= 0; i-- {
-		if err := syscall.Unmount(config.RuntimeBinds[i].Target, 0); err != nil {
-			return fmt.Errorf("unmount runtime bind %s: %w", config.RuntimeBinds[i].Target, err)
+	// Mount order is workspace, runtime assets, runtime binds, exchange, so the
+	// exact reverse detaches each device only once nothing is layered over it.
+	//
+	// Every unmount is attempted even after one fails, and errors are collected
+	// rather than returned early: giving up partway would leave the writable
+	// exchange mounted and skip the power-off entirely, so the host would either
+	// hang waiting for the VM or read back a filesystem that was never flushed.
+	var problems []error
+	for _, step := range unmountPlan(config) {
+		if err := syscall.Unmount(step.Target, 0); err != nil {
+			problems = append(problems, fmt.Errorf("unmount %s: %w", step.Label, err))
 		}
 	}
-	if config.RuntimeMount != "" {
-		if err := syscall.Unmount(config.RuntimeMount, 0); err != nil {
-			return fmt.Errorf("unmount runtime assets: %w", err)
-		}
-	}
-	if config.ExchangeMount != "" {
-		if err := syscall.Unmount(config.ExchangeMount, 0); err != nil {
-			return fmt.Errorf("unmount exchange: %w", err)
-		}
-	}
-	if err := syscall.Unmount(config.WorkspaceMount, 0); err != nil {
-		return fmt.Errorf("unmount workspace: %w", err)
-	}
+
+	// Flush unconditionally: a device that refused to unmount still has dirty
+	// pages the host is about to read.
 	syscall.Sync()
 	if err := syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
-		return fmt.Errorf("power off guest: %w", err)
+		problems = append(problems, fmt.Errorf("power off guest: %w", err))
 	}
-	return nil
+	return errors.Join(problems...)
+}
+
+// unmountStep is one entry in the shutdown order.
+type unmountStep struct {
+	Target string
+	Label  string
+}
+
+// unmountPlan returns the exact reverse of the mount order, skipping devices
+// that were never attached. Kept separate from the syscalls so the ordering
+// itself is testable.
+func unmountPlan(config bootConfig) []unmountStep {
+	var plan []unmountStep
+	add := func(target string, label string) {
+		if target == "" {
+			return
+		}
+		plan = append(plan, unmountStep{Target: target, Label: label})
+	}
+
+	add(config.ExchangeMount, "exchange")
+	for i := len(config.RuntimeBinds) - 1; i >= 0; i-- {
+		add(config.RuntimeBinds[i].Target, "runtime bind "+config.RuntimeBinds[i].Target)
+	}
+	add(config.RuntimeMount, "runtime assets")
+	add(config.WorkspaceMount, "workspace")
+	return plan
 }
 
 const (
@@ -162,6 +185,8 @@ func mountRuntimeAssets(config bootConfig) error {
 	if config.RuntimeMount == "" {
 		return nil
 	}
+	// Deliberately not MS_NOEXEC: staged gh-aw engine and MCP executables are
+	// meant to run from here. MS_RDONLY plus MS_NOSUID is what keeps that safe.
 	const flags = syscall.MS_RDONLY | syscall.MS_NOSUID | syscall.MS_NODEV
 	if err := mountBlockDevice(config.RuntimeDevice, config.RuntimeMount, flags, 0555); err != nil {
 		return fmt.Errorf("mount runtime assets: %w", err)

--- a/guest/firecracker-supervisor/runtime_linux.go
+++ b/guest/firecracker-supervisor/runtime_linux.go
@@ -273,6 +273,11 @@ func mountBlockDevice(device, target string, flags uintptr, mode os.FileMode) er
 	return syscall.Mount(device, target, "", flags, "")
 }
 
+// workspaceMountFlags keeps the only writable guest filesystem from carrying
+// privilege escalation vectors. MS_NOEXEC is deliberately not set: builds and
+// tests legitimately execute binaries from the workspace.
+const workspaceMountFlags = syscall.MS_NOSUID | syscall.MS_NODEV
+
 func mountWorkspace(config bootConfig) error {
 	info, err := os.Stat(config.WorkspaceDevice)
 	if err != nil {
@@ -284,7 +289,13 @@ func mountWorkspace(config bootConfig) error {
 	if err := os.MkdirAll(config.WorkspaceMount, 0755); err != nil {
 		return fmt.Errorf("create workspace mount: %w", err)
 	}
-	if err := syscall.Mount(config.WorkspaceDevice, config.WorkspaceMount, "", 0, ""); err != nil {
+	flags := uintptr(workspaceMountFlags)
+	if err := syscall.Mount(config.WorkspaceDevice, config.WorkspaceMount, "ext4", flags, ""); err == nil {
+		return nil
+	} else if !errors.Is(err, syscall.ENODEV) {
+		return fmt.Errorf("mount workspace: %w", err)
+	}
+	if err := syscall.Mount(config.WorkspaceDevice, config.WorkspaceMount, "", flags, ""); err != nil {
 		return fmt.Errorf("mount workspace: %w", err)
 	}
 	return nil

--- a/guest/firecracker-supervisor/runtime_linux_test.go
+++ b/guest/firecracker-supervisor/runtime_linux_test.go
@@ -28,3 +28,40 @@ func TestResolveCommandRejectsRelativeExecutablePath(t *testing.T) {
 		t.Fatal("expected relative executable path to fail")
 	}
 }
+
+func TestUnmountPlanIsExactReverseOfMountOrder(t *testing.T) {
+	config := bootConfig{
+		WorkspaceMount: "/workspace",
+		RuntimeMount:   "/awf/runtime",
+		ExchangeMount:  "/awf/exchange",
+		RuntimeBinds: []runtimeBind{
+			{ID: "runner-temp", Target: "/awf/runner-temp/gh-aw"},
+			{ID: "compiler-tmp", Target: "/tmp/gh-aw"},
+		},
+	}
+
+	want := []string{
+		"/awf/exchange",
+		"/tmp/gh-aw",
+		"/awf/runner-temp/gh-aw",
+		"/awf/runtime",
+		"/workspace",
+	}
+	plan := unmountPlan(config)
+	if len(plan) != len(want) {
+		t.Fatalf("unmount plan length = %d, want %d", len(plan), len(want))
+	}
+	for i, step := range plan {
+		if step.Target != want[i] {
+			t.Fatalf("unmount plan[%d] = %q, want %q", i, step.Target, want[i])
+		}
+	}
+}
+
+func TestUnmountPlanSkipsAbsentOptionalDevices(t *testing.T) {
+	// A workspace-only guest must still produce a valid, workspace-last plan.
+	plan := unmountPlan(bootConfig{WorkspaceMount: "/workspace"})
+	if len(plan) != 1 || plan[0].Target != "/workspace" {
+		t.Fatalf("unmount plan = %+v, want workspace only", plan)
+	}
+}

--- a/guest/firecracker-supervisor/runtime_linux_test.go
+++ b/guest/firecracker-supervisor/runtime_linux_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -63,5 +64,23 @@ func TestUnmountPlanSkipsAbsentOptionalDevices(t *testing.T) {
 	plan := unmountPlan(bootConfig{WorkspaceMount: "/workspace"})
 	if len(plan) != 1 || plan[0].Target != "/workspace" {
 		t.Fatalf("unmount plan = %+v, want workspace only", plan)
+	}
+}
+
+// The workspace is the only writable guest filesystem, so it must never permit
+// setuid or device nodes. MS_NOEXEC must stay off because builds and tests run
+// binaries out of the workspace.
+func TestWorkspaceMountFlagsBlockPrivilegeVectors(t *testing.T) {
+	if workspaceMountFlags&syscall.MS_NOSUID == 0 {
+		t.Fatal("workspace mount must set MS_NOSUID")
+	}
+	if workspaceMountFlags&syscall.MS_NODEV == 0 {
+		t.Fatal("workspace mount must set MS_NODEV")
+	}
+	if workspaceMountFlags&syscall.MS_NOEXEC != 0 {
+		t.Fatal("workspace mount must not set MS_NOEXEC")
+	}
+	if workspaceMountFlags&syscall.MS_RDONLY != 0 {
+		t.Fatal("workspace mount must stay writable for copy-back")
 	}
 }

--- a/guest/firecracker/build-agent-rootfs.sh
+++ b/guest/firecracker/build-agent-rootfs.sh
@@ -83,12 +83,26 @@ mkdir -p "$rootfs_tree"
 cat >"$BUILD/install-packages.sh" <<EOF
 #!/bin/sh
 set -eu
+# The snapshot archive is fetched over HTTP on purpose: the digest-pinned base
+# ships no ca-certificates, so an HTTPS index could not be verified at all here
+# (that is the very package this stage installs). Integrity does not rest on
+# transport: apt verifies the snapshot's detached OpenPGP signature against the
+# debian-archive-keyring baked into the digest-pinned base image, and the
+# snapshot timestamp pins exactly which signed index is accepted. Insecure and
+# unauthenticated repositories are refused explicitly below, so a stripped
+# signature fails the build rather than silently downgrading.
 cat >/etc/apt/sources.list <<SOURCES
-deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ ${DEBIAN_SUITE} main
-deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ ${DEBIAN_SUITE}-security main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ ${DEBIAN_SUITE} main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ ${DEBIAN_SUITE}-security main
 SOURCES
 rm -f /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
-echo 'Acquire::Check-Valid-Until "false";' >/etc/apt/apt.conf.d/99-awf-snapshot
+cat >/etc/apt/apt.conf.d/99-awf-snapshot <<APTCONF
+Acquire::Check-Valid-Until "false";
+Acquire::AllowInsecureRepositories "false";
+Acquire::AllowDowngradeToInsecureRepositories "false";
+APT::Get::AllowUnauthenticated "false";
+APTCONF
+test -s /usr/share/keyrings/debian-archive-keyring.gpg
 export DEBIAN_FRONTEND=noninteractive
 apt-get -o Acquire::Retries=3 update
 apt-get -o Acquire::Retries=3 install --yes --no-install-recommends \\
@@ -148,9 +162,18 @@ download_verified \
   "$node_tar"
 mkdir -p "$rootfs_tree/opt/node"
 tar --extract --xz --file "$node_tar" --directory "$rootfs_tree/opt/node" --strip-components=1
-ln -sf ../../opt/node/bin/node "$rootfs_tree/usr/local/bin/node"
-ln -sf ../../opt/node/bin/npm "$rootfs_tree/usr/local/bin/npm"
-ln -sf ../../opt/node/bin/npx "$rootfs_tree/usr/local/bin/npx"
+# /usr/local/bin needs three levels to reach /, not two.
+mkdir -p "$rootfs_tree/usr/local/bin"
+ln -sf ../../../opt/node/bin/node "$rootfs_tree/usr/local/bin/node"
+ln -sf ../../../opt/node/bin/npm "$rootfs_tree/usr/local/bin/npm"
+ln -sf ../../../opt/node/bin/npx "$rootfs_tree/usr/local/bin/npx"
+for link in node npm npx; do
+  test -x "$rootfs_tree/usr/local/bin/$link" ||
+    {
+      echo "node runtime link is dangling: /usr/local/bin/$link" >&2
+      exit 1
+    }
+done
 
 # --- CA bundle, pinned by checksum ------------------------------------------
 ca_bundle="$BUILD/downloads/cacert-${CA_BUNDLE_DATE}.pem"
@@ -339,5 +362,19 @@ tar \
   manifest.json \
   packages.tsv \
   sbom.spdx.json
+
+# The build must run as root for ownership fidelity, but `umask 077` then leaves
+# the artifacts unreadable to the invoking user. CI checksums, attests and
+# uploads them unprivileged, so hand the output tree back to the real caller.
+output_parent=$(dirname -- "$OUTPUT")
+if [ -n "${SUDO_UID:-}" ] && [ -n "${SUDO_GID:-}" ]; then
+  chown -R "$SUDO_UID:$SUDO_GID" "$OUTPUT"
+  chown "$SUDO_UID:$SUDO_GID" "$output_parent" 2>/dev/null || true
+fi
+# The parent is created by this script under the same umask, so it needs to be
+# traversable too or the artifacts stay unreachable regardless of their own mode.
+chmod 0755 "$output_parent" "$OUTPUT"
+find "$OUTPUT" -type f -exec chmod 0644 {} +
+chmod 0755 "$OUTPUT/awf-firecracker-supervisor"
 
 echo "agent rootfs written to $OUTPUT"

--- a/guest/firecracker/build-agent-rootfs.sh
+++ b/guest/firecracker/build-agent-rootfs.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# Builds the agent-capable Firecracker guest rootfs.
+#
+# This is deliberately a SEPARATE builder and a SEPARATE artifact from
+# guest/firecracker/build-test-artifacts.sh. That script produces the tiny
+# 128 MiB static BusyBox rootfs used for low-level boot/protocol smokes and its
+# size and composition guarantees must not change. This script produces the
+# larger rootfs needed to actually execute generated gh-aw agents: a real Bash,
+# coreutils, git, curl, iproute2, CA certificates and a Node runtime, plus the
+# same AWF guest supervisor as init.
+#
+# Every external input is pinned: the base image by manifest digest, Debian
+# packages by snapshot.debian.org timestamp, and Node.js by release SHA-256.
+set -euo pipefail
+
+umask 077
+
+# Base image pinned by manifest digest (debian:bookworm-slim).
+DEBIAN_IMAGE_DIGEST=sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+DEBIAN_IMAGE=debian@${DEBIAN_IMAGE_DIGEST}
+# Frozen Debian package snapshot; no "latest" indexes are consulted.
+DEBIAN_SNAPSHOT=20251101T000000Z
+DEBIAN_SUITE=bookworm
+NODE_VERSION=22.22.0
+NODE_SHA256=9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37
+CA_BUNDLE_DATE=2025-02-25
+CA_BUNDLE_SHA256=50a6277ec69113f00c5fd45f09e8b97a4b3e32daa35d3a95ab30137a55386cef
+SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-1767225600}
+ROOTFS_BLOCKS=${ROOTFS_BLOCKS:-524288}
+ROOTFS_UUID=1b6b0d2f-72e3-4f1b-9e6a-9d0f7c3a5f11
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+OUTPUT=${OUTPUT:-"$ROOT/release/firecracker-agent-x86_64"}
+BUILD=${BUILD:-"$ROOT/.build/firecracker-agent-x86_64"}
+
+if [ "$(uname -s)" != Linux ] || [ "$(uname -m)" != x86_64 ]; then
+  echo "Firecracker agent rootfs must be built on Linux x86_64" >&2
+  exit 1
+fi
+
+# Root is required so the exported Debian tree keeps its real ownership and
+# permissions; a user-owned tree would produce an unusable guest filesystem.
+if [ "$(id -u)" != 0 ]; then
+  echo "Firecracker agent rootfs build must run as root (ownership fidelity)" >&2
+  exit 1
+fi
+
+for tool in curl sha256sum tar docker mke2fs e2fsck go; do
+  command -v "$tool" >/dev/null || {
+    echo "required build tool not found: $tool" >&2
+    exit 1
+  }
+done
+
+rm -rf "$BUILD" "$OUTPUT"
+mkdir -p "$BUILD/downloads" "$OUTPUT"
+
+download_verified() {
+  local url=$1
+  local expected=$2
+  local destination=$3
+  curl --fail --location --proto '=https' --tlsv1.2 "$url" --output "$destination"
+  printf '%s  %s\n' "$expected" "$destination" | sha256sum --check --status
+}
+
+# --- Base filesystem from the digest-pinned Debian image ---------------------
+docker pull "$DEBIAN_IMAGE" >/dev/null
+resolved_digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$DEBIAN_IMAGE")
+case "$resolved_digest" in
+  *"$DEBIAN_IMAGE_DIGEST") ;;
+  *)
+    echo "base image digest mismatch: $resolved_digest" >&2
+    exit 1
+    ;;
+esac
+
+rootfs_tree="$BUILD/rootfs"
+mkdir -p "$rootfs_tree"
+
+# Package installation runs inside the pinned base image against a frozen
+# snapshot index, then the whole tree is exported. Nothing is fetched from a
+# mutable "latest" Debian mirror.
+cat >"$BUILD/install-packages.sh" <<EOF
+#!/bin/sh
+set -eu
+cat >/etc/apt/sources.list <<SOURCES
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ ${DEBIAN_SUITE} main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ ${DEBIAN_SUITE}-security main
+SOURCES
+rm -f /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+echo 'Acquire::Check-Valid-Until "false";' >/etc/apt/apt.conf.d/99-awf-snapshot
+export DEBIAN_FRONTEND=noninteractive
+apt-get -o Acquire::Retries=3 update
+apt-get -o Acquire::Retries=3 install --yes --no-install-recommends \\
+  bash \\
+  ca-certificates \\
+  coreutils \\
+  curl \\
+  findutils \\
+  gawk \\
+  git \\
+  grep \\
+  iproute2 \\
+  iputils-ping \\
+  jq \\
+  less \\
+  openssl \\
+  procps \\
+  sed \\
+  tar \\
+  unzip \\
+  xz-utils
+dpkg-query --show --showformat='\${Package}\t\${Version}\t\${Architecture}\n' | sort >/awf-packages.tsv
+apt-get clean
+rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb
+EOF
+chmod 0755 "$BUILD/install-packages.sh"
+
+container=$(docker create "$DEBIAN_IMAGE" /bin/sh -c 'sleep 3600')
+cleanup_container() {
+  docker rm --force "$container" >/dev/null 2>&1 || true
+}
+trap cleanup_container EXIT
+docker start "$container" >/dev/null
+docker cp "$BUILD/install-packages.sh" "$container:/install-packages.sh"
+docker exec "$container" /install-packages.sh
+docker cp "$container:/awf-packages.tsv" "$BUILD/packages.tsv"
+docker export "$container" >"$BUILD/rootfs.tar"
+cleanup_container
+trap - EXIT
+
+tar --extract --file "$BUILD/rootfs.tar" --directory "$rootfs_tree" \
+  --numeric-owner \
+  --same-owner \
+  --preserve-permissions \
+  --exclude='.dockerenv' \
+  --exclude='awf-packages.tsv' \
+  --exclude='install-packages.sh' \
+  --exclude='dev/*' \
+  --exclude='proc/*' \
+  --exclude='sys/*'
+
+# --- Node.js runtime, pinned by release checksum ----------------------------
+node_tar="$BUILD/downloads/node-v${NODE_VERSION}-linux-x64.tar.xz"
+download_verified \
+  "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+  "$NODE_SHA256" \
+  "$node_tar"
+mkdir -p "$rootfs_tree/opt/node"
+tar --extract --xz --file "$node_tar" --directory "$rootfs_tree/opt/node" --strip-components=1
+ln -sf ../../opt/node/bin/node "$rootfs_tree/usr/local/bin/node"
+ln -sf ../../opt/node/bin/npm "$rootfs_tree/usr/local/bin/npm"
+ln -sf ../../opt/node/bin/npx "$rootfs_tree/usr/local/bin/npx"
+
+# --- CA bundle, pinned by checksum ------------------------------------------
+ca_bundle="$BUILD/downloads/cacert-${CA_BUNDLE_DATE}.pem"
+download_verified \
+  "https://curl.se/ca/cacert-${CA_BUNDLE_DATE}.pem" \
+  "$CA_BUNDLE_SHA256" \
+  "$ca_bundle"
+install -D -m 0644 "$ca_bundle" "$rootfs_tree/etc/ssl/certs/ca-certificates.crt"
+
+# --- AWF guest supervisor (same init contract as the test rootfs) ------------
+supervisor="$OUTPUT/awf-firecracker-supervisor"
+VERSION="${VERSION:-agent-${DEBIAN_SUITE}-${DEBIAN_SNAPSHOT}}" \
+  OUTPUT="$supervisor" \
+  "$ROOT/guest/firecracker-supervisor/build.sh"
+install -m 0755 "$supervisor" "$rootfs_tree/sbin/awf-supervisor"
+
+# --- Guest identity and mount points ----------------------------------------
+mkdir -p \
+  "$rootfs_tree/awf/exchange" \
+  "$rootfs_tree/awf/runner-temp" \
+  "$rootfs_tree/awf/runtime" \
+  "$rootfs_tree/dev" \
+  "$rootfs_tree/proc" \
+  "$rootfs_tree/sys" \
+  "$rootfs_tree/tmp" \
+  "$rootfs_tree/workspace"
+cat >"$rootfs_tree/etc/passwd" <<'PASSWD'
+root:x:0:0:root:/root:/bin/bash
+awf:x:1000:1000:AWF guest:/workspace:/bin/bash
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+PASSWD
+cat >"$rootfs_tree/etc/group" <<'GROUP'
+root:x:0:
+awf:x:1000:
+nogroup:x:65534:
+GROUP
+cat >"$rootfs_tree/etc/resolv.conf" <<'RESOLV'
+# Direct DNS is intentionally unavailable in the Firecracker preview.
+RESOLV
+cat >"$rootfs_tree/etc/hostname" <<'HOSTNAME'
+awf-firecracker
+HOSTNAME
+# No host credential material, package caches, or machine identity ships here.
+rm -f \
+  "$rootfs_tree/etc/machine-id" \
+  "$rootfs_tree/etc/shadow" \
+  "$rootfs_tree/etc/shadow-" \
+  "$rootfs_tree/etc/gshadow" \
+  "$rootfs_tree/etc/gshadow-" \
+  "$rootfs_tree/root/.bash_history"
+chmod 0755 "$rootfs_tree/awf/runner-temp" "$rootfs_tree/awf/runtime" "$rootfs_tree/awf/exchange"
+chmod 01777 "$rootfs_tree/tmp"
+
+# setuid/setgid binaries are unnecessary for the guest workload and are a
+# privilege-escalation surface once repository-controlled code runs inside.
+find "$rootfs_tree" -xdev -type f -perm /6000 -exec chmod a-s {} +
+if find "$rootfs_tree" -xdev -type f -perm /6000 | grep -q .; then
+  echo "setuid/setgid binaries remain in the agent rootfs" >&2
+  exit 1
+fi
+
+find "$rootfs_tree" -print0 | xargs -0 touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
+
+# --- Image ------------------------------------------------------------------
+rootfs="$OUTPUT/rootfs.ext4"
+E2FSPROGS_FAKE_TIME="$SOURCE_DATE_EPOCH" mke2fs \
+  -t ext4 \
+  -F \
+  -q \
+  -b 4096 \
+  -d "$rootfs_tree" \
+  -U "$ROOTFS_UUID" \
+  -E lazy_itable_init=0,lazy_journal_init=0 \
+  "$rootfs" \
+  "$ROOTFS_BLOCKS"
+E2FSPROGS_FAKE_TIME="$SOURCE_DATE_EPOCH" e2fsck -f -y "$rootfs" >/dev/null
+
+"$ROOT/guest/firecracker/verify-agent-rootfs.sh" "$rootfs_tree"
+# Re-verify the published image itself so the artifact, not just the staging
+# tree, is what carries the contract.
+"$ROOT/guest/firecracker/verify-agent-rootfs.sh" "$rootfs"
+
+(
+  cd "$OUTPUT"
+  sha256sum rootfs.ext4 awf-firecracker-supervisor >SHA256SUMS
+)
+
+package_json=$(
+  awk -F'\t' 'BEGIN { printf "[" } {
+    if (NR > 1) printf ",";
+    printf "\n      {\"name\": \"%s\", \"version\": \"%s\", \"architecture\": \"%s\"}", $1, $2, $3
+  } END { printf "\n    ]" }' "$BUILD/packages.tsv"
+)
+
+cat >"$OUTPUT/manifest.json" <<MANIFEST
+{
+  "schemaVersion": 1,
+  "purpose": "AWF Firecracker agent-capable guest rootfs for gh-aw workloads",
+  "artifact": "firecracker-agent-x86_64",
+  "architecture": "x86_64",
+  "sourceDateEpoch": ${SOURCE_DATE_EPOCH},
+  "base": {
+    "image": "debian:bookworm-slim",
+    "digest": "${DEBIAN_IMAGE_DIGEST}",
+    "snapshot": "${DEBIAN_SNAPSHOT}",
+    "suite": "${DEBIAN_SUITE}"
+  },
+  "node": {
+    "version": "${NODE_VERSION}",
+    "tarballSha256": "${NODE_SHA256}"
+  },
+  "caBundle": {
+    "date": "${CA_BUNDLE_DATE}",
+    "sha256": "${CA_BUNDLE_SHA256}"
+  },
+  "rootfs": {
+    "uuid": "${ROOTFS_UUID}",
+    "blockSizeBytes": 4096,
+    "blocks": ${ROOTFS_BLOCKS}
+  },
+  "packages": ${package_json}
+}
+MANIFEST
+
+cat >"$OUTPUT/sbom.spdx.json" <<SBOM
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "awf-firecracker-agent-x86_64",
+  "documentNamespace": "https://github.com/github/gh-aw-firewall/firecracker-agent/${SOURCE_DATE_EPOCH}",
+  "creationInfo": {
+    "created": "2026-01-01T00:00:00Z",
+    "creators": ["Tool: guest/firecracker/build-agent-rootfs.sh"]
+  },
+  "packages": [
+    {
+      "name": "debian",
+      "SPDXID": "SPDXRef-Debian",
+      "versionInfo": "${DEBIAN_SUITE}@${DEBIAN_SNAPSHOT}",
+      "downloadLocation": "https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/",
+      "filesAnalyzed": false,
+      "checksums": [
+        { "algorithm": "SHA256", "checksumValue": "${DEBIAN_IMAGE_DIGEST#sha256:}" }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "name": "nodejs",
+      "SPDXID": "SPDXRef-NodeJS",
+      "versionInfo": "${NODE_VERSION}",
+      "downloadLocation": "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz",
+      "filesAnalyzed": false,
+      "checksums": [
+        { "algorithm": "SHA256", "checksumValue": "${NODE_SHA256}" }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    { "spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-Debian" },
+    { "spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-NodeJS" }
+  ]
+}
+SBOM
+
+cp "$BUILD/packages.tsv" "$OUTPUT/packages.tsv"
+
+tar \
+  --sort=name \
+  --mtime="@${SOURCE_DATE_EPOCH}" \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  --create \
+  --gzip \
+  --file "$OUTPUT/awf-firecracker-agent-x86_64.tar.gz" \
+  --directory "$OUTPUT" \
+  rootfs.ext4 \
+  awf-firecracker-supervisor \
+  SHA256SUMS \
+  manifest.json \
+  packages.tsv \
+  sbom.spdx.json
+
+echo "agent rootfs written to $OUTPUT"

--- a/guest/firecracker/verify-agent-rootfs.sh
+++ b/guest/firecracker/verify-agent-rootfs.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Proves the agent rootfs satisfies the gh-aw execution contract.
+#
+# Usage: verify-agent-rootfs.sh <rootfs-tree|rootfs.ext4>
+#
+# Generated gh-aw agents need a real Bash/Node userspace, not just the binaries
+# themselves: every required executable must have its interpreter and shared
+# libraries present inside the guest tree. This checks both, and re-asserts the
+# security properties the builder relies on.
+#
+# Passing an ext4 image verifies the published artifact rather than the staging
+# tree. The image is only ever read: it is dumped through debugfs in read-only
+# mode, so verification can run unprivileged in CI and can never mutate the
+# artifact it is attesting.
+set -euo pipefail
+
+target=${1:?usage: verify-agent-rootfs.sh <rootfs-tree|rootfs.ext4>}
+image=
+extracted=
+
+cleanup() {
+  [ -n "$extracted" ] && rm -rf -- "$extracted"
+}
+trap cleanup EXIT
+
+if [ -f "$target" ]; then
+  command -v debugfs >/dev/null || {
+    echo "verify-agent-rootfs: debugfs is required to verify an ext4 image" >&2
+    exit 1
+  }
+  image=$target
+  extracted=$(mktemp -d)
+  # debugfs without -w opens the image read-only.
+  debugfs -R "rdump / $extracted" "$target" >/dev/null 2>&1
+  if [ ! -d "$extracted/etc" ]; then
+    # Some debugfs versions nest the dump one level deep.
+    for candidate in "$extracted"/*; do
+      if [ -d "$candidate/etc" ]; then
+        extracted_root=$candidate
+        break
+      fi
+    done
+    target=${extracted_root:?verify-agent-rootfs: could not locate rootfs in image dump}
+  else
+    target=$extracted
+  fi
+fi
+
+tree=$(CDPATH= cd -- "$target" && pwd)
+
+failures=0
+fail() {
+  echo "verify-agent-rootfs: $*" >&2
+  failures=$((failures + 1))
+}
+
+require_file() {
+  local relative=$1
+  local path="$tree/$relative"
+  if [ ! -e "$path" ]; then
+    fail "missing required path: /$relative"
+    return 1
+  fi
+  return 0
+}
+
+require_executable() {
+  local relative=$1
+  require_file "$relative" || return 0
+  local path="$tree/$relative"
+  local resolved
+  resolved=$(readlink -f "$path" 2>/dev/null || true)
+  if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+    fail "/$relative does not resolve to a regular file"
+    return 0
+  fi
+  case "$resolved" in
+    "$tree"/*) ;;
+    *)
+      fail "/$relative resolves outside the rootfs tree: $resolved"
+      return 0
+      ;;
+  esac
+  if [ ! -x "$resolved" ]; then
+    fail "/$relative is not executable"
+    return 0
+  fi
+  verify_dependencies "$relative" "$resolved"
+}
+
+# Resolves ELF interpreter and NEEDED libraries and proves each exists in-tree.
+verify_dependencies() {
+  local relative=$1
+  local resolved=$2
+  local header
+  header=$(head -c 4 "$resolved" | od -An -tx1 | tr -d ' \n')
+  if [ "$header" != "7f454c46" ]; then
+    # Script: prove the shebang interpreter exists inside the tree.
+    local shebang
+    shebang=$(head -c 128 "$resolved" | head -n 1)
+    case "$shebang" in
+      '#!'*)
+        local interpreter
+        interpreter=$(printf '%s' "${shebang#\#!}" | awk '{print $1}')
+        case "$interpreter" in
+          /usr/bin/env)
+            local program
+            program=$(printf '%s' "${shebang#\#!}" | awk '{print $2}')
+            [ -e "$tree/usr/bin/env" ] || fail "/$relative needs /usr/bin/env"
+            command -v true >/dev/null
+            if [ -n "$program" ] &&
+              [ ! -e "$tree/usr/bin/$program" ] &&
+              [ ! -e "$tree/bin/$program" ] &&
+              [ ! -e "$tree/usr/local/bin/$program" ]; then
+              fail "/$relative needs interpreter $program"
+            fi
+            ;;
+          /*)
+            [ -e "$tree$interpreter" ] || fail "/$relative needs interpreter $interpreter"
+            ;;
+        esac
+        ;;
+    esac
+    return 0
+  fi
+  if ! command -v readelf >/dev/null; then
+    return 0
+  fi
+  local interpreter
+  interpreter=$(readelf -l "$resolved" 2>/dev/null |
+    sed -n 's/.*program interpreter: \(.*\)\]/\1/p' | head -n 1)
+  if [ -n "$interpreter" ] && [ ! -e "$tree$interpreter" ]; then
+    fail "/$relative needs ELF interpreter $interpreter"
+  fi
+  local needed
+  needed=$(readelf -d "$resolved" 2>/dev/null |
+    sed -n 's/.*(NEEDED).*Shared library: \[\(.*\)\]/\1/p')
+  local library
+  for library in $needed; do
+    if ! find "$tree/lib" "$tree/lib64" "$tree/usr/lib" "$tree/usr/lib64" \
+      -name "$library" -print -quit 2>/dev/null | grep -q .; then
+      fail "/$relative needs shared library $library"
+    fi
+  done
+}
+
+for executable in \
+  bin/bash \
+  bin/sh \
+  sbin/awf-supervisor \
+  usr/bin/env \
+  usr/bin/git \
+  usr/bin/curl \
+  usr/bin/cat \
+  usr/bin/cp \
+  usr/bin/find \
+  usr/bin/grep \
+  usr/bin/id \
+  usr/bin/mkdir \
+  usr/bin/sed \
+  usr/bin/tar \
+  usr/sbin/ip \
+  usr/local/bin/node \
+  usr/local/bin/npm; do
+  require_executable "$executable"
+done
+
+for path in \
+  etc/group \
+  etc/passwd \
+  etc/resolv.conf \
+  etc/ssl/certs/ca-certificates.crt \
+  awf/exchange \
+  awf/runner-temp \
+  awf/runtime \
+  workspace; do
+  require_file "$path" || true
+done
+
+# The guest must never ship host or provider credential material.
+for forbidden in \
+  etc/shadow \
+  etc/gshadow \
+  root/.netrc \
+  root/.git-credentials \
+  root/.ssh \
+  root/.aws \
+  root/.docker \
+  root/.npmrc; do
+  if [ -e "$tree/$forbidden" ]; then
+    fail "credential-bearing path present: /$forbidden"
+  fi
+done
+
+if find "$tree" -xdev -type f -perm /6000 | grep -q .; then
+  fail "setuid/setgid binaries present"
+fi
+
+# debugfs `rdump` restores only the nine rwx bits and skips device nodes, FIFOs
+# and sockets, so the tree walk above can never observe setuid/setgid or special
+# files that exist in the image. Read the inode modes out of the image itself.
+verify_image_inode_modes() {
+  local image=$1 tree=$2
+  local commands listing
+  commands=$(mktemp)
+  listing=$(mktemp)
+  {
+    echo "ls -l -p /"
+    (cd "$tree" && find . -type d -print) |
+      sed -e 's|^\.||' -e '/^$/d' |
+      while IFS= read -r directory; do
+        printf 'ls -l -p %s\n' "$directory"
+      done
+  } >"$commands"
+  debugfs -f "$commands" "$image" 2>/dev/null >"$listing"
+
+  local offenders
+  # `ls -l -p` emits ` /inode/mode/uid/gid/name/size/date/`, so real rows have a
+  # blank first field; debugfs echoes its own commands, which do not.
+  offenders=$(awk -F/ '
+    $1 ~ /^[[:space:]]*$/ && NF >= 7 && $3 ~ /^[0-7]{5,7}$/ {
+      mode = $3
+      name = $6
+      if (name == "" || name == "." || name == "..") next
+      type = substr(mode, 1, length(mode) - 4)
+      special = substr(mode, length(mode) - 3, 1)
+      # Only 0 and the sticky bit (1) are permitted; 2/4 are setgid/setuid.
+      if (special != "0" && special != "1") {
+        print "setuid/setgid inode in image: " name " mode " mode
+      }
+      # 10 regular, 04 directory, 12 symlink; anything else is a special file.
+      else if (type != "10" && type != "04" && type != "12") {
+        print "special filesystem inode in image: " name " mode " mode
+      }
+    }' "$listing")
+  rm -f "$commands" "$listing"
+
+  if [ -n "$offenders" ]; then
+    while IFS= read -r offender; do
+      fail "$offender"
+    done <<<"$offenders"
+  fi
+}
+
+if [ -n "$image" ]; then
+  verify_image_inode_modes "$image" "$tree"
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "verify-agent-rootfs: $failures check(s) failed" >&2
+  exit 1
+fi
+
+echo "verify-agent-rootfs: agent rootfs contract satisfied"

--- a/guest/firecracker/verify-agent-rootfs.sh
+++ b/guest/firecracker/verify-agent-rootfs.sh
@@ -202,6 +202,65 @@ if find "$tree" -xdev -type f -perm /6000 | grep -q .; then
   fail "setuid/setgid binaries present"
 fi
 
+# gh-aw engines ship prebuilt glibc binaries, so a musl rootfs would fail at run
+# time rather than at build time. Prove the C library family explicitly.
+verify_glibc() {
+  local loader found=""
+  for loader in \
+    lib64/ld-linux-x86-64.so.2 \
+    lib/ld-linux-x86-64.so.2 \
+    lib/ld-linux-aarch64.so.1 \
+    lib64/ld-linux-aarch64.so.1; do
+    if [ -e "$tree/$loader" ]; then
+      found=$loader
+      break
+    fi
+  done
+  if [ -z "$found" ]; then
+    fail "no glibc dynamic loader (ld-linux-*.so) found in the rootfs"
+  fi
+  if ! find "$tree/lib" "$tree/lib64" "$tree/usr/lib" "$tree/usr/lib64" \
+    -name 'libc.so.6' -print -quit 2>/dev/null | grep -q .; then
+    fail "glibc runtime (libc.so.6) missing from the rootfs"
+  fi
+  if find "$tree" -xdev \( -name 'ld-musl-*.so*' -o -name 'libc.musl-*.so*' \) \
+    -print -quit 2>/dev/null | grep -q .; then
+    fail "musl C library present; the agent rootfs must be glibc-based"
+  fi
+  # The pinned Node build is the engine host, so it must use the glibc loader.
+  local node="$tree/usr/local/bin/node"
+  if [ -e "$node" ] && command -v readelf >/dev/null; then
+    local resolved node_interpreter
+    resolved=$(readlink -f "$node" 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ -f "$resolved" ]; then
+      node_interpreter=$(readelf -l "$resolved" 2>/dev/null |
+        sed -n 's/.*program interpreter: \(.*\)\]/\1/p' | head -n 1)
+      case "$node_interpreter" in
+        */ld-linux-*) ;;
+        '')
+          fail "node is not a dynamically linked glibc executable"
+          ;;
+        *)
+          fail "node uses non-glibc interpreter $node_interpreter"
+          ;;
+      esac
+    fi
+  fi
+}
+
+verify_glibc
+
+# Host runtimes and the runner tool cache must never be baked into the guest.
+for forbidden_tree in \
+  opt/hostedtoolcache \
+  opt/actions-runner \
+  home/runner \
+  usr/local/share/hostedtoolcache; do
+  if [ -e "$tree/$forbidden_tree" ]; then
+    fail "host runner state present: /$forbidden_tree"
+  fi
+done
+
 # debugfs `rdump` restores only the nine rwx bits and skips device nodes, FIFOs
 # and sockets, so the tree walk above can never observe setuid/setgid or special
 # files that exist in the image. Read the inode modes out of the image itself.

--- a/guest/firecracker/verify-agent-rootfs.sh
+++ b/guest/firecracker/verify-agent-rootfs.sh
@@ -19,7 +19,13 @@ image=
 extracted=
 
 cleanup() {
-  [ -n "$extracted" ] && rm -rf -- "$extracted"
+  # Must end in a success status: under `set -e` the trap's last command becomes
+  # the script's exit status, so a bare `[ -n "$extracted" ] && rm` would fail
+  # every tree-mode verification.
+  if [ -n "$extracted" ]; then
+    rm -rf -- "$extracted"
+  fi
+  return 0
 }
 trap cleanup EXIT
 

--- a/scripts/ci/firecracker-agent-rootfs-contract.test.ts
+++ b/scripts/ci/firecracker-agent-rootfs-contract.test.ts
@@ -89,6 +89,23 @@ describe('Firecracker agent rootfs build contract', () => {
     expect(verifier).toContain('.git-credentials');
   });
 
+  it('builds its userspace from pinned inputs, never from the host', () => {
+    // A rootfs that copied host runtimes or RUNNER_TOOL_CACHE would inherit
+    // whatever the runner happened to have, defeating the pinning above.
+    expect(builder).not.toMatch(/RUNNER_TOOL_CACHE/);
+    expect(builder).not.toMatch(/hostedtoolcache/);
+    expect(builder).not.toMatch(/cp\s+-[a-zA-Z]*\s*\/usr\/(bin|lib)/);
+    expect(builder).not.toMatch(/command -v node/);
+    // Node arrives as a checksum-verified release tarball.
+    expect(builder).toMatch(/nodejs\.org\/dist\/v\$\{NODE_VERSION\}/);
+    expect(builder).toContain('NODE_SHA256');
+  });
+
+  it('strips setuid and setgid from the staged tree and proves none remain', () => {
+    expect(builder).toMatch(/-perm \/6000 -exec chmod a-s/);
+    expect(builder).toMatch(/-perm \/6000 \| grep -q \./);
+  });
+
   it('reads setuid and special-file modes from the image inode table', () => {
     // `debugfs rdump` drops setuid/setgid bits and skips special files, so a
     // find(1) walk of the dump can never observe them. The verifier has to read

--- a/scripts/ci/firecracker-agent-rootfs-contract.test.ts
+++ b/scripts/ci/firecracker-agent-rootfs-contract.test.ts
@@ -1,0 +1,108 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+const guestDir = path.resolve(__dirname, '../../guest/firecracker');
+const builderPath = path.join(guestDir, 'build-agent-rootfs.sh');
+const verifierPath = path.join(guestDir, 'verify-agent-rootfs.sh');
+const testBuilderPath = path.join(guestDir, 'build-test-artifacts.sh');
+
+function read(file: string): string {
+  return fs.readFileSync(file, 'utf-8');
+}
+
+describe('Firecracker agent rootfs build contract', () => {
+  const builder = read(builderPath);
+  const verifier = read(verifierPath);
+  const testBuilder = read(testBuilderPath);
+
+  it('ships the agent builder and verifier as separate executable scripts', () => {
+    for (const script of [builderPath, verifierPath]) {
+      expect(fs.existsSync(script)).toBe(true);
+      // eslint-disable-next-line no-bitwise
+      expect(fs.statSync(script).mode & 0o111).not.toBe(0);
+      expect(() => execFileSync('bash', ['-n', script])).not.toThrow();
+    }
+  });
+
+  it('keeps the low-level BusyBox test artifact contract untouched', () => {
+    expect(testBuilder).toContain('release/firecracker-test-x86_64');
+    expect(testBuilder).toMatch(/busybox/i);
+    // 32768 4 KiB blocks == the documented 128 MiB low-level test image.
+    expect(testBuilder).toMatch(/mke2fs[\s\S]*\n\s*32768\n/);
+
+    expect(builder).not.toContain('release/firecracker-test-x86_64');
+    expect(builder).not.toMatch(/^\s*BUSYBOX_VERSION=/m);
+  });
+
+  it('publishes the agent rootfs under a distinct artifact directory', () => {
+    expect(builder).toContain('release/firecracker-agent-x86_64');
+    expect(builder).toContain('firecracker-agent-x86_64.tar.gz');
+    for (const artifact of [
+      'rootfs.ext4',
+      'awf-firecracker-supervisor',
+      'SHA256SUMS',
+      'manifest.json',
+      'packages.tsv',
+      'sbom.spdx.json',
+    ]) {
+      expect(builder).toContain(artifact);
+    }
+  });
+
+  it('pins every external input by digest, snapshot, or checksum', () => {
+    expect(builder).toMatch(/DEBIAN_IMAGE_DIGEST=sha256:[0-9a-f]{64}$/m);
+    expect(builder).toMatch(/DEBIAN_SNAPSHOT=\d{8}T\d{6}Z$/m);
+    expect(builder).toMatch(/NODE_SHA256=[0-9a-f]{64}$/m);
+    expect(builder).toMatch(/CA_BUNDLE_SHA256=[0-9a-f]{64}$/m);
+    expect(builder).toContain('snapshot.debian.org');
+    expect(builder).toContain('SOURCE_DATE_EPOCH');
+
+    expect(builder).not.toMatch(/debian:bookworm-slim\s*$/m);
+    expect(builder).not.toMatch(/:latest/);
+    expect(builder).not.toMatch(/\bcurl\b[^\n]*\|\s*(ba)?sh\b/);
+  });
+
+  it('requires an agent-capable userspace rather than a BusyBox shell', () => {
+    for (const required of [
+      'bin/bash',
+      'sbin/awf-supervisor',
+      'usr/bin/git',
+      'usr/bin/curl',
+      'usr/sbin/ip',
+      'usr/local/bin/node',
+      'etc/ssl/certs/ca-certificates.crt',
+    ]) {
+      expect(verifier).toContain(required);
+    }
+  });
+
+  it('proves interpreter and shared library dependencies resolve inside the image', () => {
+    expect(verifier).toMatch(/ldd|NEEDED|interpreter/i);
+    expect(verifier).toMatch(/node|--version/);
+  });
+
+  it('strips setuid, setgid, and credential material from the image', () => {
+    expect(builder).toMatch(/-perm\s+\/[46]000|4000|2000/);
+    expect(builder).toMatch(/shadow/);
+    expect(verifier).toMatch(/-perm/);
+    expect(verifier).toContain('.git-credentials');
+  });
+
+  it('reads setuid and special-file modes from the image inode table', () => {
+    // `debugfs rdump` drops setuid/setgid bits and skips special files, so a
+    // find(1) walk of the dump can never observe them. The verifier has to read
+    // the modes back out of the image itself.
+    expect(verifier).toContain('verify_image_inode_modes');
+    expect(verifier).toMatch(/ls\s+-l\s+-p/);
+    expect(verifier).toMatch(/setuid\/setgid inode in image/);
+    expect(verifier).toMatch(/special filesystem inode in image/);
+  });
+
+  it('verifies the published image without ever writing to it', () => {
+    expect(builder).toContain('verify-agent-rootfs.sh');
+    expect(verifier).toContain('rdump /');
+    expect(verifier).not.toMatch(/debugfs\s+-w/);
+    expect(verifier).not.toMatch(/\bmount\b/);
+  });
+});

--- a/scripts/ci/firecracker-agent-rootfs-contract.test.ts
+++ b/scripts/ci/firecracker-agent-rootfs-contract.test.ts
@@ -153,4 +153,36 @@ describe('Firecracker agent rootfs build contract', () => {
     expect(verifier).not.toMatch(/debugfs\s+-w/);
     expect(verifier).not.toMatch(/\bmount\b/);
   });
+
+  it('proves the rootfs is glibc-based rather than musl', () => {
+    // gh-aw engines ship prebuilt glibc binaries.
+    expect(verifier).toContain('verify_glibc');
+    expect(verifier).toContain('ld-linux-x86-64.so.2');
+    expect(verifier).toContain('libc.so.6');
+    expect(verifier).toMatch(/ld-musl-\*\.so\*/);
+    expect(verifier).toContain('must be glibc-based');
+    // Debian is glibc-based; a musl base would silently break the engines.
+    expect(builder).toMatch(/DEBIAN_IMAGE_DIGEST=sha256:[0-9a-f]{64}/);
+    expect(builder).toContain('DEBIAN_IMAGE=debian@${DEBIAN_IMAGE_DIGEST}');
+    expect(builder).not.toMatch(/\balpine\b/);
+  });
+
+  it('proves the pinned Node build uses the glibc loader', () => {
+    expect(verifier).toContain('node is not a dynamically linked glibc executable');
+    expect(verifier).toContain('uses non-glibc interpreter');
+  });
+
+  it('refuses host runner state and the runner tool cache', () => {
+    for (const forbidden of [
+      'opt/hostedtoolcache',
+      'opt/actions-runner',
+      'home/runner',
+    ]) {
+      expect(verifier).toContain(forbidden);
+    }
+    expect(verifier).toContain('host runner state present');
+    // The builder must never copy host runtimes into the guest image.
+    expect(builder).not.toContain('RUNNER_TOOL_CACHE');
+    expect(builder).not.toContain('hostedtoolcache');
+  });
 });

--- a/scripts/ci/firecracker-agent-rootfs-contract.test.ts
+++ b/scripts/ci/firecracker-agent-rootfs-contract.test.ts
@@ -99,6 +99,37 @@ describe('Firecracker agent rootfs build contract', () => {
     expect(verifier).toMatch(/special filesystem inode in image/);
   });
 
+  it('does not need CA certificates before it can install them', () => {
+    // The pinned Debian base ships no ca-certificates, so an HTTPS apt index
+    // could never be verified at this stage. Integrity comes from apt's OpenPGP
+    // signature check instead, which must stay mandatory.
+    expect(builder).not.toMatch(/deb .*https:\/\/snapshot\.debian\.org/);
+    expect(builder).toMatch(/deb .*http:\/\/snapshot\.debian\.org/);
+    expect(builder).toContain('AllowInsecureRepositories "false"');
+    expect(builder).toContain('AllowUnauthenticated "false"');
+    expect(builder).toContain('debian-archive-keyring.gpg');
+  });
+
+  it('links the Node runtime with a path that actually resolves', () => {
+    // /usr/local/bin needs three levels to reach /, not two.
+    expect(builder).not.toMatch(/ln -sf \.\.\/\.\.\/opt\/node/);
+    expect(builder).toMatch(/ln -sf \.\.\/\.\.\/\.\.\/opt\/node\/bin\/node/);
+    expect(builder).toMatch(/dangling/);
+  });
+
+  it('hands the artifacts back to the invoking user', () => {
+    // The build must run as root, but CI checksums, attests and uploads
+    // unprivileged, and umask 077 would otherwise make that impossible.
+    expect(builder).toContain('SUDO_UID');
+    expect(builder).toMatch(/chmod 0755 "\$output_parent" "\$OUTPUT"/);
+  });
+
+  it('does not let its own cleanup trap fail a successful verification', () => {
+    // Under `set -e` the trap's last command becomes the exit status.
+    expect(verifier).not.toMatch(/^\s*\[ -n "\$extracted" \] && rm/m);
+    expect(verifier).toMatch(/return 0/);
+  });
+
   it('verifies the published image without ever writing to it', () => {
     expect(builder).toContain('verify-agent-rootfs.sh');
     expect(verifier).toContain('rdump /');

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -725,6 +725,76 @@
               "$ref": "#/$defs/sha256Digest"
             }
           }
+        },
+        "ghAwRuntime": {
+          "type": "object",
+          "description": "AWF-owned staging contract for generated gh-aw agent runtime assets. Sources are fixed by AWF (canonical RUNNER_TEMP/gh-aw and the compiler tmp gh-aw tree); this is never a general bind-mount facility and never stages credentials.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Stage the fixed gh-aw runtime asset set onto a dedicated read-only guest block device."
+            },
+            "runnerTempPath": {
+              "type": "string",
+              "description": "Absolute host RUNNER_TEMP whose gh-aw subtree is staged. Defaults to $RUNNER_TEMP."
+            },
+            "compilerTmpPath": {
+              "type": "string",
+              "description": "Absolute host tmp root whose gh-aw subtree is staged. Defaults to /tmp."
+            },
+            "maxFileBytes": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 67108864,
+              "description": "Per-file byte cap enforced while staging runtime assets."
+            },
+            "maxTotalBytes": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 536870912,
+              "description": "Total byte cap enforced while staging runtime assets."
+            },
+            "maxFileCount": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 20000,
+              "description": "File count cap enforced while staging runtime assets."
+            },
+            "safeOutputs": {
+              "type": "object",
+              "description": "Bounded safe-output exchange device. Guest writes are copied back to the host only after confirmed VM stop.",
+              "additionalProperties": false,
+              "required": [
+                "hostDirectory"
+              ],
+              "properties": {
+                "hostDirectory": {
+                  "type": "string",
+                  "description": "Absolute host directory that receives a per-run subdirectory of validated safe outputs."
+                },
+                "maxFileBytes": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 16777216,
+                  "description": "Per-file byte cap enforced during copy-back."
+                },
+                "maxTotalBytes": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 67108864,
+                  "description": "Total byte cap enforced during copy-back."
+                },
+                "maxFileCount": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 2000,
+                  "description": "File count cap enforced during copy-back."
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -197,6 +197,22 @@ program
   .option('--firecracker-kernel-sha256 <digest>', 'Expected SHA-256 digest of the guest kernel.')
   .option('--firecracker-rootfs-sha256 <digest>', 'Expected SHA-256 digest of the guest rootfs.')
   .option('--firecracker-supervisor-sha256 <digest>', 'Expected SHA-256 digest of the AWF guest supervisor.')
+  .option(
+   '--firecracker-gh-aw-runtime',
+   'Stage generated gh-aw agent runtime assets into the guest on a read-only device.\n' +
+   '                                       Sources are fixed by AWF (RUNNER_TEMP/gh-aw and /tmp/gh-aw);\n' +
+   '                                       this is NOT a general bind-mount facility.',
+   false
+  )
+  .option('--firecracker-gh-aw-runner-temp <path>', 'Host RUNNER_TEMP whose gh-aw subtree is staged (default: $RUNNER_TEMP).')
+  .option('--firecracker-gh-aw-compiler-tmp <path>', 'Host tmp root whose gh-aw subtree is staged (default: /tmp).')
+  .option('--firecracker-gh-aw-max-file-bytes <bytes>', 'Per-file cap for staged gh-aw runtime assets (default: 67108864).')
+  .option('--firecracker-gh-aw-max-total-bytes <bytes>', 'Total byte cap for staged gh-aw runtime assets (default: 536870912).')
+  .option('--firecracker-gh-aw-max-files <count>', 'File count cap for staged gh-aw runtime assets (default: 20000).')
+  .option('--firecracker-safe-outputs-dir <path>', 'Host directory receiving guest safe outputs after the VM stops.')
+  .option('--firecracker-safe-outputs-max-file-bytes <bytes>', 'Per-file cap for copied-back safe outputs (default: 16777216).')
+  .option('--firecracker-safe-outputs-max-total-bytes <bytes>', 'Total byte cap for copied-back safe outputs (default: 67108864).')
+  .option('--firecracker-safe-outputs-max-files <count>', 'File count cap for copied-back safe outputs (default: 2000).')
 
   // -- Container Configuration --
   .option(

--- a/src/commands/build-config.test.ts
+++ b/src/commands/build-config.test.ts
@@ -593,3 +593,137 @@ describe('buildConfig', () => {
     });
   });
 });
+
+describe('Firecracker gh-aw runtime staging configuration', () => {
+  it('leaves the contract undefined when no staging option is supplied', () => {
+    const config = buildConfig(makeInputs({
+      options: { ...makeInputs().options, containerRuntime: 'firecracker' },
+    }));
+
+    expect(config.firecracker?.ghAwRuntime).toBeUndefined();
+  });
+
+  it('applies documented defaults when staging is enabled with no caps', () => {
+    const config = buildConfig(makeInputs({
+      options: {
+        ...makeInputs().options,
+        containerRuntime: 'firecracker',
+        firecrackerGhAwRuntime: true,
+      },
+    }));
+
+    expect(config.firecracker?.ghAwRuntime).toEqual({
+      enabled: true,
+      runnerTempPath: undefined,
+      compilerTmpPath: '/tmp',
+      maxFileBytes: 64 * 1024 * 1024,
+      maxTotalBytes: 512 * 1024 * 1024,
+      maxFileCount: 20000,
+      safeOutputs: undefined,
+    });
+  });
+
+  it('records explicit caps and paths without enabling staging implicitly', () => {
+    const config = buildConfig(makeInputs({
+      options: {
+        ...makeInputs().options,
+        containerRuntime: 'firecracker',
+        firecrackerGhAwRunnerTemp: '/runner/_temp',
+        firecrackerGhAwCompilerTmp: '/var/tmp',
+        firecrackerGhAwMaxFileBytes: '1024',
+        firecrackerGhAwMaxTotalBytes: '4096',
+        firecrackerGhAwMaxFiles: '12',
+      },
+    }));
+
+    expect(config.firecracker?.ghAwRuntime).toEqual({
+      enabled: false,
+      runnerTempPath: '/runner/_temp',
+      compilerTmpPath: '/var/tmp',
+      maxFileBytes: 1024,
+      maxTotalBytes: 4096,
+      maxFileCount: 12,
+      safeOutputs: undefined,
+    });
+  });
+
+  it('builds the safe-output exchange only when a host directory is given', () => {
+    const config = buildConfig(makeInputs({
+      options: {
+        ...makeInputs().options,
+        containerRuntime: 'firecracker',
+        firecrackerGhAwRuntime: true,
+        firecrackerSafeOutputsDir: '/var/tmp/awf-safe-outputs',
+        firecrackerSafeOutputsMaxFileBytes: '2048',
+        firecrackerSafeOutputsMaxTotalBytes: '8192',
+        firecrackerSafeOutputsMaxFiles: '9',
+      },
+    }));
+
+    expect(config.firecracker?.ghAwRuntime?.safeOutputs).toEqual({
+      hostDirectory: '/var/tmp/awf-safe-outputs',
+      maxFileBytes: 2048,
+      maxTotalBytes: 8192,
+      maxFileCount: 9,
+    });
+  });
+
+  it.each([
+    ['firecrackerGhAwMaxFileBytes', '--firecracker-gh-aw-max-file-bytes'],
+    ['firecrackerGhAwMaxTotalBytes', '--firecracker-gh-aw-max-total-bytes'],
+    ['firecrackerGhAwMaxFiles', '--firecracker-gh-aw-max-files'],
+    ['firecrackerSafeOutputsMaxFileBytes', '--firecracker-safe-outputs-max-file-bytes'],
+    ['firecrackerSafeOutputsMaxTotalBytes', '--firecracker-safe-outputs-max-total-bytes'],
+    ['firecrackerSafeOutputsMaxFiles', '--firecracker-safe-outputs-max-files'],
+  ])('rejects a non-numeric %s', (key, flag) => {
+    expect(() => buildConfig(makeInputs({
+      options: {
+        ...makeInputs().options,
+        containerRuntime: 'firecracker',
+        firecrackerGhAwRuntime: true,
+        firecrackerSafeOutputsDir: '/var/tmp/awf-safe-outputs',
+        [key]: 'not-a-number',
+      },
+    }))).toThrow(new RegExp(flag.replace(/-/g, '\\-')));
+  });
+
+  it('maps the config-file block onto the same CLI options', () => {
+    const options = mapAwfFileConfigToCliOptions({
+      firecracker: {
+        ghAwRuntime: {
+          enabled: true,
+          runnerTempPath: '/runner/_temp',
+          compilerTmpPath: '/var/tmp',
+          maxFileBytes: 1024,
+          maxTotalBytes: 4096,
+          maxFileCount: 12,
+          safeOutputs: {
+            hostDirectory: '/var/tmp/awf-safe-outputs',
+            maxFileBytes: 512,
+            maxTotalBytes: 2048,
+            maxFileCount: 6,
+          },
+        },
+      },
+    });
+
+    expect(options).toMatchObject({
+      firecrackerGhAwRuntime: true,
+      firecrackerGhAwRunnerTemp: '/runner/_temp',
+      firecrackerGhAwCompilerTmp: '/var/tmp',
+      firecrackerGhAwMaxFileBytes: 1024,
+      firecrackerGhAwMaxTotalBytes: 4096,
+      firecrackerGhAwMaxFiles: 12,
+      firecrackerSafeOutputsDir: '/var/tmp/awf-safe-outputs',
+      firecrackerSafeOutputsMaxFileBytes: 512,
+      firecrackerSafeOutputsMaxTotalBytes: 2048,
+      firecrackerSafeOutputsMaxFiles: 6,
+    });
+
+    const config = buildConfig(makeInputs({
+      options: { ...makeInputs().options, containerRuntime: 'firecracker', ...options },
+    }));
+    expect(config.firecracker?.ghAwRuntime?.enabled).toBe(true);
+    expect(config.firecracker?.ghAwRuntime?.safeOutputs?.maxFileCount).toBe(6);
+  });
+});

--- a/src/commands/build-config.test.ts
+++ b/src/commands/build-config.test.ts
@@ -623,11 +623,12 @@ describe('Firecracker gh-aw runtime staging configuration', () => {
     });
   });
 
-  it('records explicit caps and paths without enabling staging implicitly', () => {
+  it('records explicit caps and paths when staging is enabled', () => {
     const config = buildConfig(makeInputs({
       options: {
         ...makeInputs().options,
         containerRuntime: 'firecracker',
+        firecrackerGhAwRuntime: true,
         firecrackerGhAwRunnerTemp: '/runner/_temp',
         firecrackerGhAwCompilerTmp: '/var/tmp',
         firecrackerGhAwMaxFileBytes: '1024',
@@ -637,7 +638,7 @@ describe('Firecracker gh-aw runtime staging configuration', () => {
     }));
 
     expect(config.firecracker?.ghAwRuntime).toEqual({
-      enabled: false,
+      enabled: true,
       runnerTempPath: '/runner/_temp',
       compilerTmpPath: '/var/tmp',
       maxFileBytes: 1024,
@@ -645,6 +646,28 @@ describe('Firecracker gh-aw runtime staging configuration', () => {
       maxFileCount: 12,
       safeOutputs: undefined,
     });
+  });
+
+  it('rejects staging flags that are given without the enabling flag', () => {
+    // Accepting these silently would report a staged run that staged nothing.
+    expect(() => buildConfig(makeInputs({
+      options: {
+        ...makeInputs().options,
+        containerRuntime: 'firecracker',
+        firecrackerGhAwRunnerTemp: '/runner/_temp',
+      },
+    }))).toThrow('--firecracker-gh-aw-runtime');
+  });
+
+  it('rejects safe-output caps that are given without a safe-output directory', () => {
+    expect(() => buildConfig(makeInputs({
+      options: {
+        ...makeInputs().options,
+        containerRuntime: 'firecracker',
+        firecrackerGhAwRuntime: true,
+        firecrackerSafeOutputsMaxFiles: '5',
+      },
+    }))).toThrow('--firecracker-safe-outputs-dir');
   });
 
   it('builds the safe-output exchange only when a host directory is given', () => {

--- a/src/commands/build-config.ts
+++ b/src/commands/build-config.ts
@@ -6,9 +6,17 @@ import { logger } from '../logger';
 import {
   FIRECRACKER_DEFAULT_API_TIMEOUT_MS,
   FIRECRACKER_DEFAULT_BINARY,
+  FIRECRACKER_DEFAULT_GH_AW_COMPILER_TMP,
+  FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_BYTES,
+  FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_COUNT,
+  FIRECRACKER_DEFAULT_GH_AW_MAX_TOTAL_BYTES,
   FIRECRACKER_DEFAULT_JAILER_BINARY,
   FIRECRACKER_DEFAULT_MEMORY_MIB,
+  FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_BYTES,
+  FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_COUNT,
+  FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_TOTAL_BYTES,
   FIRECRACKER_DEFAULT_VCPU_COUNT,
+  type FirecrackerGhAwRuntimeOptions,
 } from '../types/runtime-options';
 
 /**
@@ -252,7 +260,17 @@ function buildFirecrackerConfig(
       'firecrackerKernelSha256',
       'firecrackerRootfsSha256',
       'firecrackerSupervisorSha256',
-    ].some((key) => options[key] !== undefined);
+      'firecrackerGhAwRunnerTemp',
+      'firecrackerGhAwCompilerTmp',
+      'firecrackerGhAwMaxFileBytes',
+      'firecrackerGhAwMaxTotalBytes',
+      'firecrackerGhAwMaxFiles',
+      'firecrackerSafeOutputsDir',
+      'firecrackerSafeOutputsMaxFileBytes',
+      'firecrackerSafeOutputsMaxTotalBytes',
+      'firecrackerSafeOutputsMaxFiles',
+    ].some((key) => options[key] !== undefined)
+    || options.firecrackerGhAwRuntime === true;
   if (!selected && !configured) return undefined;
 
   const sha256 = {
@@ -291,6 +309,67 @@ function buildFirecrackerConfig(
     sha256: Object.values(sha256).some((value) => value !== undefined)
       ? sha256
       : undefined,
+    ghAwRuntime: buildFirecrackerGhAwRuntime(options),
+  };
+}
+
+function buildFirecrackerGhAwRuntime(
+  options: Record<string, unknown>,
+): FirecrackerGhAwRuntimeOptions | undefined {
+  const enabled = options.firecrackerGhAwRuntime === true;
+  const safeOutputsDirectory = options.firecrackerSafeOutputsDir as string | undefined;
+  const touched = enabled || [
+    'firecrackerGhAwRunnerTemp',
+    'firecrackerGhAwCompilerTmp',
+    'firecrackerGhAwMaxFileBytes',
+    'firecrackerGhAwMaxTotalBytes',
+    'firecrackerGhAwMaxFiles',
+    'firecrackerSafeOutputsDir',
+    'firecrackerSafeOutputsMaxFileBytes',
+    'firecrackerSafeOutputsMaxTotalBytes',
+    'firecrackerSafeOutputsMaxFiles',
+  ].some((key) => options[key] !== undefined);
+  if (!touched) return undefined;
+
+  return {
+    enabled,
+    runnerTempPath: options.firecrackerGhAwRunnerTemp as string | undefined,
+    compilerTmpPath:
+      (options.firecrackerGhAwCompilerTmp as string | undefined)
+      ?? FIRECRACKER_DEFAULT_GH_AW_COMPILER_TMP,
+    maxFileBytes: parseFirecrackerPositiveInteger(
+      options.firecrackerGhAwMaxFileBytes,
+      '--firecracker-gh-aw-max-file-bytes',
+      FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_BYTES,
+    ),
+    maxTotalBytes: parseFirecrackerPositiveInteger(
+      options.firecrackerGhAwMaxTotalBytes,
+      '--firecracker-gh-aw-max-total-bytes',
+      FIRECRACKER_DEFAULT_GH_AW_MAX_TOTAL_BYTES,
+    ),
+    maxFileCount: parseFirecrackerPositiveInteger(
+      options.firecrackerGhAwMaxFiles,
+      '--firecracker-gh-aw-max-files',
+      FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_COUNT,
+    ),
+    safeOutputs: safeOutputsDirectory === undefined ? undefined : {
+      hostDirectory: safeOutputsDirectory,
+      maxFileBytes: parseFirecrackerPositiveInteger(
+        options.firecrackerSafeOutputsMaxFileBytes,
+        '--firecracker-safe-outputs-max-file-bytes',
+        FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_BYTES,
+      ),
+      maxTotalBytes: parseFirecrackerPositiveInteger(
+        options.firecrackerSafeOutputsMaxTotalBytes,
+        '--firecracker-safe-outputs-max-total-bytes',
+        FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_TOTAL_BYTES,
+      ),
+      maxFileCount: parseFirecrackerPositiveInteger(
+        options.firecrackerSafeOutputsMaxFiles,
+        '--firecracker-safe-outputs-max-files',
+        FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_COUNT,
+      ),
+    },
   };
 }
 

--- a/src/commands/build-config.ts
+++ b/src/commands/build-config.ts
@@ -331,6 +331,25 @@ function buildFirecrackerGhAwRuntime(
   ].some((key) => options[key] !== undefined);
   if (!touched) return undefined;
 
+  // A subordinate flag without its enabler is almost always a typo or a stale
+  // command line, and silently ignoring it means the run appears to stage
+  // assets or collect outputs when it does neither.
+  if (!enabled) {
+    throw new Error(
+      'gh-aw runtime staging flags require --firecracker-gh-aw-runtime',
+    );
+  }
+  const orphanedSafeOutputFlags = [
+    ['firecrackerSafeOutputsMaxFileBytes', '--firecracker-safe-outputs-max-file-bytes'],
+    ['firecrackerSafeOutputsMaxTotalBytes', '--firecracker-safe-outputs-max-total-bytes'],
+    ['firecrackerSafeOutputsMaxFiles', '--firecracker-safe-outputs-max-files'],
+  ].filter(([key]) => options[key] !== undefined).map(([, flag]) => flag);
+  if (safeOutputsDirectory === undefined && orphanedSafeOutputFlags.length > 0) {
+    throw new Error(
+      `${orphanedSafeOutputFlags.join(', ')} require --firecracker-safe-outputs-dir`,
+    );
+  }
+
   return {
     enabled,
     runnerTempPath: options.firecrackerGhAwRunnerTemp as string | undefined,

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -134,6 +134,20 @@ export interface AwfFileConfig {
     memoryMib?: number;
     apiTimeoutMs?: number;
     sha256?: FirecrackerArtifactDigests;
+    ghAwRuntime?: {
+      enabled?: boolean;
+      runnerTempPath?: string;
+      compilerTmpPath?: string;
+      maxFileBytes?: number;
+      maxTotalBytes?: number;
+      maxFileCount?: number;
+      safeOutputs?: {
+        hostDirectory?: string;
+        maxFileBytes?: number;
+        maxTotalBytes?: number;
+        maxFileCount?: number;
+      };
+    };
   };
   chroot?: {
     binariesSourcePath?: string;

--- a/src/config-mapper.ts
+++ b/src/config-mapper.ts
@@ -128,6 +128,18 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     firecrackerKernelSha256: config.firecracker?.sha256?.kernel,
     firecrackerRootfsSha256: config.firecracker?.sha256?.rootfs,
     firecrackerSupervisorSha256: config.firecracker?.sha256?.supervisor,
+    firecrackerGhAwRuntime: config.firecracker?.ghAwRuntime?.enabled,
+    firecrackerGhAwRunnerTemp: config.firecracker?.ghAwRuntime?.runnerTempPath,
+    firecrackerGhAwCompilerTmp: config.firecracker?.ghAwRuntime?.compilerTmpPath,
+    firecrackerGhAwMaxFileBytes: config.firecracker?.ghAwRuntime?.maxFileBytes,
+    firecrackerGhAwMaxTotalBytes: config.firecracker?.ghAwRuntime?.maxTotalBytes,
+    firecrackerGhAwMaxFiles: config.firecracker?.ghAwRuntime?.maxFileCount,
+    firecrackerSafeOutputsDir: config.firecracker?.ghAwRuntime?.safeOutputs?.hostDirectory,
+    firecrackerSafeOutputsMaxFileBytes:
+      config.firecracker?.ghAwRuntime?.safeOutputs?.maxFileBytes,
+    firecrackerSafeOutputsMaxTotalBytes:
+      config.firecracker?.ghAwRuntime?.safeOutputs?.maxTotalBytes,
+    firecrackerSafeOutputsMaxFiles: config.firecracker?.ghAwRuntime?.safeOutputs?.maxFileCount,
     chrootBinariesSourcePath: config.chroot?.binariesSourcePath,
     chrootIdentityHome: config.chroot?.identity?.home,
     chrootIdentityUser: config.chroot?.identity?.user,

--- a/src/firecracker-runtime-backend.test.ts
+++ b/src/firecracker-runtime-backend.test.ts
@@ -9,6 +9,9 @@ import {
   type FirecrackerRuntimeBackendDependencies,
 } from './firecracker-runtime-backend';
 import { assertFirecrackerSelection } from './firecracker/runtime-validation';
+import { collectRealCredentialValues } from './firecracker-runtime-backend';
+import type { FirecrackerRuntimeAssetPlan } from './firecracker/runtime-assets';
+import type { FirecrackerExchangePlan } from './firecracker/exchange-image';
 import type { FirecrackerInfrastructureSnapshot } from './firecracker/infrastructure';
 
 const digest = 'a'.repeat(64);
@@ -425,5 +428,71 @@ describe('Firecracker runtime backend', () => {
     expect(() => assertFirecrackerSelection(
       config({ containerRuntime: 'gvisor' }),
     )).toThrow(/require --container-runtime firecracker/);
+  });
+});
+
+describe('Firecracker gh-aw guest staging environment', () => {
+  const runtimeAssets: FirecrackerRuntimeAssetPlan = {
+    entries: [{
+      id: 'gh-aw-runner-temp',
+      hostPath: '/runner/_temp/gh-aw',
+      guestPath: '/awf/runner-temp/gh-aw',
+    }],
+    limits: { maxFileBytes: 1024, maxTotalBytes: 4096, maxFileCount: 16 },
+    guestMountPoint: '/awf/runtime',
+    guestRunnerTemp: '/awf/runner-temp',
+  };
+  const safeOutputs: FirecrackerExchangePlan = {
+    hostDirectory: '/var/tmp/awf-safe-outputs',
+    guestMountPoint: '/awf/exchange',
+    guestOutputDirectory: '/awf/exchange/safe-outputs',
+    guestOutputFile: '/awf/exchange/safe-outputs/outputs.jsonl',
+    maxFileBytes: 1024,
+    maxTotalBytes: 4096,
+    maxFileCount: 16,
+  };
+
+  it('omits staging variables when nothing is staged', () => {
+    const environment = buildFirecrackerGuestEnvironment(config(), infrastructure());
+
+    expect(environment.RUNNER_TEMP).toBeUndefined();
+    expect(environment.AWF_GH_AW_RUNTIME_MOUNT).toBeUndefined();
+    expect(environment.AWF_SAFE_OUTPUTS_DIR).toBeUndefined();
+    expect(environment.GITHUB_AW_SAFE_OUTPUTS).toBeUndefined();
+  });
+
+  it('points gh-aw at guest paths rather than host paths', () => {
+    const environment = buildFirecrackerGuestEnvironment(
+      config({ additionalEnv: { RUNNER_TEMP: '/runner/_temp' } }),
+      infrastructure(),
+      '100.64.0.2',
+      { runtimeAssets, safeOutputs },
+    );
+
+    expect(environment.RUNNER_TEMP).toBe('/awf/runner-temp');
+    expect(environment.AWF_GH_AW_RUNTIME_MOUNT).toBe('/awf/runtime');
+    expect(environment.AWF_SAFE_OUTPUTS_DIR).toBe('/awf/exchange/safe-outputs');
+    expect(environment.GITHUB_AW_SAFE_OUTPUTS).toBe('/awf/exchange/safe-outputs/outputs.jsonl');
+  });
+
+  it('still refuses real provider credentials while staging is active', () => {
+    expect(() => buildFirecrackerGuestEnvironment(
+      config({
+        anthropicApiKey: 'sk-ant-real-value',
+        additionalEnv: { LEAK: 'sk-ant-real-value' },
+      }),
+      infrastructure(),
+      '100.64.0.2',
+      { runtimeAssets, safeOutputs },
+    )).toThrow(/Refusing to pass a real provider credential/);
+  });
+
+  it('collects only substantial real credential values for staging denial', () => {
+    expect(collectRealCredentialValues(config({
+      openaiApiKey: 'sk-openai-secret',
+      githubToken: 'ghp_secret_token',
+      anthropicApiKey: 'short',
+    }))).toEqual(['sk-openai-secret', 'ghp_secret_token']);
+    expect(collectRealCredentialValues(config())).toEqual([]);
   });
 });

--- a/src/firecracker-runtime-backend.ts
+++ b/src/firecracker-runtime-backend.ts
@@ -26,6 +26,15 @@ import {
   assertFirecrackerRuntimeCompatibility,
   requireFirecrackerConfig,
 } from './firecracker/runtime-validation';
+import {
+  resolveFirecrackerGhAwRuntimePlan,
+  FIRECRACKER_GUEST_RUNNER_TEMP,
+  type FirecrackerRuntimeAssetPlan,
+} from './firecracker/runtime-assets';
+import {
+  resolveFirecrackerExchangePlan,
+  type FirecrackerExchangePlan,
+} from './firecracker/exchange-image';
 export {
   assertFirecrackerPreSecurityCompatibility,
   assertFirecrackerRuntimeCompatibility,
@@ -41,6 +50,12 @@ interface FirecrackerBackendLogger {
   debug(message: string, ...args: unknown[]): void;
   info(message: string, ...args: unknown[]): void;
   warn(message: string, ...args: unknown[]): void;
+}
+
+export interface FirecrackerGuestStaging {
+  readonly runtimeAssets?: FirecrackerRuntimeAssetPlan;
+  readonly safeOutputs?: FirecrackerExchangePlan;
+  readonly forbiddenStagedContents?: readonly string[];
 }
 
 interface FirecrackerManagerAdapter {
@@ -68,6 +83,7 @@ export interface FirecrackerRuntimeBackendDependencies {
     workspacePath: string,
     homePath: string,
     identity: { uid: number; gid: number },
+    staging?: FirecrackerGuestStaging,
   ): FirecrackerManagerAdapter;
   workspacePath(): string;
   homePath(): string;
@@ -86,7 +102,7 @@ function defaultDependencies(
     preflight: runFirecrackerPreflight,
     resolveInfrastructure: (enableApiProxy, ipPath) =>
       resolveFirecrackerInfrastructure(enableApiProxy, undefined, ipPath),
-    createManager: (config, workDir, infrastructure, workspacePath, homePath, identity) =>
+    createManager: (config, workDir, infrastructure, workspacePath, homePath, identity, staging) =>
       new FirecrackerManager(
         config,
         workDir,
@@ -102,6 +118,11 @@ function defaultDependencies(
           supervisorBinaryPath: config.supervisorPath!,
           supervisorSha256: config.sha256!.supervisor!,
           identity,
+          ...(staging?.runtimeAssets ? { runtimeAssets: staging.runtimeAssets } : {}),
+          ...(staging?.safeOutputs ? { safeOutputs: staging.safeOutputs } : {}),
+          ...(staging?.forbiddenStagedContents?.length
+            ? { forbiddenStagedContents: staging.forbiddenStagedContents }
+            : {}),
         },
       ),
     workspacePath: () => process.env.GITHUB_WORKSPACE || process.cwd(),
@@ -133,6 +154,7 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
   private stopping: Promise<void> | undefined;
   private identity: { uid: number; gid: number } | undefined;
   private preflightResult: FirecrackerPreflightResult | undefined;
+  private staging: FirecrackerGuestStaging | undefined;
 
   constructor(
     private readonly config: WrapperConfig,
@@ -185,6 +207,8 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
         Boolean(this.config.enableApiProxy),
         this.preflightResult?.tools.ip,
       );
+      stage = 'gh-aw-runtime-staging';
+      this.staging = await this.resolveStaging(firecracker);
       this.identity = this.dependencies.identity();
       this.manager = this.dependencies.createManager(
         firecracker,
@@ -193,6 +217,7 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
         this.dependencies.workspacePath(),
         this.dependencies.homePath(),
         this.identity,
+        this.staging,
       );
 
       stage = 'topology-revalidation';
@@ -206,6 +231,7 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
         this.config,
         infrastructure,
         this.manager.guestIp,
+        this.staging,
       );
       stage = 'guest-boot';
       await this.manager.startInstance();
@@ -365,6 +391,36 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
     await this.manager?.stop({ preserve });
   }
 
+  /**
+   * Resolves the AWF-owned gh-aw staging contract before any guest exists so a
+   * contract violation fails closed at startup rather than mid-boot.
+   */
+  private async resolveStaging(
+    firecracker: FirecrackerOptions,
+  ): Promise<FirecrackerGuestStaging | undefined> {
+    const runtime = firecracker.ghAwRuntime;
+    if (!runtime?.enabled) return undefined;
+    const resolution = await resolveFirecrackerGhAwRuntimePlan(runtime);
+    if (!resolution.plan) return undefined;
+    for (const id of resolution.skipped) {
+      this.dependencies.logger.warn(
+        `[firecracker] gh-aw runtime source ${id} is absent; continuing without it`,
+      );
+    }
+    this.dependencies.logger.info(
+      `[firecracker] Staging ${resolution.plan.entries.length} read-only gh-aw runtime ` +
+      `source(s): ${resolution.plan.entries.map((entry) => entry.guestPath).join(', ')}`,
+    );
+    const forbiddenStagedContents = collectRealCredentialValues(this.config);
+    return {
+      runtimeAssets: resolution.plan,
+      ...(runtime.safeOutputs
+        ? { safeOutputs: resolveFirecrackerExchangePlan(runtime.safeOutputs) }
+        : {}),
+      ...(forbiddenStagedContents.length > 0 ? { forbiddenStagedContents } : {}),
+    };
+  }
+
   private async probeGuestConnectivity(): Promise<void> {
     const manager = this.manager!;
     const environment = this.environment!;
@@ -402,6 +458,7 @@ export function buildFirecrackerGuestEnvironment(
   config: WrapperConfig,
   infrastructure: Pick<FirecrackerInfrastructureSnapshot, 'squidIp' | 'apiProxyIp'>,
   guestIp = '100.64.0.2',
+  staging?: FirecrackerGuestStaging,
 ): Record<string, string> {
   const networkConfig = {
     subnet: NETWORK_SUBNET,
@@ -425,8 +482,33 @@ export function buildFirecrackerGuestEnvironment(
     HOSTNAME: 'awf-firecracker',
     AWF_RUNTIME: 'firecracker',
   });
+  if (staging?.runtimeAssets) {
+    Object.assign(environment, {
+      RUNNER_TEMP: FIRECRACKER_GUEST_RUNNER_TEMP,
+      AWF_GH_AW_RUNTIME_MOUNT: staging.runtimeAssets.guestMountPoint,
+    });
+  }
+  if (staging?.safeOutputs) {
+    Object.assign(environment, {
+      AWF_SAFE_OUTPUTS_DIR: staging.safeOutputs.guestOutputDirectory,
+      GITHUB_AW_SAFE_OUTPUTS: staging.safeOutputs.guestOutputFile,
+    });
+  }
   assertNoProviderSecrets(config, environment);
   return environment;
+}
+
+/** Real credential values that must never be staged onto a guest device. */
+export function collectRealCredentialValues(config: WrapperConfig): string[] {
+  return [
+    config.openaiApiKey,
+    config.anthropicApiKey,
+    config.copilotGithubToken,
+    config.copilotProviderApiKey,
+    config.geminiApiKey,
+    config.googleApiKey,
+    config.githubToken,
+  ].filter((value): value is string => typeof value === 'string' && value.length >= 8);
 }
 
 function assertNoProviderSecrets(

--- a/src/firecracker/bounded-copy.test.ts
+++ b/src/firecracker/bounded-copy.test.ts
@@ -1,0 +1,390 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  BOUNDED_COPY_MAX_DEPTH,
+  BoundedCopyBudget,
+  assertCanonicalDirectory,
+  assertContained,
+  assertPrivateHostDirectory,
+  copyBoundedTree,
+} from './bounded-copy';
+
+/** macOS resolves /tmp through a symlink, which the canonical check rejects. */
+async function makeTempRoot(prefix: string): Promise<string> {
+  const base = await fs.realpath(os.tmpdir());
+  return fs.mkdtemp(path.join(base, prefix));
+}
+
+async function makeRoots(): Promise<{ source: string; destination: string; root: string }> {
+  const root = await makeTempRoot('awf-bounded-copy-');
+  const source = path.join(root, 'source');
+  const destination = path.join(root, 'destination');
+  await fs.mkdir(source, { mode: 0o700 });
+  await fs.mkdir(destination, { mode: 0o700 });
+  return { source, destination, root };
+}
+
+function budget(overrides: Partial<{
+  maxFileBytes: number;
+  maxTotalBytes: number;
+  maxFileCount: number;
+}> = {}): BoundedCopyBudget {
+  return new BoundedCopyBudget({
+    maxFileBytes: 1024,
+    maxTotalBytes: 8192,
+    maxFileCount: 64,
+    ...overrides,
+  });
+}
+
+describe('copyBoundedTree', () => {
+  let roots: { source: string; destination: string; root: string };
+
+  beforeEach(async () => {
+    roots = await makeRoots();
+  });
+
+  afterEach(async () => {
+    await fs.rm(roots.root, { recursive: true, force: true });
+  });
+
+  function copy(overrides: Record<string, unknown> = {}, limits = budget()) {
+    return copyBoundedTree(
+      {
+        sourceRoot: roots.source,
+        destinationRoot: roots.destination,
+        label: 'test staging',
+        ...overrides,
+      } as never,
+      limits,
+    );
+  }
+
+  it('copies files, directories, and safe relative symlinks with hardened modes', async () => {
+    await fs.mkdir(path.join(roots.source, 'nested'));
+    await fs.writeFile(path.join(roots.source, 'nested/data.json'), '{"a":1}', { mode: 0o666 });
+    await fs.writeFile(path.join(roots.source, 'run.sh'), '#!/bin/sh\n', { mode: 0o755 });
+    await fs.symlink('nested/data.json', path.join(roots.source, 'link.json'));
+
+    const totals = await copy();
+
+    expect(totals).toEqual({ files: 2, directories: 1, symlinks: 1, bytes: 17 });
+    await expect(
+      fs.readFile(path.join(roots.destination, 'nested/data.json'), 'utf8'),
+    ).resolves.toBe('{"a":1}');
+    const dataStat = await fs.stat(path.join(roots.destination, 'nested/data.json'));
+    expect(dataStat.mode & 0o777).toBe(0o600);
+    const scriptStat = await fs.stat(path.join(roots.destination, 'run.sh'));
+    expect(scriptStat.mode & 0o777).toBe(0o700);
+    const directoryStat = await fs.stat(path.join(roots.destination, 'nested'));
+    expect(directoryStat.mode & 0o777).toBe(0o700);
+    await expect(
+      fs.readlink(path.join(roots.destination, 'link.json')),
+    ).resolves.toBe('nested/data.json');
+  });
+
+  it('rejects symlinks that escape the source root', async () => {
+    await fs.symlink('../escape.txt', path.join(roots.source, 'escape'));
+    await fs.writeFile(path.join(roots.root, 'escape.txt'), 'secret');
+
+    await expect(copy()).rejects.toThrow(/symlink target/);
+  });
+
+  it('rejects absolute symlinks', async () => {
+    await fs.symlink('/etc/passwd', path.join(roots.source, 'passwd'));
+
+    await expect(copy()).rejects.toThrow(/absolute symlink/);
+  });
+
+  it('rejects hard-linked regular files that can alias host state', async () => {
+    const target = path.join(roots.root, 'outside.txt');
+    await fs.writeFile(target, 'host-owned');
+    await fs.link(target, path.join(roots.source, 'aliased.txt'));
+
+    await expect(copy()).rejects.toThrow(/hard-linked file/);
+  });
+
+  it('rejects setuid and setgid files', async () => {
+    const file = path.join(roots.source, 'suid');
+    await fs.writeFile(file, 'x');
+    await fs.chmod(file, 0o4755);
+
+    await expect(copy()).rejects.toThrow(/setuid\/setgid/);
+  });
+
+  it('rejects special filesystem entries', async () => {
+    await fs.mkdir(path.join(roots.source, 'fifo-holder'));
+    const fifo = path.join(roots.source, 'fifo-holder', 'pipe');
+    const { execFileSync } = await import('child_process');
+    try {
+      execFileSync('mkfifo', [fifo]);
+    } catch {
+      return; // mkfifo unavailable; nothing to assert on this platform
+    }
+
+    await expect(copy()).rejects.toThrow(/special filesystem entry/);
+  });
+
+  it('rejects traversal-style and unsafe entry names', async () => {
+    await fs.writeFile(path.join(roots.source, 'ok.txt'), 'a');
+    // The walker validates names it reads back from the directory; a name with
+    // a path separator cannot exist, so assert the guard directly instead.
+    expect(() =>
+      assertContained(roots.destination, path.join(roots.destination, '..', 'evil'), 'dest'),
+    ).toThrow(/escapes/);
+  });
+
+  it('enforces the per-file byte cap', async () => {
+    await fs.writeFile(path.join(roots.source, 'big.bin'), Buffer.alloc(2048));
+
+    await expect(copy({}, budget({ maxFileBytes: 1024, maxTotalBytes: 4096 })))
+      .rejects.toThrow(/per-file cap/);
+  });
+
+  it('enforces the total byte cap across trees sharing one budget', async () => {
+    await fs.writeFile(path.join(roots.source, 'a.bin'), Buffer.alloc(600));
+    await fs.writeFile(path.join(roots.source, 'b.bin'), Buffer.alloc(600));
+
+    await expect(copy({}, budget({ maxFileBytes: 700, maxTotalBytes: 1000 })))
+      .rejects.toThrow(/total cap/);
+  });
+
+  it('enforces the entry count cap', async () => {
+    await fs.writeFile(path.join(roots.source, 'a.txt'), 'a');
+    await fs.writeFile(path.join(roots.source, 'b.txt'), 'b');
+    await fs.writeFile(path.join(roots.source, 'c.txt'), 'c');
+
+    await expect(copy({}, budget({ maxFileCount: 2 }))).rejects.toThrow(/entry cap/);
+  });
+
+  it('enforces the directory depth cap', async () => {
+    let current = roots.source;
+    for (let depth = 0; depth <= BOUNDED_COPY_MAX_DEPTH + 1; depth += 1) {
+      current = path.join(current, 'd');
+      await fs.mkdir(current);
+    }
+
+    await expect(copy({}, budget({ maxFileCount: 1024 }))).rejects.toThrow(/depth cap/);
+  });
+
+  it('refuses files containing a real credential value', async () => {
+    await fs.writeFile(
+      path.join(roots.source, 'settings.json'),
+      '{"token":"ghp_realsecretvalue"}',
+    );
+
+    await expect(copy({ forbiddenContents: ['ghp_realsecretvalue'] }))
+      .rejects.toThrow(/contains a real credential value/);
+  });
+
+  it('detects a credential value split across read chunks', async () => {
+    const secret = 'ghp_boundarysecret';
+    const filler = Buffer.alloc(1024 * 1024 - 8, 0x61);
+    await fs.writeFile(
+      path.join(roots.source, 'large.log'),
+      Buffer.concat([filler, Buffer.from(secret)]),
+    );
+
+    await expect(
+      copy(
+        { forbiddenContents: [secret] },
+        budget({ maxFileBytes: 4 * 1024 * 1024, maxTotalBytes: 8 * 1024 * 1024 }),
+      ),
+    ).rejects.toThrow(/contains a real credential value/);
+  });
+
+  it('refuses forbidden basenames and relative paths', async () => {
+    await fs.mkdir(path.join(roots.source, 'sub'));
+    await fs.writeFile(path.join(roots.source, 'sub/.netrc'), 'machine github.com');
+
+    await expect(copy({ forbiddenBasenames: ['.netrc'] }))
+      .rejects.toThrow(/credential or reserved entry/);
+    await fs.rm(path.join(roots.destination), { recursive: true, force: true });
+    await fs.mkdir(roots.destination, { mode: 0o700 });
+    await expect(copy({ forbiddenRelativePaths: ['sub/.netrc'] }))
+      .rejects.toThrow(/credential or reserved entry/);
+  });
+
+  it('fails closed when a destination entry already exists', async () => {
+    await fs.writeFile(path.join(roots.source, 'a.txt'), 'a');
+    await fs.writeFile(path.join(roots.destination, 'a.txt'), 'pre-existing');
+
+    await expect(copy()).rejects.toThrow(/EEXIST/);
+  });
+
+  it('fails closed when the source file changes during the copy', async () => {
+    const file = path.join(roots.source, 'racy.bin');
+    await fs.writeFile(file, Buffer.alloc(512, 0x41));
+    const realOpen = fs.open.bind(fs);
+    const spy = jest.spyOn(fs, 'open').mockImplementation((async (
+      target: string,
+      flags: unknown,
+      mode?: unknown,
+    ) => {
+      const handle = await (realOpen as never as (
+        t: string, f: unknown, m?: unknown,
+      ) => Promise<Awaited<ReturnType<typeof realOpen>>>)(target, flags, mode);
+      if (target === file) {
+        await fs.writeFile(file, Buffer.alloc(512, 0x42));
+      }
+      return handle;
+    }) as never);
+
+    try {
+      await expect(copy()).rejects.toThrow(/changed while staging|source changed/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('assertCanonicalDirectory', () => {
+  it('rejects a root reached through a symlink', async () => {
+    const root = await makeTempRoot('awf-canonical-');
+    try {
+      const real = path.join(root, 'real');
+      await fs.mkdir(real);
+      const link = path.join(root, 'link');
+      await fs.symlink(real, link);
+
+      await expect(assertCanonicalDirectory(link, 'test')).rejects.toThrow(/symlink|canonical/i);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects relative and traversal roots', async () => {
+    await expect(assertCanonicalDirectory('relative/path', 'test')).rejects.toThrow(/absolute/);
+    await expect(assertCanonicalDirectory('/tmp/../etc', 'test'))
+      .rejects.toThrow(/normalized|canonical|symlink/i);
+  });
+
+  it('rejects magic-link roots such as /proc/self/root', async () => {
+    await expect(assertCanonicalDirectory('/proc/self/root', 'test')).rejects.toThrow();
+  });
+
+  it('rejects a path that is not a directory', async () => {
+    const root = await makeTempRoot('awf-canonical-file-');
+    try {
+      const file = path.join(root, 'file.txt');
+      await fs.writeFile(file, 'x');
+      await expect(assertCanonicalDirectory(file, 'test')).rejects.toThrow(/directory/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('assertContained', () => {
+  it('accepts contained paths and rejects escapes', () => {
+    expect(() => assertContained('/awf/runtime', '/awf/runtime/child', 'test')).not.toThrow();
+    expect(() => assertContained('/awf/runtime', '/awf/runtime', 'test')).not.toThrow();
+    expect(() => assertContained('/awf/runtime', '/awf/runtime-sibling', 'test'))
+      .toThrow(/escapes/);
+    expect(() => assertContained('/awf/runtime', '/etc/passwd', 'test')).toThrow(/escapes/);
+  });
+});
+
+describe('BoundedCopyBudget', () => {
+  it('rejects non-positive and inverted limits', () => {
+    expect(() => new BoundedCopyBudget({
+      maxFileBytes: 0, maxTotalBytes: 10, maxFileCount: 1,
+    })).toThrow(/maxFileBytes/);
+    expect(() => new BoundedCopyBudget({
+      maxFileBytes: 10, maxTotalBytes: 5, maxFileCount: 1,
+    })).toThrow(/exceeds total cap/);
+  });
+});
+
+describe('copyBoundedTree race and destination hardening', () => {
+  let roots: { source: string; destination: string; root: string };
+
+  beforeEach(async () => {
+    roots = await makeRoots();
+  });
+
+  afterEach(async () => {
+    await fs.rm(roots.root, { recursive: true, force: true });
+  });
+
+  function copy(overrides: Record<string, unknown> = {}) {
+    return copyBoundedTree(
+      {
+        sourceRoot: roots.source,
+        destinationRoot: roots.destination,
+        label: 'test',
+        ...overrides,
+      },
+      budget(),
+    );
+  }
+
+  it('refuses a destination root that is not exclusively owned', async () => {
+    await fs.chmod(roots.destination, 0o755);
+
+    await expect(copy()).rejects.toThrow(/must be mode 0700/);
+  });
+
+  it('refuses a destination root replaced by a symlink after creation', async () => {
+    const elsewhere = path.join(roots.root, 'elsewhere');
+    await fs.mkdir(elsewhere, { mode: 0o700 });
+    await fs.rm(roots.destination, { recursive: true, force: true });
+    await fs.symlink(elsewhere, roots.destination);
+
+    await expect(copy()).rejects.toThrow();
+  });
+
+  it('does not descend through a directory swapped for a symlink mid-walk', async () => {
+    // The staged tree is enumerated through a pinned descriptor, so replacing
+    // an already-inspected directory cannot redirect the walk.
+    const secrets = path.join(roots.root, 'secrets');
+    await fs.mkdir(secrets, { mode: 0o700 });
+    await fs.writeFile(path.join(secrets, 'token'), 'super-secret');
+    const victim = path.join(roots.source, 'assets');
+    await fs.mkdir(victim, { mode: 0o700 });
+    await fs.writeFile(path.join(victim, 'real'), 'benign');
+
+    const realReaddir = fs.readdir.bind(fs) as (target: string) => Promise<string[]>;
+    const spy = jest.spyOn(fs, 'readdir').mockImplementation((async (target: string) => {
+      const entries = await realReaddir(target);
+      if (entries.includes('assets')) {
+        // Swap the directory for a symlink exactly between inspection and use.
+        await fs.rm(victim, { recursive: true, force: true });
+        await fs.symlink(secrets, victim);
+      }
+      return entries;
+    }) as unknown as typeof fs.readdir);
+
+    try {
+      const staged = await copy().catch(() => undefined);
+      const leaked = await fs
+        .readFile(path.join(roots.destination, 'assets', 'token'), 'utf-8')
+        .catch(() => undefined);
+      expect(leaked).toBeUndefined();
+      if (staged) {
+        expect(staged.files).toBe(1);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('accepts a private host directory and rejects a shared one', async () => {
+    await expect(assertPrivateHostDirectory(roots.destination, 'test root'))
+      .resolves.toBeUndefined();
+
+    const shared = path.join(roots.root, 'shared');
+    await fs.mkdir(shared, { mode: 0o700 });
+    await fs.chmod(shared, 0o777);
+    await expect(assertPrivateHostDirectory(shared, 'test root'))
+      .rejects.toThrow(/group- or world-writable/);
+  });
+
+  it('refuses a host directory that is a symlink', async () => {
+    const link = path.join(roots.root, 'link');
+    await fs.symlink(roots.destination, link);
+
+    await expect(assertPrivateHostDirectory(link, 'test root')).rejects.toThrow();
+  });
+});

--- a/src/firecracker/bounded-copy.ts
+++ b/src/firecracker/bounded-copy.ts
@@ -380,6 +380,7 @@ async function assertExclusivelyCreatedDirectory(
 export async function assertPrivateHostDirectory(
   directory: string,
   label: string,
+  allowedOwnerUids: number[] = [],
 ): Promise<void> {
   const pinned = await pinDirectory(directory, directory, label);
   try {
@@ -390,10 +391,18 @@ export async function assertPrivateHostDirectory(
         `0${(stat.mode & 0o777).toString(8)}: ${directory}`,
       );
     }
-    const uid = process.getuid?.();
-    if (uid !== undefined && stat.uid !== uid) {
+    const self = process.getuid?.();
+    // Under sudo the directory legitimately belongs to the invoking user rather
+    // than to root, and that user is the one the outputs are destined for. Any
+    // other owner is a third party who could swap the directory out from under
+    // a privileged write.
+    const owners = new Set(
+      [self, ...allowedOwnerUids].filter((uid): uid is number => uid !== undefined),
+    );
+    if (owners.size > 0 && !owners.has(stat.uid)) {
       throw new Error(
-        `Firecracker ${label} must be owned by the AWF process: ${directory}`,
+        `Firecracker ${label} must be owned by the AWF process or the target ` +
+        `user, found uid ${stat.uid}: ${directory}`,
       );
     }
   } finally {

--- a/src/firecracker/bounded-copy.ts
+++ b/src/firecracker/bounded-copy.ts
@@ -1,0 +1,626 @@
+import { constants, existsSync, promises as fs, type Stats } from 'fs';
+import * as path from 'path';
+
+/**
+ * Hardened, bounded tree copier shared by every Firecracker staging path.
+ *
+ * The copier is deliberately paranoid: it never follows a symlink, never
+ * crosses the source root, never preserves privileged bits, creates every
+ * destination entry exclusively, and re-verifies each source file after the
+ * bytes are read so that a file changed mid-copy fails the whole run closed.
+ *
+ * Both trees are traversed through pinned directory descriptors rather than by
+ * re-resolving path strings. `O_NOFOLLOW` only refuses a symlink in the final
+ * component, so a check-by-path followed by a use-by-path lets a concurrent
+ * attacker swap an *intermediate* directory for a symlink and redirect the
+ * whole subtree. Every child operation is therefore issued relative to the
+ * descriptor of the directory that was already validated, which is immune to
+ * renames of any ancestor.
+ */
+
+/** Maximum directory depth AWF will descend while staging. */
+export const BOUNDED_COPY_MAX_DEPTH = 64;
+
+/** Maximum symlink target length AWF will reproduce. */
+export const BOUNDED_COPY_MAX_SYMLINK_TARGET = 1024;
+
+/**
+ * A directory held open for the duration of its subtree walk.
+ *
+ * On Linux `/proc/self/fd/<fd>` is a magic link the kernel resolves to the
+ * pinned inode, which makes `join(operationPath, name)` equivalent to
+ * `openat(fd, name, ...)`. Where procfs is unavailable (developer macOS runs;
+ * the Firecracker runtime itself is Linux-only) the walk falls back to the
+ * real path and relies on the per-entry `dev`/`ino` verification below.
+ */
+interface PinnedDirectory {
+  readonly handle: fs.FileHandle;
+  readonly operationPath: string;
+  readonly displayPath: string;
+}
+
+let procFdRootCache: string | null | undefined;
+
+function procFdRoot(): string | null {
+  if (procFdRootCache === undefined) {
+    procFdRootCache = existsSync('/proc/self/fd') ? '/proc/self/fd' : null;
+  }
+  return procFdRootCache;
+}
+
+/** Opens a directory without following it, and pins it for child operations. */
+async function pinDirectory(
+  openPath: string,
+  displayPath: string,
+  label: string,
+): Promise<PinnedDirectory> {
+  const handle = await fs.open(
+    openPath,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const stat = await handle.stat();
+    if (!stat.isDirectory()) {
+      throw new Error(`Firecracker ${label} is not a directory: ${displayPath}`);
+    }
+  } catch (error) {
+    await handle.close();
+    throw error;
+  }
+  const procRoot = procFdRoot();
+  return {
+    handle,
+    operationPath: procRoot === null ? openPath : `${procRoot}/${handle.fd}`,
+    displayPath,
+  };
+}
+
+/** Pins a child directory, proving it is the very inode that was inspected. */
+async function pinChildDirectory(
+  parent: PinnedDirectory,
+  name: string,
+  observed: Stats,
+  label: string,
+): Promise<PinnedDirectory> {
+  const displayPath = path.join(parent.displayPath, name);
+  const pinned = await pinDirectory(
+    path.join(parent.operationPath, name),
+    displayPath,
+    label,
+  );
+  const opened = await pinned.handle.stat();
+  if (opened.dev !== observed.dev || opened.ino !== observed.ino) {
+    await pinned.handle.close();
+    throw new Error(
+      `Firecracker ${label} directory ${displayPath} was replaced while staging`,
+    );
+  }
+  return pinned;
+}
+
+export interface BoundedCopyLimits {
+  readonly maxFileBytes: number;
+  readonly maxTotalBytes: number;
+  readonly maxFileCount: number;
+}
+
+export interface BoundedCopyTotals {
+  files: number;
+  directories: number;
+  symlinks: number;
+  bytes: number;
+}
+
+export interface BoundedCopyOptions {
+  /** Canonical source directory; must not contain a symlink in its own path. */
+  readonly sourceRoot: string;
+  /** Existing destination directory that AWF created exclusively. */
+  readonly destinationRoot: string;
+  /** Human-readable label used in every failure message. */
+  readonly label: string;
+  /** Identity applied to staged entries; omitted when running unprivileged. */
+  readonly ownership?: { readonly uid: number; readonly gid: number };
+  /**
+   * Literal secret values that must never appear in a staged file. Matching
+   * fails the run closed rather than silently redacting.
+   */
+  readonly forbiddenContents?: readonly string[];
+  /** Relative paths (POSIX separators) that are refused outright. */
+  readonly forbiddenRelativePaths?: readonly string[];
+  /** Basenames that are refused anywhere in the tree (credential stores). */
+  readonly forbiddenBasenames?: readonly string[];
+}
+
+/**
+ * Shared cap accounting so several staged trees consume one global budget.
+ */
+export class BoundedCopyBudget {
+  readonly totals: BoundedCopyTotals = {
+    files: 0,
+    directories: 0,
+    symlinks: 0,
+    bytes: 0,
+  };
+
+  constructor(private readonly limits: BoundedCopyLimits) {
+    assertPositiveInteger(limits.maxFileBytes, 'maxFileBytes');
+    assertPositiveInteger(limits.maxTotalBytes, 'maxTotalBytes');
+    assertPositiveInteger(limits.maxFileCount, 'maxFileCount');
+    if (limits.maxFileBytes > limits.maxTotalBytes) {
+      throw new Error(
+        `Firecracker staging per-file cap ${limits.maxFileBytes} exceeds total cap ` +
+        `${limits.maxTotalBytes}`,
+      );
+    }
+  }
+
+  get maxFileBytes(): number {
+    return this.limits.maxFileBytes;
+  }
+
+  countEntry(label: string, relativePath: string): void {
+    const entries = this.totals.files + this.totals.directories + this.totals.symlinks;
+    if (entries + 1 > this.limits.maxFileCount) {
+      throw new Error(
+        `Firecracker ${label} exceeds the ${this.limits.maxFileCount} entry cap at ${relativePath}`,
+      );
+    }
+  }
+
+  reserveBytes(label: string, relativePath: string, size: number): void {
+    if (size > this.limits.maxFileBytes) {
+      throw new Error(
+        `Firecracker ${label} file ${relativePath} is ${size} bytes, exceeding the ` +
+        `${this.limits.maxFileBytes} byte per-file cap`,
+      );
+    }
+    if (this.totals.bytes + size > this.limits.maxTotalBytes) {
+      throw new Error(
+        `Firecracker ${label} exceeds the ${this.limits.maxTotalBytes} byte total cap at ` +
+        relativePath,
+      );
+    }
+  }
+}
+
+/**
+ * Copies `sourceRoot` into `destinationRoot`, enforcing every staging rule.
+ */
+export async function copyBoundedTree(
+  options: BoundedCopyOptions,
+  budget: BoundedCopyBudget,
+): Promise<BoundedCopyTotals> {
+  const sourceRoot = await assertCanonicalDirectory(options.sourceRoot, options.label);
+  const destinationRoot = path.resolve(options.destinationRoot);
+  const forbiddenRelative = new Set(options.forbiddenRelativePaths ?? []);
+  const forbiddenBasenames = new Set(options.forbiddenBasenames ?? []);
+  const secrets = (options.forbiddenContents ?? []).filter((value) => value.length > 0);
+  const before: BoundedCopyTotals = { ...budget.totals };
+
+  const walk = async (
+    source: PinnedDirectory,
+    destination: PinnedDirectory,
+    relativePath: string,
+    depth: number,
+  ): Promise<void> => {
+    if (depth > BOUNDED_COPY_MAX_DEPTH) {
+      throw new Error(
+        `Firecracker ${options.label} exceeds the ${BOUNDED_COPY_MAX_DEPTH} directory depth cap ` +
+        `at ${relativePath}`,
+      );
+    }
+    const entries = await fs.readdir(source.operationPath);
+    entries.sort();
+    for (const entry of entries) {
+      assertSafeEntryName(entry, options.label);
+      const childRelative = relativePath === '' ? entry : `${relativePath}/${entry}`;
+      if (forbiddenRelative.has(childRelative) || forbiddenBasenames.has(entry)) {
+        throw new Error(
+          `Firecracker ${options.label} refuses credential or reserved entry: ${childRelative}`,
+        );
+      }
+      assertContained(
+        destinationRoot,
+        path.join(destinationRoot, childRelative),
+        `${options.label} destination`,
+      );
+      const childSource = path.join(source.operationPath, entry);
+      const childDestination = path.join(destination.operationPath, entry);
+      const stat = await fs.lstat(childSource);
+      budget.countEntry(options.label, childRelative);
+      if (stat.isDirectory()) {
+        await fs.mkdir(childDestination, { mode: 0o700 });
+        budget.totals.directories += 1;
+        const childSourcePin = await pinChildDirectory(
+          source,
+          entry,
+          stat,
+          `${options.label} source`,
+        );
+        try {
+          const childDestinationPin = await pinFreshDirectory(
+            destination,
+            entry,
+            `${options.label} destination`,
+          );
+          try {
+            if (options.ownership) {
+              await childDestinationPin.handle.chown(
+                options.ownership.uid,
+                options.ownership.gid,
+              );
+            }
+            await walk(childSourcePin, childDestinationPin, childRelative, depth + 1);
+          } finally {
+            await childDestinationPin.handle.close();
+          }
+        } finally {
+          await childSourcePin.handle.close();
+        }
+      } else if (stat.isSymbolicLink()) {
+        await stageSymlink(
+          childSource,
+          childDestination,
+          childRelative,
+          relativePath,
+          options,
+        );
+        budget.totals.symlinks += 1;
+      } else if (stat.isFile()) {
+        await stageFile(
+          childSource,
+          childDestination,
+          childRelative,
+          stat,
+          options,
+          budget,
+          secrets,
+        );
+        budget.totals.files += 1;
+      } else {
+        throw new Error(
+          `Firecracker ${options.label} refuses special filesystem entry: ${childRelative}`,
+        );
+      }
+    }
+  };
+
+  const sourcePin = await pinDirectory(sourceRoot, sourceRoot, `${options.label} source root`);
+  try {
+    const destinationPin = await pinDestinationRoot(destinationRoot, options.label);
+    try {
+      await walk(sourcePin, destinationPin, '', 0);
+    } finally {
+      await destinationPin.handle.close();
+    }
+  } finally {
+    await sourcePin.handle.close();
+  }
+  return {
+    files: budget.totals.files - before.files,
+    directories: budget.totals.directories - before.directories,
+    symlinks: budget.totals.symlinks - before.symlinks,
+    bytes: budget.totals.bytes - before.bytes,
+  };
+}
+
+/**
+ * Pins a directory AWF just created exclusively.
+ *
+ * An attacker who can write the parent may rename the new directory away and
+ * substitute their own between `mkdir` and first use. They cannot produce a
+ * root-owned, empty, 0700 directory, so proving those properties against the
+ * open descriptor closes the substitution.
+ */
+async function pinFreshDirectory(
+  parent: PinnedDirectory,
+  name: string,
+  label: string,
+): Promise<PinnedDirectory> {
+  const pinned = await pinDirectory(
+    path.join(parent.operationPath, name),
+    path.join(parent.displayPath, name),
+    label,
+  );
+  try {
+    await assertExclusivelyCreatedDirectory(pinned, label);
+  } catch (error) {
+    await pinned.handle.close();
+    throw error;
+  }
+  return pinned;
+}
+
+/** Pins the destination root, refusing any directory AWF does not fully own. */
+async function pinDestinationRoot(
+  destinationRoot: string,
+  label: string,
+): Promise<PinnedDirectory> {
+  const pinned = await pinDirectory(
+    destinationRoot,
+    destinationRoot,
+    `${label} destination root`,
+  );
+  try {
+    await assertExclusivelyCreatedDirectory(pinned, `${label} destination root`);
+  } catch (error) {
+    await pinned.handle.close();
+    throw error;
+  }
+  return pinned;
+}
+
+async function assertExclusivelyCreatedDirectory(
+  pinned: PinnedDirectory,
+  label: string,
+): Promise<void> {
+  const stat = await pinned.handle.stat();
+  if ((stat.mode & 0o777) !== 0o700) {
+    throw new Error(
+      `Firecracker ${label} must be mode 0700, found ` +
+      `0${(stat.mode & 0o777).toString(8)}: ${pinned.displayPath}`,
+    );
+  }
+  const uid = process.getuid?.();
+  if (uid !== undefined && stat.uid !== uid) {
+    throw new Error(
+      `Firecracker ${label} must be owned by the AWF process: ${pinned.displayPath}`,
+    );
+  }
+}
+
+/**
+ * Refuses a host directory that anyone but AWF can write.
+ *
+ * A configured destination root may already exist. If another local user owns
+ * it, or it is group/other writable, they can rename AWF's freshly created
+ * run directory away and substitute a symlink, so root would then write
+ * guest-controlled content through it.
+ */
+export async function assertPrivateHostDirectory(
+  directory: string,
+  label: string,
+): Promise<void> {
+  const pinned = await pinDirectory(directory, directory, label);
+  try {
+    const stat = await pinned.handle.stat();
+    if ((stat.mode & 0o022) !== 0) {
+      throw new Error(
+        `Firecracker ${label} must not be group- or world-writable, found ` +
+        `0${(stat.mode & 0o777).toString(8)}: ${directory}`,
+      );
+    }
+    const uid = process.getuid?.();
+    if (uid !== undefined && stat.uid !== uid) {
+      throw new Error(
+        `Firecracker ${label} must be owned by the AWF process: ${directory}`,
+      );
+    }
+  } finally {
+    await pinned.handle.close();
+  }
+}
+
+async function stageSymlink(
+  source: string,
+  destination: string,
+  relativePath: string,
+  parentRelativePath: string,
+  options: BoundedCopyOptions,
+): Promise<void> {
+  const target = await fs.readlink(source);
+  if (target.length === 0 || target.length > BOUNDED_COPY_MAX_SYMLINK_TARGET) {
+    throw new Error(
+      `Firecracker ${options.label} refuses symlink with unsupported target length: ${relativePath}`,
+    );
+  }
+  if (path.isAbsolute(target) || path.posix.isAbsolute(target)) {
+    throw new Error(
+      `Firecracker ${options.label} refuses absolute symlink ${relativePath} -> ${target}`,
+    );
+  }
+  // Containment is evaluated in tree-relative terms because the source is
+  // addressed through a pinned descriptor rather than its real path.
+  const resolved = path.posix.normalize(path.posix.join(parentRelativePath, target));
+  if (resolved === '..' || resolved.startsWith('../') || path.posix.isAbsolute(resolved)) {
+    throw new Error(
+      `Firecracker ${options.label} symlink target for ${relativePath} escapes the staged root: ` +
+      target,
+    );
+  }
+  await fs.symlink(target, destination);
+  await applyOwnership(destination, options.ownership, true);
+}
+
+async function stageFile(
+  source: string,
+  destination: string,
+  relativePath: string,
+  observed: Stats,
+  options: BoundedCopyOptions,
+  budget: BoundedCopyBudget,
+  secrets: readonly string[],
+): Promise<void> {
+  if ((observed.mode & 0o6000) !== 0) {
+    throw new Error(
+      `Firecracker ${options.label} refuses setuid/setgid file: ${relativePath}`,
+    );
+  }
+  if (observed.nlink > 1) {
+    throw new Error(
+      `Firecracker ${options.label} refuses hard-linked file ${relativePath}; a hard link can ` +
+      `alias host state outside the staged root`,
+    );
+  }
+  budget.reserveBytes(options.label, relativePath, observed.size);
+
+  const handle = await fs.open(source, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = await handle.stat();
+    assertUnchanged(observed, opened, options.label, relativePath);
+    if (!opened.isFile()) {
+      throw new Error(
+        `Firecracker ${options.label} refuses non-regular file: ${relativePath}`,
+      );
+    }
+    const executable = (observed.mode & 0o111) !== 0;
+    const target = await fs.open(destination, 'wx', executable ? 0o700 : 0o600);
+    try {
+      const copied = await streamBoundedFile(
+        handle,
+        target,
+        opened.size,
+        options.label,
+        relativePath,
+        secrets,
+      );
+      if (copied !== opened.size) {
+        throw new Error(
+          `Firecracker ${options.label} source changed while staging ${relativePath}`,
+        );
+      }
+      const after = await handle.stat();
+      assertUnchanged(observed, after, options.label, relativePath);
+      await target.chmod(executable ? 0o700 : 0o600);
+      if (options.ownership) {
+        await target.chown(options.ownership.uid, options.ownership.gid);
+      }
+      budget.totals.bytes += copied;
+    } finally {
+      await target.close();
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+async function streamBoundedFile(
+  source: fs.FileHandle,
+  destination: fs.FileHandle,
+  expectedBytes: number,
+  label: string,
+  relativePath: string,
+  secrets: readonly string[],
+): Promise<number> {
+  const chunkSize = 1024 * 1024;
+  const buffer = Buffer.allocUnsafe(chunkSize);
+  const longestSecret = secrets.reduce((longest, secret) => Math.max(longest, secret.length), 0);
+  let carry = Buffer.alloc(0);
+  let copied = 0;
+  let position = 0;
+  for (;;) {
+    const { bytesRead } = await source.read(buffer, 0, chunkSize, position);
+    if (bytesRead === 0) break;
+    position += bytesRead;
+    copied += bytesRead;
+    if (copied > expectedBytes) {
+      throw new Error(
+        `Firecracker ${label} source grew while staging ${relativePath}`,
+      );
+    }
+    const chunk = buffer.subarray(0, bytesRead);
+    if (secrets.length > 0) {
+      const window = carry.length > 0 ? Buffer.concat([carry, chunk]) : chunk;
+      assertNoForbiddenContent(window, secrets, label, relativePath);
+      carry = longestSecret > 1
+        ? Buffer.from(window.subarray(Math.max(0, window.length - (longestSecret - 1))))
+        : Buffer.alloc(0);
+    }
+    await destination.write(chunk, 0, bytesRead);
+  }
+  return copied;
+}
+
+function assertNoForbiddenContent(
+  window: Buffer,
+  secrets: readonly string[],
+  label: string,
+  relativePath: string,
+): void {
+  const text = window.toString('binary');
+  for (const secret of secrets) {
+    if (text.includes(Buffer.from(secret).toString('binary'))) {
+      throw new Error(
+        `Firecracker ${label} refuses ${relativePath}; it contains a real credential value`,
+      );
+    }
+  }
+}
+
+function assertUnchanged(
+  expected: Stats,
+  actual: Stats,
+  label: string,
+  relativePath: string,
+): void {
+  if (
+    expected.dev !== actual.dev ||
+    expected.ino !== actual.ino ||
+    expected.mode !== actual.mode ||
+    expected.size !== actual.size ||
+    expected.nlink !== actual.nlink ||
+    expected.mtimeMs !== actual.mtimeMs ||
+    expected.ctimeMs !== actual.ctimeMs
+  ) {
+    throw new Error(
+      `Firecracker ${label} source changed while staging ${relativePath}`,
+    );
+  }
+}
+
+async function applyOwnership(
+  target: string,
+  ownership: { readonly uid: number; readonly gid: number } | undefined,
+  symbolicLink: boolean,
+): Promise<void> {
+  if (!ownership) return;
+  if (symbolicLink) await fs.lchown(target, ownership.uid, ownership.gid);
+  else await fs.chown(target, ownership.uid, ownership.gid);
+}
+
+/**
+ * Rejects a root whose own path traverses a symlink or a magic link, which is
+ * how `/proc/self/...` style sources would otherwise smuggle host state in.
+ */
+export async function assertCanonicalDirectory(
+  directory: string,
+  label: string,
+): Promise<string> {
+  if (!path.isAbsolute(directory)) {
+    throw new Error(`Firecracker ${label} root must be an absolute path: ${directory}`);
+  }
+  const resolved = path.resolve(directory);
+  if (path.normalize(directory) !== resolved) {
+    throw new Error(`Firecracker ${label} root must be normalized: ${directory}`);
+  }
+  const real = await fs.realpath(resolved);
+  if (real !== resolved) {
+    throw new Error(
+      `Firecracker ${label} root must not traverse a symlink: ${directory} resolves to ${real}`,
+    );
+  }
+  const stat = await fs.lstat(resolved);
+  if (!stat.isDirectory()) {
+    throw new Error(`Firecracker ${label} root must be a real directory: ${directory}`);
+  }
+  return resolved;
+}
+
+export function assertContained(root: string, candidate: string, label: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Firecracker ${label} escapes ${root}: ${candidate}`);
+  }
+}
+
+function assertSafeEntryName(name: string, label: string): void {
+  if (name === '' || name === '.' || name === '..' || name.includes('/') || name.includes('\0')) {
+    throw new Error(`Firecracker ${label} refuses unsafe entry name: ${JSON.stringify(name)}`);
+  }
+}
+
+function assertPositiveInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`Firecracker staging ${field} must be a positive integer: ${value}`);
+  }
+}

--- a/src/firecracker/debugfs.test-utils.ts
+++ b/src/firecracker/debugfs.test-utils.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+/**
+ * `debugfs` exits 0 even when the `-R` subcommand fails, so the fake used by the
+ * image tests reproduces both the success output and the exit-0 diagnostics that
+ * the production code must detect.
+ */
+const DEBUGFS_BANNER = 'debugfs 1.47.0 (5-Feb-2023)';
+
+export type FakeDebugfsFailure =
+  | 'none'
+  | 'rdump-silent'
+  | 'rdump-empty'
+  | 'write-silent'
+  | 'dump-missing'
+  | 'stat-wrong-mode';
+
+export interface FakeToolRunnerOptions {
+  /** Bytes a `dump` of the embedded supervisor reproduces. */
+  readonly supervisorBytes?: string;
+  /** Extra content materialised by a successful `rdump`. */
+  readonly onRdump?: (destination: string) => Promise<void>;
+  readonly onCommand?: (
+    command: string,
+    args: readonly string[],
+  ) => void | Promise<void>;
+  readonly failure?: FakeDebugfsFailure;
+}
+
+function subcommandOf(args: readonly string[]): string {
+  const index = args.indexOf('-R');
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : '';
+}
+
+export function createFakeToolRunner(
+  options: FakeToolRunnerOptions = {},
+): (command: string, args: readonly string[]) => Promise<string> {
+  const failure = options.failure ?? 'none';
+  return async (command, args) => {
+    await options.onCommand?.(command, args);
+    if (!command.endsWith('debugfs')) return '';
+    const subcommand = subcommandOf(args);
+    const [verb, first, second] = subcommand.split(/\s+/);
+
+    if (verb === 'rdump') {
+      if (failure === 'rdump-silent') {
+        return `${DEBUGFS_BANNER}\nrdump: No such file or directory while statting ${second}`;
+      }
+      if (failure === 'rdump-empty') return DEBUGFS_BANNER;
+      await fs.mkdir(path.join(second, 'lost+found'), { recursive: true });
+      await options.onRdump?.(second);
+      return DEBUGFS_BANNER;
+    }
+    if (verb === 'write') {
+      if (failure === 'write-silent') {
+        return `${DEBUGFS_BANNER}\ndo_write_internal: No such file or directory ` +
+          `while opening "${first}" to copy\nwrite: No such file or directory `;
+      }
+      return `${DEBUGFS_BANNER}\nAllocated inode: 15`;
+    }
+    if (verb === 'dump') {
+      if (failure === 'dump-missing') {
+        return `${DEBUGFS_BANNER}\n${first}: File not found by ext2_lookup`;
+      }
+      await fs.writeFile(second, options.supervisorBytes ?? 'binary');
+      return DEBUGFS_BANNER;
+    }
+    if (verb === 'stat') {
+      const mode = failure === 'stat-wrong-mode' ? '0644' : '0755';
+      return `${DEBUGFS_BANNER}\nInode: 14   Type: regular    Mode:  ${mode}   Flags: 0x80000`;
+    }
+    return DEBUGFS_BANNER;
+  };
+}

--- a/src/firecracker/debugfs.test.ts
+++ b/src/firecracker/debugfs.test.ts
@@ -1,0 +1,128 @@
+import {
+  assertDebugfsExtractionProduced,
+  assertDebugfsOperand,
+  assertDebugfsQuerySucceeded,
+  assertDebugfsSucceeded,
+  debugfsFailureLines,
+  parseDebugfsStatMode,
+} from './debugfs';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const BANNER = 'debugfs 1.47.0 (5-Feb-2023)';
+
+describe('debugfs exit-0 failure detection', () => {
+  it('accepts the output a successful mutation produces', () => {
+    expect(() => assertDebugfsSucceeded(BANNER, 'testing')).not.toThrow();
+    expect(() => assertDebugfsSucceeded(`${BANNER}\n`, 'testing')).not.toThrow();
+    expect(() => assertDebugfsSucceeded(`${BANNER}\n\n`, 'testing')).not.toThrow();
+    expect(() => assertDebugfsSucceeded(
+      `${BANNER}\nAllocated inode: 15`,
+      'testing',
+    )).not.toThrow();
+    expect(() => assertDebugfsSucceeded(
+      `${BANNER}\r\nAllocated inode: 4242\r\n`,
+      'testing',
+    )).not.toThrow();
+  });
+
+  it('accepts other debugfs version banners', () => {
+    expect(() => assertDebugfsSucceeded(
+      'debugfs 1.46.5 (30-Dec-2021)',
+      'testing',
+    )).not.toThrow();
+    expect(() => assertDebugfsSucceeded(
+      'debugfs 1.47.0-rc1 (5-Feb-2023)',
+      'testing',
+    )).not.toThrow();
+  });
+
+  it.each([
+    ['a missing rdump destination', `${BANNER}\nrdump: No such file or directory while statting /nope`],
+    ['a missing rdump source', `${BANNER}\n/nope: File not found by ext2_lookup`],
+    ['a missing write source', `${BANNER}\ndo_write_internal: No such file or directory while opening "/no" to copy\nwrite: No such file or directory `],
+    ['a missing dump source', `${BANNER}\n/sbin/awf-supervisor: File not found by ext2_lookup`],
+  ])('rejects %s even though debugfs exited 0', (_label, output) => {
+    expect(() => assertDebugfsSucceeded(output, 'testing')).toThrow(
+      /debugfs reported a failure while testing/,
+    );
+    expect(debugfsFailureLines(output).length).toBeGreaterThan(0);
+  });
+
+  it('reports every diagnostic line', () => {
+    expect(() => assertDebugfsSucceeded(
+      `${BANNER}\nfirst failure\nsecond failure`,
+      'testing',
+    )).toThrow(/first failure; second failure/);
+  });
+
+  it('checks query subcommands against diagnostics rather than silence', () => {
+    const stat = `${BANNER}\nInode: 14   Type: regular    Mode:  0755   Flags: 0x80000`;
+    expect(() => assertDebugfsQuerySucceeded(stat, 'testing')).not.toThrow();
+    expect(() => assertDebugfsQuerySucceeded(
+      `${BANNER}\n/sbin/awf-supervisor: File not found by ext2_lookup`,
+      'testing',
+    )).toThrow(/debugfs reported a failure/);
+    expect(() => assertDebugfsQuerySucceeded(
+      `${BANNER}\ndebugfs: Filesystem not open`,
+      'testing',
+    )).toThrow(/debugfs reported a failure/);
+  });
+
+  it('parses the mode reported by debugfs stat', () => {
+    expect(parseDebugfsStatMode(
+      `${BANNER}\nInode: 14   Type: regular    Mode:  0755   Flags: 0x80000`,
+    )).toBe(0o755);
+    expect(parseDebugfsStatMode(
+      `${BANNER}\nInode: 14   Type: regular    Mode:  0644   Flags: 0x80000`,
+    )).toBe(0o644);
+    expect(parseDebugfsStatMode(BANNER)).toBeUndefined();
+  });
+
+  it('rejects operands that could break out of a -R command string', () => {
+    expect(() => assertDebugfsOperand('/tmp/safe-path', 'test path')).not.toThrow();
+    for (const unsafe of ['/tmp/a b', '/tmp/a"b', "/tmp/a'b", '/tmp/a;b', '/tmp/a`b', '/tmp/a\nb']) {
+      expect(() => assertDebugfsOperand(unsafe, 'test path')).toThrow(/unsafe for debugfs/);
+    }
+  });
+});
+
+describe('assertDebugfsExtractionProduced', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'awf-debugfs-')));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('accepts an extraction carrying every sentinel', async () => {
+    await fs.mkdir(path.join(root, 'lost+found'));
+    await fs.writeFile(path.join(root, '.awf-exchange'), '{}');
+    await expect(assertDebugfsExtractionProduced(
+      root,
+      ['lost+found', '.awf-exchange'],
+      'the test device',
+    )).resolves.toBeUndefined();
+  });
+
+  it('rejects an empty extraction that debugfs reported as success', async () => {
+    await expect(assertDebugfsExtractionProduced(
+      root,
+      ['lost+found'],
+      'the test device',
+    )).rejects.toThrow(/missing the 'lost\+found' entry/);
+  });
+
+  it('rejects a partial extraction missing a later sentinel', async () => {
+    await fs.mkdir(path.join(root, 'lost+found'));
+    await expect(assertDebugfsExtractionProduced(
+      root,
+      ['lost+found', '.awf-exchange'],
+      'the test device',
+    )).rejects.toThrow(/missing the '\.awf-exchange' entry/);
+  });
+});

--- a/src/firecracker/debugfs.ts
+++ b/src/firecracker/debugfs.ts
@@ -1,0 +1,105 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * `debugfs` exits 0 even when the subcommand supplied through `-R` fails. A
+ * missing source file, an unwritable destination and a `write` into a missing
+ * directory all report success to the shell while performing no work. Every
+ * failure does emit a diagnostic line, so success is defined here as an
+ * allowlist of the only lines a successful mutation or dump may produce.
+ */
+const DEBUGFS_BANNER_LINE = /^debugfs \d+\.\d+(\.\d+)?(-\S+)?\s+\(.*\)$/;
+const DEBUGFS_ALLOCATED_INODE_LINE = /^Allocated inode: \d+$/;
+
+export function debugfsFailureLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.replace(/\r$/, '').trim())
+    .filter((line) => line.length > 0)
+    .filter(
+      (line) =>
+        !DEBUGFS_BANNER_LINE.test(line) &&
+        !DEBUGFS_ALLOCATED_INODE_LINE.test(line),
+    );
+}
+
+/**
+ * Fail closed when a silent `debugfs` subcommand emitted any diagnostic.
+ */
+export function assertDebugfsSucceeded(output: string, label: string): void {
+  const failures = debugfsFailureLines(output);
+  if (failures.length === 0) return;
+  throw new Error(
+    `debugfs reported a failure while ${label} (debugfs exits 0 on ` +
+    `subcommand failure): ${failures.join('; ')}`,
+  );
+}
+
+const DEBUGFS_QUERY_ERROR_MARKERS = [
+  'file not found by ext2_lookup',
+  'no such file or directory',
+  'permission denied',
+  'bad magic number',
+  'couldn\'t find valid filesystem superblock',
+  'filesystem not open',
+  'invalid argument',
+];
+
+/**
+ * Query subcommands legitimately print results, so they are checked against the
+ * diagnostics `debugfs` emits instead of requiring silence.
+ */
+export function assertDebugfsQuerySucceeded(output: string, label: string): void {
+  const lowered = output.toLowerCase();
+  const marker = DEBUGFS_QUERY_ERROR_MARKERS.find((entry) => lowered.includes(entry));
+  if (!marker) return;
+  throw new Error(
+    `debugfs reported a failure while ${label} (debugfs exits 0 on ` +
+    `subcommand failure): ${output.trim()}`,
+  );
+}
+
+/**
+ * `debugfs stat` renders the mode as `Mode:  0755`.
+ */
+export function parseDebugfsStatMode(output: string): number | undefined {
+  const match = /\bMode:\s+0?([0-7]{3,4})\b/.exec(output);
+  if (!match) return undefined;
+  return Number.parseInt(match[1], 8);
+}
+
+/**
+ * A successful `rdump /` always materialises the `lost+found` directory that
+ * `mke2fs` creates, so its absence proves the dump produced nothing usable.
+ * This is the last guard before `rsync --delete` replaces host state.
+ */
+export async function assertDebugfsExtractionProduced(
+  extractionDirectory: string,
+  sentinels: readonly string[],
+  label: string,
+): Promise<void> {
+  for (const sentinel of sentinels) {
+    const target = path.join(extractionDirectory, sentinel);
+    const stat = await fs.lstat(target).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined;
+      throw error;
+    });
+    if (!stat) {
+      throw new Error(
+        `debugfs extraction for ${label} is missing the '${sentinel}' entry ` +
+        'that every successful dump produces; refusing to treat the empty ' +
+        'extraction as guest output',
+      );
+    }
+  }
+}
+
+/**
+ * Reject shell-significant characters before interpolating a value into a
+ * `debugfs -R` command string.
+ */
+export function assertDebugfsOperand(value: string, label: string): void {
+  if (/[\s"'\\;`\r\n]/.test(value)) {
+    throw new Error(`Firecracker ${label} is unsafe for debugfs commands: ${value}`);
+  }
+}

--- a/src/firecracker/exchange-image.test.ts
+++ b/src/firecracker/exchange-image.test.ts
@@ -260,3 +260,87 @@ describe('FirecrackerExchangeImage', () => {
     await expect(image.extractAfterStop()).rejects.toThrow(/must not traverse a symlink/);
   });
 });
+
+describe('FirecrackerExchangeImage failure and ownership handling', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot('awf-exchange-fail-');
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function makeImage(
+    overrides: Partial<FirecrackerSafeOutputsOptions> = {},
+    write?: (destination: string) => Promise<void>,
+  ) {
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const hostDirectory = path.join(root, 'outputs');
+    const plan = resolveFirecrackerExchangePlan(
+      safeOutputs({ hostDirectory, maxTotalBytes: 4096, maxFileBytes: 2048, ...overrides }),
+    );
+    const image = new FirecrackerExchangeImage(
+      {
+        runId: 'run-1',
+        runDirectory,
+        plan,
+        uid: process.getuid?.() ?? 0,
+        gid: process.getgid?.() ?? 0,
+      },
+      {
+        runTool: async (command) => {
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
+          }
+          if (command === 'debugfs') {
+            const destination = image.extractionDirectory;
+            const outputs = path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME);
+            await fs.mkdir(outputs, { recursive: true });
+            await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
+            if (write) await write(outputs);
+            else await fs.writeFile(path.join(outputs, 'outputs.jsonl'), '{}\n');
+          }
+        },
+      },
+    );
+    return { image, hostDirectory };
+  }
+
+  it('publishes nothing when the copy-back breaches a cap', async () => {
+    // A truncated run directory is indistinguishable from a complete result.
+    const { image, hostDirectory } = await makeImage(
+      { maxFileBytes: 8, maxTotalBytes: 8 },
+      async (outputs) => {
+        await fs.writeFile(path.join(outputs, 'a.jsonl'), 'x'.repeat(4));
+        await fs.writeFile(path.join(outputs, 'b.jsonl'), 'y'.repeat(4096));
+      },
+    );
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow();
+
+    const published = await fs.readdir(path.join(hostDirectory, 'run-1')).catch(() => undefined);
+    expect(published).toBeUndefined();
+  });
+
+  it('refuses a pre-existing safe-output root that other users can write', async () => {
+    const hostDirectory = path.join(root, 'outputs');
+    await fs.mkdir(hostDirectory, { recursive: true, mode: 0o700 });
+    await fs.chmod(hostDirectory, 0o777);
+    const { image } = await makeImage();
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(/group- or world-writable/);
+  });
+
+  it('creates the per-run destination exclusively', async () => {
+    const { image, hostDirectory } = await makeImage();
+    await image.prepare();
+    await fs.mkdir(path.join(hostDirectory, 'run-1'), { recursive: true, mode: 0o700 });
+
+    await expect(image.extractAfterStop()).rejects.toThrow();
+  });
+});

--- a/src/firecracker/exchange-image.test.ts
+++ b/src/firecracker/exchange-image.test.ts
@@ -1,0 +1,262 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  FIRECRACKER_EXCHANGE_MARKER,
+  FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
+  FIRECRACKER_GUEST_EXCHANGE_MOUNT,
+  FIRECRACKER_GUEST_SAFE_OUTPUTS_DIR,
+  FIRECRACKER_GUEST_SAFE_OUTPUTS_FILE,
+  FirecrackerExchangeImage,
+  resolveFirecrackerExchangePlan,
+} from './exchange-image';
+import {
+  FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_BYTES,
+  FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_COUNT,
+  FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_TOTAL_BYTES,
+  type FirecrackerSafeOutputsOptions,
+} from '../types/runtime-options';
+
+async function makeTempRoot(prefix: string): Promise<string> {
+  const base = await fs.realpath(os.tmpdir());
+  return fs.mkdtemp(path.join(base, prefix));
+}
+
+function safeOutputs(
+  overrides: Partial<FirecrackerSafeOutputsOptions> = {},
+): FirecrackerSafeOutputsOptions {
+  return {
+    hostDirectory: '/var/tmp/awf-safe-outputs',
+    maxFileBytes: FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_BYTES,
+    maxTotalBytes: FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_TOTAL_BYTES,
+    maxFileCount: FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_COUNT,
+    ...overrides,
+  };
+}
+
+describe('resolveFirecrackerExchangePlan', () => {
+  it('pins the guest exchange paths', () => {
+    const plan = resolveFirecrackerExchangePlan(safeOutputs());
+
+    expect(plan.guestMountPoint).toBe(FIRECRACKER_GUEST_EXCHANGE_MOUNT);
+    expect(plan.guestOutputDirectory).toBe(FIRECRACKER_GUEST_SAFE_OUTPUTS_DIR);
+    expect(plan.guestOutputFile).toBe(FIRECRACKER_GUEST_SAFE_OUTPUTS_FILE);
+    expect(plan.guestOutputDirectory.startsWith(`${plan.guestMountPoint}/`)).toBe(true);
+  });
+
+  it.each([
+    ['relative host directory', { hostDirectory: 'relative/outputs' }, /absolute normalized/],
+    ['traversal host directory', { hostDirectory: '/var/tmp/../etc' }, /absolute normalized/],
+    ['root host directory', { hostDirectory: '/' }, /absolute normalized|safe path/],
+    ['zero file cap', { maxFileBytes: 0 }, /positive integer/],
+    ['negative total cap', { maxTotalBytes: -1 }, /positive integer/],
+    ['fractional count cap', { maxFileCount: 1.5 }, /positive integer/],
+  ])('rejects %s', (_name, overrides, pattern) => {
+    expect(() => resolveFirecrackerExchangePlan(safeOutputs(overrides))).toThrow(pattern);
+  });
+
+  it('rejects a per-file cap larger than the total cap', () => {
+    expect(() => resolveFirecrackerExchangePlan(safeOutputs({
+      maxFileBytes: 1024,
+      maxTotalBytes: 512,
+    }))).toThrow(/may not exceed/);
+  });
+});
+
+describe('FirecrackerExchangeImage', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot('awf-exchange-');
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function makeImage(overrides: Partial<FirecrackerSafeOutputsOptions> = {}) {
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const hostDirectory = path.join(root, 'outputs');
+    const plan = resolveFirecrackerExchangePlan(
+      safeOutputs({ hostDirectory, maxTotalBytes: 4096, maxFileBytes: 2048, ...overrides }),
+    );
+    const commands: Array<{ command: string; args: readonly string[] }> = [];
+    const image = new FirecrackerExchangeImage(
+      { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
+      {
+        runTool: async (command, args) => {
+          commands.push({ command, args });
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
+          }
+          if (command === 'debugfs') {
+            // Simulate `rdump /` of the guest device into the extraction dir.
+            const destination = image.extractionDirectory;
+            await fs.mkdir(path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME), {
+              recursive: true,
+            });
+            await fs.mkdir(path.join(destination, 'lost+found'), { recursive: true });
+            await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
+            await fs.writeFile(
+              path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME, 'outputs.jsonl'),
+              '{"type":"add-comment"}\n',
+            );
+          }
+        },
+      },
+    );
+    return { image, commands, hostDirectory, runDirectory };
+  }
+
+  it('creates an empty device carrying only the marker and output directory', async () => {
+    const { image, commands, runDirectory } = await makeImage();
+
+    const preparation = await image.prepare();
+
+    expect(commands.map((entry) => entry.command)).toEqual(['mke2fs', 'e2fsck']);
+    expect(preparation.imagePath).toBe(path.join(runDirectory, 'exchange.ext4'));
+    const staged = await fs.readdir(image.stagingDirectory);
+    expect(staged.sort()).toEqual([FIRECRACKER_EXCHANGE_MARKER, 'safe-outputs'].sort());
+  });
+
+  it('copies guest outputs back into an exclusive per-run host directory', async () => {
+    const { image, hostDirectory } = await makeImage();
+    await image.prepare();
+
+    const totals = await image.extractAfterStop();
+
+    expect(totals.files).toBe(1);
+    await expect(
+      fs.readFile(path.join(hostDirectory, 'run-1', 'outputs.jsonl'), 'utf8'),
+    ).resolves.toBe('{"type":"add-comment"}\n');
+    // Neither the marker nor lost+found is ever copied back to the host.
+    const copied = await fs.readdir(path.join(hostDirectory, 'run-1'));
+    expect(copied).toEqual(['outputs.jsonl']);
+    await expect(fs.access(image.extractionDirectory)).rejects.toThrow();
+  });
+
+  it('refuses extraction before preparation and refuses a second extraction', async () => {
+    const { image } = await makeImage();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(/has not been prepared/);
+    await image.prepare();
+    await image.extractAfterStop();
+    await expect(image.extractAfterStop()).rejects.toThrow(/already extracted/);
+  });
+
+  it('enforces copy-back caps', async () => {
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const hostDirectory = path.join(root, 'outputs');
+    const plan = resolveFirecrackerExchangePlan(
+      safeOutputs({ hostDirectory, maxFileBytes: 8, maxTotalBytes: 16, maxFileCount: 8 }),
+    );
+    const image: FirecrackerExchangeImage = new FirecrackerExchangeImage(
+      { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
+      {
+        runTool: async (command) => {
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
+          }
+          if (command === 'debugfs') {
+            const outputs = path.join(
+              image.extractionDirectory,
+              FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
+            );
+            await fs.mkdir(outputs, { recursive: true });
+            await fs.writeFile(path.join(outputs, 'big.jsonl'), Buffer.alloc(64));
+          }
+        },
+      },
+    );
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(/per-file cap/);
+  });
+
+  it('rejects an unsafe symlink written by the guest', async () => {
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const hostDirectory = path.join(root, 'outputs');
+    const plan = resolveFirecrackerExchangePlan(safeOutputs({ hostDirectory }));
+    const image: FirecrackerExchangeImage = new FirecrackerExchangeImage(
+      { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
+      {
+        runTool: async (command) => {
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
+          }
+          if (command === 'debugfs') {
+            const outputs = path.join(
+              image.extractionDirectory,
+              FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
+            );
+            await fs.mkdir(outputs, { recursive: true });
+            await fs.symlink('/etc/passwd', path.join(outputs, 'escape'));
+          }
+        },
+      },
+    );
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(/absolute symlink/);
+  });
+
+  it('returns empty totals when the guest wrote no outputs', async () => {
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const plan = resolveFirecrackerExchangePlan(
+      safeOutputs({ hostDirectory: path.join(root, 'outputs') }),
+    );
+    const image = new FirecrackerExchangeImage(
+      { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
+      {
+        runTool: async (command) => {
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
+          }
+        },
+      },
+    );
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).resolves.toEqual({
+      files: 0,
+      directories: 0,
+      symlinks: 0,
+      bytes: 0,
+    });
+  });
+
+  it('refuses a host output directory reached through a symlink', async () => {
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const real = path.join(root, 'real-outputs');
+    await fs.mkdir(real, { recursive: true });
+    const link = path.join(root, 'linked-outputs');
+    await fs.symlink(real, link);
+    const plan = resolveFirecrackerExchangePlan(safeOutputs({ hostDirectory: link }));
+    const image: FirecrackerExchangeImage = new FirecrackerExchangeImage(
+      { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
+      {
+        runTool: async (command) => {
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
+          }
+          if (command === 'debugfs') {
+            const outputs = path.join(
+              image.extractionDirectory,
+              FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
+            );
+            await fs.mkdir(outputs, { recursive: true });
+            await fs.writeFile(path.join(outputs, 'outputs.jsonl'), '{}\n');
+          }
+        },
+      },
+    );
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(/must not traverse a symlink/);
+  });
+});

--- a/src/firecracker/exchange-image.test.ts
+++ b/src/firecracker/exchange-image.test.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { createFakeToolRunner } from './debugfs.test-utils';
 import {
   FIRECRACKER_EXCHANGE_MARKER,
   FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
@@ -85,25 +86,23 @@ describe('FirecrackerExchangeImage', () => {
     const image = new FirecrackerExchangeImage(
       { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
       {
-        runTool: async (command, args) => {
-          commands.push({ command, args });
-          if (command === 'mke2fs') {
+        runTool: createFakeToolRunner({
+          onCommand: async (command, args) => {
+            commands.push({ command, args });
+            if (command !== 'mke2fs') return;
             await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
-          }
-          if (command === 'debugfs') {
-            // Simulate `rdump /` of the guest device into the extraction dir.
-            const destination = image.extractionDirectory;
+          },
+          onRdump: async (destination) => {
             await fs.mkdir(path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME), {
               recursive: true,
             });
-            await fs.mkdir(path.join(destination, 'lost+found'), { recursive: true });
             await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
             await fs.writeFile(
               path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME, 'outputs.jsonl'),
               '{"type":"add-comment"}\n',
             );
-          }
-        },
+          },
+        }),
       },
     );
     return { image, commands, hostDirectory, runDirectory };
@@ -155,19 +154,18 @@ describe('FirecrackerExchangeImage', () => {
     const image: FirecrackerExchangeImage = new FirecrackerExchangeImage(
       { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
       {
-        runTool: async (command) => {
-          if (command === 'mke2fs') {
+        runTool: createFakeToolRunner({
+          onCommand: async (command) => {
+            if (command !== 'mke2fs') return;
             await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
-          }
-          if (command === 'debugfs') {
-            const outputs = path.join(
-              image.extractionDirectory,
-              FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
-            );
+          },
+          onRdump: async (destination) => {
+            await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
+            const outputs = path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME);
             await fs.mkdir(outputs, { recursive: true });
             await fs.writeFile(path.join(outputs, 'big.jsonl'), Buffer.alloc(64));
-          }
-        },
+          },
+        }),
       },
     );
     await image.prepare();
@@ -183,19 +181,18 @@ describe('FirecrackerExchangeImage', () => {
     const image: FirecrackerExchangeImage = new FirecrackerExchangeImage(
       { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
       {
-        runTool: async (command) => {
-          if (command === 'mke2fs') {
+        runTool: createFakeToolRunner({
+          onCommand: async (command) => {
+            if (command !== 'mke2fs') return;
             await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
-          }
-          if (command === 'debugfs') {
-            const outputs = path.join(
-              image.extractionDirectory,
-              FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
-            );
+          },
+          onRdump: async (destination) => {
+            await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
+            const outputs = path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME);
             await fs.mkdir(outputs, { recursive: true });
             await fs.symlink('/etc/passwd', path.join(outputs, 'escape'));
-          }
-        },
+          },
+        }),
       },
     );
     await image.prepare();
@@ -212,11 +209,15 @@ describe('FirecrackerExchangeImage', () => {
     const image = new FirecrackerExchangeImage(
       { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
       {
-        runTool: async (command) => {
-          if (command === 'mke2fs') {
+        runTool: createFakeToolRunner({
+          onCommand: async (command) => {
+            if (command !== 'mke2fs') return;
             await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
-          }
-        },
+          },
+          onRdump: async (destination) => {
+            await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
+          },
+        }),
       },
     );
     await image.prepare();
@@ -240,19 +241,18 @@ describe('FirecrackerExchangeImage', () => {
     const image: FirecrackerExchangeImage = new FirecrackerExchangeImage(
       { runId: 'run-1', runDirectory, plan, uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 },
       {
-        runTool: async (command) => {
-          if (command === 'mke2fs') {
+        runTool: createFakeToolRunner({
+          onCommand: async (command) => {
+            if (command !== 'mke2fs') return;
             await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
-          }
-          if (command === 'debugfs') {
-            const outputs = path.join(
-              image.extractionDirectory,
-              FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
-            );
+          },
+          onRdump: async (destination) => {
+            await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
+            const outputs = path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME);
             await fs.mkdir(outputs, { recursive: true });
             await fs.writeFile(path.join(outputs, 'outputs.jsonl'), '{}\n');
-          }
-        },
+          },
+        }),
       },
     );
     await image.prepare();
@@ -291,19 +291,19 @@ describe('FirecrackerExchangeImage failure and ownership handling', () => {
         gid: process.getgid?.() ?? 0,
       },
       {
-        runTool: async (command) => {
-          if (command === 'mke2fs') {
+        runTool: createFakeToolRunner({
+          onCommand: async (command) => {
+            if (command !== 'mke2fs') return;
             await fs.writeFile(path.join(runDirectory, 'exchange.ext4'), 'image');
-          }
-          if (command === 'debugfs') {
-            const destination = image.extractionDirectory;
+          },
+          onRdump: async (destination) => {
             const outputs = path.join(destination, FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME);
             await fs.mkdir(outputs, { recursive: true });
             await fs.writeFile(path.join(destination, FIRECRACKER_EXCHANGE_MARKER), '{}');
             if (write) await write(outputs);
             else await fs.writeFile(path.join(outputs, 'outputs.jsonl'), '{}\n');
-          }
-        },
+          },
+        }),
       },
     );
     return { image, hostDirectory };

--- a/src/firecracker/exchange-image.ts
+++ b/src/firecracker/exchange-image.ts
@@ -197,7 +197,7 @@ export class FirecrackerExchangeImage {
       }
       await fs.chmod(outputs, 0o700);
       const destination = await this.prepareHostDirectory();
-      const totals = await copyBoundedTree(
+      const totals = await this.copyOrDiscard(destination, () => copyBoundedTree(
         {
           sourceRoot: outputs,
           destinationRoot: destination,
@@ -211,14 +211,35 @@ export class FirecrackerExchangeImage {
           maxTotalBytes: this.config.plan.maxTotalBytes,
           maxFileCount: this.config.plan.maxFileCount,
         }),
-      );
+      ));
       // Handed to the invoking user only after the bounded copy has finished
       // proving the destination was AWF-owned for the whole copy-back.
       await this.applyOwnership(destination);
       this.extracted = true;
       return totals;
     } finally {
-      await fs.rm(this.extractionDirectory, { recursive: true, force: true });
+      // Never let cleanup replace a real extraction failure.
+      await fs.rm(this.extractionDirectory, { recursive: true, force: true })
+        .catch(() => undefined);
+    }
+  }
+
+  /**
+   * Publishes nothing on failure.
+   *
+   * A cap breach part-way through would otherwise leave a truncated run
+   * directory that looks like a complete result, and the caller has no way to
+   * tell the two apart.
+   */
+  private async copyOrDiscard(
+    destination: string,
+    copy: () => Promise<BoundedCopyTotals>,
+  ): Promise<BoundedCopyTotals> {
+    try {
+      return await copy();
+    } catch (error) {
+      await fs.rm(destination, { recursive: true, force: true }).catch(() => undefined);
+      throw error;
     }
   }
 
@@ -242,7 +263,10 @@ export class FirecrackerExchangeImage {
     }
     // A pre-existing root that another user can write lets them substitute the
     // run directory after AWF creates it, so refuse it outright.
-    await assertPrivateHostDirectory(root, 'safe-output directory');
+    await assertPrivateHostDirectory(root, 'safe-output directory', [this.config.uid]);
+    // A root this process just created as root would otherwise be untraversable
+    // by the user the outputs belong to.
+    await this.applyOwnership(root);
     const destination = path.join(root, this.config.runId);
     assertContained(root, destination, 'safe-output destination');
     await fs.mkdir(destination, { mode: 0o700 });

--- a/src/firecracker/exchange-image.ts
+++ b/src/firecracker/exchange-image.ts
@@ -1,0 +1,277 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import type { FirecrackerSafeOutputsOptions } from '../types/runtime-options';
+import {
+  BoundedCopyBudget,
+  assertContained,
+  assertPrivateHostDirectory,
+  copyBoundedTree,
+  type BoundedCopyTotals,
+} from './bounded-copy';
+import {
+  defaultRuntimeAssetDependencies,
+  type FirecrackerRuntimeAssetImageDependencies,
+} from './runtime-assets';
+
+const MIB = 1024 * 1024;
+const EXCHANGE_BLOCK_BYTES = 4096;
+const EXCHANGE_HEADROOM_BYTES = 8 * MIB;
+const EXCHANGE_MIN_BYTES = 16 * MIB;
+
+/** Guest mount point of the writable safe-output exchange device. */
+export const FIRECRACKER_GUEST_EXCHANGE_MOUNT = '/awf/exchange';
+/** Guest directory the agent writes safe outputs into. */
+export const FIRECRACKER_GUEST_SAFE_OUTPUTS_DIR = `${FIRECRACKER_GUEST_EXCHANGE_MOUNT}/safe-outputs`;
+/** Default safe-output file AWF advertises to generated gh-aw agents. */
+export const FIRECRACKER_GUEST_SAFE_OUTPUTS_FILE = `${FIRECRACKER_GUEST_SAFE_OUTPUTS_DIR}/outputs.jsonl`;
+/** Marker AWF writes into the exchange device so the guest can verify ordering. */
+export const FIRECRACKER_EXCHANGE_MARKER = '.awf-exchange';
+/** Relative name of the guest-writable safe-output directory on the device. */
+export const FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME = 'safe-outputs';
+
+export interface FirecrackerExchangePlan {
+  readonly hostDirectory: string;
+  readonly guestMountPoint: string;
+  readonly guestOutputDirectory: string;
+  readonly guestOutputFile: string;
+  readonly maxFileBytes: number;
+  readonly maxTotalBytes: number;
+  readonly maxFileCount: number;
+}
+
+/**
+ * Validates the safe-output exchange contract before any VM is created.
+ */
+export function resolveFirecrackerExchangePlan(
+  options: FirecrackerSafeOutputsOptions,
+): FirecrackerExchangePlan {
+  const hostDirectory = options.hostDirectory;
+  if (!path.isAbsolute(hostDirectory) || path.normalize(hostDirectory) !== hostDirectory) {
+    throw new Error(
+      `Firecracker safe-output directory must be an absolute normalized path: ${hostDirectory}`,
+    );
+  }
+  if (hostDirectory === '/' || hostDirectory.includes('..')) {
+    throw new Error(`Firecracker safe-output directory is not a safe path: ${hostDirectory}`);
+  }
+  for (const cap of ['maxFileBytes', 'maxTotalBytes', 'maxFileCount'] as const) {
+    if (!Number.isSafeInteger(options[cap]) || options[cap] <= 0) {
+      throw new Error(`Firecracker safe-output ${cap} must be a positive integer`);
+    }
+  }
+  if (options.maxFileBytes > options.maxTotalBytes) {
+    throw new Error(
+      'Firecracker safe-output maxFileBytes may not exceed maxTotalBytes',
+    );
+  }
+  return {
+    hostDirectory,
+    guestMountPoint: FIRECRACKER_GUEST_EXCHANGE_MOUNT,
+    guestOutputDirectory: FIRECRACKER_GUEST_SAFE_OUTPUTS_DIR,
+    guestOutputFile: FIRECRACKER_GUEST_SAFE_OUTPUTS_FILE,
+    maxFileBytes: options.maxFileBytes,
+    maxTotalBytes: options.maxTotalBytes,
+    maxFileCount: options.maxFileCount,
+  };
+}
+
+export interface FirecrackerExchangeImageConfig {
+  readonly runId: string;
+  readonly runDirectory: string;
+  readonly plan: FirecrackerExchangePlan;
+  readonly uid: number;
+  readonly gid: number;
+}
+
+export interface FirecrackerExchangePreparation {
+  readonly imagePath: string;
+  readonly imageBytes: number;
+}
+
+/**
+ * Owns the dedicated, bounded exchange device used for safe outputs.
+ *
+ * The device is created empty — no host output or host config is ever exposed
+ * on writable guest storage — and it is only read back after the Firecracker
+ * process termination has been confirmed by the caller.
+ */
+export class FirecrackerExchangeImage {
+  readonly imagePath: string;
+  readonly stagingDirectory: string;
+  readonly extractionDirectory: string;
+  private prepared = false;
+  private extracted = false;
+
+  constructor(
+    private readonly config: FirecrackerExchangeImageConfig,
+    private readonly dependencies: FirecrackerRuntimeAssetImageDependencies =
+    defaultRuntimeAssetDependencies,
+    private readonly tools?: { mke2fs?: string; e2fsck?: string; debugfs?: string },
+  ) {
+    this.imagePath = path.join(config.runDirectory, 'exchange.ext4');
+    this.stagingDirectory = path.join(config.runDirectory, 'exchange-staging');
+    this.extractionDirectory = path.join(config.runDirectory, 'exchange-extracted');
+  }
+
+  async prepare(): Promise<FirecrackerExchangePreparation> {
+    if (this.prepared) throw new Error('Firecracker exchange image is already prepared');
+    await fs.mkdir(this.stagingDirectory, { recursive: true, mode: 0o700 });
+    const outputDirectory = path.join(
+      this.stagingDirectory,
+      FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
+    );
+    await fs.mkdir(outputDirectory, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(this.stagingDirectory, FIRECRACKER_EXCHANGE_MARKER),
+      `${JSON.stringify({ schemaVersion: 1, runId: this.config.runId })}\n`,
+      { flag: 'wx', mode: 0o600 },
+    );
+    await this.applyOwnership(outputDirectory);
+
+    const imageBytes = alignExchangeBytes(
+      this.config.plan.maxTotalBytes + EXCHANGE_HEADROOM_BYTES,
+    );
+    const handle = await fs.open(this.imagePath, 'wx', 0o600);
+    try {
+      await handle.truncate(imageBytes);
+    } finally {
+      await handle.close();
+    }
+    await this.runTool('mke2fs', [
+      '-t', 'ext4',
+      '-F',
+      '-q',
+      '-b', String(EXCHANGE_BLOCK_BYTES),
+      '-N', String(Math.max(1024, this.config.plan.maxFileCount * 2)),
+      '-d', this.stagingDirectory,
+      this.imagePath,
+      String(imageBytes / EXCHANGE_BLOCK_BYTES),
+    ]);
+    await this.runTool('e2fsck', ['-f', '-y', this.imagePath]);
+    this.prepared = true;
+    return { imagePath: this.imagePath, imageBytes };
+  }
+
+  /**
+   * Must only be called after the Firecracker process termination is confirmed.
+   */
+  async extractAfterStop(changedImagePath = this.imagePath): Promise<BoundedCopyTotals> {
+    if (!this.prepared) {
+      throw new Error('Firecracker exchange image has not been prepared');
+    }
+    if (this.extracted) {
+      throw new Error('Firecracker exchange image was already extracted');
+    }
+    assertDebugfsOperand(this.extractionDirectory, 'exchange extraction directory');
+    assertDebugfsOperand(changedImagePath, 'exchange image path');
+    try {
+      await fs.rm(this.extractionDirectory, { recursive: true, force: true });
+      await fs.mkdir(this.extractionDirectory, { recursive: true, mode: 0o700 });
+      await this.runTool('e2fsck', ['-f', '-y', changedImagePath]);
+      await this.runTool('debugfs', [
+        '-R', `rdump / ${this.extractionDirectory}`,
+        changedImagePath,
+      ]);
+      for (const reserved of ['lost+found', FIRECRACKER_EXCHANGE_MARKER]) {
+        await fs.rm(path.join(this.extractionDirectory, reserved), {
+          recursive: true,
+          force: true,
+        });
+      }
+      const outputs = path.join(
+        this.extractionDirectory,
+        FIRECRACKER_EXCHANGE_OUTPUT_DIRNAME,
+      );
+      const stat = await fs.lstat(outputs).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') return undefined;
+        throw error;
+      });
+      if (!stat) {
+        this.extracted = true;
+        return { files: 0, directories: 0, symlinks: 0, bytes: 0 };
+      }
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error(
+          'Firecracker safe-output exchange root must be a directory on the guest device',
+        );
+      }
+      await fs.chmod(outputs, 0o700);
+      const destination = await this.prepareHostDirectory();
+      const totals = await copyBoundedTree(
+        {
+          sourceRoot: outputs,
+          destinationRoot: destination,
+          label: 'safe-output copy-back',
+          ...(process.getuid?.() === 0
+            ? { ownership: { uid: this.config.uid, gid: this.config.gid } }
+            : {}),
+        },
+        new BoundedCopyBudget({
+          maxFileBytes: this.config.plan.maxFileBytes,
+          maxTotalBytes: this.config.plan.maxTotalBytes,
+          maxFileCount: this.config.plan.maxFileCount,
+        }),
+      );
+      // Handed to the invoking user only after the bounded copy has finished
+      // proving the destination was AWF-owned for the whole copy-back.
+      await this.applyOwnership(destination);
+      this.extracted = true;
+      return totals;
+    } finally {
+      await fs.rm(this.extractionDirectory, { recursive: true, force: true });
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    await fs.rm(this.stagingDirectory, { recursive: true, force: true });
+    await fs.rm(this.extractionDirectory, { recursive: true, force: true });
+  }
+
+  /**
+   * Creates the run-scoped host destination exclusively so a copy-back never
+   * overwrites or merges into pre-existing host state.
+   */
+  private async prepareHostDirectory(): Promise<string> {
+    const root = this.config.plan.hostDirectory;
+    await fs.mkdir(root, { recursive: true, mode: 0o700 });
+    const real = await fs.realpath(root);
+    if (real !== root) {
+      throw new Error(
+        `Firecracker safe-output directory must not traverse a symlink: ${root} -> ${real}`,
+      );
+    }
+    // A pre-existing root that another user can write lets them substitute the
+    // run directory after AWF creates it, so refuse it outright.
+    await assertPrivateHostDirectory(root, 'safe-output directory');
+    const destination = path.join(root, this.config.runId);
+    assertContained(root, destination, 'safe-output destination');
+    await fs.mkdir(destination, { mode: 0o700 });
+    return destination;
+  }
+
+  private async applyOwnership(target: string): Promise<void> {
+    if (process.getuid?.() !== 0) return;
+    await fs.chown(target, this.config.uid, this.config.gid);
+  }
+
+  private runTool(
+    command: 'mke2fs' | 'e2fsck' | 'debugfs',
+    args: readonly string[],
+  ): Promise<void> {
+    return this.dependencies.runTool(this.tools?.[command] ?? command, args);
+  }
+}
+
+function alignExchangeBytes(requestedBytes: number): number {
+  if (!Number.isSafeInteger(requestedBytes) || requestedBytes <= 0) {
+    throw new Error(`Invalid Firecracker exchange image size: ${requestedBytes}`);
+  }
+  const requested = Math.max(EXCHANGE_MIN_BYTES, requestedBytes);
+  return Math.ceil(requested / EXCHANGE_BLOCK_BYTES) * EXCHANGE_BLOCK_BYTES;
+}
+
+function assertDebugfsOperand(value: string, label: string): void {
+  if (/[\s"'\\;`\r\n]/.test(value)) {
+    throw new Error(`Firecracker ${label} is unsafe for debugfs commands: ${value}`);
+  }
+}

--- a/src/firecracker/exchange-image.ts
+++ b/src/firecracker/exchange-image.ts
@@ -12,6 +12,11 @@ import {
   defaultRuntimeAssetDependencies,
   type FirecrackerRuntimeAssetImageDependencies,
 } from './runtime-assets';
+import {
+  assertDebugfsExtractionProduced,
+  assertDebugfsOperand,
+  assertDebugfsSucceeded,
+} from './debugfs';
 
 const MIB = 1024 * 1024;
 const EXCHANGE_BLOCK_BYTES = 4096;
@@ -168,10 +173,19 @@ export class FirecrackerExchangeImage {
       await fs.rm(this.extractionDirectory, { recursive: true, force: true });
       await fs.mkdir(this.extractionDirectory, { recursive: true, mode: 0o700 });
       await this.runTool('e2fsck', ['-f', '-y', changedImagePath]);
-      await this.runTool('debugfs', [
-        '-R', `rdump / ${this.extractionDirectory}`,
-        changedImagePath,
-      ]);
+      assertDebugfsSucceeded(
+        await this.runTool('debugfs', [
+          '-R', `rdump / ${this.extractionDirectory}`,
+          changedImagePath,
+        ]),
+        'extracting the safe-output exchange image',
+      );
+      // A silent `debugfs` failure would otherwise be reported as "no outputs".
+      await assertDebugfsExtractionProduced(
+        this.extractionDirectory,
+        ['lost+found', FIRECRACKER_EXCHANGE_MARKER],
+        'the safe-output exchange',
+      );
       for (const reserved of ['lost+found', FIRECRACKER_EXCHANGE_MARKER]) {
         await fs.rm(path.join(this.extractionDirectory, reserved), {
           recursive: true,
@@ -281,7 +295,7 @@ export class FirecrackerExchangeImage {
   private runTool(
     command: 'mke2fs' | 'e2fsck' | 'debugfs',
     args: readonly string[],
-  ): Promise<void> {
+  ): Promise<string> {
     return this.dependencies.runTool(this.tools?.[command] ?? command, args);
   }
 }
@@ -294,8 +308,3 @@ function alignExchangeBytes(requestedBytes: number): number {
   return Math.ceil(requested / EXCHANGE_BLOCK_BYTES) * EXCHANGE_BLOCK_BYTES;
 }
 
-function assertDebugfsOperand(value: string, label: string): void {
-  if (/[\s"'\\;`\r\n]/.test(value)) {
-    throw new Error(`Firecracker ${label} is unsafe for debugfs commands: ${value}`);
-  }
-}

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -16,6 +16,8 @@ import type {
 } from './network';
 import type { FirecrackerVsockClient } from './vsock-client';
 import type { FirecrackerWorkspaceImage } from './workspace-image';
+import type { FirecrackerRuntimeAssetImage, FirecrackerRuntimeAssetPlan } from './runtime-assets';
+import type { FirecrackerExchangeImage, FirecrackerExchangePlan } from './exchange-image';
 import type { FirecrackerHostToolPaths } from './preflight';
 
 const hostTools: FirecrackerHostToolPaths = {
@@ -113,6 +115,8 @@ function dependencies(
     createClient: jest.fn().mockReturnValue(client),
     createNetwork: jest.fn((plan) => networkLifecycle(plan)),
     createWorkspaceImage: jest.fn(),
+    createRuntimeAssetImage: jest.fn(),
+    createExchangeImage: jest.fn(),
     createVsockClient: jest.fn(),
     resolveIdentity: jest.fn().mockReturnValue({ uid: 1000, gid: 1000 }),
     ...overrides,
@@ -777,4 +781,213 @@ describe('FirecrackerManager', () => {
       { mode: 0o600 },
     );
   });
+});
+
+describe('FirecrackerManager gh-aw runtime staging', () => {
+  const runtimeAssets: FirecrackerRuntimeAssetPlan = {
+    entries: [
+      {
+        id: 'gh-aw-runner-temp',
+        hostPath: '/runner/_temp/gh-aw',
+        guestPath: '/awf/runner-temp/gh-aw',
+      },
+      { id: 'gh-aw-tmp', hostPath: '/tmp/gh-aw', guestPath: '/tmp/gh-aw' },
+    ],
+    limits: { maxFileBytes: 1024, maxTotalBytes: 4096, maxFileCount: 16 },
+    guestMountPoint: '/awf/runtime',
+    guestRunnerTemp: '/awf/runner-temp',
+  };
+  const safeOutputs: FirecrackerExchangePlan = {
+    hostDirectory: '/var/tmp/awf-safe-outputs',
+    guestMountPoint: '/awf/exchange',
+    guestOutputDirectory: '/awf/exchange/safe-outputs',
+    guestOutputFile: '/awf/exchange/safe-outputs/outputs.jsonl',
+    maxFileBytes: 1024,
+    maxTotalBytes: 4096,
+    maxFileCount: 16,
+  };
+
+  function guestConfig(overrides: Record<string, unknown> = {}) {
+    return {
+      workspacePath: '/workspace',
+      homePath: '/home/runner',
+      supervisorBinaryPath: '/opt/awf-supervisor',
+      supervisorSha256: 'a'.repeat(64),
+      ...overrides,
+    };
+  }
+
+  it('omits the runtime and exchange boot arguments when staging is disabled', () => {
+    const args = buildSupervisorBootArgs(networkPlan(), guestConfig());
+
+    expect(args).not.toContain('awf.runtime-device');
+    expect(args).not.toContain('awf.exchange-device');
+  });
+
+  it('names guest devices in drive-registration order', () => {
+    const args = buildSupervisorBootArgs(
+      networkPlan(),
+      guestConfig({ runtimeAssets, safeOutputs }),
+    );
+
+    expect(args).toContain('awf.workspace-device=/dev/vdb');
+    expect(args).toContain('awf.runtime-device=/dev/vdc');
+    expect(args).toContain('awf.runtime-mount=/awf/runtime');
+    expect(args).toContain(
+      'awf.runtime-bind=gh-aw-runner-temp:/awf/runner-temp/gh-aw,gh-aw-tmp:/tmp/gh-aw',
+    );
+    expect(args).toContain('awf.exchange-device=/dev/vdd');
+    expect(args).toContain('awf.exchange-mount=/awf/exchange');
+  });
+
+  it('shifts the exchange device when runtime staging is absent', () => {
+    const args = buildSupervisorBootArgs(networkPlan(), guestConfig({ safeOutputs }));
+
+    expect(args).toContain('awf.exchange-device=/dev/vdc');
+    expect(args).not.toContain('awf.runtime-device');
+  });
+
+  it('rejects boot argument values that could inject another argument', () => {
+    expect(() => buildSupervisorBootArgs(networkPlan(), guestConfig({
+      runtimeAssets: { ...runtimeAssets, guestMountPoint: '/awf/runtime evil=1' },
+    }))).toThrow(/unsafe/i);
+  });
+
+  it('registers a read-only runtime drive and a writable exchange drive', async () => {
+    const { manager, deps } = stagedManager();
+
+    const client = await manager.start();
+
+    expect(client.putDrive).toHaveBeenCalledWith({
+      drive_id: 'runtime-assets',
+      path_on_host: '/runtime-assets.ext4',
+      is_root_device: false,
+      is_read_only: true,
+    });
+    expect(client.putDrive).toHaveBeenCalledWith({
+      drive_id: 'exchange',
+      path_on_host: '/exchange.ext4',
+      is_root_device: false,
+      is_read_only: false,
+    });
+    const driveOrder = (client.putDrive as jest.Mock).mock.calls.map((call) => call[0].drive_id);
+    expect(driveOrder).toEqual(['rootfs', 'workspace', 'runtime-assets', 'exchange']);
+    expect(deps.chmod).toHaveBeenCalledWith(
+      expect.stringContaining('runtime-assets.ext4'),
+      0o400,
+    );
+  });
+
+  it('copies safe outputs back only after the VM process has terminated', async () => {
+    const order: string[] = [];
+    const { manager, child, exchange } = stagedManager(order);
+
+    await manager.start();
+    await manager.startInstance();
+    await manager.stop();
+
+    expect(order).toEqual(['extract-workspace', 'extract-exchange']);
+    expect(child.exitCode).toBe(0);
+    expect(exchange.extractAfterStop).toHaveBeenCalledWith(
+      expect.stringContaining('exchange.ext4'),
+    );
+  });
+
+  it('does not copy safe outputs back when the instance never started', async () => {
+    const { manager, exchange } = stagedManager();
+
+    await manager.start();
+    await manager.stop();
+
+    expect(exchange.extractAfterStop).not.toHaveBeenCalled();
+  });
+
+  function networkPlan(): FirecrackerNetworkPlan {
+    return {
+      runId: 'run',
+      namespaceName: 'ns',
+      netnsPath: '/var/run/netns/ns',
+      nftTableName: 'table',
+      infrastructureBridge: 'awfbr0',
+      hostVethName: 'host',
+      namespaceVethName: 'namespace',
+      tapName: 'tap',
+      infrastructureIp: '172.30.0.20',
+      infrastructureCidr: '172.30.0.0/24',
+      hostGatewayIp: '172.30.0.1',
+      guestSubnet: '100.64.0.0/30',
+      guestIp: '100.64.0.2',
+      guestGatewayIp: '100.64.0.1',
+      guestPrefixLength: 30,
+      guestMac: '02:00:00:00:00:01',
+      jailerUid: 1000,
+      jailerGid: 1000,
+      allowedEndpoints: [],
+      networkInterface: { iface_id: 'eth0', host_dev_name: 'tap' },
+    } as unknown as FirecrackerNetworkPlan;
+  }
+
+  function stagedManager(order: string[] = []) {
+    const child = processMock();
+    const workspace = {
+      prepare: jest.fn().mockResolvedValue({
+        workspaceImagePath: '/tmp/prepared-workspace.ext4',
+        rootfsImagePath: '/tmp/prepared-rootfs.ext4',
+        imageBytes: 1024,
+        originalManifest: new Map(),
+      }),
+      extractAfterStop: jest.fn(async () => {
+        order.push('extract-workspace');
+        expect(child.exitCode).toBe(0);
+      }),
+      cleanup: jest.fn().mockResolvedValue(undefined),
+      runDirectory: '/tmp/awf/firecracker-images/run',
+    } as unknown as FirecrackerWorkspaceImage;
+    const runtimeImage = {
+      prepare: jest.fn().mockResolvedValue({
+        imagePath: '/tmp/runtime-assets.ext4',
+        imageBytes: 4096,
+        totals: { files: 1, directories: 0, symlinks: 0, bytes: 10 },
+      }),
+      cleanup: jest.fn().mockResolvedValue(undefined),
+    } as unknown as FirecrackerRuntimeAssetImage;
+    const exchange = {
+      prepare: jest.fn().mockResolvedValue({
+        imagePath: '/tmp/exchange.ext4',
+        imageBytes: 4096,
+      }),
+      extractAfterStop: jest.fn(async () => {
+        order.push('extract-exchange');
+        expect(child.exitCode).toBe(0);
+        return { files: 0, directories: 0, symlinks: 0, bytes: 0 };
+      }),
+      cleanup: jest.fn().mockResolvedValue(undefined),
+    } as unknown as FirecrackerExchangeImage;
+    const guestClient = {
+      connect: jest.fn().mockResolvedValue({
+        version: 1,
+        type: 'ready',
+        requestId: 'control',
+        capabilities: { stdin: true, tty: false, resize: false },
+      }),
+      shutdown: jest.fn().mockResolvedValue(undefined),
+      destroy: jest.fn(),
+    } as unknown as FirecrackerVsockClient;
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(child),
+      createWorkspaceImage: jest.fn().mockReturnValue(workspace),
+      createRuntimeAssetImage: jest.fn().mockReturnValue(runtimeImage),
+      createExchangeImage: jest.fn().mockReturnValue(exchange),
+      createVsockClient: jest.fn().mockReturnValue(guestClient),
+    });
+    const manager = new FirecrackerManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'guest',
+      networkConfig(),
+      guestConfig({ runtimeAssets, safeOutputs }) as never,
+    );
+    return { manager, deps, child, workspace, runtimeImage, exchange };
+  }
 });

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -902,6 +902,31 @@ describe('FirecrackerManager gh-aw runtime staging', () => {
     expect(exchange.extractAfterStop).not.toHaveBeenCalled();
   });
 
+  it('keeps the jail when safe outputs could not be copied back', async () => {
+    // The jail holds the exchange image, which is the only remaining copy of the
+    // run's results once extraction has failed.
+    const { manager, deps, exchange } = stagedManager();
+    (exchange.extractAfterStop as jest.Mock).mockRejectedValue(new Error('cap exceeded'));
+
+    await manager.start();
+    await manager.startInstance();
+    await expect(manager.stop()).rejects.toThrow('cap exceeded');
+
+    const removed = (deps.rm as jest.Mock).mock.calls.map((call) => String(call[0]));
+    expect(removed.some((target) => /firecracker\/[^/]+$/.test(target))).toBe(false);
+  });
+
+  it('removes the jail on a clean stop', async () => {
+    const { manager, deps } = stagedManager();
+
+    await manager.start();
+    await manager.startInstance();
+    await manager.stop();
+
+    const removed = (deps.rm as jest.Mock).mock.calls.map((call) => String(call[0]));
+    expect(removed.some((target) => /firecracker\/[^/]+$/.test(target))).toBe(true);
+  });
+
   function networkPlan(): FirecrackerNetworkPlan {
     return {
       runId: 'run',

--- a/src/firecracker/manager.ts
+++ b/src/firecracker/manager.ts
@@ -26,21 +26,37 @@ import {
 } from './vsock-client';
 import {
   FirecrackerWorkspaceImage,
+  firecrackerRunImageDirectory,
   type FirecrackerWorkspaceImageConfig,
 } from './workspace-image';
+import {
+  FirecrackerRuntimeAssetImage,
+  type FirecrackerRuntimeAssetImageConfig,
+  type FirecrackerRuntimeAssetPlan,
+} from './runtime-assets';
+import {
+  FirecrackerExchangeImage,
+  type FirecrackerExchangeImageConfig,
+  type FirecrackerExchangePlan,
+} from './exchange-image';
 
 const API_SOCKET_NAME = 'firecracker.socket';
 const VSOCK_SOCKET_NAME = 'awf-vsock.socket';
 const WORKSPACE_IMAGE_NAME = 'workspace.ext4';
+const RUNTIME_ASSETS_IMAGE_NAME = 'runtime-assets.ext4';
+const EXCHANGE_IMAGE_NAME = 'exchange.ext4';
 const FIRECRACKER_LOG_NAME = 'firecracker.log';
 const FIRECRACKER_METRICS_NAME = 'firecracker.metrics.jsonl';
 const FIRECRACKER_CAPTURE_LIMIT_BYTES = 1024 * 1024;
 const KERNEL_JAIL_PATH = '/kernel';
 const ROOTFS_JAIL_PATH = '/rootfs';
 const WORKSPACE_JAIL_PATH = '/workspace.ext4';
+const RUNTIME_ASSETS_JAIL_PATH = `/${RUNTIME_ASSETS_IMAGE_NAME}`;
+const EXCHANGE_JAIL_PATH = `/${EXCHANGE_IMAGE_NAME}`;
 const VSOCK_JAIL_PATH = `/run/${VSOCK_SOCKET_NAME}`;
 export const FIRECRACKER_GUEST_VSOCK_PORT = 52;
 const FIRECRACKER_GUEST_SHUTDOWN_GRACE_MS = 5_000;
+const FIRECRACKER_MAX_BOOT_ARGS_LENGTH = 2048;
 
 export interface FirecrackerRunPaths {
   runId: string;
@@ -50,6 +66,8 @@ export interface FirecrackerRunPaths {
   kernelPath: string;
   rootfsPath: string;
   workspacePath: string;
+  runtimeAssetsPath: string;
+  exchangePath: string;
   vsockSocketPath: string;
   logPath: string;
   metricsPath: string;
@@ -78,6 +96,14 @@ export interface FirecrackerManagerDependencies {
   createClient(socketPath: string, timeoutMs: number): FirecrackerApiClient;
   createNetwork(plan: FirecrackerNetworkPlan, tools: FirecrackerHostToolPaths): FirecrackerNetworkLifecycle;
   createWorkspaceImage(config: FirecrackerWorkspaceImageConfig, tools: FirecrackerHostToolPaths): FirecrackerWorkspaceImage;
+  createRuntimeAssetImage(
+    config: FirecrackerRuntimeAssetImageConfig,
+    tools: FirecrackerHostToolPaths,
+  ): FirecrackerRuntimeAssetImage;
+  createExchangeImage(
+    config: FirecrackerExchangeImageConfig,
+    tools: FirecrackerHostToolPaths,
+  ): FirecrackerExchangeImage;
   createVsockClient(socketPath: string, guestPort: number, timeoutMs: number): FirecrackerVsockClient;
   resolveIdentity(): { uid: number; gid: number };
 }
@@ -96,6 +122,12 @@ export interface FirecrackerManagerGuestConfig {
   readonly maxWorkspaceImageBytes?: number;
   readonly vsockPort?: number;
   readonly identity?: { uid: number; gid: number };
+  /** Bounded, read-only gh-aw runtime asset device contract. */
+  readonly runtimeAssets?: FirecrackerRuntimeAssetPlan;
+  /** Bounded, post-stop safe-output exchange contract. */
+  readonly safeOutputs?: FirecrackerExchangePlan;
+  /** Literal credential values that must never appear in staged assets. */
+  readonly forbiddenStagedContents?: readonly string[];
 }
 
 async function readBoundedTail(filePath: string, maxBytes: number): Promise<Buffer> {
@@ -131,6 +163,9 @@ const defaultDependencies: FirecrackerManagerDependencies = {
     new FirecrackerLinuxNetworkCommands(undefined, tools),
   ),
   createWorkspaceImage: (config, tools) => new FirecrackerWorkspaceImage(config, undefined, tools),
+  createRuntimeAssetImage: (config, tools) =>
+    new FirecrackerRuntimeAssetImage(config, undefined, tools),
+  createExchangeImage: (config, tools) => new FirecrackerExchangeImage(config, undefined, tools),
   createVsockClient: (socketPath, guestPort, timeoutMs) => new FirecrackerVsockClient({
     socketPath,
     guestPort,
@@ -196,6 +231,8 @@ export function createFirecrackerRunPaths(
     kernelPath: path.join(jailRoot, KERNEL_JAIL_PATH),
     rootfsPath: path.join(jailRoot, ROOTFS_JAIL_PATH),
     workspacePath: path.join(jailRoot, WORKSPACE_IMAGE_NAME),
+    runtimeAssetsPath: path.join(jailRoot, RUNTIME_ASSETS_IMAGE_NAME),
+    exchangePath: path.join(jailRoot, EXCHANGE_IMAGE_NAME),
     vsockSocketPath: path.join(jailRoot, 'run', VSOCK_SOCKET_NAME),
     logPath: path.join(jailRoot, 'run', FIRECRACKER_LOG_NAME),
     metricsPath: path.join(jailRoot, 'run', FIRECRACKER_METRICS_NAME),
@@ -211,6 +248,8 @@ export class FirecrackerManager {
   private client: FirecrackerApiClient | undefined;
   private network: FirecrackerNetworkLifecycle | undefined;
   private workspace: FirecrackerWorkspaceImage | undefined;
+  private runtimeAssets: FirecrackerRuntimeAssetImage | undefined;
+  private exchange: FirecrackerExchangeImage | undefined;
   private guestClient: FirecrackerVsockClient | undefined;
   private networkPlan: FirecrackerNetworkPlan | undefined;
   private instanceStarted = false;
@@ -257,6 +296,8 @@ export class FirecrackerManager {
       await this.network.setup();
       let rootfsSource = artifacts.rootfsPath;
       let workspaceSource: string | undefined;
+      let runtimeAssetsSource: string | undefined;
+      let exchangeSource: string | undefined;
       if (this.guestConfig) {
         this.workspace = this.dependencies.createWorkspaceImage({
           runId: this.paths.runId,
@@ -275,6 +316,30 @@ export class FirecrackerManager {
         const preparation = await this.workspace.prepare();
         rootfsSource = preparation.rootfsImagePath;
         workspaceSource = preparation.workspaceImagePath;
+
+        if (this.guestConfig.runtimeAssets) {
+          this.runtimeAssets = this.dependencies.createRuntimeAssetImage({
+            runId: this.paths.runId,
+            runDirectory: firecrackerRunImageDirectory(this.workDir, this.paths.runId),
+            plan: this.guestConfig.runtimeAssets,
+            uid: identity.uid,
+            gid: identity.gid,
+            ...(this.guestConfig.forbiddenStagedContents
+              ? { forbiddenContents: this.guestConfig.forbiddenStagedContents }
+              : {}),
+          }, artifacts.tools);
+          runtimeAssetsSource = (await this.runtimeAssets.prepare()).imagePath;
+        }
+        if (this.guestConfig.safeOutputs) {
+          this.exchange = this.dependencies.createExchangeImage({
+            runId: this.paths.runId,
+            runDirectory: firecrackerRunImageDirectory(this.workDir, this.paths.runId),
+            plan: this.guestConfig.safeOutputs,
+            uid: identity.uid,
+            gid: identity.gid,
+          }, artifacts.tools);
+          exchangeSource = (await this.exchange.prepare()).imagePath;
+        }
       }
       await this.dependencies.mkdir(this.paths.chrootBaseDir, {
         recursive: true,
@@ -312,6 +377,17 @@ export class FirecrackerManager {
       await this.stageArtifact(rootfsSource, this.paths.rootfsPath, 0o600, identity);
       if (workspaceSource) {
         await this.stageArtifact(workspaceSource, this.paths.workspacePath, 0o600, identity);
+      }
+      if (runtimeAssetsSource) {
+        await this.stageArtifact(
+          runtimeAssetsSource,
+          this.paths.runtimeAssetsPath,
+          0o400,
+          identity,
+        );
+      }
+      if (exchangeSource) {
+        await this.stageArtifact(exchangeSource, this.paths.exchangePath, 0o600, identity);
       }
 
       this.client = this.dependencies.createClient(
@@ -353,6 +429,22 @@ export class FirecrackerManager {
           is_root_device: false,
           is_read_only: false,
         });
+        if (runtimeAssetsSource) {
+          await this.client.putDrive({
+            drive_id: 'runtime-assets',
+            path_on_host: RUNTIME_ASSETS_JAIL_PATH,
+            is_root_device: false,
+            is_read_only: true,
+          });
+        }
+        if (exchangeSource) {
+          await this.client.putDrive({
+            drive_id: 'exchange',
+            path_on_host: EXCHANGE_JAIL_PATH,
+            is_root_device: false,
+            is_read_only: false,
+          });
+        }
         await this.client.putVsock({
           guest_cid: 3,
           uds_path: VSOCK_JAIL_PATH,
@@ -497,6 +589,13 @@ export class FirecrackerManager {
         errors.push(error);
       }
     }
+    if (this.exchange && instanceWasStarted) {
+      try {
+        await this.exchange.extractAfterStop(this.paths.exchangePath);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
     this.instanceStarted = false;
 
     if (options.preserve) {
@@ -538,6 +637,20 @@ export class FirecrackerManager {
       errors.push(error);
     }
     this.workspace = undefined;
+
+    try {
+      await this.runtimeAssets?.cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+    this.runtimeAssets = undefined;
+
+    try {
+      await this.exchange?.cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+    this.exchange = undefined;
 
     if (errors.length === 1) throw errors[0];
     if (errors.length > 1) {
@@ -660,7 +773,7 @@ export function buildSupervisorBootArgs(
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
     throw new Error(`Firecracker guest vsock port must be in 1-65535: ${port}`);
   }
-  return [
+  const args = [
     'console=ttyS0',
     'reboot=k',
     'panic=1',
@@ -673,7 +786,53 @@ export function buildSupervisorBootArgs(
     `awf.guest-prefix=${networkPlan.guestPrefixLength}`,
     `awf.guest-gateway=${networkPlan.guestGatewayIp}`,
     'awf.guest-interface=eth0',
-  ].join(' ');
+  ];
+
+  // Guest block devices are named in drive-registration order, which is fixed
+  // as rootfs, workspace, runtime assets, exchange.
+  let deviceIndex = 1;
+  if (guestConfig.runtimeAssets) {
+    deviceIndex += 1;
+    const binds = guestConfig.runtimeAssets.entries
+      .map((entry) => `${entry.id}:${entry.guestPath}`)
+      .join(',');
+    assertSafeBootArgValue(binds, 'runtime asset bind list');
+    assertSafeBootArgValue(guestConfig.runtimeAssets.guestMountPoint, 'runtime mount point');
+    args.push(
+      `awf.runtime-device=${guestDeviceName(deviceIndex)}`,
+      `awf.runtime-mount=${guestConfig.runtimeAssets.guestMountPoint}`,
+      `awf.runtime-bind=${binds}`,
+    );
+  }
+  if (guestConfig.safeOutputs) {
+    deviceIndex += 1;
+    assertSafeBootArgValue(guestConfig.safeOutputs.guestMountPoint, 'exchange mount point');
+    args.push(
+      `awf.exchange-device=${guestDeviceName(deviceIndex)}`,
+      `awf.exchange-mount=${guestConfig.safeOutputs.guestMountPoint}`,
+    );
+  }
+
+  const bootArgs = args.join(' ');
+  if (bootArgs.length > FIRECRACKER_MAX_BOOT_ARGS_LENGTH) {
+    throw new Error(
+      `Firecracker guest boot arguments exceed ${FIRECRACKER_MAX_BOOT_ARGS_LENGTH} characters`,
+    );
+  }
+  return bootArgs;
+}
+
+function guestDeviceName(index: number): string {
+  if (!Number.isInteger(index) || index < 0 || index > 25) {
+    throw new Error(`Firecracker guest block device index is out of range: ${index}`);
+  }
+  return `/dev/vd${String.fromCharCode('a'.charCodeAt(0) + index)}`;
+}
+
+function assertSafeBootArgValue(value: string, label: string): void {
+  if (value.length === 0 || /[\s"'\\;`\r\n]/.test(value)) {
+    throw new Error(`Firecracker ${label} is unsafe for guest boot arguments: ${value}`);
+  }
 }
 
 function formatError(error: unknown): string {

--- a/src/firecracker/manager.ts
+++ b/src/firecracker/manager.ts
@@ -589,10 +589,12 @@ export class FirecrackerManager {
         errors.push(error);
       }
     }
+    let exchangeExtractionFailed = false;
     if (this.exchange && instanceWasStarted) {
       try {
         await this.exchange.extractAfterStop(this.paths.exchangePath);
       } catch (error) {
+        exchangeExtractionFailed = true;
         errors.push(error);
       }
     }
@@ -616,7 +618,12 @@ export class FirecrackerManager {
       errors.push(error);
     }
 
-    if (!instanceWasStarted || terminationConfirmed) {
+
+    // The jail holds the exchange image. If safe outputs could not be read out
+    // of it, deleting it destroys the only copy of the run's results, so keep
+    // it for manual recovery and let the surfaced error explain why.
+    const jailHoldsUnrecoveredOutputs = exchangeExtractionFailed;
+    if ((!instanceWasStarted || terminationConfirmed) && !jailHoldsUnrecoveredOutputs) {
       try {
         await this.dependencies.rm(
           path.join(
@@ -631,26 +638,28 @@ export class FirecrackerManager {
       }
     }
 
+    // Each reference is dropped only once its own cleanup succeeded, so a caller
+    // that retries stop() can still reach an image directory that leaked.
     try {
       await this.workspace?.cleanup(!instanceWasStarted);
+      this.workspace = undefined;
     } catch (error) {
       errors.push(error);
     }
-    this.workspace = undefined;
 
     try {
       await this.runtimeAssets?.cleanup();
+      this.runtimeAssets = undefined;
     } catch (error) {
       errors.push(error);
     }
-    this.runtimeAssets = undefined;
 
     try {
       await this.exchange?.cleanup();
+      this.exchange = undefined;
     } catch (error) {
       errors.push(error);
     }
-    this.exchange = undefined;
 
     if (errors.length === 1) throw errors[0];
     if (errors.length > 1) {

--- a/src/firecracker/runtime-assets.test.ts
+++ b/src/firecracker/runtime-assets.test.ts
@@ -8,6 +8,7 @@ import {
   FIRECRACKER_RUNTIME_MARKER,
   FirecrackerRuntimeAssetImage,
   assertFirecrackerGuestDestinations,
+  assertPermittedStagingRoot,
   calculateFirecrackerRuntimeImageBytes,
   firecrackerForbiddenStagingBasenames,
   resolveFirecrackerGhAwRuntimePlan,
@@ -330,5 +331,68 @@ describe('FirecrackerRuntimeAssetImage', () => {
     await image.prepare();
 
     await expect(image.prepare()).rejects.toThrow(/already prepared/);
+  });
+});
+
+describe('assertPermittedStagingRoot', () => {
+  const env = { HOME: '/home/runner', RUNNER_TOOL_CACHE: '/opt/hostedtoolcache' };
+
+  it('permits a runner temp nested inside the home directory', () => {
+    // The real GitHub layout is /home/runner/work/_temp, so nesting under HOME
+    // has to stay legal even though HOME itself does not.
+    expect(() => assertPermittedStagingRoot('/home/runner/work/_temp', 'runnerTemp root', env))
+      .not.toThrow();
+    expect(() => assertPermittedStagingRoot('/tmp', 'compilerTmp root', env)).not.toThrow();
+  });
+
+  it('refuses the home directory itself', () => {
+    expect(() => assertPermittedStagingRoot('/home/runner', 'runnerTemp root', env))
+      .toThrow(/home directory/);
+  });
+
+  it('refuses the host tool cache', () => {
+    expect(() => assertPermittedStagingRoot('/opt/hostedtoolcache', 'runnerTemp root', env))
+      .toThrow(/hostedtoolcache/);
+    expect(() => assertPermittedStagingRoot('/opt/hostedtoolcache/node/22', 'runnerTemp root', env))
+      .toThrow(/hostedtoolcache/);
+  });
+
+  it('refuses a tool cache declared only through the environment', () => {
+    expect(() => assertPermittedStagingRoot(
+      '/mnt/cache/node',
+      'runnerTemp root',
+      { RUNNER_TOOL_CACHE: '/mnt/cache' },
+    )).toThrow(/RUNNER_TOOL_CACHE/);
+  });
+
+  it('refuses filesystem and system roots', () => {
+    for (const root of ['/', '/root', '/home', '/etc', '/usr/share', '/var/lib']) {
+      expect(() => assertPermittedStagingRoot(root, 'runnerTemp root', env)).toThrow();
+    }
+  });
+
+  it('refuses a symlinked root outright, whatever it points at', async () => {
+    const base = await fs.realpath(os.tmpdir());
+    const directory = await fs.mkdtemp(path.join(base, 'awf-staging-root-'));
+    try {
+      const cache = path.join(directory, 'tool-cache');
+      await fs.mkdir(path.join(cache, 'gh-aw'), { recursive: true, mode: 0o700 });
+      const link = path.join(directory, 'temp');
+      await fs.symlink(cache, link);
+      // A symlinked root cannot be reasoned about safely at all, so it is
+      // refused before its target is even considered. The post-canonicalization
+      // recheck in resolveFirecrackerGhAwRuntimePlan stays as defence in depth
+      // for targets realpath cannot see through, such as bind mounts.
+      await expect(resolveFirecrackerGhAwRuntimePlan({
+        enabled: true,
+        runnerTempPath: link,
+        compilerTmpPath: path.join(directory, 'absent'),
+        maxFileBytes: 1024,
+        maxTotalBytes: 4096,
+        maxFileCount: 16,
+      }, { RUNNER_TOOL_CACHE: cache })).rejects.toThrow(/symlink/);
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/src/firecracker/runtime-assets.test.ts
+++ b/src/firecracker/runtime-assets.test.ts
@@ -212,9 +212,12 @@ describe('firecrackerForbiddenStagingBasenames', () => {
     for (const name of ['.ssh', '.aws', '.docker', '.netrc', '.git-credentials', 'id_rsa']) {
       expect(forbidden).toContain(name);
     }
-    for (const name of ['config', 'config.json', 'credentials.json', 'package.json']) {
+    for (const name of ['config', 'config.json', 'package.json']) {
       expect(forbidden).not.toContain(name);
     }
+    // Fails closed: a gh-aw asset that genuinely needs this name would abort the
+    // run with a clear message rather than silently shipping a credential store.
+    expect(forbidden).toContain('credentials.json');
   });
 });
 

--- a/src/firecracker/runtime-assets.test.ts
+++ b/src/firecracker/runtime-assets.test.ts
@@ -288,6 +288,7 @@ describe('FirecrackerRuntimeAssetImage', () => {
           if (command === 'mke2fs') {
             await fs.writeFile(path.join(runDirectory, 'runtime-assets.ext4'), 'image');
           }
+          return '';
         },
       },
     );

--- a/src/firecracker/runtime-assets.test.ts
+++ b/src/firecracker/runtime-assets.test.ts
@@ -1,0 +1,331 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  FIRECRACKER_GH_AW_SOURCES,
+  FIRECRACKER_GUEST_RUNNER_TEMP,
+  FIRECRACKER_GUEST_RUNTIME_MOUNT,
+  FIRECRACKER_RUNTIME_MARKER,
+  FirecrackerRuntimeAssetImage,
+  assertFirecrackerGuestDestinations,
+  calculateFirecrackerRuntimeImageBytes,
+  firecrackerForbiddenStagingBasenames,
+  resolveFirecrackerGhAwRuntimePlan,
+} from './runtime-assets';
+import {
+  FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_BYTES,
+  FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_COUNT,
+  FIRECRACKER_DEFAULT_GH_AW_MAX_TOTAL_BYTES,
+  type FirecrackerGhAwRuntimeOptions,
+} from '../types/runtime-options';
+
+async function makeTempRoot(prefix: string): Promise<string> {
+  const base = await fs.realpath(os.tmpdir());
+  return fs.mkdtemp(path.join(base, prefix));
+}
+
+function options(
+  overrides: Partial<FirecrackerGhAwRuntimeOptions> = {},
+): FirecrackerGhAwRuntimeOptions {
+  return {
+    enabled: true,
+    maxFileBytes: FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_BYTES,
+    maxTotalBytes: FIRECRACKER_DEFAULT_GH_AW_MAX_TOTAL_BYTES,
+    maxFileCount: FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_COUNT,
+    ...overrides,
+  };
+}
+
+describe('FIRECRACKER_GH_AW_SOURCES', () => {
+  it('is a fixed contract rooted only in RUNNER_TEMP and the compiler tmp tree', () => {
+    expect(FIRECRACKER_GH_AW_SOURCES.map((source) => source.id))
+      .toEqual(['gh-aw-runner-temp', 'gh-aw-tmp']);
+    expect(FIRECRACKER_GH_AW_SOURCES.every((source) => source.relativePath === 'gh-aw')).toBe(true);
+    expect(FIRECRACKER_GH_AW_SOURCES.map((source) => source.guestPath))
+      .toEqual([`${FIRECRACKER_GUEST_RUNNER_TEMP}/gh-aw`, '/tmp/gh-aw']);
+  });
+});
+
+describe('resolveFirecrackerGhAwRuntimePlan', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot('awf-runtime-plan-');
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns no plan when staging is disabled', async () => {
+    await expect(resolveFirecrackerGhAwRuntimePlan(options({ enabled: false }), {}))
+      .resolves.toEqual({ skipped: [] });
+  });
+
+  it('resolves both fixed sources and records skipped ones', async () => {
+    const runnerTemp = path.join(root, 'runner-temp');
+    const compilerTmp = path.join(root, 'tmp');
+    await fs.mkdir(path.join(runnerTemp, 'gh-aw'), { recursive: true });
+    await fs.mkdir(compilerTmp, { recursive: true });
+
+    const resolution = await resolveFirecrackerGhAwRuntimePlan(
+      options({ runnerTempPath: runnerTemp, compilerTmpPath: compilerTmp }),
+      {},
+    );
+
+    expect(resolution.skipped).toEqual(['gh-aw-tmp']);
+    expect(resolution.plan?.entries).toEqual([
+      {
+        id: 'gh-aw-runner-temp',
+        hostPath: path.join(runnerTemp, 'gh-aw'),
+        guestPath: `${FIRECRACKER_GUEST_RUNNER_TEMP}/gh-aw`,
+      },
+    ]);
+    expect(resolution.plan?.guestMountPoint).toBe(FIRECRACKER_GUEST_RUNTIME_MOUNT);
+  });
+
+  it('falls back to RUNNER_TEMP from the environment', async () => {
+    const runnerTemp = path.join(root, 'env-runner-temp');
+    const compilerTmp = path.join(root, 'empty-tmp');
+    await fs.mkdir(path.join(runnerTemp, 'gh-aw'), { recursive: true });
+    await fs.mkdir(compilerTmp, { recursive: true });
+
+    const resolution = await resolveFirecrackerGhAwRuntimePlan(
+      options({ compilerTmpPath: compilerTmp }),
+      { RUNNER_TEMP: runnerTemp },
+    );
+
+    expect(resolution.plan?.entries).toHaveLength(1);
+  });
+
+  it('fails closed when an explicitly configured root does not exist', async () => {
+    const runnerTemp = path.join(root, 'runner-temp');
+    await fs.mkdir(path.join(runnerTemp, 'gh-aw'), { recursive: true });
+
+    await expect(
+      resolveFirecrackerGhAwRuntimePlan(
+        options({ runnerTempPath: runnerTemp, compilerTmpPath: path.join(root, 'typo') }),
+        {},
+      ),
+    ).rejects.toThrow(/ENOENT|no such file/);
+  });
+
+  it('requires a RUNNER_TEMP value', async () => {
+    await expect(resolveFirecrackerGhAwRuntimePlan(options(), {}))
+      .rejects.toThrow(/requires RUNNER_TEMP/);
+  });
+
+  it('fails when neither fixed source exists', async () => {
+    const runnerTemp = path.join(root, 'a');
+    const compilerTmp = path.join(root, 'b');
+    await fs.mkdir(runnerTemp, { recursive: true });
+    await fs.mkdir(compilerTmp, { recursive: true });
+
+    await expect(
+      resolveFirecrackerGhAwRuntimePlan(
+        options({ runnerTempPath: runnerTemp, compilerTmpPath: compilerTmp }),
+        {},
+      ),
+    ).rejects.toThrow(/neither/);
+  });
+
+  it('rejects a source root reached through a symlink', async () => {
+    const real = path.join(root, 'real-runner-temp');
+    await fs.mkdir(path.join(real, 'gh-aw'), { recursive: true });
+    const link = path.join(root, 'link-runner-temp');
+    await fs.symlink(real, link);
+
+    const compilerTmp = path.join(root, 'empty-tmp');
+    await fs.mkdir(compilerTmp, { recursive: true });
+
+    await expect(
+      resolveFirecrackerGhAwRuntimePlan(
+        options({ runnerTempPath: link, compilerTmpPath: compilerTmp }),
+        {},
+      ),
+    ).rejects.toThrow(/symlink/);
+  });
+
+  it('rejects a gh-aw source that is a symlink rather than a directory', async () => {
+    const runnerTemp = path.join(root, 'runner-temp');
+    await fs.mkdir(runnerTemp, { recursive: true });
+    await fs.mkdir(path.join(root, 'elsewhere'), { recursive: true });
+    await fs.symlink(path.join(root, 'elsewhere'), path.join(runnerTemp, 'gh-aw'));
+    const compilerTmp = path.join(root, 'empty-tmp');
+    await fs.mkdir(compilerTmp, { recursive: true });
+
+    await expect(
+      resolveFirecrackerGhAwRuntimePlan(
+        options({ runnerTempPath: runnerTemp, compilerTmpPath: compilerTmp }),
+        {},
+      ),
+    ).rejects.toThrow(/must be a real directory/);
+  });
+});
+
+describe('assertFirecrackerGuestDestinations', () => {
+  const entry = (id: string, guestPath: string) => ({ id, hostPath: '/host', guestPath });
+
+  it('accepts the shipped contract', () => {
+    expect(() =>
+      assertFirecrackerGuestDestinations(
+        FIRECRACKER_GH_AW_SOURCES.map((source) => entry(source.id, source.guestPath)),
+      ),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['relative destination', entry('a', 'tmp/gh-aw'), /absolute and normalized/],
+    ['traversal destination', entry('a', '/tmp/../etc'), /absolute and normalized/],
+    ['root destination', entry('a', '/'), /absolute and normalized|safe path/],
+    ['trailing slash', entry('a', '/tmp/gh-aw/'), /absolute and normalized|safe path/],
+    ['reserved /etc', entry('a', '/etc/gh-aw'), /reserved path/],
+    ['reserved workspace', entry('a', '/workspace/gh-aw'), /reserved path/],
+    ['reserved runtime mount', entry('a', `${FIRECRACKER_GUEST_RUNTIME_MOUNT}/x`), /reserved path/],
+    ['reserved exchange', entry('a', '/awf/exchange/x'), /reserved path/],
+    ['unsafe characters', entry('a', '/tmp/gh aw'), /unsafe characters/],
+    ['comma in path', entry('a', '/tmp/gh,aw'), /unsafe characters/],
+    ['unsafe id', entry('Bad_Id', '/tmp/gh-aw'), /safe slug/],
+  ])('rejects %s', (_name, candidate, pattern) => {
+    expect(() => assertFirecrackerGuestDestinations([candidate])).toThrow(pattern);
+  });
+
+  it('rejects duplicate ids and overlapping destinations', () => {
+    expect(() => assertFirecrackerGuestDestinations([
+      entry('same', '/tmp/one'),
+      entry('same', '/tmp/two'),
+    ])).toThrow(/duplicated/);
+    expect(() => assertFirecrackerGuestDestinations([
+      entry('a', '/tmp/gh-aw'),
+      entry('b', '/tmp/gh-aw'),
+    ])).toThrow(/overlap/);
+    expect(() => assertFirecrackerGuestDestinations([
+      entry('a', '/tmp/gh-aw'),
+      entry('b', '/tmp/gh-aw/nested'),
+    ])).toThrow(/overlap/);
+  });
+});
+
+describe('firecrackerForbiddenStagingBasenames', () => {
+  it('blocks credential stores without blocking generic compiler output names', () => {
+    const forbidden = firecrackerForbiddenStagingBasenames();
+    for (const name of ['.ssh', '.aws', '.docker', '.netrc', '.git-credentials', 'id_rsa']) {
+      expect(forbidden).toContain(name);
+    }
+    for (const name of ['config', 'config.json', 'credentials.json', 'package.json']) {
+      expect(forbidden).not.toContain(name);
+    }
+  });
+});
+
+describe('calculateFirecrackerRuntimeImageBytes', () => {
+  const cap = 2 * 1024 * 1024 * 1024;
+
+  it('adds headroom, enforces a floor, and aligns to the block size', () => {
+    const small = calculateFirecrackerRuntimeImageBytes(1, cap);
+    expect(small).toBeGreaterThanOrEqual(32 * 1024 * 1024);
+    expect(small % 4096).toBe(0);
+    const large = calculateFirecrackerRuntimeImageBytes(512 * 1024 * 1024, cap);
+    expect(large).toBeGreaterThan(512 * 1024 * 1024);
+    expect(large % 4096).toBe(0);
+  });
+
+  it('rejects invalid sizes and sizes past the cap', () => {
+    expect(() => calculateFirecrackerRuntimeImageBytes(-1, cap)).toThrow(/Invalid/);
+    expect(() => calculateFirecrackerRuntimeImageBytes(1.5, cap)).toThrow(/Invalid/);
+    expect(() => calculateFirecrackerRuntimeImageBytes(cap, cap)).toThrow(/exceeding cap/);
+  });
+});
+
+describe('FirecrackerRuntimeAssetImage', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot('awf-runtime-image-');
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function buildImage(overrides: {
+    forbiddenContents?: readonly string[];
+    fileContent?: string;
+  } = {}) {
+    const runnerTemp = path.join(root, 'runner-temp');
+    await fs.mkdir(path.join(runnerTemp, 'gh-aw'), { recursive: true });
+    await fs.writeFile(
+      path.join(runnerTemp, 'gh-aw', 'agent.cjs'),
+      overrides.fileContent ?? 'console.log("agent");\n',
+    );
+    const compilerTmp = path.join(root, 'empty-tmp');
+    await fs.mkdir(compilerTmp, { recursive: true });
+    const resolution = await resolveFirecrackerGhAwRuntimePlan(
+      options({ runnerTempPath: runnerTemp, compilerTmpPath: compilerTmp }),
+      {},
+    );
+    const commands: Array<{ command: string; args: readonly string[] }> = [];
+    const runDirectory = path.join(root, 'run');
+    await fs.mkdir(runDirectory, { recursive: true, mode: 0o700 });
+    const image = new FirecrackerRuntimeAssetImage(
+      {
+        runId: 'run-1',
+        runDirectory,
+        plan: resolution.plan!,
+        uid: process.getuid?.() ?? 0,
+        gid: process.getgid?.() ?? 0,
+        ...(overrides.forbiddenContents
+          ? { forbiddenContents: overrides.forbiddenContents }
+          : {}),
+      },
+      {
+        runTool: async (command, args) => {
+          commands.push({ command, args });
+          if (command === 'mke2fs') {
+            await fs.writeFile(path.join(runDirectory, 'runtime-assets.ext4'), 'image');
+          }
+        },
+      },
+    );
+    return { image, commands, runDirectory };
+  }
+
+  it('stages assets, writes the ordering marker, and builds a read-only image', async () => {
+    const { image, commands, runDirectory } = await buildImage();
+
+    const preparation = await image.prepare();
+
+    expect(preparation.totals.files).toBe(1);
+    expect(commands.map((entry) => entry.command)).toEqual(['mke2fs', 'e2fsck']);
+    const marker = JSON.parse(
+      await fs.readFile(
+        path.join(image.stagingDirectory, FIRECRACKER_RUNTIME_MARKER),
+        'utf8',
+      ),
+    );
+    expect(marker.entries).toEqual([
+      { id: 'gh-aw-runner-temp', guestPath: `${FIRECRACKER_GUEST_RUNNER_TEMP}/gh-aw` },
+    ]);
+    await expect(
+      fs.readFile(path.join(image.stagingDirectory, 'gh-aw-runner-temp', 'agent.cjs'), 'utf8'),
+    ).resolves.toContain('agent');
+    const imageStat = await fs.stat(path.join(runDirectory, 'runtime-assets.ext4'));
+    expect(imageStat.mode & 0o777).toBe(0o400);
+  });
+
+  it('refuses to stage a file containing a real credential value', async () => {
+    const { image } = await buildImage({
+      fileContent: 'const token = "ghp_realsecret";\n',
+      forbiddenContents: ['ghp_realsecret'],
+    });
+
+    await expect(image.prepare()).rejects.toThrow(/real credential value/);
+  });
+
+  it('refuses a second preparation of the same image', async () => {
+    const { image } = await buildImage();
+    await image.prepare();
+
+    await expect(image.prepare()).rejects.toThrow(/already prepared/);
+  });
+});

--- a/src/firecracker/runtime-assets.ts
+++ b/src/firecracker/runtime-assets.ts
@@ -284,7 +284,8 @@ export interface FirecrackerRuntimeAssetImageConfig {
 }
 
 export interface FirecrackerRuntimeAssetImageDependencies {
-  runTool(command: string, args: readonly string[]): Promise<void>;
+  /** Resolves with the combined stdout/stderr of the tool. */
+  runTool(command: string, args: readonly string[]): Promise<string>;
 }
 
 export interface FirecrackerRuntimeAssetPreparation {
@@ -300,11 +301,12 @@ export const defaultRuntimeAssetDependencies: FirecrackerRuntimeAssetImageDepend
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 120_000,
     });
-    if (result.exitCode === 0) return;
+    const output = `${result.stdout}\n${result.stderr}`;
+    if (result.exitCode === 0) return output;
     if (
       (command === 'e2fsck' || command.endsWith('/e2fsck')) &&
       result.exitCode === E2FSCK_REPAIR_EXIT_CODE
-    ) return;
+    ) return output;
     throw new Error(
       `${command} exited with code ${result.exitCode}: ` +
       `${result.stderr.trim() || result.stdout.trim()}`,
@@ -423,7 +425,7 @@ export class FirecrackerRuntimeAssetImage {
     await fs.chown(target, ownership.uid, ownership.gid);
   }
 
-  private runTool(command: 'mke2fs' | 'e2fsck', args: readonly string[]): Promise<void> {
+  private runTool(command: 'mke2fs' | 'e2fsck', args: readonly string[]): Promise<string> {
     return this.dependencies.runTool(this.tools?.[command] ?? command, args);
   }
 }

--- a/src/firecracker/runtime-assets.ts
+++ b/src/firecracker/runtime-assets.ts
@@ -43,6 +43,68 @@ export const FIRECRACKER_GH_AW_SOURCES = [
   },
 ] as const;
 
+/**
+ * Host directories that may never themselves be a staging root.
+ *
+ * Only `<root>/gh-aw` is ever staged, so no tree here is copied wholesale. This
+ * exists to stop a root from being *pointed at* one of them, which would turn
+ * the narrow gh-aw subtree into `$HOME/gh-aw` or a tool-cache subtree and
+ * quietly widen the contract.
+ *
+ * A legitimate `RUNNER_TEMP` is normally nested inside the home directory
+ * (`/home/runner/work/_temp`), so the home directory is refused only as an
+ * exact match. The tool cache has no such legitimate nesting and is refused as
+ * an ancestor too.
+ */
+const FORBIDDEN_STAGING_ROOTS_EXACT = [
+  '/', '/home', '/root', '/tmp/gh-aw',
+];
+
+const FORBIDDEN_STAGING_ROOT_TREES = [
+  '/bin', '/boot', '/dev', '/etc', '/lib', '/lib64', '/proc', '/sbin',
+  '/sys', '/usr', '/var', '/opt/hostedtoolcache',
+];
+
+/**
+ * Refuses a staging root that would widen the contract beyond gh-aw assets.
+ */
+export function assertPermittedStagingRoot(
+  root: string,
+  label: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): void {
+  const normalized = path.normalize(root);
+  const within = (ancestor: string): boolean =>
+    normalized === ancestor || normalized.startsWith(`${ancestor}/`);
+
+  if (FORBIDDEN_STAGING_ROOTS_EXACT.includes(normalized)) {
+    throw new Error(
+      `Firecracker gh-aw ${label} must not be ${normalized}: only gh-aw assets may be staged`,
+    );
+  }
+  for (const tree of FORBIDDEN_STAGING_ROOT_TREES) {
+    if (within(tree)) {
+      throw new Error(
+        `Firecracker gh-aw ${label} must not be inside ${tree}: only gh-aw assets may be staged`,
+      );
+    }
+  }
+  const toolCache = environment.RUNNER_TOOL_CACHE;
+  if (toolCache && within(path.normalize(toolCache))) {
+    throw new Error(
+      `Firecracker gh-aw ${label} must not be inside RUNNER_TOOL_CACHE: ` +
+      'host tool caches are never staged',
+    );
+  }
+  const home = environment.HOME;
+  if (home && normalized === path.normalize(home)) {
+    throw new Error(
+      `Firecracker gh-aw ${label} must not be the home directory: ` +
+      'only gh-aw assets may be staged',
+    );
+  }
+}
+
 /** Guest paths AWF refuses to shadow with a staged bind. */
 const RESERVED_GUEST_PREFIXES = [
   '/bin', '/boot', '/dev', '/etc', '/lib', '/lib64', '/proc', '/root',
@@ -107,6 +169,7 @@ export async function resolveFirecrackerGhAwRuntimePlan(
       skipped.push(source.id);
       continue;
     }
+    assertPermittedStagingRoot(root.path, `${source.root} root`, environment);
     let canonicalRoot: string;
     try {
       canonicalRoot = await assertCanonicalDirectory(root.path, `${source.id} root`);
@@ -119,6 +182,9 @@ export async function resolveFirecrackerGhAwRuntimePlan(
       }
       throw error;
     }
+    // Re-checked after canonicalization: the configured value could be a
+    // symlink whose target lands in a forbidden tree.
+    assertPermittedStagingRoot(canonicalRoot, `${source.root} root`, environment);
     const hostPath = path.join(canonicalRoot, source.relativePath);
     let stat;
     try {

--- a/src/firecracker/runtime-assets.ts
+++ b/src/firecracker/runtime-assets.ts
@@ -1,0 +1,402 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import execa from 'execa';
+import {
+  FIRECRACKER_DEFAULT_GH_AW_COMPILER_TMP,
+  type FirecrackerGhAwRuntimeOptions,
+  type FirecrackerStagingLimits,
+} from '../types/runtime-options';
+import { CREDENTIAL_ENTRIES } from '../config/mount-policy';
+import {
+  BoundedCopyBudget,
+  assertCanonicalDirectory,
+  copyBoundedTree,
+  type BoundedCopyTotals,
+} from './bounded-copy';
+
+const MIB = 1024 * 1024;
+const RUNTIME_BLOCK_BYTES = 4096;
+const RUNTIME_IMAGE_HEADROOM_BYTES = 16 * MIB;
+const RUNTIME_IMAGE_MIN_BYTES = 32 * MIB;
+const E2FSCK_REPAIR_EXIT_CODE = 1;
+
+/** Guest mount point of the read-only runtime asset device. */
+export const FIRECRACKER_GUEST_RUNTIME_MOUNT = '/awf/runtime';
+/** Guest `RUNNER_TEMP`; writable rootfs scratch that is never copied back. */
+export const FIRECRACKER_GUEST_RUNNER_TEMP = '/awf/runner-temp';
+/** Marker AWF writes into the runtime device so the guest can verify ordering. */
+export const FIRECRACKER_RUNTIME_MARKER = '.awf-runtime-assets';
+
+/** Guest destinations that generated gh-aw agents actually read from. */
+export const FIRECRACKER_GH_AW_SOURCES = [
+  {
+    id: 'gh-aw-runner-temp',
+    root: 'runnerTemp',
+    relativePath: 'gh-aw',
+    guestPath: `${FIRECRACKER_GUEST_RUNNER_TEMP}/gh-aw`,
+  },
+  {
+    id: 'gh-aw-tmp',
+    root: 'compilerTmp',
+    relativePath: 'gh-aw',
+    guestPath: '/tmp/gh-aw',
+  },
+] as const;
+
+/** Guest paths AWF refuses to shadow with a staged bind. */
+const RESERVED_GUEST_PREFIXES = [
+  '/bin', '/boot', '/dev', '/etc', '/lib', '/lib64', '/proc', '/root',
+  '/run', '/sbin', '/sys', '/usr', '/var', '/workspace', '/awf/exchange',
+  FIRECRACKER_GUEST_RUNTIME_MOUNT,
+];
+
+export interface FirecrackerRuntimeAssetEntry {
+  readonly id: string;
+  readonly hostPath: string;
+  readonly guestPath: string;
+}
+
+export interface FirecrackerRuntimeAssetPlan {
+  readonly entries: readonly FirecrackerRuntimeAssetEntry[];
+  readonly limits: FirecrackerStagingLimits;
+  readonly guestMountPoint: string;
+  readonly guestRunnerTemp: string;
+}
+
+export interface FirecrackerRuntimeAssetResolution {
+  readonly plan?: FirecrackerRuntimeAssetPlan;
+  readonly skipped: readonly string[];
+}
+
+/**
+ * Resolves the fixed gh-aw staging contract against a host environment.
+ *
+ * Only AWF-owned sources are eligible; callers cannot introduce a new source
+ * or retarget a guest destination, which keeps this separate from `--mount`.
+ */
+export async function resolveFirecrackerGhAwRuntimePlan(
+  options: FirecrackerGhAwRuntimeOptions,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<FirecrackerRuntimeAssetResolution> {
+  if (!options.enabled) return { skipped: [] };
+  const roots: Record<'runnerTemp' | 'compilerTmp', {
+    path: string | undefined;
+    explicit: boolean;
+  }> = {
+    runnerTemp: {
+      path: options.runnerTempPath ?? environment.RUNNER_TEMP,
+      explicit: options.runnerTempPath !== undefined,
+    },
+    compilerTmp: {
+      path: options.compilerTmpPath ?? FIRECRACKER_DEFAULT_GH_AW_COMPILER_TMP,
+      explicit: options.compilerTmpPath !== undefined,
+    },
+  };
+  if (!roots.runnerTemp.path) {
+    throw new Error(
+      'Firecracker gh-aw runtime staging requires RUNNER_TEMP or an explicit ' +
+      '--firecracker-gh-aw-runner-temp value',
+    );
+  }
+
+  const entries: FirecrackerRuntimeAssetEntry[] = [];
+  const skipped: string[] = [];
+  for (const source of FIRECRACKER_GH_AW_SOURCES) {
+    const root = roots[source.root];
+    if (!root.path) {
+      skipped.push(source.id);
+      continue;
+    }
+    let canonicalRoot: string;
+    try {
+      canonicalRoot = await assertCanonicalDirectory(root.path, `${source.id} root`);
+    } catch (error) {
+      // A configured-but-absent root is a typo and must fail closed; a merely
+      // defaulted root that does not exist simply has nothing to stage.
+      if (!root.explicit && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+        skipped.push(source.id);
+        continue;
+      }
+      throw error;
+    }
+    const hostPath = path.join(canonicalRoot, source.relativePath);
+    let stat;
+    try {
+      stat = await fs.lstat(hostPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      skipped.push(source.id);
+      continue;
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(
+        `Firecracker gh-aw runtime source must be a real directory: ${hostPath}`,
+      );
+    }
+    entries.push({ id: source.id, hostPath, guestPath: source.guestPath });
+  }
+
+  if (entries.length === 0) {
+    throw new Error(
+      'Firecracker gh-aw runtime staging is enabled but neither ' +
+      `${roots.runnerTemp.path}/gh-aw nor ${roots.compilerTmp.path}/gh-aw exists`,
+    );
+  }
+  assertFirecrackerGuestDestinations(entries);
+  return {
+    plan: {
+      entries,
+      limits: {
+        maxFileBytes: options.maxFileBytes,
+        maxTotalBytes: options.maxTotalBytes,
+        maxFileCount: options.maxFileCount,
+      },
+      guestMountPoint: FIRECRACKER_GUEST_RUNTIME_MOUNT,
+      guestRunnerTemp: FIRECRACKER_GUEST_RUNNER_TEMP,
+    },
+    skipped,
+  };
+}
+
+/**
+ * Rejects absolute-path abuse, traversal, duplicates, overlaps, and any guest
+ * destination that would shadow a system path.
+ */
+export function assertFirecrackerGuestDestinations(
+  entries: readonly FirecrackerRuntimeAssetEntry[],
+): void {
+  const seenIds = new Set<string>();
+  const seenPaths: string[] = [];
+  for (const entry of entries) {
+    if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(entry.id)) {
+      throw new Error(`Firecracker runtime asset id is not a safe slug: ${entry.id}`);
+    }
+    if (seenIds.has(entry.id)) {
+      throw new Error(`Firecracker runtime asset id is duplicated: ${entry.id}`);
+    }
+    seenIds.add(entry.id);
+
+    const guestPath = entry.guestPath;
+    if (!guestPath.startsWith('/') || path.posix.normalize(guestPath) !== guestPath) {
+      throw new Error(`Firecracker guest destination must be absolute and normalized: ${guestPath}`);
+    }
+    if (guestPath === '/' || guestPath.endsWith('/') || guestPath.includes('..')) {
+      throw new Error(`Firecracker guest destination is not a safe path: ${guestPath}`);
+    }
+    if (/[\s,:\0]/.test(guestPath)) {
+      throw new Error(`Firecracker guest destination contains unsafe characters: ${guestPath}`);
+    }
+    for (const reserved of RESERVED_GUEST_PREFIXES) {
+      if (guestPath === reserved || guestPath.startsWith(`${reserved}/`)) {
+        throw new Error(
+          `Firecracker guest destination may not shadow reserved path ${reserved}: ${guestPath}`,
+        );
+      }
+    }
+    for (const existing of seenPaths) {
+      if (
+        existing === guestPath ||
+        guestPath.startsWith(`${existing}/`) ||
+        existing.startsWith(`${guestPath}/`)
+      ) {
+        throw new Error(
+          `Firecracker guest destinations overlap: ${existing} and ${guestPath}`,
+        );
+      }
+    }
+    seenPaths.push(guestPath);
+  }
+}
+
+export interface FirecrackerRuntimeAssetImageConfig {
+  readonly runId: string;
+  readonly runDirectory: string;
+  readonly plan: FirecrackerRuntimeAssetPlan;
+  readonly uid: number;
+  readonly gid: number;
+  readonly forbiddenContents?: readonly string[];
+}
+
+export interface FirecrackerRuntimeAssetImageDependencies {
+  runTool(command: string, args: readonly string[]): Promise<void>;
+}
+
+export interface FirecrackerRuntimeAssetPreparation {
+  readonly imagePath: string;
+  readonly imageBytes: number;
+  readonly totals: BoundedCopyTotals;
+}
+
+export const defaultRuntimeAssetDependencies: FirecrackerRuntimeAssetImageDependencies = {
+  runTool: async (command, args) => {
+    const result = await execa(command, [...args], {
+      reject: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    });
+    if (result.exitCode === 0) return;
+    if (
+      (command === 'e2fsck' || command.endsWith('/e2fsck')) &&
+      result.exitCode === E2FSCK_REPAIR_EXIT_CODE
+    ) return;
+    throw new Error(
+      `${command} exited with code ${result.exitCode}: ` +
+      `${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  },
+};
+
+/**
+ * Builds the single-use, read-only ext4 device that carries gh-aw runtime
+ * assets. The workspace image stays the only writable copy-back filesystem.
+ */
+export class FirecrackerRuntimeAssetImage {
+  readonly imagePath: string;
+  readonly stagingDirectory: string;
+  private prepared = false;
+
+  constructor(
+    private readonly config: FirecrackerRuntimeAssetImageConfig,
+    private readonly dependencies: FirecrackerRuntimeAssetImageDependencies =
+    defaultRuntimeAssetDependencies,
+    private readonly tools?: { mke2fs?: string; e2fsck?: string },
+  ) {
+    this.imagePath = path.join(config.runDirectory, 'runtime-assets.ext4');
+    this.stagingDirectory = path.join(config.runDirectory, 'runtime-staging');
+  }
+
+  async prepare(): Promise<FirecrackerRuntimeAssetPreparation> {
+    if (this.prepared) {
+      throw new Error('Firecracker runtime asset image is already prepared');
+    }
+    assertFirecrackerGuestDestinations(this.config.plan.entries);
+    await fs.mkdir(this.stagingDirectory, { recursive: true, mode: 0o700 });
+    const budget = new BoundedCopyBudget(this.config.plan.limits);
+    const forbiddenBasenames = firecrackerForbiddenStagingBasenames();
+
+    for (const entry of this.config.plan.entries) {
+      const destination = path.join(this.stagingDirectory, entry.id);
+      await fs.mkdir(destination, { mode: 0o700 });
+      await copyBoundedTree(
+        {
+          sourceRoot: entry.hostPath,
+          destinationRoot: destination,
+          label: `gh-aw runtime asset ${entry.id}`,
+          ownership: this.ownership(),
+          forbiddenBasenames,
+          ...(this.config.forbiddenContents
+            ? { forbiddenContents: this.config.forbiddenContents }
+            : {}),
+        },
+        budget,
+      );
+      // Ownership is applied after the copy so the bounded copier can prove the
+      // destination is still the root-owned directory it created.
+      await this.applyOwnership(destination);
+    }
+
+    const markerPath = path.join(this.stagingDirectory, FIRECRACKER_RUNTIME_MARKER);
+    await fs.writeFile(
+      markerPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        runId: this.config.runId,
+        entries: this.config.plan.entries.map((entry) => ({
+          id: entry.id,
+          guestPath: entry.guestPath,
+        })),
+      }, null, 2)}\n`,
+      { flag: 'wx', mode: 0o600 },
+    );
+    await this.applyOwnership(markerPath);
+
+    const imageBytes = calculateFirecrackerRuntimeImageBytes(
+      budget.totals.bytes +
+      (budget.totals.files + budget.totals.directories + budget.totals.symlinks + 8) *
+      RUNTIME_BLOCK_BYTES,
+      this.config.plan.limits.maxTotalBytes + RUNTIME_IMAGE_HEADROOM_BYTES * 2,
+    );
+    const inodeCount = Math.max(
+      1024,
+      budget.totals.files + budget.totals.directories + budget.totals.symlinks + 512,
+    );
+    const handle = await fs.open(this.imagePath, 'wx', 0o600);
+    try {
+      await handle.truncate(imageBytes);
+    } finally {
+      await handle.close();
+    }
+    await this.runTool('mke2fs', [
+      '-t', 'ext4',
+      '-F',
+      '-q',
+      '-b', String(RUNTIME_BLOCK_BYTES),
+      '-N', String(inodeCount),
+      '-d', this.stagingDirectory,
+      this.imagePath,
+      String(imageBytes / RUNTIME_BLOCK_BYTES),
+    ]);
+    await this.runTool('e2fsck', ['-f', '-y', this.imagePath]);
+    await fs.chmod(this.imagePath, 0o400);
+    this.prepared = true;
+    return { imagePath: this.imagePath, imageBytes, totals: { ...budget.totals } };
+  }
+
+  async cleanup(): Promise<void> {
+    await fs.rm(this.stagingDirectory, { recursive: true, force: true });
+  }
+
+  private ownership(): { uid: number; gid: number } | undefined {
+    if (process.getuid?.() !== 0) return undefined;
+    return { uid: this.config.uid, gid: this.config.gid };
+  }
+
+  private async applyOwnership(target: string): Promise<void> {
+    const ownership = this.ownership();
+    if (!ownership) return;
+    await fs.chown(target, ownership.uid, ownership.gid);
+  }
+
+  private runTool(command: 'mke2fs' | 'e2fsck', args: readonly string[]): Promise<void> {
+    return this.dependencies.runTool(this.tools?.[command] ?? command, args);
+  }
+}
+
+export function calculateFirecrackerRuntimeImageBytes(
+  contentBytes: number,
+  maximumBytes: number,
+): number {
+  if (!Number.isSafeInteger(contentBytes) || contentBytes < 0) {
+    throw new Error(`Invalid Firecracker runtime asset content size: ${contentBytes}`);
+  }
+  const requested = Math.max(
+    RUNTIME_IMAGE_MIN_BYTES,
+    Math.ceil(contentBytes * 1.25) + RUNTIME_IMAGE_HEADROOM_BYTES,
+  );
+  const aligned = Math.ceil(requested / RUNTIME_BLOCK_BYTES) * RUNTIME_BLOCK_BYTES;
+  if (aligned > maximumBytes) {
+    throw new Error(
+      `Firecracker runtime asset image requires ${aligned} bytes, exceeding cap ${maximumBytes}`,
+    );
+  }
+  return aligned;
+}
+
+/**
+ * Credential store names that must never reach a guest device. Distinctive
+ * names are curated here and cross-checked against the shared mount policy so
+ * a new credential store cannot be added in one place only.
+ */
+export function firecrackerForbiddenStagingBasenames(): readonly string[] {
+  const generic = new Set(['.config', '.local', '.cache', '.npm']);
+  const names = new Set<string>([
+    '.ssh', '.aws', '.azure', '.kube', '.gnupg', '.docker', '.gcloud',
+    '.netrc', '_netrc', '.git-credentials', '.npmrc', '.dockercfg', '.pypirc',
+    'id_rsa', 'id_ed25519', 'id_ecdsa', 'id_dsa',
+  ]);
+  for (const entry of CREDENTIAL_ENTRIES) {
+    const top = entry.path.split('/')[0];
+    if (top && top.startsWith('.') && !generic.has(top)) names.add(top);
+  }
+  return [...names];
+}

--- a/src/firecracker/runtime-assets.ts
+++ b/src/firecracker/runtime-assets.ts
@@ -393,6 +393,7 @@ export function firecrackerForbiddenStagingBasenames(): readonly string[] {
     '.ssh', '.aws', '.azure', '.kube', '.gnupg', '.docker', '.gcloud',
     '.netrc', '_netrc', '.git-credentials', '.npmrc', '.dockercfg', '.pypirc',
     'id_rsa', 'id_ed25519', 'id_ecdsa', 'id_dsa',
+    'credentials.json',
   ]);
   for (const entry of CREDENTIAL_ENTRIES) {
     const top = entry.path.split('/')[0];

--- a/src/firecracker/runtime-validation.test.ts
+++ b/src/firecracker/runtime-validation.test.ts
@@ -1,10 +1,12 @@
 import type { WrapperConfig } from '../types';
 import {
+  assertFirecrackerGhAwRuntimeContract,
   assertFirecrackerPreSecurityCompatibility,
   assertFirecrackerRuntimeCompatibility,
   assertFirecrackerSelection,
   requireFirecrackerConfig,
 } from './runtime-validation';
+import type { FirecrackerGhAwRuntimeOptions } from '../types/runtime-options';
 
 const digest = 'a'.repeat(64);
 
@@ -102,5 +104,106 @@ describe('Firecracker runtime validation', () => {
     expect(() => assertFirecrackerPreSecurityCompatibility(config({
       awfDockerHost: 'unix:///var/run/docker.sock',
     }))).not.toThrow();
+  });
+});
+
+describe('Firecracker gh-aw runtime staging contract', () => {
+  const base: FirecrackerGhAwRuntimeOptions = {
+    enabled: true,
+    maxFileBytes: 1024,
+    maxTotalBytes: 4096,
+    maxFileCount: 16,
+  };
+
+  function withRuntime(ghAwRuntime: FirecrackerGhAwRuntimeOptions): WrapperConfig {
+    const valid = config();
+    return {
+      ...valid,
+      firecracker: { ...valid.firecracker!, ghAwRuntime },
+    } as WrapperConfig;
+  }
+
+  it('still refuses arbitrary host volume mounts when staging is enabled', () => {
+    expect(() => assertFirecrackerRuntimeCompatibility(withRuntime({
+      ...base,
+      volumeMounts: ['/etc:/etc'],
+    } as never))).not.toThrow();
+    expect(() => assertFirecrackerPreSecurityCompatibility({
+      ...withRuntime(base),
+      volumeMounts: ['/etc:/etc'],
+    } as WrapperConfig)).toThrow(/does not support additional host volume mounts/);
+  });
+
+  it('accepts the default contract and a complete safe-output block', () => {
+    expect(() => assertFirecrackerGhAwRuntimeContract({ ghAwRuntime: base } as never))
+      .not.toThrow();
+    expect(() => assertFirecrackerGhAwRuntimeContract({
+      ghAwRuntime: {
+        ...base,
+        runnerTempPath: '/runner/_temp',
+        compilerTmpPath: '/tmp',
+        safeOutputs: {
+          hostDirectory: '/var/tmp/awf-safe-outputs',
+          maxFileBytes: 512,
+          maxTotalBytes: 1024,
+          maxFileCount: 8,
+        },
+      },
+    } as never)).not.toThrow();
+  });
+
+  it('is a no-op when the contract is absent', () => {
+    expect(() => assertFirecrackerGhAwRuntimeContract({} as never)).not.toThrow();
+    expect(() => assertFirecrackerGhAwRuntimeContract({
+      ghAwRuntime: { ...base, enabled: false },
+    } as never)).not.toThrow();
+  });
+
+  it.each([
+    [
+      'safe outputs without staging',
+      { ...base, enabled: false, safeOutputs: {
+        hostDirectory: '/var/tmp/out', maxFileBytes: 1, maxTotalBytes: 2, maxFileCount: 1,
+      } },
+      /requires --firecracker-gh-aw-runtime/,
+    ],
+    ['relative runner temp', { ...base, runnerTempPath: 'runner/_temp' }, /absolute path/],
+    ['traversal runner temp', { ...base, runnerTempPath: '/runner/../etc' }, /absolute path/],
+    ['whitespace compiler tmp', { ...base, compilerTmpPath: '/tmp evil' }, /absolute path/],
+    ['zero file cap', { ...base, maxFileBytes: 0 }, /positive integer/],
+    ['negative total cap', { ...base, maxTotalBytes: -1 }, /positive integer/],
+    ['fractional count cap', { ...base, maxFileCount: 2.5 }, /positive integer/],
+    [
+      'per-file cap above total cap',
+      { ...base, maxFileBytes: 8192 },
+      /may not exceed/,
+    ],
+    [
+      'relative safe-output directory',
+      { ...base, safeOutputs: {
+        hostDirectory: 'outputs', maxFileBytes: 1, maxTotalBytes: 2, maxFileCount: 1,
+      } },
+      /absolute path/,
+    ],
+    [
+      'safe-output cap inversion',
+      { ...base, safeOutputs: {
+        hostDirectory: '/var/tmp/out', maxFileBytes: 4, maxTotalBytes: 2, maxFileCount: 1,
+      } },
+      /may not exceed/,
+    ],
+    [
+      'safe-output zero count cap',
+      { ...base, safeOutputs: {
+        hostDirectory: '/var/tmp/out', maxFileBytes: 1, maxTotalBytes: 2, maxFileCount: 0,
+      } },
+      /positive integer/,
+    ],
+  ])('rejects %s', (_name, ghAwRuntime, pattern) => {
+    expect(() => assertFirecrackerGhAwRuntimeContract({ ghAwRuntime } as never))
+      .toThrow(pattern);
+    expect(() => assertFirecrackerRuntimeCompatibility(
+      withRuntime(ghAwRuntime as FirecrackerGhAwRuntimeOptions),
+    )).toThrow(pattern);
   });
 });

--- a/src/firecracker/runtime-validation.ts
+++ b/src/firecracker/runtime-validation.ts
@@ -25,6 +25,7 @@ export function assertFirecrackerRuntimeCompatibility(
     throw new Error('Firecracker preview requires API proxy credential isolation');
   }
   assertFirecrackerPreSecurityCompatibility(config);
+  assertFirecrackerGhAwRuntimeContract(firecracker);
   if (!firecracker.kernelPath || !firecracker.rootfsPath || !firecracker.supervisorPath) {
     throw new Error(
       'Firecracker preview requires explicit kernel, rootfs, and guest supervisor artifacts',
@@ -89,4 +90,76 @@ export function requireFirecrackerConfig(config: WrapperConfig): FirecrackerOpti
     throw new Error('Firecracker backend resolved without Firecracker runtime configuration');
   }
   return config.firecracker;
+}
+
+/**
+ * Validates the AWF-owned gh-aw staging contract.
+ *
+ * This deliberately mirrors the `--mount` rejection above: the contract only
+ * ever stages AWF's fixed source set, so enabling it must never be read as
+ * permission to bind arbitrary host paths into the guest.
+ */
+export function assertFirecrackerGhAwRuntimeContract(
+  firecracker: FirecrackerOptions,
+): void {
+  const runtime = firecracker.ghAwRuntime;
+  if (!runtime) return;
+  if (!runtime.enabled) {
+    if (runtime.safeOutputs) {
+      throw new Error(
+        'Firecracker safe-output exchange requires --firecracker-gh-aw-runtime',
+      );
+    }
+    return;
+  }
+  for (const [flag, value] of [
+    ['--firecracker-gh-aw-runner-temp', runtime.runnerTempPath],
+    ['--firecracker-gh-aw-compiler-tmp', runtime.compilerTmpPath],
+  ] as const) {
+    if (value === undefined) continue;
+    if (!value.startsWith('/') || value.includes('..') || /[\s\0]/.test(value)) {
+      throw new Error(`${flag} must be an absolute path without traversal: ${value}`);
+    }
+  }
+  for (const [flag, value] of [
+    ['--firecracker-gh-aw-max-file-bytes', runtime.maxFileBytes],
+    ['--firecracker-gh-aw-max-total-bytes', runtime.maxTotalBytes],
+    ['--firecracker-gh-aw-max-files', runtime.maxFileCount],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`${flag} must be a positive integer`);
+    }
+  }
+  if (runtime.maxFileBytes > runtime.maxTotalBytes) {
+    throw new Error(
+      '--firecracker-gh-aw-max-file-bytes may not exceed --firecracker-gh-aw-max-total-bytes',
+    );
+  }
+  const safeOutputs = runtime.safeOutputs;
+  if (!safeOutputs) return;
+  if (
+    !safeOutputs.hostDirectory.startsWith('/') ||
+    safeOutputs.hostDirectory.includes('..') ||
+    /[\s\0]/.test(safeOutputs.hostDirectory)
+  ) {
+    throw new Error(
+      `--firecracker-safe-outputs-dir must be an absolute path without traversal: ` +
+      safeOutputs.hostDirectory,
+    );
+  }
+  for (const [flag, value] of [
+    ['--firecracker-safe-outputs-max-file-bytes', safeOutputs.maxFileBytes],
+    ['--firecracker-safe-outputs-max-total-bytes', safeOutputs.maxTotalBytes],
+    ['--firecracker-safe-outputs-max-files', safeOutputs.maxFileCount],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`${flag} must be a positive integer`);
+    }
+  }
+  if (safeOutputs.maxFileBytes > safeOutputs.maxTotalBytes) {
+    throw new Error(
+      '--firecracker-safe-outputs-max-file-bytes may not exceed ' +
+      '--firecracker-safe-outputs-max-total-bytes',
+    );
+  }
 }

--- a/src/firecracker/workspace-image.test.ts
+++ b/src/firecracker/workspace-image.test.ts
@@ -3,6 +3,10 @@ import { createHash } from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  createFakeToolRunner,
+  type FakeDebugfsFailure,
+} from './debugfs.test-utils';
+import {
   FIRECRACKER_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
   FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES,
   FirecrackerWorkspaceImage,
@@ -41,13 +45,16 @@ describe('Firecracker workspace images', () => {
     await fs.writeFile(supervisor, 'binary');
     const commands: Array<{ command: string; args: readonly string[] }> = [];
     const dependencies: FirecrackerWorkspaceImageDependencies = {
-      runTool: jest.fn(async (command, args) => {
-        commands.push({ command, args });
-      }),
+      runTool: jest.fn(createFakeToolRunner({
+        onCommand: (command, args) => {
+          commands.push({ command, args });
+        },
+      })),
     };
     const image = new FirecrackerWorkspaceImage({
       runId: 'run-1',
       workDir: root,
+      recoveryDirectory: path.join(root, 'recovery'),
       workspacePath: workspace,
       homePath: home,
       baseRootfsPath: baseRootfs,
@@ -78,9 +85,12 @@ describe('Firecracker workspace images', () => {
       path.join(image.stagingDirectory, 'workspace', '.awf-home', '.config', 'gh'),
     )).rejects.toThrow();
     expect(commands.map(({ command }) => command)).toEqual([
-      'mke2fs', 'debugfs', 'debugfs', 'debugfs', 'e2fsck',
+      'mke2fs', 'debugfs', 'debugfs', 'debugfs', 'e2fsck', 'debugfs', 'debugfs',
     ]);
     expect(commands[1].args).toContain('rm /sbin/awf-supervisor');
+    // The supervisor is read back out of the image and re-hashed after e2fsck.
+    expect(commands[5].args[1]).toMatch(/^dump \/sbin\/awf-supervisor /);
+    expect(commands[6].args).toContain('stat /sbin/awf-supervisor');
     expect(commands[0].args).toEqual(expect.arrayContaining(['-b', '4096']));
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -152,16 +162,19 @@ describe('Firecracker workspace images', () => {
     await fs.writeFile(path.join(root, 'base.ext4'), 'rootfs');
     await fs.writeFile(path.join(root, 'supervisor'), 'binary');
     let e2fsckCalls = 0;
+    const fake = createFakeToolRunner();
     const dependencies: FirecrackerWorkspaceImageDependencies = {
-      runTool: jest.fn(async (command) => {
+      runTool: jest.fn(async (command, args) => {
         if (command === 'e2fsck' && ++e2fsckCalls > 1) {
           throw new Error('corrupt image');
         }
+        return fake(command, args);
       }),
     };
     const image = new FirecrackerWorkspaceImage({
       runId: 'run-2',
       workDir: root,
+      recoveryDirectory: path.join(root, 'recovery'),
       workspacePath: workspace,
       homePath: home,
       baseRootfsPath: path.join(root, 'base.ext4'),
@@ -191,6 +204,7 @@ describe('Firecracker workspace images', () => {
     const image = new FirecrackerWorkspaceImage({
       runId: 'run-3',
       workDir: root,
+      recoveryDirectory: path.join(root, 'recovery'),
       workspacePath: workspace,
       homePath: home,
       baseRootfsPath: path.join(root, 'base.ext4'),
@@ -199,25 +213,25 @@ describe('Firecracker workspace images', () => {
       uid: process.getuid?.() ?? 1000,
       gid: process.getgid?.() ?? 1000,
     }, {
-      runTool: jest.fn(async (command, args) => {
-        if (command === 'debugfs' && args[0] === '-R' && args[1].startsWith('rdump ')) {
-          const extracted = path.join(image.runDirectory, 'extracted');
+      runTool: jest.fn(createFakeToolRunner({
+        onRdump: async (extracted) => {
           await fs.writeFile(path.join(extracted, 'file'), 'after');
           await fs.mkdir(path.join(extracted, '.awf-home'), { recursive: true });
           await fs.writeFile(path.join(extracted, '.awf-home', 'token'), 'guest-only');
-          await fs.mkdir(path.join(extracted, 'lost+found'), { recursive: true });
-        }
-        if (command === 'rsync') {
+        },
+        onCommand: async (command, args) => {
+          if (command !== 'rsync') return;
           rsyncCalls.push([...args]);
           const sourceDirectory = args[args.length - 2];
           const destinationDirectory = args[args.length - 1];
           if (!sourceDirectory || !destinationDirectory) return;
-          const sourceFile = path.join(sourceDirectory, 'file');
-          const destinationFile = path.join(destinationDirectory, 'file');
-          await fs.mkdir(path.dirname(destinationFile), { recursive: true });
-          await fs.copyFile(sourceFile, destinationFile);
-        }
-      }),
+          await fs.mkdir(destinationDirectory, { recursive: true });
+          await fs.copyFile(
+            path.join(sourceDirectory, 'file'),
+            path.join(destinationDirectory, 'file'),
+          );
+        },
+      })),
     });
 
     await image.prepare();
@@ -232,6 +246,200 @@ describe('Firecracker workspace images', () => {
     await expect(fs.readFile(path.join(workspace, 'file'), 'utf8')).resolves.toBe('after');
     await image.cleanup();
     await expect(fs.access(image.runDirectory)).rejects.toThrow();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+});
+
+describe('Firecracker recovery image placement', () => {
+  const base = {
+    runId: 'run-x',
+    workDir: '/var/tmp/awf-run',
+    workspacePath: '/home/runner/work/repo/repo',
+    homePath: '/home/runner',
+    baseRootfsPath: '/var/tmp/base.ext4',
+    supervisorBinaryPath: '/var/tmp/supervisor',
+    supervisorSha256: 'a'.repeat(64),
+    uid: 1000,
+    gid: 1000,
+  };
+
+  it('defaults outside the workspace and the run directory', () => {
+    const image = new FirecrackerWorkspaceImage(base);
+    expect(image.recoveryImagePath.startsWith(base.workspacePath)).toBe(false);
+    expect(image.recoveryImagePath.startsWith(image.runDirectory)).toBe(false);
+    expect(image.recoveryImagePath).toBe(
+      path.join(os.tmpdir(), 'awf-firecracker-recovery', 'run-x-workspace.ext4'),
+    );
+  });
+
+  it('refuses a recovery directory inside the guest-writable workspace', () => {
+    expect(() => new FirecrackerWorkspaceImage({
+      ...base,
+      recoveryDirectory: path.join(base.workspacePath, '.awf-firecracker-recovery'),
+    })).toThrow(/must not live inside the workspace/);
+    expect(() => new FirecrackerWorkspaceImage({
+      ...base,
+      recoveryDirectory: base.workspacePath,
+    })).toThrow(/must not live inside the workspace/);
+  });
+
+  it('refuses a recovery directory inside the per-run control directory', () => {
+    expect(() => new FirecrackerWorkspaceImage({
+      ...base,
+      recoveryDirectory: path.join(base.workDir, 'firecracker-images', 'run-x', 'r'),
+    })).toThrow(/must not live inside the run directory/);
+  });
+
+  it('accepts an isolated recovery directory', () => {
+    const image = new FirecrackerWorkspaceImage({
+      ...base,
+      recoveryDirectory: '/var/tmp/awf-recovery',
+    });
+    expect(image.recoveryImagePath).toBe('/var/tmp/awf-recovery/run-x-workspace.ext4');
+  });
+});
+
+describe('Firecracker workspace copy-back refuses unverified debugfs results', () => {
+  async function makeImage(
+    runId: string,
+    failure: FakeDebugfsFailure,
+    supervisorBytes?: string,
+  ) {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'awf-workspace-dbg-')),
+    );
+    const workspace = path.join(root, 'source');
+    const home = path.join(root, 'home');
+    await fs.mkdir(workspace);
+    await fs.mkdir(home);
+    await fs.writeFile(path.join(workspace, 'file'), 'before');
+    await fs.writeFile(path.join(workspace, 'second'), 'before');
+    await fs.writeFile(path.join(root, 'base.ext4'), 'rootfs');
+    await fs.writeFile(path.join(root, 'supervisor'), 'binary');
+    const rsyncCalls: string[][] = [];
+    const image = new FirecrackerWorkspaceImage({
+      runId,
+      workDir: root,
+      recoveryDirectory: path.join(root, 'recovery'),
+      workspacePath: workspace,
+      homePath: home,
+      baseRootfsPath: path.join(root, 'base.ext4'),
+      supervisorBinaryPath: path.join(root, 'supervisor'),
+      supervisorSha256: createHash('sha256').update('binary').digest('hex'),
+      uid: process.getuid?.() ?? 1000,
+      gid: process.getgid?.() ?? 1000,
+    }, {
+      runTool: createFakeToolRunner({
+        failure,
+        supervisorBytes,
+        onCommand: (command, args) => {
+          if (command === 'rsync') rsyncCalls.push([...args]);
+        },
+      }),
+    });
+    return { image, root, workspace, rsyncCalls };
+  }
+
+  it('never runs rsync --delete when rdump silently failed', async () => {
+    const { image, root, workspace, rsyncCalls } = await makeImage('dbg-1', 'rdump-silent');
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(/debugfs reported a failure/);
+
+    expect(rsyncCalls).toEqual([]);
+    expect((await fs.readdir(workspace)).sort()).toEqual(['file', 'second']);
+    await expect(fs.access(image.recoveryImagePath)).resolves.toBeUndefined();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('never runs rsync --delete when rdump produced nothing at all', async () => {
+    const { image, root, workspace, rsyncCalls } = await makeImage('dbg-2', 'rdump-empty');
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(
+      /missing the 'lost\+found' entry/,
+    );
+
+    expect(rsyncCalls).toEqual([]);
+    expect((await fs.readdir(workspace)).sort()).toEqual(['file', 'second']);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('refuses to delete a populated workspace from an empty extraction', async () => {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'awf-workspace-dbg-')),
+    );
+    const workspace = path.join(root, 'source');
+    const home = path.join(root, 'home');
+    await fs.mkdir(workspace);
+    await fs.mkdir(home);
+    await fs.writeFile(path.join(workspace, 'file'), 'before');
+    await fs.writeFile(path.join(root, 'base.ext4'), 'rootfs');
+    await fs.writeFile(path.join(root, 'supervisor'), 'binary');
+    const rsyncCalls: string[][] = [];
+    const image = new FirecrackerWorkspaceImage({
+      runId: 'dbg-3',
+      workDir: root,
+      recoveryDirectory: path.join(root, 'recovery'),
+      workspacePath: workspace,
+      homePath: home,
+      baseRootfsPath: path.join(root, 'base.ext4'),
+      supervisorBinaryPath: path.join(root, 'supervisor'),
+      supervisorSha256: createHash('sha256').update('binary').digest('hex'),
+      uid: process.getuid?.() ?? 1000,
+      gid: process.getgid?.() ?? 1000,
+    }, {
+      // `lost+found` is produced, so only the emptiness guard can catch this.
+      runTool: createFakeToolRunner({
+        onCommand: (command, args) => {
+          if (command === 'rsync') rsyncCalls.push([...args]);
+        },
+      }),
+    });
+    await image.prepare();
+
+    await expect(image.extractAfterStop()).rejects.toThrow(
+      /guest workspace extraction is empty/,
+    );
+
+    expect(rsyncCalls).toEqual([]);
+    expect(await fs.readFile(path.join(workspace, 'file'), 'utf8')).toBe('before');
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects a rootfs whose supervisor write silently did nothing', async () => {
+    const { image, root } = await makeImage('dbg-4', 'write-silent');
+
+    await expect(image.prepare()).rejects.toThrow(/debugfs reported a failure/);
+
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects a rootfs whose embedded supervisor cannot be read back', async () => {
+    const { image, root } = await makeImage('dbg-5', 'dump-missing');
+
+    await expect(image.prepare()).rejects.toThrow(/debugfs reported a failure/);
+
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects a rootfs whose embedded supervisor hash does not match', async () => {
+    const { image, root } = await makeImage('dbg-6', 'none', 'tampered');
+
+    await expect(image.prepare()).rejects.toThrow(
+      /embedded guest supervisor SHA-256 mismatch/,
+    );
+
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects a rootfs whose supervisor mode was not applied', async () => {
+    const { image, root } = await makeImage('dbg-7', 'stat-wrong-mode');
+
+    await expect(image.prepare()).rejects.toThrow(
+      /supervisor mode was not applied: expected 0755, got 0644/,
+    );
+
     await fs.rm(root, { recursive: true, force: true });
   });
 });

--- a/src/firecracker/workspace-image.ts
+++ b/src/firecracker/workspace-image.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+import * as os from 'os';
 import { createReadStream, promises as fs, type Stats } from 'fs';
 import * as path from 'path';
 import execa from 'execa';
@@ -7,6 +8,13 @@ import {
   CREDENTIAL_ENTRIES,
   HOME_TOOL_SUBDIRS,
 } from '../config/mount-policy';
+import {
+  assertDebugfsExtractionProduced,
+  assertDebugfsOperand,
+  assertDebugfsQuerySucceeded,
+  assertDebugfsSucceeded,
+  parseDebugfsStatMode,
+} from './debugfs';
 
 const MIB = 1024 * 1024;
 export const FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES = 256 * MIB;
@@ -24,6 +32,11 @@ export interface FirecrackerWorkspaceImageConfig {
   readonly supervisorBinaryPath: string;
   readonly supervisorSha256: string;
   readonly maxImageBytes?: number;
+  /**
+   * Where a failed copy-back preserves the changed image. Must sit outside the
+   * workspace and outside the per-run control directories.
+   */
+  readonly recoveryDirectory?: string;
   readonly uid: number;
   readonly gid: number;
 }
@@ -44,7 +57,7 @@ export type FirecrackerWorkspaceManifest = ReadonlyMap<
 >;
 
 export interface FirecrackerWorkspaceImageDependencies {
-  runTool(command: string, args: readonly string[]): Promise<void>;
+  runTool(command: string, args: readonly string[]): Promise<string>;
 }
 
 const defaultDependencies: FirecrackerWorkspaceImageDependencies = {
@@ -54,11 +67,12 @@ const defaultDependencies: FirecrackerWorkspaceImageDependencies = {
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 120_000,
     });
-    if (result.exitCode === 0) return;
+    const output = `${result.stdout}\n${result.stderr}`;
+    if (result.exitCode === 0) return output;
     if (
       (command === 'e2fsck' || command.endsWith('/e2fsck')) &&
       result.exitCode === FIRECRACKER_E2FSCK_REPAIR_EXIT_CODE
-    ) return;
+    ) return output;
     throw new Error(
       `${command} exited with code ${result.exitCode}: ` +
       `${result.stderr.trim() || result.stdout.trim()}`,
@@ -77,6 +91,16 @@ export interface FirecrackerWorkspacePreparation {
 export function firecrackerRunImageDirectory(workDir: string, runId: string): string {
   assertSafeRunId(runId);
   return path.join(workDir, 'firecracker-images', runId);
+}
+
+/**
+ * Recovery images are deliberately kept outside the workspace and outside the
+ * per-run control directories: the workspace is guest-controlled content that a
+ * failed copy-back must never write into, and the run directory is removed by
+ * cleanup.
+ */
+export function firecrackerRecoveryDirectory(override?: string): string {
+  return override ?? path.join(os.tmpdir(), 'awf-firecracker-recovery');
 }
 
 /**
@@ -103,9 +127,10 @@ export class FirecrackerWorkspaceImage {
     this.stagingDirectory = path.join(this.runDirectory, 'staging');
     this.workspaceImagePath = path.join(this.runDirectory, 'workspace.ext4');
     this.rootfsImagePath = path.join(this.runDirectory, 'rootfs.ext4');
+    const recoveryDirectory = firecrackerRecoveryDirectory(config.recoveryDirectory);
+    assertRecoveryDirectoryIsolated(recoveryDirectory, config.workspacePath, config.workDir);
     this.recoveryImagePath = path.join(
-      config.workspacePath,
-      '.awf-firecracker-recovery',
+      recoveryDirectory,
       `${config.runId}-workspace.ext4`,
     );
   }
@@ -113,8 +138,16 @@ export class FirecrackerWorkspaceImage {
   private runTool(
     command: 'mke2fs' | 'debugfs' | 'e2fsck' | 'rsync',
     args: readonly string[],
-  ): Promise<void> {
+  ): Promise<string> {
     return this.dependencies.runTool(this.tools?.[command] ?? command, args);
+  }
+
+  /**
+   * Run a silent `debugfs` subcommand and fail closed on any diagnostic, because
+   * `debugfs` exits 0 even when the subcommand performed no work.
+   */
+  private async runDebugfs(args: readonly string[], label: string): Promise<void> {
+    assertDebugfsSucceeded(await this.runTool('debugfs', args), label);
   }
 
   async prepare(): Promise<FirecrackerWorkspacePreparation> {
@@ -203,10 +236,16 @@ export class FirecrackerWorkspaceImage {
       await fs.mkdir(extractionDirectory, { recursive: true, mode: 0o700 });
       assertDebugfsOperand(extractionDirectory, 'extraction directory');
       await this.runTool('e2fsck', ['-f', '-y', changedImagePath]);
-      await this.runTool('debugfs', [
-        '-R', `rdump / ${extractionDirectory}`,
-        changedImagePath,
-      ]);
+      await this.runDebugfs(
+        ['-R', `rdump / ${extractionDirectory}`, changedImagePath],
+        'extracting the guest workspace image',
+      );
+      // Proves the dump actually ran before `rsync --delete` replaces host state.
+      await assertDebugfsExtractionProduced(
+        extractionDirectory,
+        ['lost+found'],
+        'the guest workspace',
+      );
       await fs.rm(path.join(extractionDirectory, '.awf-home'), {
         recursive: true,
         force: true,
@@ -217,6 +256,13 @@ export class FirecrackerWorkspaceImage {
       });
       const guestWorkspace = extractionDirectory;
       const guestManifest = await buildFirecrackerWorkspaceManifest(guestWorkspace);
+      if (guestManifest.size === 0 && this.originalManifest.size > 0) {
+        throw new Error(
+          'the guest workspace extraction is empty while the staged workspace ' +
+          `contained ${this.originalManifest.size} entries; refusing to delete ` +
+          'the host workspace from an unverified extraction',
+        );
+      }
       const currentManifest = await buildFirecrackerWorkspaceManifest(this.config.workspacePath);
       assertNoWorkspaceConflicts(this.originalManifest, guestManifest, currentManifest);
       await this.applyWorkspaceUpdateAtomically(guestWorkspace, guestManifest);
@@ -296,30 +342,92 @@ export class FirecrackerWorkspaceImage {
     await fs.copyFile(this.config.supervisorBinaryPath, localSupervisor);
     await fs.chmod(localSupervisor, 0o500);
     assertDebugfsOperand(localSupervisor, 'supervisor staging path');
-    await this.runTool('debugfs', [
-      '-w',
-      '-R', 'rm /sbin/awf-supervisor',
-      this.rootfsImagePath,
-    ]);
-    await this.dependencies.runTool('debugfs', [
-      '-w',
-      '-R', `write ${localSupervisor} /sbin/awf-supervisor`,
-      this.rootfsImagePath,
-    ]);
-    await this.runTool('debugfs', [
-      '-w',
-      '-R', 'sif /sbin/awf-supervisor mode 0100755',
-      this.rootfsImagePath,
-    ]);
+    await this.runDebugfs(
+      ['-w', '-R', 'rm /sbin/awf-supervisor', this.rootfsImagePath],
+      'removing the previous guest supervisor',
+    ).catch((error: unknown) => {
+      // The base rootfs legitimately may not carry a supervisor yet.
+      if (`${error}`.includes('File not found by ext2_lookup')) return;
+      throw error;
+    });
+    assertDebugfsSucceeded(
+      await this.dependencies.runTool(this.tools?.debugfs ?? 'debugfs', [
+        '-w',
+        '-R', `write ${localSupervisor} /sbin/awf-supervisor`,
+        this.rootfsImagePath,
+      ]),
+      'writing the guest supervisor into the rootfs image',
+    );
+    await this.runDebugfs(
+      ['-w', '-R', 'sif /sbin/awf-supervisor mode 0100755', this.rootfsImagePath],
+      'setting the guest supervisor mode',
+    );
     await this.runTool('e2fsck', ['-f', '-y', this.rootfsImagePath]);
+    await this.verifyEmbeddedSupervisor(actual);
+  }
+
+  /**
+   * `debugfs` reports success for a `write` that copied nothing, so the embedded
+   * supervisor is read back out of the image and re-hashed before the rootfs is
+   * ever booted.
+   */
+  private async verifyEmbeddedSupervisor(expectedSha256: string): Promise<void> {
+    const readback = path.join(this.runDirectory, 'awf-supervisor.readback');
+    await fs.rm(readback, { force: true });
+    assertDebugfsOperand(readback, 'supervisor verification path');
+    try {
+      await this.runDebugfs(
+        ['-R', `dump /sbin/awf-supervisor ${readback}`, this.rootfsImagePath],
+        'reading back the embedded guest supervisor',
+      );
+      const embedded = await sha256File(readback).catch(
+        (error: NodeJS.ErrnoException) => {
+          if (error.code === 'ENOENT') {
+            throw new Error(
+              'the embedded guest supervisor could not be read back from the ' +
+              'rootfs image',
+            );
+          }
+          throw error;
+        },
+      );
+      if (embedded !== expectedSha256) {
+        throw new Error(
+          `embedded guest supervisor SHA-256 mismatch: expected ` +
+          `${expectedSha256}, image contains ${embedded}`,
+        );
+      }
+      const statOutput = await this.runTool('debugfs', [
+        '-R', 'stat /sbin/awf-supervisor',
+        this.rootfsImagePath,
+      ]);
+      assertDebugfsQuerySucceeded(
+        statOutput,
+        'inspecting the embedded guest supervisor',
+      );
+      const mode = parseDebugfsStatMode(statOutput);
+      if (mode !== 0o755) {
+        throw new Error(
+          'embedded guest supervisor mode was not applied: expected 0755, got ' +
+          (mode === undefined ? 'unknown' : `0${mode.toString(8)}`),
+        );
+      }
+    } finally {
+      await fs.rm(readback, { force: true });
+    }
   }
 
   private async preserveRecoveryImage(changedImagePath: string): Promise<void> {
     if (this.recoveryPreserved) return;
-    await fs.mkdir(path.dirname(this.recoveryImagePath), {
-      recursive: true,
-      mode: 0o700,
-    });
+    const recoveryDirectory = path.dirname(this.recoveryImagePath);
+    await fs.mkdir(recoveryDirectory, { recursive: true, mode: 0o700 });
+    await fs.chmod(recoveryDirectory, 0o700);
+    const directoryStat = await fs.lstat(recoveryDirectory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      throw new Error(
+        `Firecracker recovery directory must be a real directory: ${recoveryDirectory}`,
+      );
+    }
     const temporary = `${this.recoveryImagePath}.tmp-${process.pid}`;
     await fs.copyFile(changedImagePath, temporary);
     await fs.chmod(temporary, 0o600);
@@ -600,9 +708,30 @@ function assertSafeRunId(runId: string): void {
   }
 }
 
-function assertDebugfsOperand(value: string, label: string): void {
-  if (/[\s"'\\;`\r\n]/.test(value)) {
-    throw new Error(`Firecracker ${label} is unsafe for debugfs commands: ${value}`);
+/**
+ * The workspace is guest-controlled and the run directory is deleted by cleanup,
+ * so neither may host the recovery image.
+ */
+function assertRecoveryDirectoryIsolated(
+  recoveryDirectory: string,
+  workspacePath: string,
+  workDir: string,
+): void {
+  const recovery = path.resolve(recoveryDirectory);
+  for (const [label, candidate] of [
+    ['workspace', workspacePath],
+    ['run directory', path.join(workDir, 'firecracker-images')],
+  ] as const) {
+    const resolved = path.resolve(candidate);
+    const relative = path.relative(resolved, recovery);
+    const contained = relative === '' ||
+      (!relative.startsWith('..') && !path.isAbsolute(relative));
+    if (contained) {
+      throw new Error(
+        `Firecracker recovery directory must not live inside the ${label}: ` +
+        `${recovery}`,
+      );
+    }
   }
 }
 

--- a/src/firecracker/workspace-image.ts
+++ b/src/firecracker/workspace-image.ts
@@ -73,6 +73,12 @@ export interface FirecrackerWorkspacePreparation {
   readonly originalManifest: FirecrackerWorkspaceManifest;
 }
 
+/** Single source of truth for the per-run image directory layout. */
+export function firecrackerRunImageDirectory(workDir: string, runId: string): string {
+  assertSafeRunId(runId);
+  return path.join(workDir, 'firecracker-images', runId);
+}
+
 /**
  * Owns the host-only population and post-stop extraction of one writable image.
  */
@@ -93,7 +99,7 @@ export class FirecrackerWorkspaceImage {
     private readonly tools?: Pick<FirecrackerHostToolPaths, 'mke2fs' | 'debugfs' | 'e2fsck' | 'rsync'>,
   ) {
     assertSafeRunId(config.runId);
-    this.runDirectory = path.join(config.workDir, 'firecracker-images', config.runId);
+    this.runDirectory = firecrackerRunImageDirectory(config.workDir, config.runId);
     this.stagingDirectory = path.join(this.runDirectory, 'staging');
     this.workspaceImagePath = path.join(this.runDirectory, 'workspace.ext4');
     this.rootfsImagePath = path.join(this.runDirectory, 'rootfs.ext4');

--- a/src/types/runtime-options.ts
+++ b/src/types/runtime-options.ts
@@ -11,12 +11,71 @@ export const FIRECRACKER_DEFAULT_VCPU_COUNT = 2;
 export const FIRECRACKER_DEFAULT_MEMORY_MIB = 512;
 export const FIRECRACKER_DEFAULT_API_TIMEOUT_MS = 5_000;
 
+const FIRECRACKER_MIB = 1024 * 1024;
+
+/** Bounded defaults for the AWF-owned gh-aw runtime asset staging contract. */
+export const FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_BYTES = 64 * FIRECRACKER_MIB;
+export const FIRECRACKER_DEFAULT_GH_AW_MAX_TOTAL_BYTES = 512 * FIRECRACKER_MIB;
+export const FIRECRACKER_DEFAULT_GH_AW_MAX_FILE_COUNT = 20_000;
+
+/** Bounded defaults for the post-stop safe-output exchange. */
+export const FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_BYTES = 16 * FIRECRACKER_MIB;
+export const FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_TOTAL_BYTES = 64 * FIRECRACKER_MIB;
+export const FIRECRACKER_DEFAULT_SAFE_OUTPUT_MAX_FILE_COUNT = 2_000;
+
+/** Default host root that holds the gh-aw compiler's `/tmp/gh-aw` output tree. */
+export const FIRECRACKER_DEFAULT_GH_AW_COMPILER_TMP = '/tmp';
+
 export interface FirecrackerArtifactDigests {
   firecracker?: string;
   jailer?: string;
   kernel?: string;
   rootfs?: string;
   supervisor?: string;
+}
+
+/**
+ * Bounded copy caps applied while AWF stages host trees into guest devices.
+ *
+ * Every cap is enforced during the copy itself, not after it, so a source tree
+ * that grows while it is being staged still fails closed.
+ */
+export interface FirecrackerStagingLimits {
+  /** Largest single regular file AWF will stage, in bytes. */
+  maxFileBytes: number;
+  /** Largest total staged payload, in bytes. */
+  maxTotalBytes: number;
+  /** Largest number of staged entries (files, directories, and symlinks). */
+  maxFileCount: number;
+}
+
+/**
+ * Post-stop safe-output exchange contract.
+ *
+ * The guest writes into a dedicated writable exchange device that is never
+ * populated from host state. AWF copies the result to `hostDirectory` only
+ * after the Firecracker process termination is confirmed.
+ */
+export interface FirecrackerSafeOutputsOptions extends FirecrackerStagingLimits {
+  /** Absolute, canonical host directory that receives validated guest output. */
+  hostDirectory: string;
+}
+
+/**
+ * AWF-owned staging contract for generated gh-aw agents.
+ *
+ * The source set is fixed by AWF: only the canonical `RUNNER_TEMP/gh-aw` and
+ * compiler `/tmp/gh-aw` trees are eligible, and guest destinations are AWF
+ * constants. This is deliberately not a general bind-mount facility, so
+ * `--mount` / `volumeMounts` stay rejected for the Firecracker runtime.
+ */
+export interface FirecrackerGhAwRuntimeOptions extends FirecrackerStagingLimits {
+  enabled: boolean;
+  /** Canonical `RUNNER_TEMP` root; `<root>/gh-aw` is staged read-only. */
+  runnerTempPath?: string;
+  /** Canonical compiler tmp root; `<root>/gh-aw` is staged read-only. */
+  compilerTmpPath?: string;
+  safeOutputs?: FirecrackerSafeOutputsOptions;
 }
 
 /**
@@ -36,6 +95,8 @@ export interface FirecrackerOptions {
   memoryMib: number;
   apiTimeoutMs: number;
   sha256?: FirecrackerArtifactDigests;
+  /** Bounded gh-aw runtime asset staging and safe-output exchange contract. */
+  ghAwRuntime?: FirecrackerGhAwRuntimeOptions;
 }
 
 export interface RuntimeOptions {


### PR DESCRIPTION
Layer 1 of a two-PR stack. This is the smallest secure, functional staging contract that lets a generated gh-aw agent actually run under the merged Firecracker preview runtime, plus a separately named agent-capable rootfs for CI smokes. **Please do not merge** until the layer-2 smoke PR is up.

## Why

Generated gh-aw agents cannot run under the Firecracker runtime today, for two independent reasons:

1. Workspace staging snapshots only `GITHUB_WORKSPACE`, so the compiler assets under `RUNNER_TEMP/gh-aw` and `/tmp/gh-aw` never reach the guest.
2. `guest/firecracker/build-test-artifacts.sh` produces a 128 MiB static BusyBox + supervisor rootfs with no Bash and no Node, so there is nothing to execute those assets with.

Both gaps have to close before repository-controlled npm tests and mutable external Go fixtures can be moved off the host — the two constraints security review flagged for layer 2.

## Contract, not a mount

`src/firecracker/runtime-validation.ts` still rejects arbitrary `volumeMounts`, and nothing here relaxes that. The new surface is a **fixed source contract**: callers enable named sources, never paths. There is deliberately no general `--mount`, and no way to reinterpret one.

Sources are rooted only in canonical `GITHUB_WORKSPACE` and canonical `RUNNER_TEMP/gh-aw`, plus the narrowly justified compiler output path `/tmp/gh-aw`.

```
--firecracker-gh-aw-runtime
--firecracker-gh-aw-runner-temp / --firecracker-gh-aw-compiler-tmp
--firecracker-gh-aw-max-file-bytes / --max-total-bytes / --max-files
--firecracker-safe-outputs-dir
--firecracker-safe-outputs-max-file-bytes / --max-total-bytes / --max-files
```

with an equivalent `firecracker.ghAwRuntime` config block and JSON-schema coverage. Subordinate flags supplied without their enabler are rejected rather than silently ignored. Full reference in `docs/firecracker-integration.md` Part 17.

## Storage topology

Runtime assets ride a **separate read-only block device**, so `/workspace` remains the only writable, copy-back filesystem. Safe outputs use a **dedicated bounded exchange device** drained only after the VM is confirmed stopped, so a live guest can never race extraction. Device letters are computed host-side from drive order, and each device carries a marker file the guest supervisor checks so a mis-ordered attach fails closed instead of mounting the wrong image.

## Bounded copier

Every staged and returned byte funnels through one copier in `src/firecracker/bounded-copy.ts`. It walks **pinned directory descriptors** rather than re-resolving paths, because `O_NOFOLLOW` only protects the final component — without pinning, swapping an intermediate directory for a symlink mid-walk would redirect the copy at arbitrary host files. Destination roots are proved exclusively created and privately owned for the same reason, so a pre-existing shared safe-output root cannot be substituted after `mkdir`.

Enforced fail-closed: per-file / total-byte / file-count caps, path traversal, absolute and overlapping destinations, symlink escape, magic links, special files, setuid/setgid, duplicate destinations, hardlinks (`nlink > 1`, deliberately strict), and changed-file races. A cap breach mid-copy publishes nothing and retains the exchange image so results stay recoverable.

## Credentials

Real provider, GitHub, OIDC and Docker credentials and credential stores are never staged. The API proxy is preserved and guests continue to receive only synthetic proxy auth. Network restrictions are untouched.

## Rootfs

`guest/firecracker/build-agent-rootfs.sh` is a **separately named builder producing a separately named artifact** (`firecracker-agent-x86_64`); `build-test-artifacts.sh` is byte-identical to `main` and its guarantees are unchanged.

Includes `/bin/bash`, CA certificates, git/curl/coreutils/ip, Node 22.22.0 and the supervisor. Base image digest, package snapshot date, Node tarball SHA256 and CA bundle are all pinned — no `latest`, no unverified assets — and the build emits an SBOM, manifest and `SHA256SUMS`. Generated Copilot/Claude/Codex/MCP tools are staged rather than baked in, but `verify-agent-rootfs.sh` proves interpreter and shared-library closure for every required executable, so "staged" never means "unresolvable at runtime".

The verifier reads modes from the **image inode table** via `debugfs ls -l -p`, because `debugfs rdump` silently drops setuid/setgid bits and skips special files — an image-level check based on walking the dump would be vacuous.

## Reviews

Both a security-review specialist pass and a rubber-duck review ran against this branch. Every finding is fixed here, each with a regression test.

Security review:

| | Finding | Fix |
|---|---|---|
| HIGH | Intermediate-directory symlink swap could redirect the staging walk | fd-pinned traversal |
| HIGH | Shared safe-output root allowed post-`mkdir` destination substitution | private-root + exclusive-creation assertions |
| LOW | Image setuid check could never fire under `rdump` | inode-table enumeration |

Rubber-duck review found four independent reasons the rootfs build would have failed on its first CI run, none of which the string-matching contract tests caught:

- HTTPS apt index against a base image with no `ca-certificates` — now HTTP with mandatory OpenPGP verification, which is the stronger guarantee anyway
- `../../opt/node/...` from `/usr/local/bin` resolves to `/usr/opt`, so every Node/npm/npx link dangled
- the verifier's cleanup trap ended in a false test, and under `set -e` that becomes the exit status, so successful tree verification failed and aborted the builder
- root + `umask 077` left artifacts unreadable to the unprivileged CI steps that checksum, attest and upload them

Plus: guest shutdown returned on the first unmount failure (could leave the exchange mounted and skip power-off entirely), cleanup dropped resource references even when cleanup threw, and four documentation claims did not match the implementation.

A second round of review raised four more blocking issues, all fixed here:

**`debugfs` exits 0 when its `-R` subcommand does nothing.** Confirmed empirically in a container: a missing `rdump` destination, a missing `rdump` source, and a `write` whose source cannot be opened all exit 0 while printing a diagnostic. Only an unknown subcommand *name* exits non-zero. That mattered a great deal, because a silently failed `rdump` produces an empty extraction directory and `applyWorkspaceUpdateAtomically` then runs `rsync -a --delete` from it — a silent tool failure could have deleted the user's workspace.

The fix treats debugfs *output*, not its exit status, as the result:

- silent subcommands may print only the version banner and `Allocated inode: N`; any other line fails the run and names every diagnostic emitted
- a successful `rdump /` always materialises the `lost+found` that `mke2fs` creates, so its absence now fails instead of being read as "the guest produced nothing" (the exchange device additionally requires its AWF-written marker)
- an empty extraction against a non-empty staged manifest aborts copy-back and preserves the image
- the embedded guest supervisor is dumped back out of the rootfs image, re-hashed against the expected SHA-256, and its mode confirmed — a `write` or `sif` that silently did nothing now fails before the VM boots

**The recovery image was written inside the guest-controlled workspace.** `<workspace>/.awf-firecracker-recovery/` is content the guest can write, so the guest could pre-place a symlink there and redirect a root-owned `copyFile`. It also meant the one recoverable copy of a failed copy-back lived in the tree the failure was about. It now defaults to `$TMPDIR/awf-firecracker-recovery` and AWF refuses any recovery directory nested inside the workspace or the run directory.

**`/workspace` is now mounted `MS_NOSUID | MS_NODEV`** — `MS_NOEXEC` is deliberately not set, because builds and tests legitimately execute binaries from the workspace.

**The agent rootfs must be glibc-based.** gh-aw engines ship prebuilt glibc binaries, so a musl base would fail at agent run time rather than build time. The verifier now requires a glibc loader and `libc.so.6`, rejects `ld-musl-*`/`libc.musl-*`, and confirms the pinned Node build's ELF interpreter is the glibc loader. It also fails if host runner state (`opt/hostedtoolcache`, `opt/actions-runner`, `home/runner`) was baked in, and the builder never reads `RUNNER_TOOL_CACHE`.

`docs/firecracker-integration.md` now carries a guest writable-state audit: with the read-only runtime device in place, `/workspace` is the only writable filesystem whose contents reach the host, and `/awf/exchange` (bounded, `noexec`) is the only other writable device. Rootfs writes are permitted but discarded — nothing on `vda` is copied back.

## Validation

- `npm test` — 301 suites / 4825 tests pass
- `tsc --noEmit`, `tsc --noUnusedLocals --noUnusedParameters`, `npm run build` clean
- `gofmt` / `go vet` / `go build` clean; Go suite executed **on Linux in a container**, so the `//go:build linux` supervisor tests genuinely ran rather than being skipped
- `bash -n` clean on both new scripts; the awk mode parser was exercised against synthetic `debugfs` output covering setuid, setgid, char device, FIFO and sticky `/tmp`
- New coverage: bounded copier (27), runtime assets (28), exchange image (18), rootfs contract (18), debugfs verification (11), recovery-image placement (4), plus copy-back regression tests that assert `rsync` is never invoked when an extraction is unverified, and staging/failure-mode cases in the manager, runtime-validation, build-config and runtime-backend suites

## Known limitations

`build-agent-rootfs.sh` needs Linux x86_64 + root + Docker and cannot execute end-to-end on this macOS host, so it is proven here by `bash -n`, the contract tests, and the new `build-agent-rootfs` CI job. Expect the first CI run to be the real proof. ESLint could not run locally (registry unreachable); `tsc --noUnusedLocals --noUnusedParameters` was used as a proxy and CI will run the real linter.

