### PR TITLE
Extract VMM-neutral microVM foundation from src/firecracker (stack layer 1)

### DIFF
--- a/guest/firecracker-supervisor/protocol.go
+++ b/guest/firecracker-supervisor/protocol.go
@@ -1,5 +1,14 @@
 package main
 
+// This file implements the guest side of the AWF framed guest-supervisor
+// protocol. It is intentionally VMM-neutral: the length-prefixed JSON
+// framing and frame types here mirror src/microvm/guest-protocol.ts on the
+// host side, and this binary (despite its package's historical
+// "firecracker-supervisor" name/path) does not depend on any
+// Firecracker-specific transport. A future VMM backend can reuse this
+// supervisor as-is, addressed through the same vsock/UDS compatibility
+// boundary, without protocol changes.
+
 import (
 	"bytes"
 	"encoding/base64"

--- a/src/firecracker-runtime-backend.test.ts
+++ b/src/firecracker-runtime-backend.test.ts
@@ -9,7 +9,7 @@ import {
   type FirecrackerRuntimeBackendDependencies,
 } from './firecracker-runtime-backend';
 import { assertFirecrackerSelection } from './firecracker/runtime-validation';
-import type { FirecrackerInfrastructureSnapshot } from './firecracker/infrastructure';
+import type { MicrovmInfrastructureSnapshot } from './microvm/infrastructure';
 
 const digest = 'a'.repeat(64);
 
@@ -56,7 +56,7 @@ function config(overrides: Partial<WrapperConfig> = {}): WrapperConfig {
   } as WrapperConfig;
 }
 
-function infrastructure(): FirecrackerInfrastructureSnapshot {
+function infrastructure(): MicrovmInfrastructureSnapshot {
   return {
     networkId: 'a'.repeat(64),
     bridgeName: 'br-aaaaaaaaaaaa',

--- a/src/firecracker-runtime-backend.ts
+++ b/src/firecracker-runtime-backend.ts
@@ -7,16 +7,16 @@ import {
   SQUID_IP,
 } from './config/network-policy';
 import {
-  resolveFirecrackerInfrastructure,
-  type FirecrackerInfrastructureSnapshot,
-} from './firecracker/infrastructure';
+  resolveMicrovmInfrastructure,
+  type MicrovmInfrastructureSnapshot,
+} from './microvm/infrastructure';
+import type {
+  GuestExecutionRequest,
+  GuestExecutionResult,
+} from './microvm/vsock-client';
 import type { FirecrackerPreflightResult } from './firecracker/preflight';
 import { FirecrackerManager } from './firecracker/manager';
 import { runFirecrackerPreflight } from './firecracker/preflight';
-import type {
-  FirecrackerGuestExecutionRequest,
-  FirecrackerGuestExecutionResult,
-} from './firecracker/vsock-client';
 import { getRealUserHome, getSafeHostGid, getSafeHostUid } from './host-identity';
 import { logger } from './logger';
 import { buildAgentEnvironment } from './services/agent-service';
@@ -49,7 +49,7 @@ interface FirecrackerManagerAdapter {
   readonly networkNamespace?: string;
   start(): Promise<unknown>;
   startInstance(): Promise<void>;
-  execute(request: FirecrackerGuestExecutionRequest): Promise<FirecrackerGuestExecutionResult>;
+  execute(request: GuestExecutionRequest): Promise<GuestExecutionResult>;
   cancel(reason?: string, requestId?: string): Promise<void>;
   writeStdin(data: Buffer, requestId?: string): Promise<void>;
   endStdin(requestId?: string): Promise<void>;
@@ -60,11 +60,11 @@ interface FirecrackerManagerAdapter {
 export interface FirecrackerRuntimeBackendDependencies {
   startInfrastructure: WorkflowDependencies['startContainers'];
   preflight(config: FirecrackerOptions): Promise<FirecrackerPreflightResult>;
-  resolveInfrastructure(enableApiProxy: boolean, ipPath?: string): Promise<FirecrackerInfrastructureSnapshot>;
+  resolveInfrastructure(enableApiProxy: boolean, ipPath?: string): Promise<MicrovmInfrastructureSnapshot>;
   createManager(
     config: FirecrackerOptions,
     workDir: string,
-    infrastructure: FirecrackerInfrastructureSnapshot,
+    infrastructure: MicrovmInfrastructureSnapshot,
     workspacePath: string,
     homePath: string,
     identity: { uid: number; gid: number },
@@ -85,7 +85,7 @@ function defaultDependencies(
     startInfrastructure,
     preflight: runFirecrackerPreflight,
     resolveInfrastructure: (enableApiProxy, ipPath) =>
-      resolveFirecrackerInfrastructure(enableApiProxy, undefined, ipPath),
+      resolveMicrovmInfrastructure(enableApiProxy, undefined, ipPath),
     createManager: (config, workDir, infrastructure, workspacePath, homePath, identity) =>
       new FirecrackerManager(
         config,
@@ -127,7 +127,7 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
   private manager: FirecrackerManagerAdapter | undefined;
   private environment: Record<string, string> | undefined;
   private activeExecution:
-    | { requestId: string; promise: Promise<FirecrackerGuestExecutionResult> }
+    | { requestId: string; promise: Promise<GuestExecutionResult> }
     | undefined;
   private stopped = false;
   private stopping: Promise<void> | undefined;
@@ -400,7 +400,7 @@ export class FirecrackerRuntimeBackend implements ExternalAgentRuntimeBackend {
 
 export function buildFirecrackerGuestEnvironment(
   config: WrapperConfig,
-  infrastructure: Pick<FirecrackerInfrastructureSnapshot, 'squidIp' | 'apiProxyIp'>,
+  infrastructure: Pick<MicrovmInfrastructureSnapshot, 'squidIp' | 'apiProxyIp'>,
   guestIp = '100.64.0.2',
 ): Record<string, string> {
   const networkConfig = {

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -1,5 +1,11 @@
 import type { ExecaChildProcess } from 'execa';
 import { PassThrough } from 'stream';
+import type {
+  MicrovmNetworkLifecycle,
+  MicrovmNetworkPlan,
+} from '../microvm/network';
+import type { MicrovmVsockClient } from '../microvm/vsock-client';
+import type { MicrovmWorkspaceImage } from '../microvm/workspace';
 import type { FirecrackerOptions } from '../types/runtime-options';
 import type { FirecrackerApiClient } from './api-client';
 import {
@@ -10,12 +16,6 @@ import {
   type FirecrackerManagerDependencies,
   type FirecrackerManagerNetworkConfig,
 } from './manager';
-import type {
-  FirecrackerNetworkLifecycle,
-  FirecrackerNetworkPlan,
-} from './network';
-import type { FirecrackerVsockClient } from './vsock-client';
-import type { FirecrackerWorkspaceImage } from './workspace-image';
 import type { FirecrackerHostToolPaths } from './preflight';
 
 const hostTools: FirecrackerHostToolPaths = {
@@ -67,7 +67,7 @@ function networkConfig(
   };
 }
 
-function networkLifecycle(plan: FirecrackerNetworkPlan): FirecrackerNetworkLifecycle {
+function networkLifecycle(plan: MicrovmNetworkPlan): MicrovmNetworkLifecycle {
   return {
     plan,
     setup: jest.fn().mockResolvedValue(plan),
@@ -130,7 +130,7 @@ describe('FirecrackerManager', () => {
     await expect(child).resolves.toMatchObject({ exitCode: 0 });
     await expect(defaults.sleep(0)).resolves.toBeUndefined();
     expect(defaults.createClient('/tmp/firecracker.socket', 100)).toBeDefined();
-    expect(defaults.createNetwork({} as FirecrackerNetworkPlan, hostTools)).toBeDefined();
+    expect(defaults.createNetwork({} as MicrovmNetworkPlan, hostTools)).toBeDefined();
     expect(defaults.createWorkspaceImage({
       runId: 'adapter-test',
       workDir: '/tmp/awf',
@@ -179,17 +179,17 @@ describe('FirecrackerManager', () => {
       '/tmp/awf',
       '/opt/firecracker',
       '../escape',
-    )).toThrow(/Unsafe Firecracker run id/);
+    )).toThrow(/Unsafe microVM run id/);
     expect(() => createFirecrackerRunPaths(
       '/tmp/awf',
       '/opt/firecracker',
       'run_1',
-    )).toThrow(/Unsafe Firecracker run id/);
+    )).toThrow(/Unsafe microVM run id/);
     expect(() => createFirecrackerRunPaths(
       '/tmp/awf',
       '/opt/firecracker',
       `run-${'a'.repeat(61)}`,
-    )).toThrow(/Unsafe Firecracker run id/);
+    )).toThrow(/Unsafe microVM run id/);
   });
 
   it('launches jailer and configures machine, kernel, and root drive', async () => {
@@ -237,13 +237,13 @@ describe('FirecrackerManager', () => {
     expect(deps.createNetwork).toHaveBeenCalledWith(
       expect.objectContaining({
         infrastructureBridge: 'awfbr0',
-        jailerUid: 1000,
-        jailerGid: 1000,
+        tapOwnerUid: 1000,
+        tapOwnerGid: 1000,
       }),
       hostTools,
     );
     const lifecycle = (deps.createNetwork as jest.Mock).mock.results[0]
-      .value as FirecrackerNetworkLifecycle;
+      .value as MicrovmNetworkLifecycle;
     expect(lifecycle.setup).toHaveBeenCalledTimes(1);
   });
 
@@ -273,7 +273,7 @@ describe('FirecrackerManager', () => {
       { recursive: true, force: true },
     );
     const lifecycle = (deps.createNetwork as jest.Mock).mock.results[0]
-      .value as FirecrackerNetworkLifecycle;
+      .value as MicrovmNetworkLifecycle;
     expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
   });
 
@@ -355,7 +355,7 @@ describe('FirecrackerManager', () => {
           expect(child.exitCode).toBe(0);
         }),
         cleanup: jest.fn().mockResolvedValue(undefined),
-      } as unknown as FirecrackerWorkspaceImage;
+      } as unknown as MicrovmWorkspaceImage;
       const guestClient = {
         connect: jest.fn().mockResolvedValue({
           version: 1,
@@ -371,7 +371,7 @@ describe('FirecrackerManager', () => {
         }),
         shutdown: jest.fn().mockResolvedValue(undefined),
         destroy: jest.fn(),
-      } as unknown as FirecrackerVsockClient;
+      } as unknown as MicrovmVsockClient;
       const deps = dependencies({
         launch: jest.fn().mockReturnValue(child),
         createWorkspaceImage: jest.fn().mockReturnValue(workspace),
@@ -451,7 +451,7 @@ describe('FirecrackerManager', () => {
         resize: jest.fn().mockResolvedValue(undefined),
         shutdown: jest.fn().mockResolvedValue(undefined),
         destroy: jest.fn(),
-      } as unknown as FirecrackerVsockClient;
+      } as unknown as MicrovmVsockClient;
       const workspace = {
         prepare: jest.fn().mockResolvedValue({
           workspaceImagePath: '/tmp/workspace.ext4',
@@ -461,7 +461,7 @@ describe('FirecrackerManager', () => {
         }),
         extractAfterStop: jest.fn().mockResolvedValue(undefined),
         cleanup: jest.fn().mockResolvedValue(undefined),
-      } as unknown as FirecrackerWorkspaceImage;
+      } as unknown as MicrovmWorkspaceImage;
       const deps = dependencies({
         createVsockClient: jest.fn().mockReturnValue(guestClient),
         createWorkspaceImage: jest.fn().mockReturnValue(workspace),
@@ -504,12 +504,12 @@ describe('FirecrackerManager', () => {
         }),
         extractAfterStop: jest.fn().mockResolvedValue(undefined),
         cleanup: jest.fn().mockResolvedValue(undefined),
-      } as unknown as FirecrackerWorkspaceImage;
+      } as unknown as MicrovmWorkspaceImage;
       const guestClient = {
         connect: jest.fn().mockResolvedValue(undefined),
         shutdown: jest.fn().mockResolvedValue(undefined),
         destroy: jest.fn(),
-      } as unknown as FirecrackerVsockClient;
+      } as unknown as MicrovmVsockClient;
       const deps = dependencies({
         launch: jest.fn().mockReturnValue(child),
         createWorkspaceImage: jest.fn().mockReturnValue(workspace),
@@ -534,7 +534,7 @@ describe('FirecrackerManager', () => {
       await manager.stop({ preserve: true });
 
       const lifecycle = (deps.createNetwork as jest.Mock).mock.results[0]
-        .value as FirecrackerNetworkLifecycle;
+        .value as MicrovmNetworkLifecycle;
       expect(workspace.extractAfterStop).toHaveBeenCalledTimes(1);
       expect(lifecycle.cleanup).not.toHaveBeenCalled();
       expect(workspace.cleanup).not.toHaveBeenCalled();
@@ -559,8 +559,8 @@ describe('FirecrackerManager', () => {
         guestGatewayIp: '100.64.0.1',
         guestPrefixLength: 30,
         guestMac: '02:00:00:00:00:01',
-        jailerUid: 1000,
-        jailerGid: 1000,
+        tapOwnerUid: 1000,
+        tapOwnerGid: 1000,
         allowedEndpoints: [],
         networkInterface: { iface_id: 'eth0', host_dev_name: 'tap' },
       }, {
@@ -595,12 +595,12 @@ describe('FirecrackerManager', () => {
         }),
         extractAfterStop: jest.fn().mockResolvedValue(undefined),
         cleanup: jest.fn().mockResolvedValue(undefined),
-      } as unknown as FirecrackerWorkspaceImage;
+      } as unknown as MicrovmWorkspaceImage;
       const guestClient = {
         connect: jest.fn().mockResolvedValue(undefined),
         shutdown: jest.fn().mockResolvedValue(undefined),
         destroy: jest.fn(),
-      } as unknown as FirecrackerVsockClient;
+      } as unknown as MicrovmVsockClient;
       const deps = dependencies({
         launch: jest.fn().mockReturnValue(child),
         createWorkspaceImage: jest.fn().mockReturnValue(workspace),
@@ -624,7 +624,7 @@ describe('FirecrackerManager', () => {
 
       await expect(manager.stop()).rejects.toThrow(/stopped before workspace\/network removal/);
       const lifecycle = (deps.createNetwork as jest.Mock).mock.results[0]
-        .value as FirecrackerNetworkLifecycle;
+        .value as MicrovmNetworkLifecycle;
       expect(lifecycle.cleanup).not.toHaveBeenCalled();
       expect(workspace.extractAfterStop).not.toHaveBeenCalled();
       expect(deps.rm).not.toHaveBeenCalled();
@@ -646,12 +646,12 @@ describe('FirecrackerManager', () => {
       }),
       extractAfterStop: jest.fn().mockResolvedValue(undefined),
       cleanup: jest.fn().mockResolvedValue(undefined),
-    } as unknown as FirecrackerWorkspaceImage;
+    } as unknown as MicrovmWorkspaceImage;
     const guestClient = {
       connect: jest.fn().mockResolvedValue(undefined),
       shutdown: jest.fn().mockResolvedValue(undefined),
       destroy: jest.fn(),
-    } as unknown as FirecrackerVsockClient;
+    } as unknown as MicrovmVsockClient;
     let sleepCalls = 0;
     const deps = dependencies({
       launch: jest.fn().mockReturnValue(child),
@@ -706,7 +706,7 @@ describe('FirecrackerManager', () => {
     await expect(manager.start()).rejects.toThrow('invalid NIC');
 
     const lifecycle = (deps.createNetwork as jest.Mock).mock.results[0]
-      .value as FirecrackerNetworkLifecycle;
+      .value as MicrovmNetworkLifecycle;
     expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
     expect(deps.rm).toHaveBeenCalled();
   });

--- a/src/firecracker/manager.ts
+++ b/src/firecracker/manager.ts
@@ -7,27 +7,27 @@ import {
   type FirecrackerOptions,
 } from '../types/runtime-options';
 import { getSafeHostGid, getSafeHostUid } from '../host-identity';
-import { FirecrackerApiClient } from './api-client';
 import {
-  FirecrackerLinuxNetworkCommands,
-  FirecrackerNetworkManager,
-  assertSafeFirecrackerRunId,
-  createFirecrackerNetworkPlan,
-  type FirecrackerControlPeer,
-  type FirecrackerNetworkLifecycle,
-  type FirecrackerNetworkPlan,
-} from './network';
+  LinuxNetworkCommands,
+  MicrovmNetworkManager,
+  assertSafeMicrovmRunId,
+  createMicrovmNetworkPlan,
+  type MicrovmControlPeer,
+  type MicrovmNetworkLifecycle,
+  type MicrovmNetworkPlan,
+} from '../microvm/network';
+import {
+  MicrovmVsockClient,
+  type GuestExecutionRequest,
+  type GuestExecutionResult,
+} from '../microvm/vsock-client';
+import {
+  MicrovmWorkspaceImage,
+  type MicrovmWorkspaceImageConfig,
+} from '../microvm/workspace';
+import { FirecrackerApiClient } from './api-client';
 import { runFirecrackerPreflight } from './preflight';
 import type { FirecrackerHostToolPaths } from './preflight';
-import {
-  FirecrackerVsockClient,
-  type FirecrackerGuestExecutionRequest,
-  type FirecrackerGuestExecutionResult,
-} from './vsock-client';
-import {
-  FirecrackerWorkspaceImage,
-  type FirecrackerWorkspaceImageConfig,
-} from './workspace-image';
 
 const API_SOCKET_NAME = 'firecracker.socket';
 const VSOCK_SOCKET_NAME = 'awf-vsock.socket';
@@ -76,16 +76,16 @@ export interface FirecrackerManagerDependencies {
   rm(directory: string, options: { recursive: true; force: true }): Promise<void>;
   sleep(milliseconds: number): Promise<void>;
   createClient(socketPath: string, timeoutMs: number): FirecrackerApiClient;
-  createNetwork(plan: FirecrackerNetworkPlan, tools: FirecrackerHostToolPaths): FirecrackerNetworkLifecycle;
-  createWorkspaceImage(config: FirecrackerWorkspaceImageConfig, tools: FirecrackerHostToolPaths): FirecrackerWorkspaceImage;
-  createVsockClient(socketPath: string, guestPort: number, timeoutMs: number): FirecrackerVsockClient;
+  createNetwork(plan: MicrovmNetworkPlan, tools: FirecrackerHostToolPaths): MicrovmNetworkLifecycle;
+  createWorkspaceImage(config: MicrovmWorkspaceImageConfig, tools: FirecrackerHostToolPaths): MicrovmWorkspaceImage;
+  createVsockClient(socketPath: string, guestPort: number, timeoutMs: number): MicrovmVsockClient;
   resolveIdentity(): { uid: number; gid: number };
 }
 
 export interface FirecrackerManagerNetworkConfig {
   infrastructureBridge: string;
   enableApiProxy: boolean;
-  controlPeer?: FirecrackerControlPeer;
+  controlPeer?: MicrovmControlPeer;
 }
 
 export interface FirecrackerManagerGuestConfig {
@@ -126,12 +126,12 @@ const defaultDependencies: FirecrackerManagerDependencies = {
   rm: fs.rm,
   sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   createClient: (socketPath, timeoutMs) => new FirecrackerApiClient({ socketPath, timeoutMs }),
-  createNetwork: (plan, tools) => new FirecrackerNetworkManager(
+  createNetwork: (plan, tools) => new MicrovmNetworkManager(
     plan,
-    new FirecrackerLinuxNetworkCommands(undefined, tools),
+    new LinuxNetworkCommands(undefined, tools),
   ),
-  createWorkspaceImage: (config, tools) => new FirecrackerWorkspaceImage(config, undefined, tools),
-  createVsockClient: (socketPath, guestPort, timeoutMs) => new FirecrackerVsockClient({
+  createWorkspaceImage: (config, tools) => new MicrovmWorkspaceImage(config, undefined, tools),
+  createVsockClient: (socketPath, guestPort, timeoutMs) => new MicrovmVsockClient({
     socketPath,
     guestPort,
     connectTimeoutMs: timeoutMs,
@@ -180,7 +180,7 @@ export function createFirecrackerRunPaths(
   firecrackerBinary: string,
   runId = `awf-${process.pid}-${randomBytes(6).toString('hex')}`,
 ): FirecrackerRunPaths {
-  assertSafeFirecrackerRunId(runId);
+  assertSafeMicrovmRunId(runId);
   const chrootBaseDir = path.join(workDir, 'firecracker-jailer');
   const jailRoot = path.join(
     chrootBaseDir,
@@ -209,10 +209,10 @@ export class FirecrackerManager {
   readonly paths: FirecrackerRunPaths;
   private process: ExecaChildProcess<string> | undefined;
   private client: FirecrackerApiClient | undefined;
-  private network: FirecrackerNetworkLifecycle | undefined;
-  private workspace: FirecrackerWorkspaceImage | undefined;
-  private guestClient: FirecrackerVsockClient | undefined;
-  private networkPlan: FirecrackerNetworkPlan | undefined;
+  private network: MicrovmNetworkLifecycle | undefined;
+  private workspace: MicrovmWorkspaceImage | undefined;
+  private guestClient: MicrovmVsockClient | undefined;
+  private networkPlan: MicrovmNetworkPlan | undefined;
   private instanceStarted = false;
   private readonly stdoutCapture = new BoundedOutputCapture(FIRECRACKER_CAPTURE_LIMIT_BYTES);
   private readonly stderrCapture = new BoundedOutputCapture(FIRECRACKER_CAPTURE_LIMIT_BYTES);
@@ -247,10 +247,10 @@ export class FirecrackerManager {
     try {
       const artifacts = await this.dependencies.preflight(this.config);
       const identity = this.guestConfig?.identity ?? this.dependencies.resolveIdentity();
-      const networkPlan = createFirecrackerNetworkPlan(this.paths.runId, {
+      const networkPlan = createMicrovmNetworkPlan(this.paths.runId, {
         ...this.networkConfig,
-        jailerUid: identity.uid,
-        jailerGid: identity.gid,
+        tapOwnerUid: identity.uid,
+        tapOwnerGid: identity.gid,
       });
       this.networkPlan = networkPlan;
       this.network = this.dependencies.createNetwork(networkPlan, artifacts.tools);
@@ -389,8 +389,8 @@ export class FirecrackerManager {
   }
 
   async execute(
-    request: FirecrackerGuestExecutionRequest,
-  ): Promise<FirecrackerGuestExecutionResult> {
+    request: GuestExecutionRequest,
+  ): Promise<GuestExecutionResult> {
     if (!this.guestClient) {
       throw new Error('Firecracker guest supervisor is not ready');
     }
@@ -653,7 +653,7 @@ export class FirecrackerManager {
 }
 
 export function buildSupervisorBootArgs(
-  networkPlan: FirecrackerNetworkPlan,
+  networkPlan: MicrovmNetworkPlan,
   guestConfig: FirecrackerManagerGuestConfig,
 ): string {
   const port = guestConfig.vsockPort ?? FIRECRACKER_GUEST_VSOCK_PORT;

--- a/src/microvm/guest-protocol.test.ts
+++ b/src/microvm/guest-protocol.test.ts
@@ -1,25 +1,25 @@
 import {
-  FIRECRACKER_GUEST_PROTOCOL_VERSION,
-  FIRECRACKER_MAX_FRAME_BYTES,
-  FIRECRACKER_MAX_STREAM_CHUNK_BYTES,
-  FirecrackerFrameDecoder,
-  FirecrackerProtocolError,
-  encodeFirecrackerFrame,
-  validateFirecrackerFrame,
-  type FirecrackerGuestFrame,
-} from './vsock-protocol';
+  GUEST_PROTOCOL_VERSION,
+  GUEST_MAX_FRAME_BYTES,
+  GUEST_MAX_STREAM_CHUNK_BYTES,
+  GuestFrameDecoder,
+  GuestProtocolError,
+  encodeGuestFrame,
+  validateGuestFrame,
+  type GuestProtocolFrame,
+} from './guest-protocol';
 
-const ready: FirecrackerGuestFrame = {
-  version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+const ready: GuestProtocolFrame = {
+  version: GUEST_PROTOCOL_VERSION,
   type: 'ready',
   requestId: 'control',
   capabilities: { stdin: true, tty: false, resize: false },
 };
 
-describe('Firecracker guest vsock protocol', () => {
+describe('AWF guest protocol framing', () => {
   it('frames and incrementally decodes typed messages', () => {
-    const encoded = encodeFirecrackerFrame(ready);
-    const decoder = new FirecrackerFrameDecoder();
+    const encoded = encodeGuestFrame(ready);
+    const decoder = new GuestFrameDecoder();
     expect(decoder.push(encoded.subarray(0, 2))).toEqual([]);
     expect(decoder.push(encoded.subarray(2, 7))).toEqual([]);
     expect(decoder.push(encoded.subarray(7))).toEqual([ready]);
@@ -27,36 +27,36 @@ describe('Firecracker guest vsock protocol', () => {
   });
 
   it('decodes multiple frames and rejects incomplete terminal data', () => {
-    const decoder = new FirecrackerFrameDecoder();
+    const decoder = new GuestFrameDecoder();
     expect(decoder.push(Buffer.concat([
-      encodeFirecrackerFrame(ready),
-      encodeFirecrackerFrame({ ...ready, requestId: 'second' }),
+      encodeGuestFrame(ready),
+      encodeGuestFrame({ ...ready, requestId: 'second' }),
     ]))).toHaveLength(2);
     decoder.push(Buffer.from([0, 0]));
     expect(() => decoder.finish()).toThrow(/incomplete frame/);
   });
 
   it('rejects oversized, empty, malformed, and unknown frames', () => {
-    const decoder = new FirecrackerFrameDecoder();
+    const decoder = new GuestFrameDecoder();
     const oversized = Buffer.alloc(4);
-    oversized.writeUInt32BE(FIRECRACKER_MAX_FRAME_BYTES + 1);
+    oversized.writeUInt32BE(GUEST_MAX_FRAME_BYTES + 1);
     expect(() => decoder.push(oversized)).toThrow(/Invalid.*length/);
 
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       ...ready,
       version: 2,
-    })).toThrow(new FirecrackerProtocolError(
+    })).toThrow(new GuestProtocolError(
       'protocol_version_mismatch',
-      'Unsupported Firecracker guest protocol version 2; expected 1',
+      'Unsupported guest protocol version 2; expected 1',
     ));
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       ...ready,
       unexpected: true,
     })).toThrow(/Unexpected frame property/);
   });
 
   it('validates execute schemas, identifiers, and bounded environment data', () => {
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       version: 1,
       type: 'execute',
       requestId: '../escape',
@@ -67,7 +67,7 @@ describe('Firecracker guest vsock protocol', () => {
       gid: 1000,
       tty: false,
     })).toThrow(/requestId/);
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       version: 1,
       type: 'execute',
       requestId: 'run',
@@ -78,7 +78,7 @@ describe('Firecracker guest vsock protocol', () => {
       gid: 1000,
       tty: false,
     })).toThrow(/argv/);
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       version: 1,
       type: 'execute',
       requestId: 'run',
@@ -92,13 +92,13 @@ describe('Firecracker guest vsock protocol', () => {
   });
 
   it('enforces decoded stream chunk limits and exact result semantics', () => {
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       version: 1,
       type: 'stdout',
       requestId: 'run',
-      data: Buffer.alloc(FIRECRACKER_MAX_STREAM_CHUNK_BYTES + 1).toString('base64'),
+      data: Buffer.alloc(GUEST_MAX_STREAM_CHUNK_BYTES + 1).toString('base64'),
     })).toThrow(/decoded stream data exceeds/);
-    expect(() => validateFirecrackerFrame({
+    expect(() => validateGuestFrame({
       version: 1,
       type: 'result',
       requestId: 'run',
@@ -109,7 +109,7 @@ describe('Firecracker guest vsock protocol', () => {
   });
 
   it('validates every host and guest frame schema boundary', () => {
-    const validFrames: FirecrackerGuestFrame[] = [
+    const validFrames: GuestProtocolFrame[] = [
       {
         version: 1,
         type: 'execute',
@@ -151,7 +151,7 @@ describe('Firecracker guest vsock protocol', () => {
       { version: 1, type: 'shutting_down', requestId: 'shutdown' },
     ];
     for (const frame of validFrames) {
-      expect(() => validateFirecrackerFrame(frame)).not.toThrow();
+      expect(() => validateGuestFrame(frame)).not.toThrow();
     }
 
     const invalidFrames: unknown[] = [
@@ -206,7 +206,7 @@ describe('Firecracker guest vsock protocol', () => {
       { version: 1, type: 'unknown', requestId: 'run' },
     ];
     for (const frame of invalidFrames) {
-      expect(() => validateFirecrackerFrame(frame)).toThrow(FirecrackerProtocolError);
+      expect(() => validateGuestFrame(frame)).toThrow(GuestProtocolError);
     }
   });
 
@@ -215,7 +215,7 @@ describe('Firecracker guest vsock protocol', () => {
     const malformedWire = Buffer.alloc(4 + malformed.length);
     malformedWire.writeUInt32BE(malformed.length, 0);
     malformed.copy(malformedWire, 4);
-    expect(() => new FirecrackerFrameDecoder().push(malformedWire))
+    expect(() => new GuestFrameDecoder().push(malformedWire))
       .toThrow(/invalid JSON/);
 
     const oversizedFrame = {
@@ -233,7 +233,7 @@ describe('Firecracker guest vsock protocol', () => {
       uid: 1000,
       gid: 1000,
       tty: false,
-    } as FirecrackerGuestFrame;
-    expect(() => encodeFirecrackerFrame(oversizedFrame)).toThrow(/exceeds/);
+    } as GuestProtocolFrame;
+    expect(() => encodeGuestFrame(oversizedFrame)).toThrow(/exceeds/);
   });
 });

--- a/src/microvm/guest-protocol.ts
+++ b/src/microvm/guest-protocol.ts
@@ -1,11 +1,16 @@
-export const FIRECRACKER_GUEST_PROTOCOL_VERSION = 1 as const;
-export const FIRECRACKER_MAX_FRAME_BYTES = 1024 * 1024;
-export const FIRECRACKER_MAX_STREAM_CHUNK_BYTES = 64 * 1024;
-export const FIRECRACKER_MAX_ENV_ENTRIES = 512;
-export const FIRECRACKER_MAX_ARGV_ENTRIES = 4096;
-export const FIRECRACKER_MAX_STRING_BYTES = 256 * 1024;
+/**
+ * AWF framed guest-supervisor protocol. Transport-independent: the same
+ * length-prefixed JSON framing is used regardless of which VMM backend
+ * (Firecracker today, others later) carries the bytes over vsock/UDS.
+ */
+export const GUEST_PROTOCOL_VERSION = 1 as const;
+export const GUEST_MAX_FRAME_BYTES = 1024 * 1024;
+export const GUEST_MAX_STREAM_CHUNK_BYTES = 64 * 1024;
+export const GUEST_MAX_ENV_ENTRIES = 512;
+export const GUEST_MAX_ARGV_ENTRIES = 4096;
+export const GUEST_MAX_STRING_BYTES = 256 * 1024;
 
-export type FirecrackerGuestErrorCode =
+export type GuestProtocolErrorCode =
   | 'invalid_frame'
   | 'protocol_version_mismatch'
   | 'invalid_request'
@@ -15,12 +20,12 @@ export type FirecrackerGuestErrorCode =
   | 'internal_error';
 
 interface ProtocolFrame {
-  readonly version: typeof FIRECRACKER_GUEST_PROTOCOL_VERSION;
+  readonly version: typeof GUEST_PROTOCOL_VERSION;
   readonly type: string;
   readonly requestId: string;
 }
 
-export interface FirecrackerReadyFrame extends ProtocolFrame {
+export interface GuestReadyFrame extends ProtocolFrame {
   readonly type: 'ready';
   readonly capabilities: {
     readonly stdin: boolean;
@@ -29,7 +34,7 @@ export interface FirecrackerReadyFrame extends ProtocolFrame {
   };
 }
 
-export interface FirecrackerExecuteFrame extends ProtocolFrame {
+export interface GuestExecuteFrame extends ProtocolFrame {
   readonly type: 'execute';
   readonly argv: readonly string[];
   readonly env: Readonly<Record<string, string>>;
@@ -40,74 +45,74 @@ export interface FirecrackerExecuteFrame extends ProtocolFrame {
   readonly timeoutMs?: number;
 }
 
-export interface FirecrackerStreamFrame extends ProtocolFrame {
+export interface GuestStreamFrame extends ProtocolFrame {
   readonly type: 'stdout' | 'stderr';
   readonly data: string;
 }
 
-export interface FirecrackerStdinFrame extends ProtocolFrame {
+export interface GuestStdinFrame extends ProtocolFrame {
   readonly type: 'stdin';
   readonly data?: string;
   readonly eof?: boolean;
 }
 
-export interface FirecrackerResizeFrame extends ProtocolFrame {
+export interface GuestResizeFrame extends ProtocolFrame {
   readonly type: 'resize';
   readonly columns: number;
   readonly rows: number;
 }
 
-export interface FirecrackerCancelFrame extends ProtocolFrame {
+export interface GuestCancelFrame extends ProtocolFrame {
   readonly type: 'cancel';
   readonly reason: string;
 }
 
-export interface FirecrackerResultFrame extends ProtocolFrame {
+export interface GuestResultFrame extends ProtocolFrame {
   readonly type: 'result';
   readonly exitCode: number | null;
   readonly signal: string | null;
   readonly timedOut: boolean;
 }
 
-export interface FirecrackerErrorFrame extends ProtocolFrame {
+export interface GuestErrorFrame extends ProtocolFrame {
   readonly type: 'error';
-  readonly code: FirecrackerGuestErrorCode;
+  readonly code: GuestProtocolErrorCode;
   readonly message: string;
   readonly expectedVersion?: number;
 }
 
-export interface FirecrackerShutdownFrame extends ProtocolFrame {
+export interface GuestShutdownFrame extends ProtocolFrame {
   readonly type: 'shutdown' | 'shutting_down';
 }
 
-export type FirecrackerGuestFrame =
-  | FirecrackerReadyFrame
-  | FirecrackerExecuteFrame
-  | FirecrackerStreamFrame
-  | FirecrackerStdinFrame
-  | FirecrackerResizeFrame
-  | FirecrackerCancelFrame
-  | FirecrackerResultFrame
-  | FirecrackerErrorFrame
-  | FirecrackerShutdownFrame;
+export type GuestProtocolFrame =
+  | GuestReadyFrame
+  | GuestExecuteFrame
+  | GuestStreamFrame
+  | GuestStdinFrame
+  | GuestResizeFrame
+  | GuestCancelFrame
+  | GuestResultFrame
+  | GuestErrorFrame
+  | GuestShutdownFrame;
 
-export class FirecrackerProtocolError extends Error {
+export class GuestProtocolError extends Error {
   constructor(
-    readonly code: FirecrackerGuestErrorCode,
+    readonly code: GuestProtocolErrorCode,
     message: string,
   ) {
     super(message);
-    this.name = 'FirecrackerProtocolError';
+    this.name = 'GuestProtocolError';
   }
 }
 
-export function encodeFirecrackerFrame(frame: FirecrackerGuestFrame): Buffer {
-  validateFirecrackerFrame(frame);
+export function encodeGuestFrame(frame: GuestProtocolFrame): Buffer {
+  validateGuestFrame(frame);
   const payload = Buffer.from(JSON.stringify(frame), 'utf8');
-  if (payload.length > FIRECRACKER_MAX_FRAME_BYTES) {
-    throw new FirecrackerProtocolError(
+  if (payload.length > GUEST_MAX_FRAME_BYTES) {
+    throw new GuestProtocolError(
       'invalid_frame',
-      `Firecracker guest frame exceeds ${FIRECRACKER_MAX_FRAME_BYTES} bytes`,
+      `guest frame exceeds ${GUEST_MAX_FRAME_BYTES} bytes`,
     );
   }
   const header = Buffer.allocUnsafe(4);
@@ -115,25 +120,25 @@ export function encodeFirecrackerFrame(frame: FirecrackerGuestFrame): Buffer {
   return Buffer.concat([header, payload]);
 }
 
-export class FirecrackerFrameDecoder {
+export class GuestFrameDecoder {
   private buffered: Buffer = Buffer.alloc(0);
 
   get pendingBytes(): number {
     return this.buffered.length;
   }
 
-  push(chunk: Buffer): FirecrackerGuestFrame[] {
+  push(chunk: Buffer): GuestProtocolFrame[] {
     if (chunk.length === 0) return [];
     this.buffered = this.buffered.length === 0
       ? chunk
       : Buffer.concat([this.buffered, chunk]);
-    const frames: FirecrackerGuestFrame[] = [];
+    const frames: GuestProtocolFrame[] = [];
     while (this.buffered.length >= 4) {
       const payloadLength = this.buffered.readUInt32BE(0);
-      if (payloadLength === 0 || payloadLength > FIRECRACKER_MAX_FRAME_BYTES) {
-        throw new FirecrackerProtocolError(
+      if (payloadLength === 0 || payloadLength > GUEST_MAX_FRAME_BYTES) {
+        throw new GuestProtocolError(
           'invalid_frame',
-          `Invalid Firecracker guest frame length: ${payloadLength}`,
+          `Invalid guest frame length: ${payloadLength}`,
         );
       }
       if (this.buffered.length < payloadLength + 4) break;
@@ -143,12 +148,12 @@ export class FirecrackerFrameDecoder {
       try {
         decoded = JSON.parse(payload.toString('utf8'));
       } catch (error) {
-        throw new FirecrackerProtocolError(
+        throw new GuestProtocolError(
           'invalid_frame',
-          `Firecracker guest frame contains invalid JSON: ${formatError(error)}`,
+          `guest frame contains invalid JSON: ${formatError(error)}`,
         );
       }
-      validateFirecrackerFrame(decoded);
+      validateGuestFrame(decoded);
       frames.push(decoded);
     }
     return frames;
@@ -156,22 +161,22 @@ export class FirecrackerFrameDecoder {
 
   finish(): void {
     if (this.buffered.length !== 0) {
-      throw new FirecrackerProtocolError(
+      throw new GuestProtocolError(
         'invalid_frame',
-        `Firecracker guest connection ended with ${this.buffered.length} incomplete frame bytes`,
+        `guest connection ended with ${this.buffered.length} incomplete frame bytes`,
       );
     }
   }
 }
 
-export function validateFirecrackerFrame(value: unknown): asserts value is FirecrackerGuestFrame {
+export function validateGuestFrame(value: unknown): asserts value is GuestProtocolFrame {
   const frame = asRecord(value, 'frame');
   const version = frame.version;
-  if (version !== FIRECRACKER_GUEST_PROTOCOL_VERSION) {
-    throw new FirecrackerProtocolError(
+  if (version !== GUEST_PROTOCOL_VERSION) {
+    throw new GuestProtocolError(
       'protocol_version_mismatch',
-      `Unsupported Firecracker guest protocol version ${String(version)}; ` +
-      `expected ${FIRECRACKER_GUEST_PROTOCOL_VERSION}`,
+      `Unsupported guest protocol version ${String(version)}; ` +
+      `expected ${GUEST_PROTOCOL_VERSION}`,
     );
   }
   const type = requiredString(frame.type, 'type', 64);
@@ -193,23 +198,23 @@ export function validateFirecrackerFrame(value: unknown): asserts value is Firec
       if (
         !Array.isArray(frame.argv) ||
         frame.argv.length === 0 ||
-        frame.argv.length > FIRECRACKER_MAX_ARGV_ENTRIES
+        frame.argv.length > GUEST_MAX_ARGV_ENTRIES
       ) {
-        invalid(`argv must contain 1-${FIRECRACKER_MAX_ARGV_ENTRIES} strings`);
+        invalid(`argv must contain 1-${GUEST_MAX_ARGV_ENTRIES} strings`);
       }
       for (const [index, arg] of frame.argv.entries()) {
-        requiredString(arg, `argv[${index}]`, FIRECRACKER_MAX_STRING_BYTES);
+        requiredString(arg, `argv[${index}]`, GUEST_MAX_STRING_BYTES);
       }
       const env = asRecord(frame.env, 'env');
       const entries = Object.entries(env);
-      if (entries.length > FIRECRACKER_MAX_ENV_ENTRIES) {
-        invalid(`env exceeds ${FIRECRACKER_MAX_ENV_ENTRIES} entries`);
+      if (entries.length > GUEST_MAX_ENV_ENTRIES) {
+        invalid(`env exceeds ${GUEST_MAX_ENV_ENTRIES} entries`);
       }
       for (const [name, envValue] of entries) {
         if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || name.length > 256) {
           invalid(`Invalid environment variable name: ${name}`);
         }
-        requiredString(envValue, `env.${name}`, FIRECRACKER_MAX_STRING_BYTES, true);
+        requiredString(envValue, `env.${name}`, GUEST_MAX_STRING_BYTES, true);
       }
       const cwd = requiredString(frame.cwd, 'cwd', 4096);
       if (!cwd.startsWith('/') || cwd.includes('\0')) invalid('cwd must be an absolute path');
@@ -225,7 +230,7 @@ export function validateFirecrackerFrame(value: unknown): asserts value is Firec
       const data = requiredString(
         frame.data,
         'data',
-        Math.ceil(FIRECRACKER_MAX_STREAM_CHUNK_BYTES * 4 / 3) + 4,
+        Math.ceil(GUEST_MAX_STREAM_CHUNK_BYTES * 4 / 3) + 4,
         true,
       );
       validateBase64Chunk(data);
@@ -240,7 +245,7 @@ export function validateFirecrackerFrame(value: unknown): asserts value is Firec
         validateBase64Chunk(requiredString(
           frame.data,
           'data',
-          Math.ceil(FIRECRACKER_MAX_STREAM_CHUNK_BYTES * 4 / 3) + 4,
+          Math.ceil(GUEST_MAX_STREAM_CHUNK_BYTES * 4 / 3) + 4,
           true,
         ));
       }
@@ -292,7 +297,7 @@ export function validateFirecrackerFrame(value: unknown): asserts value is Firec
       assertKeys(frame, ['version', 'type', 'requestId']);
       return;
     default:
-      invalid(`Unknown Firecracker guest frame type: ${type}`);
+      invalid(`Unknown guest frame type: ${type}`);
   }
 }
 
@@ -300,8 +305,8 @@ function validateBase64Chunk(value: string): void {
   if (value.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
     invalid('stream data must be canonical base64');
   }
-  if (Buffer.byteLength(value, 'base64') > FIRECRACKER_MAX_STREAM_CHUNK_BYTES) {
-    invalid(`decoded stream data exceeds ${FIRECRACKER_MAX_STREAM_CHUNK_BYTES} bytes`);
+  if (Buffer.byteLength(value, 'base64') > GUEST_MAX_STREAM_CHUNK_BYTES) {
+    invalid(`decoded stream data exceeds ${GUEST_MAX_STREAM_CHUNK_BYTES} bytes`);
   }
 }
 
@@ -359,7 +364,7 @@ function boundedInteger(value: unknown, label: string, minimum: number, maximum:
 }
 
 function invalid(message: string): never {
-  throw new FirecrackerProtocolError('invalid_request', message);
+  throw new GuestProtocolError('invalid_request', message);
 }
 
 function formatError(error: unknown): string {

--- a/src/microvm/infrastructure.test.ts
+++ b/src/microvm/infrastructure.test.ts
@@ -1,6 +1,6 @@
 import {
-  resolveFirecrackerInfrastructure,
-  type FirecrackerInfrastructureDependencies,
+  resolveMicrovmInfrastructure,
+  type MicrovmInfrastructureDependencies,
 } from './infrastructure';
 import execa from 'execa';
 
@@ -31,7 +31,7 @@ function networkInspection(
 
 function dependencies(
   inspection: unknown = networkInspection(),
-): jest.Mocked<FirecrackerInfrastructureDependencies> {
+): jest.Mocked<MicrovmInfrastructureDependencies> {
   return {
     inspectNetwork: jest.fn().mockResolvedValue(inspection),
     inspectLink: jest.fn(async (bridgeName: string) => [{
@@ -41,7 +41,7 @@ function dependencies(
   };
 }
 
-describe('Firecracker infrastructure discovery', () => {
+describe('microVM infrastructure discovery', () => {
   beforeEach(() => {
     mockedExeca.mockReset();
   });
@@ -62,7 +62,7 @@ describe('Firecracker infrastructure discovery', () => {
         stderr: '',
       } as never);
 
-    await expect(resolveFirecrackerInfrastructure(true)).resolves.toEqual(
+    await expect(resolveMicrovmInfrastructure(true)).resolves.toEqual(
       expect.objectContaining({ squidIp: '172.30.0.10', apiProxyIp: '172.30.0.30' }),
     );
     expect(mockedExeca).toHaveBeenNthCalledWith(
@@ -85,7 +85,7 @@ describe('Firecracker infrastructure discovery', () => {
       stdout: '',
       stderr: 'network unavailable',
     } as never);
-    await expect(resolveFirecrackerInfrastructure(true))
+    await expect(resolveMicrovmInfrastructure(true))
       .rejects.toThrow(/Could not inspect.*network unavailable/);
 
     mockedExeca
@@ -99,13 +99,13 @@ describe('Firecracker infrastructure discovery', () => {
         stdout: '',
         stderr: 'link unavailable',
       } as never);
-    await expect(resolveFirecrackerInfrastructure(true))
+    await expect(resolveMicrovmInfrastructure(true))
       .rejects.toThrow(/Could not inspect.*bridge.*link unavailable/);
   });
 
   it('derives the Docker bridge from the live network ID and revalidates targets', async () => {
     const deps = dependencies();
-    const resolved = await resolveFirecrackerInfrastructure(true, deps);
+    const resolved = await resolveMicrovmInfrastructure(true, deps);
 
     expect(resolved).toEqual(expect.objectContaining({
       networkId: 'a'.repeat(64),
@@ -121,17 +121,17 @@ describe('Firecracker infrastructure discovery', () => {
   });
 
   it('rejects ambiguous, non-internal, or address-shifted topology', async () => {
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies([networkInspection()[0], networkInspection()[0]]),
     )).rejects.toThrow(/exactly one Docker network inspection/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({ Internal: false })),
-    )).rejects.toThrow(/Unexpected Firecracker infrastructure topology/);
+    )).rejects.toThrow(/Unexpected microVM infrastructure topology/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({
         Containers: {
@@ -141,12 +141,12 @@ describe('Firecracker infrastructure discovery', () => {
       })),
     )).rejects.toThrow(/Unexpected "awf-squid" address/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({ Id: 'invalid' })),
     )).rejects.toThrow(/invalid network ID/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({ IPAM: { Config: [] } })),
     )).rejects.toThrow(/must have exactly 172\.30\.0\.0\/24/);
@@ -155,7 +155,7 @@ describe('Firecracker infrastructure discovery', () => {
   it('validates the bridge and required service endpoint shape', async () => {
     const badLink = dependencies();
     badLink.inspectLink.mockResolvedValue([]);
-    await expect(resolveFirecrackerInfrastructure(true, badLink))
+    await expect(resolveMicrovmInfrastructure(true, badLink))
       .rejects.toThrow(/exactly one host bridge/);
 
     const nonBridge = dependencies();
@@ -163,29 +163,29 @@ describe('Firecracker infrastructure discovery', () => {
       ifname: `br-${'a'.repeat(12)}`,
       linkinfo: { info_kind: 'veth' },
     }]);
-    await expect(resolveFirecrackerInfrastructure(true, nonBridge))
+    await expect(resolveMicrovmInfrastructure(true, nonBridge))
       .rejects.toThrow(/is not the Docker bridge/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({ Containers: {} })),
     )).rejects.toThrow(/Expected exactly one "awf-squid" endpoint/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({
         Options: { 'com.docker.network.bridge.name': 'unsafe bridge' },
       })),
-    )).rejects.toThrow(/Unsafe Firecracker infrastructure bridge name/);
+    )).rejects.toThrow(/Unsafe microVM infrastructure bridge name/);
 
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies([null]),
     )).rejects.toThrow(/Docker network inspection is not an object/);
   });
 
   it('supports Squid-only infrastructure without an API proxy', async () => {
-    const resolved = await resolveFirecrackerInfrastructure(
+    const resolved = await resolveMicrovmInfrastructure(
       false,
       dependencies(networkInspection({
         Containers: {
@@ -197,7 +197,7 @@ describe('Firecracker infrastructure discovery', () => {
   });
 
   it('rejects an accidentally composed primary agent', async () => {
-    await expect(resolveFirecrackerInfrastructure(
+    await expect(resolveMicrovmInfrastructure(
       true,
       dependencies(networkInspection({
         Containers: {
@@ -214,7 +214,7 @@ describe('Firecracker infrastructure discovery', () => {
     deps.inspectNetwork
       .mockResolvedValueOnce(networkInspection())
       .mockResolvedValueOnce(networkInspection({ Id: 'b'.repeat(64) }));
-    const resolved = await resolveFirecrackerInfrastructure(true, deps);
+    const resolved = await resolveMicrovmInfrastructure(true, deps);
 
     await expect(resolved.revalidate()).rejects.toThrow(/topology changed/);
   });

--- a/src/microvm/infrastructure.ts
+++ b/src/microvm/infrastructure.ts
@@ -41,7 +41,7 @@ interface IpLinkInspection {
   };
 }
 
-export interface FirecrackerInfrastructureSnapshot {
+export interface MicrovmInfrastructureSnapshot {
   readonly networkId: string;
   readonly bridgeName: string;
   readonly subnet: string;
@@ -51,12 +51,12 @@ export interface FirecrackerInfrastructureSnapshot {
   revalidate(): Promise<void>;
 }
 
-export interface FirecrackerInfrastructureDependencies {
+export interface MicrovmInfrastructureDependencies {
   inspectNetwork(): Promise<unknown>;
   inspectLink(bridgeName: string, ipPath?: string): Promise<unknown>;
 }
 
-const defaultDependencies: FirecrackerInfrastructureDependencies = {
+const defaultDependencies: MicrovmInfrastructureDependencies = {
   inspectNetwork: async () => {
     const result = await execa('docker', ['network', 'inspect', NETWORK_NAME], {
       env: getLocalDockerEnv(),
@@ -65,7 +65,7 @@ const defaultDependencies: FirecrackerInfrastructureDependencies = {
     });
     if (result.exitCode !== 0) {
       throw new Error(
-        `Could not inspect Firecracker infrastructure network "${NETWORK_NAME}": ` +
+        `Could not inspect microVM infrastructure network "${NETWORK_NAME}": ` +
         result.stderr.trim(),
       );
     }
@@ -78,7 +78,7 @@ const defaultDependencies: FirecrackerInfrastructureDependencies = {
     });
     if (result.exitCode !== 0) {
       throw new Error(
-        `Could not inspect Firecracker infrastructure bridge "${bridgeName}": ` +
+        `Could not inspect microVM infrastructure bridge "${bridgeName}": ` +
         result.stderr.trim(),
       );
     }
@@ -88,14 +88,15 @@ const defaultDependencies: FirecrackerInfrastructureDependencies = {
 
 /**
  * Resolves and proves the exact host bridge and service addresses used by the
- * Compose infrastructure. No default bridge name or daemon-local assumption is
+ * Compose infrastructure that any microVM backend attaches its network
+ * namespace to. No default bridge name or daemon-local assumption is
  * accepted.
  */
-export async function resolveFirecrackerInfrastructure(
+export async function resolveMicrovmInfrastructure(
   enableApiProxy: boolean,
-  dependencies: FirecrackerInfrastructureDependencies = defaultDependencies,
+  dependencies: MicrovmInfrastructureDependencies = defaultDependencies,
   ipPath?: string,
-): Promise<FirecrackerInfrastructureSnapshot> {
+): Promise<MicrovmInfrastructureSnapshot> {
   const resolved = await inspectInfrastructure(enableApiProxy, dependencies, ipPath);
   return {
     ...resolved,
@@ -110,7 +111,7 @@ export async function resolveFirecrackerInfrastructure(
         live.apiProxyIp !== resolved.apiProxyIp
       ) {
         throw new Error(
-          `Firecracker infrastructure topology changed after discovery; ` +
+          `microVM infrastructure topology changed after discovery; ` +
           `refusing to attach the microVM`,
         );
       }
@@ -120,9 +121,9 @@ export async function resolveFirecrackerInfrastructure(
 
 async function inspectInfrastructure(
   enableApiProxy: boolean,
-  dependencies: FirecrackerInfrastructureDependencies,
+  dependencies: MicrovmInfrastructureDependencies,
   ipPath?: string,
-): Promise<Omit<FirecrackerInfrastructureSnapshot, 'revalidate'>> {
+): Promise<Omit<MicrovmInfrastructureSnapshot, 'revalidate'>> {
   const raw = await dependencies.inspectNetwork();
   if (!Array.isArray(raw) || raw.length !== 1) {
     throw new Error(
@@ -137,7 +138,7 @@ async function inspectInfrastructure(
     network.Internal !== true
   ) {
     throw new Error(
-      `Unexpected Firecracker infrastructure topology for "${NETWORK_NAME}": ` +
+      `Unexpected microVM infrastructure topology for "${NETWORK_NAME}": ` +
       `name=${String(network.Name)} driver=${String(network.Driver)} ` +
       `scope=${String(network.Scope)} internal=${String(network.Internal)}`,
     );
@@ -216,14 +217,14 @@ function assertContainerAbsent(
 ): void {
   if (containers.some((container) => container.Name === name)) {
     throw new Error(
-      `Unexpected Compose agent "${name}" is attached during Firecracker execution`,
+      `Unexpected Compose agent "${name}" is attached during microVM execution`,
     );
   }
 }
 
 function assertInterfaceName(name: string): void {
   if (name.length < 1 || name.length > 15 || !/^[A-Za-z0-9_.-]+$/.test(name)) {
-    throw new Error(`Unsafe Firecracker infrastructure bridge name: ${name}`);
+    throw new Error(`Unsafe microVM infrastructure bridge name: ${name}`);
   }
 }
 

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -1,39 +1,39 @@
 import {
-  FirecrackerLinuxNetworkCommands,
-  FirecrackerNetworkManager,
-  createFirecrackerNetworkPlan,
-  generateFirecrackerNftRuleset,
-  type FirecrackerConnectivityProbe,
-  type FirecrackerNetworkCommandOptions,
-  type FirecrackerNetworkPlan,
+  LinuxNetworkCommands,
+  MicrovmNetworkManager,
+  createMicrovmNetworkPlan,
+  generateMicrovmNftRuleset,
+  type MicrovmConnectivityProbe,
+  type MicrovmNetworkCommandOptions,
+  type MicrovmNetworkPlan,
 } from './network';
 
 interface CommandCall {
   command: string;
   args: readonly string[];
-  options: FirecrackerNetworkCommandOptions;
+  options: MicrovmNetworkCommandOptions;
 }
 
 function createPlan(
   runId = 'run-123',
-  overrides: Partial<Parameters<typeof createFirecrackerNetworkPlan>[1]> = {},
-): FirecrackerNetworkPlan {
-  return createFirecrackerNetworkPlan(runId, {
+  overrides: Partial<Parameters<typeof createMicrovmNetworkPlan>[1]> = {},
+): MicrovmNetworkPlan {
+  return createMicrovmNetworkPlan(runId, {
     infrastructureBridge: 'awfbr0',
     enableApiProxy: true,
-    jailerUid: 1000,
-    jailerGid: 1000,
+    tapOwnerUid: 1000,
+    tapOwnerGid: 1000,
     ...overrides,
   });
 }
 
 function commandHarness(failAt?: number): {
   calls: CommandCall[];
-  commands: FirecrackerLinuxNetworkCommands;
+  commands: LinuxNetworkCommands;
 } {
   const calls: CommandCall[] = [];
   let rejectingCall = 0;
-  const commands = new FirecrackerLinuxNetworkCommands(
+  const commands = new LinuxNetworkCommands(
     jest.fn(async (command, args, options) => {
       calls.push({ command, args, options });
       if (options.reject && ++rejectingCall === failAt) {
@@ -44,7 +44,7 @@ function commandHarness(failAt?: number): {
   return { calls, commands };
 }
 
-describe('Firecracker network planning', () => {
+describe('microVM network planning', () => {
   it('allocates deterministic, disjoint per-run guest addressing and bounded names', () => {
     const first = createPlan('run-123');
     const same = createPlan('run-123');
@@ -105,7 +105,7 @@ describe('Firecracker network planning', () => {
     expect(() => createPlan('bad-bridge', {
       infrastructureBridge: 'bridge-name-is-too-long',
     })).toThrow(/IFNAMSIZ/);
-    expect(() => createPlan('root-owner', { jailerUid: 0 })).toThrow(/uid/);
+    expect(() => createPlan('root-owner', { tapOwnerUid: 0 })).toThrow(/uid/);
     expect(() => createPlan('public-peer', {
       controlPeer: { ip: '8.8.8.8', ports: [443] },
     })).toThrow(/RFC1918/);
@@ -123,7 +123,7 @@ describe('Firecracker network planning', () => {
   it('rejects a future centralized infrastructure policy that overlaps the guest link', () => {
     const plan = createPlan('overlap-defense');
 
-    expect(() => generateFirecrackerNftRuleset({
+    expect(() => generateMicrovmNftRuleset({
       ...plan,
       infrastructureCidr: plan.guestSubnet,
       infrastructureIp: plan.guestIp,
@@ -131,10 +131,10 @@ describe('Firecracker network planning', () => {
   });
 });
 
-describe('Firecracker nftables policy', () => {
+describe('microVM nftables policy', () => {
   it('installs default-drop policy with exact endpoint, identity, and return rules', () => {
     const plan = createPlan();
-    const ruleset = generateFirecrackerNftRuleset(plan);
+    const ruleset = generateMicrovmNftRuleset(plan);
 
     expect(ruleset).toContain(`table inet ${plan.nftTableName}`);
     expect(ruleset.match(/policy drop;/g)).toHaveLength(3);
@@ -161,7 +161,7 @@ describe('Firecracker nftables policy', () => {
 
   it('emits SNAT only for the same exact allowed destination pairs', () => {
     const plan = createPlan('narrow-snat', { enableApiProxy: false });
-    const ruleset = generateFirecrackerNftRuleset(plan);
+    const ruleset = generateMicrovmNftRuleset(plan);
     const snatLines = ruleset.split('\n').filter((line) => line.includes('snat to'));
 
     expect(snatLines).toEqual([
@@ -172,14 +172,14 @@ describe('Firecracker nftables policy', () => {
   });
 });
 
-describe('Firecracker network lifecycle', () => {
+describe('microVM network lifecycle', () => {
   it('creates the namespace, veth, TAP, forwarding, and atomic policy in order', async () => {
     const plan = createPlan();
     const { calls, commands } = commandHarness();
-    const probe: FirecrackerConnectivityProbe = {
+    const probe: MicrovmConnectivityProbe = {
       verify: jest.fn().mockResolvedValue(undefined),
     };
-    const manager = new FirecrackerNetworkManager(plan, commands, probe);
+    const manager = new MicrovmNetworkManager(plan, commands, probe);
 
     await expect(manager.setup()).resolves.toBe(plan);
 
@@ -217,7 +217,7 @@ describe('Firecracker network lifecycle', () => {
       args: ['netns', 'exec', plan.namespaceName, 'nft', '-f', '-'],
       options: {
         reject: true,
-        input: generateFirecrackerNftRuleset(plan),
+        input: generateMicrovmNftRuleset(plan),
       },
     });
     expect(probe.verify).toHaveBeenCalledWith(plan);
@@ -229,7 +229,7 @@ describe('Firecracker network lifecycle', () => {
 
     for (let failAt = 1; failAt <= setupStageCount; failAt += 1) {
       const { calls, commands } = commandHarness(failAt);
-      const manager = new FirecrackerNetworkManager(plan, commands);
+      const manager = new MicrovmNetworkManager(plan, commands);
 
       await expect(manager.setup()).rejects.toThrow(`stage ${failAt} failed`);
       const cleanupCalls = calls.filter((call) => call.args.includes('delete'));
@@ -261,10 +261,10 @@ describe('Firecracker network lifecycle', () => {
   it('treats a supplied connectivity probe failure as setup failure', async () => {
     const plan = createPlan('probe-failure');
     const { calls, commands } = commandHarness();
-    const probe: FirecrackerConnectivityProbe = {
+    const probe: MicrovmConnectivityProbe = {
       verify: jest.fn().mockRejectedValue(new Error('proxy unreachable')),
     };
-    const manager = new FirecrackerNetworkManager(plan, commands, probe);
+    const manager = new MicrovmNetworkManager(plan, commands, probe);
 
     await expect(manager.setup()).rejects.toThrow('proxy unreachable');
     expect(calls.slice(-1)[0].args).toEqual([
@@ -275,7 +275,7 @@ describe('Firecracker network lifecycle', () => {
   it('disconnects the host veth before deleting the namespace and its nft policy', async () => {
     const plan = createPlan('cleanup-twice');
     const { calls, commands } = commandHarness();
-    const manager = new FirecrackerNetworkManager(plan, commands);
+    const manager = new MicrovmNetworkManager(plan, commands);
 
     await manager.setup();
     await manager.cleanup();
@@ -314,7 +314,7 @@ describe('Firecracker network lifecycle', () => {
       }
       return originalIp(args, reject);
     });
-    const manager = new FirecrackerNetworkManager(plan, commands);
+    const manager = new MicrovmNetworkManager(plan, commands);
 
     await manager.setup();
     await expect(manager.cleanup()).rejects.toThrow('host veth deletion failed');
@@ -349,7 +349,7 @@ describe('Firecracker network lifecycle', () => {
       }
       return originalIp(args, reject);
     });
-    const manager = new FirecrackerNetworkManager(plan, commands);
+    const manager = new MicrovmNetworkManager(plan, commands);
 
     await manager.setup();
     await expect(manager.cleanup()).rejects.toThrow('namespace deletion failed');

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'crypto';
 import execa from 'execa';
-import type { FirecrackerHostToolPaths } from './preflight';
 import {
   AGENT_IP,
   API_PROXY_IP,
@@ -10,36 +9,56 @@ import {
   SQUID_PORT,
   apiProxyPorts,
 } from '../config/network-policy';
-import type { FirecrackerNetworkInterface } from './api-client';
 
 const LINUX_INTERFACE_NAME_MAX_LENGTH = 15;
-const FIRECRACKER_GUEST_NETWORK_BASE = ipv4ToInteger('100.64.0.0');
-const FIRECRACKER_GUEST_SUBNET_COUNT = 1 << 20;
-const FIRECRACKER_GUEST_PREFIX_LENGTH = 30;
+const GUEST_NETWORK_BASE = ipv4ToInteger('100.64.0.0');
+const GUEST_SUBNET_COUNT = 1 << 20;
+const GUEST_PREFIX_LENGTH = 30;
 const NETNS_DIRECTORY = '/var/run/netns';
 const BLOCKED_LINK_LOCAL_CIDR = '169.254.0.0/16';
 const BLOCKED_MULTICAST_CIDR = '224.0.0.0/4';
 
-export interface FirecrackerAllowedEndpoint {
+/** Minimal host tool paths this module needs; a structural subset so callers
+ * (e.g. Firecracker's preflight-derived tool paths) can pass their own
+ * richer tool-path record without this module depending on it. */
+export interface MicrovmNetworkHostTools {
+  readonly ip: string;
+  readonly nft: string;
+  readonly sysctl: string;
+}
+
+/**
+ * Generic tap-device descriptor a VMM's network-interface configuration API
+ * needs. Field names intentionally match the wire shape already used by
+ * Firecracker's `PUT /network-interfaces`; a future backend with a
+ * differently-shaped API translates from this structural descriptor.
+ */
+export interface MicrovmTapInterface {
+  readonly iface_id: string;
+  readonly host_dev_name: string;
+  readonly guest_mac?: string;
+}
+
+export interface MicrovmAllowedEndpoint {
   readonly name: string;
   readonly ip: string;
   readonly port: number;
 }
 
-export interface FirecrackerControlPeer {
+export interface MicrovmControlPeer {
   readonly ip: string;
   readonly ports: readonly number[];
 }
 
-export interface FirecrackerNetworkPlanOptions {
+export interface MicrovmNetworkPlanOptions {
   readonly infrastructureBridge: string;
   readonly enableApiProxy: boolean;
-  readonly jailerUid: number;
-  readonly jailerGid: number;
-  readonly controlPeer?: FirecrackerControlPeer;
+  readonly tapOwnerUid: number;
+  readonly tapOwnerGid: number;
+  readonly controlPeer?: MicrovmControlPeer;
 }
 
-export interface FirecrackerNetworkPlan {
+export interface MicrovmNetworkPlan {
   readonly runId: string;
   readonly namespaceName: string;
   readonly netnsPath: string;
@@ -56,28 +75,28 @@ export interface FirecrackerNetworkPlan {
   readonly guestGatewayIp: string;
   readonly guestPrefixLength: number;
   readonly guestMac: string;
-  readonly jailerUid: number;
-  readonly jailerGid: number;
-  readonly allowedEndpoints: readonly FirecrackerAllowedEndpoint[];
-  readonly networkInterface: FirecrackerNetworkInterface;
+  readonly tapOwnerUid: number;
+  readonly tapOwnerGid: number;
+  readonly allowedEndpoints: readonly MicrovmAllowedEndpoint[];
+  readonly networkInterface: MicrovmTapInterface;
 }
 
-export interface FirecrackerConnectivityProbe {
-  verify(plan: FirecrackerNetworkPlan): Promise<void>;
+export interface MicrovmConnectivityProbe {
+  verify(plan: MicrovmNetworkPlan): Promise<void>;
 }
 
-export interface FirecrackerNetworkCommandOptions {
+export interface MicrovmNetworkCommandOptions {
   readonly reject: boolean;
   readonly input?: string;
 }
 
-export type FirecrackerNetworkCommandExecutor = (
+export type MicrovmNetworkCommandExecutor = (
   command: string,
   args: readonly string[],
-  options: FirecrackerNetworkCommandOptions,
+  options: MicrovmNetworkCommandOptions,
 ) => Promise<unknown>;
 
-const defaultCommandExecutor: FirecrackerNetworkCommandExecutor = async (
+const defaultCommandExecutor: MicrovmNetworkCommandExecutor = async (
   command,
   args,
   options,
@@ -88,10 +107,10 @@ const defaultCommandExecutor: FirecrackerNetworkCommandExecutor = async (
 /**
  * Dependency-injected argv-only Linux networking operations.
  */
-export class FirecrackerLinuxNetworkCommands {
+export class LinuxNetworkCommands {
   constructor(
-    private readonly execute: FirecrackerNetworkCommandExecutor = defaultCommandExecutor,
-    private readonly tools: Pick<FirecrackerHostToolPaths, 'ip' | 'nft' | 'sysctl'> = {
+    private readonly execute: MicrovmNetworkCommandExecutor = defaultCommandExecutor,
+    private readonly tools: MicrovmNetworkHostTools = {
       ip: 'ip',
       nft: 'nft',
       sysctl: 'sysctl',
@@ -136,27 +155,27 @@ export class FirecrackerLinuxNetworkCommands {
   }
 }
 
-export interface FirecrackerNetworkLifecycle {
-  readonly plan: FirecrackerNetworkPlan;
-  setup(): Promise<FirecrackerNetworkPlan>;
+export interface MicrovmNetworkLifecycle {
+  readonly plan: MicrovmNetworkPlan;
+  setup(): Promise<MicrovmNetworkPlan>;
   cleanup(): Promise<void>;
 }
 
 /**
- * Owns the host-side network resources for exactly one Firecracker run.
+ * Owns the host-side network resources for exactly one microVM run.
  */
-export class FirecrackerNetworkManager implements FirecrackerNetworkLifecycle {
+export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
   private setupComplete = false;
   private namespaceCreated = false;
   private hostVethCreated = false;
 
   constructor(
-    readonly plan: FirecrackerNetworkPlan,
-    private readonly commands = new FirecrackerLinuxNetworkCommands(),
-    private readonly probe?: FirecrackerConnectivityProbe,
+    readonly plan: MicrovmNetworkPlan,
+    private readonly commands = new LinuxNetworkCommands(),
+    private readonly probe?: MicrovmConnectivityProbe,
   ) {}
 
-  async setup(): Promise<FirecrackerNetworkPlan> {
+  async setup(): Promise<MicrovmNetworkPlan> {
     if (this.setupComplete) return this.plan;
 
     try {
@@ -182,8 +201,8 @@ export class FirecrackerNetworkManager implements FirecrackerNetworkLifecycle {
         'tuntap', 'add',
         'dev', this.plan.tapName,
         'mode', 'tap',
-        'user', String(this.plan.jailerUid),
-        'group', String(this.plan.jailerGid),
+        'user', String(this.plan.tapOwnerUid),
+        'group', String(this.plan.tapOwnerGid),
       ]);
       await this.commands.ipInNamespace(this.plan.namespaceName, [
         'addr', 'add',
@@ -222,7 +241,7 @@ export class FirecrackerNetworkManager implements FirecrackerNetworkLifecycle {
       await this.commands.nftInNamespace(
         this.plan.namespaceName,
         ['-f', '-'],
-        generateFirecrackerNftRuleset(this.plan),
+        generateMicrovmNftRuleset(this.plan),
       );
       await this.probe?.verify(this.plan);
       this.setupComplete = true;
@@ -232,7 +251,7 @@ export class FirecrackerNetworkManager implements FirecrackerNetworkLifecycle {
         await this.cleanup();
       } catch (cleanupError) {
         throw new Error(
-          `Firecracker network setup failed: ${formatError(error)}; ` +
+          `microVM network setup failed: ${formatError(error)}; ` +
           `rollback also failed: ${formatError(cleanupError)}`,
         );
       }
@@ -266,25 +285,25 @@ export class FirecrackerNetworkManager implements FirecrackerNetworkLifecycle {
 
     if (errors.length > 0) {
       throw new Error(
-        `Failed to clean up Firecracker network: ${errors.map(formatError).join('; ')}`,
+        `Failed to clean up microVM network: ${errors.map(formatError).join('; ')}`,
       );
     }
   }
 }
 
-export function createFirecrackerNetworkPlan(
+export function createMicrovmNetworkPlan(
   runId: string,
-  options: FirecrackerNetworkPlanOptions,
-): FirecrackerNetworkPlan {
-  assertSafeFirecrackerRunId(runId);
+  options: MicrovmNetworkPlanOptions,
+): MicrovmNetworkPlan {
+  assertSafeMicrovmRunId(runId);
   assertInterfaceName(options.infrastructureBridge, 'infrastructure bridge');
-  assertPositiveIdentity(options.jailerUid, 'jailer uid');
-  assertPositiveIdentity(options.jailerGid, 'jailer gid');
+  assertPositiveIdentity(options.tapOwnerUid, 'tap owner uid');
+  assertPositiveIdentity(options.tapOwnerGid, 'tap owner gid');
 
   const digest = createHash('sha256').update(runId).digest();
   const token = digest.toString('hex').slice(0, 12);
-  const subnetIndex = digest.readUInt32BE(0) & (FIRECRACKER_GUEST_SUBNET_COUNT - 1);
-  const subnetBase = FIRECRACKER_GUEST_NETWORK_BASE + subnetIndex * 4;
+  const subnetIndex = digest.readUInt32BE(0) & (GUEST_SUBNET_COUNT - 1);
+  const subnetBase = GUEST_NETWORK_BASE + subnetIndex * 4;
   const guestGatewayIp = integerToIpv4(subnetBase + 1);
   const guestIp = integerToIpv4(subnetBase + 2);
   const guestMac = [
@@ -313,7 +332,7 @@ export function createFirecrackerNetworkPlan(
     options.enableApiProxy,
     options.controlPeer,
   );
-  const plan: FirecrackerNetworkPlan = {
+  const plan: MicrovmNetworkPlan = {
     runId,
     namespaceName,
     netnsPath: `${NETNS_DIRECTORY}/${namespaceName}`,
@@ -325,13 +344,13 @@ export function createFirecrackerNetworkPlan(
     infrastructureIp: AGENT_IP,
     infrastructureCidr: NETWORK_SUBNET,
     hostGatewayIp: HOST_GATEWAY,
-    guestSubnet: `${integerToIpv4(subnetBase)}/${FIRECRACKER_GUEST_PREFIX_LENGTH}`,
+    guestSubnet: `${integerToIpv4(subnetBase)}/${GUEST_PREFIX_LENGTH}`,
     guestIp,
     guestGatewayIp,
-    guestPrefixLength: FIRECRACKER_GUEST_PREFIX_LENGTH,
+    guestPrefixLength: GUEST_PREFIX_LENGTH,
     guestMac,
-    jailerUid: options.jailerUid,
-    jailerGid: options.jailerGid,
+    tapOwnerUid: options.tapOwnerUid,
+    tapOwnerGid: options.tapOwnerGid,
     allowedEndpoints,
     networkInterface: {
       iface_id: 'eth0',
@@ -343,7 +362,7 @@ export function createFirecrackerNetworkPlan(
   return plan;
 }
 
-export function generateFirecrackerNftRuleset(plan: FirecrackerNetworkPlan): string {
+export function generateMicrovmNftRuleset(plan: MicrovmNetworkPlan): string {
   validatePlan(plan);
   const allowRules = plan.allowedEndpoints.flatMap((endpoint) => [
     `    iifname "${plan.tapName}" oifname "${plan.namespaceVethName}" ` +
@@ -396,9 +415,9 @@ export function generateFirecrackerNftRuleset(plan: FirecrackerNetworkPlan): str
 
 function createAllowedEndpoints(
   enableApiProxy: boolean,
-  controlPeer?: FirecrackerControlPeer,
-): readonly FirecrackerAllowedEndpoint[] {
-  const endpoints: FirecrackerAllowedEndpoint[] = [{
+  controlPeer?: MicrovmControlPeer,
+): readonly MicrovmAllowedEndpoint[] {
+  const endpoints: MicrovmAllowedEndpoint[] = [{
     name: 'squid',
     ip: SQUID_IP,
     port: SQUID_PORT,
@@ -422,16 +441,16 @@ function createAllowedEndpoints(
       isInCidr(controlPeer.ip, BLOCKED_MULTICAST_CIDR)
     ) {
       throw new Error(
-        `Unsafe Firecracker control peer IP outside ${NETWORK_SUBNET}: ${controlPeer.ip}`,
+        `Unsafe microVM control peer IP outside ${NETWORK_SUBNET}: ${controlPeer.ip}`,
       );
     }
     if (controlPeer.ports.length === 0) {
-      throw new Error('Firecracker control peer must specify at least one TCP port');
+      throw new Error('microVM control peer must specify at least one TCP port');
     }
     for (const port of controlPeer.ports) {
       assertPort(port, 'control peer port');
       if (port === 53) {
-        throw new Error('Firecracker control peer cannot enable direct DNS');
+        throw new Error('microVM control peer cannot enable direct DNS');
       }
       endpoints.push({ name: 'control-peer', ip: controlPeer.ip, port });
     }
@@ -446,8 +465,8 @@ function createAllowedEndpoints(
   });
 }
 
-function validatePlan(plan: FirecrackerNetworkPlan): void {
-  assertSafeFirecrackerRunId(plan.runId);
+function validatePlan(plan: MicrovmNetworkPlan): void {
+  assertSafeMicrovmRunId(plan.runId);
   assertSafeObjectName(plan.namespaceName, 'network namespace');
   assertSafeObjectName(plan.nftTableName, 'nftables table');
   assertInterfaceName(plan.infrastructureBridge, 'infrastructure bridge');
@@ -467,7 +486,7 @@ function validatePlan(plan: FirecrackerNetworkPlan): void {
     isInCidr(infrastructureNetworkIp, plan.guestSubnet)
   ) {
     throw new Error(
-      `Firecracker guest subnet overlaps infrastructure: ` +
+      `microVM guest subnet overlaps infrastructure: ` +
       `${plan.guestSubnet} and ${plan.infrastructureCidr}`,
     );
   }
@@ -482,7 +501,7 @@ function validatePlan(plan: FirecrackerNetworkPlan): void {
       ))
     ))
   ) {
-    throw new Error(`Unsafe Firecracker guest MAC: ${plan.guestMac}`);
+    throw new Error(`Unsafe microVM guest MAC: ${plan.guestMac}`);
   }
   for (const endpoint of plan.allowedEndpoints) {
     assertSafeObjectName(endpoint.name, 'endpoint name');
@@ -490,21 +509,21 @@ function validatePlan(plan: FirecrackerNetworkPlan): void {
     assertPort(endpoint.port, 'endpoint port');
     if (isInCidr(endpoint.ip, plan.guestSubnet)) {
       throw new Error(
-        `Firecracker endpoint ${endpoint.ip}:${endpoint.port} overlaps the guest subnet`,
+        `microVM endpoint ${endpoint.ip}:${endpoint.port} overlaps the guest subnet`,
       );
     }
   }
 }
 
-export function assertSafeFirecrackerRunId(runId: string): void {
+export function assertSafeMicrovmRunId(runId: string): void {
   if (runId.length < 1 || runId.length > 64 || !/^[A-Za-z0-9-]+$/.test(runId)) {
-    throw new Error(`Unsafe Firecracker run id: ${runId}`);
+    throw new Error(`Unsafe microVM run id: ${runId}`);
   }
 }
 
 function assertSafeObjectName(value: string, label: string): void {
   if (!/^[A-Za-z0-9_.-]+$/.test(value)) {
-    throw new Error(`Unsafe Firecracker ${label}: ${value}`);
+    throw new Error(`Unsafe microVM ${label}: ${value}`);
   }
 }
 
@@ -512,20 +531,20 @@ function assertInterfaceName(value: string, label: string): void {
   assertSafeObjectName(value, label);
   if (value.length > LINUX_INTERFACE_NAME_MAX_LENGTH) {
     throw new Error(
-      `Firecracker ${label} exceeds Linux IFNAMSIZ: ${value}`,
+      `microVM ${label} exceeds Linux IFNAMSIZ: ${value}`,
     );
   }
 }
 
 function assertPositiveIdentity(value: number, label: string): void {
   if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`Firecracker ${label} must be a positive integer`);
+    throw new Error(`microVM ${label} must be a positive integer`);
   }
 }
 
 function assertPort(value: number, label: string): void {
   if (!Number.isInteger(value) || value < 1 || value > 65_535) {
-    throw new Error(`Firecracker ${label} must be an integer in 1-65535`);
+    throw new Error(`microVM ${label} must be an integer in 1-65535`);
   }
 }
 
@@ -536,7 +555,7 @@ function assertPrivateIpv4(value: string, label: string): void {
     !isInCidr(value, '172.16.0.0/12') &&
     !isInCidr(value, '192.168.0.0/16')
   ) {
-    throw new Error(`Firecracker ${label} must be an RFC1918 address: ${value}`);
+    throw new Error(`microVM ${label} must be an RFC1918 address: ${value}`);
   }
 }
 
@@ -553,7 +572,7 @@ function assertIpv4(value: string, label: string): void {
       Number(octet) > 255
     ))
   ) {
-    throw new Error(`Invalid Firecracker ${label}: ${value}`);
+    throw new Error(`Invalid microVM ${label}: ${value}`);
   }
 }
 
@@ -562,7 +581,7 @@ function assertCidr(value: string, label: string): void {
   assertIpv4(address, label);
   const prefix = Number(rawPrefix);
   if (extra !== undefined || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) {
-    throw new Error(`Invalid Firecracker ${label}: ${value}`);
+    throw new Error(`Invalid microVM ${label}: ${value}`);
   }
 }
 

--- a/src/microvm/vsock-client.test.ts
+++ b/src/microvm/vsock-client.test.ts
@@ -4,16 +4,16 @@ import * as os from 'os';
 import * as path from 'path';
 import { PassThrough, Writable } from 'stream';
 import {
-  FIRECRACKER_GUEST_PROTOCOL_VERSION,
-  FIRECRACKER_MAX_STREAM_CHUNK_BYTES,
-  FirecrackerFrameDecoder,
-  encodeFirecrackerFrame,
-  type FirecrackerGuestFrame,
-} from './vsock-protocol';
-import { FirecrackerGuestError, FirecrackerVsockClient } from './vsock-client';
+  GUEST_PROTOCOL_VERSION,
+  GUEST_MAX_STREAM_CHUNK_BYTES,
+  GuestFrameDecoder,
+  encodeGuestFrame,
+  type GuestProtocolFrame,
+} from './guest-protocol';
+import { GuestExecutionError, MicrovmVsockClient } from './vsock-client';
 
 async function createServer(
-  handler: (frame: FirecrackerGuestFrame, socket: net.Socket) => void,
+  handler: (frame: GuestProtocolFrame, socket: net.Socket) => void,
   capabilities = { stdin: true, tty: false, resize: false },
 ): Promise<{ socketPath: string; close(): Promise<void> }> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'awf-vsock-'));
@@ -21,7 +21,7 @@ async function createServer(
   const server = net.createServer((socket) => {
     let handshaken = false;
     let handshake = Buffer.alloc(0);
-    const decoder = new FirecrackerFrameDecoder();
+    const decoder = new GuestFrameDecoder();
     socket.on('data', (chunk: Buffer) => {
       if (!handshaken) {
         handshake = Buffer.concat([handshake, chunk]);
@@ -30,8 +30,8 @@ async function createServer(
         expect(handshake.subarray(0, newline).toString()).toBe('CONNECT 52');
         handshaken = true;
         socket.write('OK 1234\n');
-        socket.write(encodeFirecrackerFrame({
-          version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+        socket.write(encodeGuestFrame({
+          version: GUEST_PROTOCOL_VERSION,
           type: 'ready',
           requestId: 'control',
           capabilities,
@@ -79,20 +79,20 @@ async function createRawServer(
   };
 }
 
-describe('FirecrackerVsockClient', () => {
+describe('MicrovmVsockClient', () => {
   it('streams output, stdin, and exact terminal status', async () => {
-    const received: FirecrackerGuestFrame[] = [];
+    const received: GuestProtocolFrame[] = [];
     const server = await createServer((frame, socket) => {
       received.push(frame);
       if (frame.type === 'execute') {
         socket.write(Buffer.concat([
-          encodeFirecrackerFrame({
+          encodeGuestFrame({
             version: 1,
             type: 'stdout',
             requestId: frame.requestId,
             data: Buffer.from('hello').toString('base64'),
           }),
-          encodeFirecrackerFrame({
+          encodeGuestFrame({
             version: 1,
             type: 'stderr',
             requestId: frame.requestId,
@@ -101,7 +101,7 @@ describe('FirecrackerVsockClient', () => {
         ]));
       }
       if (frame.type === 'stdin' && frame.eof) {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'result',
           requestId: frame.requestId,
@@ -111,7 +111,7 @@ describe('FirecrackerVsockClient', () => {
         }));
       }
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -155,7 +155,7 @@ describe('FirecrackerVsockClient', () => {
   it('cancels at the host deadline and deterministically returns 124', async () => {
     const server = await createServer((frame, socket) => {
       if (frame.type === 'cancel') {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'result',
           requestId: frame.requestId,
@@ -165,7 +165,7 @@ describe('FirecrackerVsockClient', () => {
         }));
       }
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
       cancellationGraceMs: 100,
@@ -191,7 +191,7 @@ describe('FirecrackerVsockClient', () => {
     const server = await createServer((frame, socket) => {
       if (frame.type === 'execute') socket.destroy();
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -209,7 +209,7 @@ describe('FirecrackerVsockClient', () => {
   it('preserves numeric fallback signal exit status from the guest', async () => {
     const server = await createServer((frame, socket) => {
       if (frame.type === 'execute') {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'result',
           requestId: frame.requestId,
@@ -219,7 +219,7 @@ describe('FirecrackerVsockClient', () => {
         }));
       }
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -241,7 +241,7 @@ describe('FirecrackerVsockClient', () => {
 
   it('requires advertised TTY capability', async () => {
     const server = await createServer(() => undefined);
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -262,14 +262,14 @@ describe('FirecrackerVsockClient', () => {
   it('uses an acknowledged shutdown frame before closing the transport', async () => {
     const server = await createServer((frame, socket) => {
       if (frame.type === 'shutdown') {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'shutting_down',
           requestId: frame.requestId,
         }));
       }
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -283,7 +283,7 @@ describe('FirecrackerVsockClient', () => {
     const server = await createServer((frame, socket) => {
       if (frame.type !== 'execute') return;
       execution += 1;
-      const result = encodeFirecrackerFrame({
+      const result = encodeGuestFrame({
         version: 1,
         type: 'result',
         requestId: frame.requestId,
@@ -297,7 +297,7 @@ describe('FirecrackerVsockClient', () => {
         socket.write(result.subarray(0, 2));
       }
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
       readTimeoutMs: 10,
@@ -323,11 +323,11 @@ describe('FirecrackerVsockClient', () => {
   });
 
   it('guards disconnected control methods and invalid ports', async () => {
-    expect(() => new FirecrackerVsockClient({
+    expect(() => new MicrovmVsockClient({
       socketPath: '/tmp/unused',
       guestPort: 0,
     })).toThrow(/1-65535/);
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: '/tmp/unused',
       guestPort: 52,
     });
@@ -348,11 +348,11 @@ describe('FirecrackerVsockClient', () => {
   });
 
   it('supports chunked stdin, cancellation, resize, and pending request guards', async () => {
-    const received: FirecrackerGuestFrame[] = [];
+    const received: GuestProtocolFrame[] = [];
     const server = await createServer((frame, socket) => {
       received.push(frame);
       if (frame.type === 'stdin' && frame.eof) {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'result',
           requestId: frame.requestId,
@@ -362,14 +362,14 @@ describe('FirecrackerVsockClient', () => {
         }));
       }
       if (frame.type === 'shutdown') {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'shutting_down',
           requestId: frame.requestId,
         }));
       }
     }, { stdin: true, tty: false, resize: true });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -392,7 +392,7 @@ describe('FirecrackerVsockClient', () => {
     await expect(client.shutdown()).rejects.toThrow(/while a request is running/);
     await client.resize(100, 40);
     await client.cancel('manual cancellation');
-    await client.writeStdin(Buffer.alloc(FIRECRACKER_MAX_STREAM_CHUNK_BYTES + 1, 1));
+    await client.writeStdin(Buffer.alloc(GUEST_MAX_STREAM_CHUNK_BYTES + 1, 1));
     await client.endStdin();
     await expect(execution).resolves.toEqual(expect.objectContaining({ exitCode: 0 }));
 
@@ -409,7 +409,7 @@ describe('FirecrackerVsockClient', () => {
 
   it('returns 124 when cancellation grace expires without a guest result', async () => {
     const server = await createServer(() => undefined);
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
       cancellationGraceMs: 5,
@@ -437,7 +437,7 @@ describe('FirecrackerVsockClient', () => {
     const server = await createServer((frame, socket) => {
       if (frame.type !== 'execute') return;
       request += 1;
-      socket.write(encodeFirecrackerFrame({
+      socket.write(encodeGuestFrame({
         version: 1,
         type: 'error',
         requestId: request === 1 ? frame.requestId : 'different',
@@ -445,7 +445,7 @@ describe('FirecrackerVsockClient', () => {
         message: 'rejected',
       }));
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -457,7 +457,7 @@ describe('FirecrackerVsockClient', () => {
       cwd: '/workspace',
       uid: 1000,
       gid: 1000,
-    })).rejects.toBeInstanceOf(FirecrackerGuestError);
+    })).rejects.toBeInstanceOf(GuestExecutionError);
     await expect(client.execute({
       requestId: 'unexpected',
       argv: ['false'],
@@ -473,7 +473,7 @@ describe('FirecrackerVsockClient', () => {
     const invalid = await createRawServer((socket) => {
       socket.once('data', () => setTimeout(() => socket.write('DENIED\n'), 5));
     });
-    const invalidClient = new FirecrackerVsockClient({
+    const invalidClient = new MicrovmVsockClient({
       socketPath: invalid.socketPath,
       guestPort: 52,
       connectTimeoutMs: 100,
@@ -485,7 +485,7 @@ describe('FirecrackerVsockClient', () => {
     const oversized = await createRawServer((socket) => {
       socket.once('data', () => setTimeout(() => socket.write('x'.repeat(129)), 5));
     });
-    const oversizedClient = new FirecrackerVsockClient({
+    const oversizedClient = new MicrovmVsockClient({
       socketPath: oversized.socketPath,
       guestPort: 52,
       connectTimeoutMs: 100,
@@ -495,7 +495,7 @@ describe('FirecrackerVsockClient', () => {
     await oversized.close();
 
     const silent = await createRawServer(() => undefined);
-    const silentClient = new FirecrackerVsockClient({
+    const silentClient = new MicrovmVsockClient({
       socketPath: silent.socketPath,
       guestPort: 52,
       connectTimeoutMs: 5,
@@ -507,7 +507,7 @@ describe('FirecrackerVsockClient', () => {
     const disconnected = await createRawServer((socket) => {
       socket.once('data', () => setTimeout(() => socket.destroy(), 5));
     });
-    const disconnectedClient = new FirecrackerVsockClient({
+    const disconnectedClient = new MicrovmVsockClient({
       socketPath: disconnected.socketPath,
       guestPort: 52,
       connectTimeoutMs: 100,
@@ -519,14 +519,14 @@ describe('FirecrackerVsockClient', () => {
   it('rejects unexpected guest frames and request identifiers', async () => {
     const unexpected = await createServer((frame, socket) => {
       if (frame.type === 'execute') {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'shutdown',
           requestId: frame.requestId,
         }));
       }
     });
-    const unexpectedClient = new FirecrackerVsockClient({
+    const unexpectedClient = new MicrovmVsockClient({
       socketPath: unexpected.socketPath,
       guestPort: 52,
     });
@@ -543,7 +543,7 @@ describe('FirecrackerVsockClient', () => {
 
     const mismatched = await createServer((frame, socket) => {
       if (frame.type === 'execute') {
-        socket.write(encodeFirecrackerFrame({
+        socket.write(encodeGuestFrame({
           version: 1,
           type: 'stdout',
           requestId: 'different',
@@ -551,7 +551,7 @@ describe('FirecrackerVsockClient', () => {
         }));
       }
     });
-    const mismatchedClient = new FirecrackerVsockClient({
+    const mismatchedClient = new MicrovmVsockClient({
       socketPath: mismatched.socketPath,
       guestPort: 52,
     });
@@ -563,20 +563,20 @@ describe('FirecrackerVsockClient', () => {
       cwd: '/workspace',
       uid: 1000,
       gid: 1000,
-    })).rejects.toThrow(/Unexpected Firecracker guest request id/);
+    })).rejects.toThrow(/Unexpected guest request id/);
     await mismatched.close();
   });
 
   it('honors output backpressure and unknown signal fallback status', async () => {
     const server = await createServer((frame, socket) => {
       if (frame.type !== 'execute') return;
-      socket.write(encodeFirecrackerFrame({
+      socket.write(encodeGuestFrame({
         version: 1,
         type: 'stdout',
         requestId: frame.requestId,
         data: Buffer.alloc(1024, 1).toString('base64'),
       }));
-      socket.write(encodeFirecrackerFrame({
+      socket.write(encodeGuestFrame({
         version: 1,
         type: 'result',
         requestId: frame.requestId,
@@ -591,7 +591,7 @@ describe('FirecrackerVsockClient', () => {
         setImmediate(callback);
       },
     });
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });
@@ -616,7 +616,7 @@ describe('FirecrackerVsockClient', () => {
 
   it('rejects writes after a connected transport is destroyed', async () => {
     const server = await createServer(() => undefined);
-    const client = new FirecrackerVsockClient({
+    const client = new MicrovmVsockClient({
       socketPath: server.socketPath,
       guestPort: 52,
     });

--- a/src/microvm/vsock-client.ts
+++ b/src/microvm/vsock-client.ts
@@ -3,21 +3,21 @@ import * as net from 'net';
 import { constants as osConstants } from 'os';
 import type { Writable } from 'stream';
 import {
-  FIRECRACKER_GUEST_PROTOCOL_VERSION,
-  FIRECRACKER_MAX_STREAM_CHUNK_BYTES,
-  FirecrackerFrameDecoder,
-  FirecrackerProtocolError,
-  encodeFirecrackerFrame,
-  type FirecrackerErrorFrame,
-  type FirecrackerExecuteFrame,
-  type FirecrackerGuestFrame,
-  type FirecrackerReadyFrame,
-  type FirecrackerResultFrame,
-} from './vsock-protocol';
+  GUEST_PROTOCOL_VERSION,
+  GUEST_MAX_STREAM_CHUNK_BYTES,
+  GuestFrameDecoder,
+  GuestProtocolError,
+  encodeGuestFrame,
+  type GuestErrorFrame,
+  type GuestExecuteFrame,
+  type GuestProtocolFrame,
+  type GuestReadyFrame,
+  type GuestResultFrame,
+} from './guest-protocol';
 
-const FIRECRACKER_VSOCK_HANDSHAKE_LIMIT = 128;
+const GUEST_VSOCK_HANDSHAKE_LIMIT = 128;
 
-export interface FirecrackerVsockClientOptions {
+export interface MicrovmVsockClientOptions {
   readonly socketPath: string;
   readonly guestPort: number;
   readonly connectTimeoutMs?: number;
@@ -26,7 +26,7 @@ export interface FirecrackerVsockClientOptions {
   readonly cancellationGraceMs?: number;
 }
 
-export interface FirecrackerGuestExecutionRequest {
+export interface GuestExecutionRequest {
   readonly argv: readonly string[];
   readonly env: Readonly<Record<string, string>>;
   readonly cwd: string;
@@ -39,7 +39,7 @@ export interface FirecrackerGuestExecutionRequest {
   readonly stderr?: Writable;
 }
 
-export interface FirecrackerGuestExecutionResult {
+export interface GuestExecutionResult {
   readonly requestId: string;
   readonly exitCode: number;
   readonly signal: string | null;
@@ -50,37 +50,40 @@ interface PendingExecution {
   readonly requestId: string;
   readonly stdout?: Writable;
   readonly stderr?: Writable;
-  readonly resolve: (result: FirecrackerGuestExecutionResult) => void;
+  readonly resolve: (result: GuestExecutionResult) => void;
   readonly reject: (error: Error) => void;
   hostTimedOut: boolean;
   timeout?: NodeJS.Timeout;
   cancellation?: NodeJS.Timeout;
 }
 
-export class FirecrackerGuestError extends Error {
-  constructor(readonly frame: FirecrackerErrorFrame) {
-    super(`Firecracker guest ${frame.code}: ${frame.message}`);
-    this.name = 'FirecrackerGuestError';
+export class GuestExecutionError extends Error {
+  constructor(readonly frame: GuestErrorFrame) {
+    super(`guest ${frame.code}: ${frame.message}`);
+    this.name = 'GuestExecutionError';
   }
 }
 
 /**
- * Host endpoint for Firecracker's CONNECT-over-UDS vsock mapping.
+ * Host endpoint for a VMM's CONNECT-over-UDS vsock mapping (the convention
+ * used by Firecracker and other VMMs that expose vsock via a host UDS
+ * socket). Speaks the AWF framed guest protocol once the handshake
+ * completes; independent of which VMM backend owns the socket.
  */
-export class FirecrackerVsockClient {
+export class MicrovmVsockClient {
   private readonly connectTimeoutMs: number;
   private readonly readTimeoutMs: number;
   private readonly writeTimeoutMs: number;
   private readonly cancellationGraceMs: number;
-  private readonly decoder = new FirecrackerFrameDecoder();
+  private readonly decoder = new GuestFrameDecoder();
   private socket: net.Socket | undefined;
-  private ready: FirecrackerReadyFrame | undefined;
+  private ready: GuestReadyFrame | undefined;
   private pending: PendingExecution | undefined;
   private handshakeComplete = false;
   private handshakeBuffer = Buffer.alloc(0);
   private processing = Promise.resolve();
   private readyWaiter: {
-    resolve: (frame: FirecrackerReadyFrame) => void;
+    resolve: (frame: GuestReadyFrame) => void;
     reject: (error: Error) => void;
   } | undefined;
   private shutdownWaiter: {
@@ -89,9 +92,9 @@ export class FirecrackerVsockClient {
   } | undefined;
   private frameReadTimeout: NodeJS.Timeout | undefined;
 
-  constructor(private readonly options: FirecrackerVsockClientOptions) {
+  constructor(private readonly options: MicrovmVsockClientOptions) {
     if (!Number.isInteger(options.guestPort) || options.guestPort < 1 || options.guestPort > 65_535) {
-      throw new Error(`Firecracker guest vsock port must be in 1-65535: ${options.guestPort}`);
+      throw new Error(`guest vsock port must be in 1-65535: ${options.guestPort}`);
     }
     this.connectTimeoutMs = options.connectTimeoutMs ?? 5_000;
     this.readTimeoutMs = options.readTimeoutMs ?? 30_000;
@@ -99,8 +102,8 @@ export class FirecrackerVsockClient {
     this.cancellationGraceMs = options.cancellationGraceMs ?? 2_000;
   }
 
-  async connect(): Promise<FirecrackerReadyFrame> {
-    if (this.socket) throw new Error('Firecracker guest vsock client is already connected');
+  async connect(): Promise<GuestReadyFrame> {
+    if (this.socket) throw new Error('guest vsock client is already connected');
     const socket = net.createConnection({ path: this.options.socketPath });
     this.socket = socket;
     socket.on('data', (chunk: Buffer) => this.onData(chunk));
@@ -112,12 +115,12 @@ export class FirecrackerVsockClient {
         socket.once('error', reject);
       }),
       this.connectTimeoutMs,
-      `Firecracker guest vsock UDS connect timed out after ${this.connectTimeoutMs}ms`,
+      `guest vsock UDS connect timed out after ${this.connectTimeoutMs}ms`,
     );
     await this.writeRaw(Buffer.from(`CONNECT ${this.options.guestPort}\n`, 'ascii'));
 
     return withTimeout(
-      new Promise<FirecrackerReadyFrame>((resolve, reject) => {
+      new Promise<GuestReadyFrame>((resolve, reject) => {
         this.readyWaiter = { resolve, reject };
         if (this.ready) {
           this.readyWaiter = undefined;
@@ -125,26 +128,26 @@ export class FirecrackerVsockClient {
         }
       }),
       this.connectTimeoutMs,
-      `Firecracker guest readiness timed out after ${this.connectTimeoutMs}ms`,
+      `guest readiness timed out after ${this.connectTimeoutMs}ms`,
     );
   }
 
-  execute(request: FirecrackerGuestExecutionRequest): Promise<FirecrackerGuestExecutionResult> {
+  execute(request: GuestExecutionRequest): Promise<GuestExecutionResult> {
     if (!this.ready || !this.socket) {
-      return Promise.reject(new Error('Firecracker guest supervisor is not ready'));
+      return Promise.reject(new Error('guest supervisor is not ready'));
     }
     if (this.pending) {
       return Promise.reject(new Error(
-        `Firecracker guest request ${this.pending.requestId} is still running`,
+        `guest request ${this.pending.requestId} is still running`,
       ));
     }
     if (request.tty && !this.ready.capabilities.tty) {
-      return Promise.reject(new Error('Firecracker guest supervisor does not support TTY execution'));
+      return Promise.reject(new Error('guest supervisor does not support TTY execution'));
     }
     const requestId = request.requestId ??
       `exec-${process.pid}-${randomBytes(8).toString('hex')}`;
-    const frame: FirecrackerExecuteFrame = {
-      version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+    const frame: GuestExecuteFrame = {
+      version: GUEST_PROTOCOL_VERSION,
       type: 'execute',
       requestId,
       argv: request.argv,
@@ -156,7 +159,7 @@ export class FirecrackerVsockClient {
       ...(request.timeoutMs === undefined ? {} : { timeoutMs: request.timeoutMs }),
     };
 
-    return new Promise<FirecrackerGuestExecutionResult>((resolve, reject) => {
+    return new Promise<GuestExecutionResult>((resolve, reject) => {
       const pending: PendingExecution = {
         requestId,
         stdout: request.stdout,
@@ -170,7 +173,7 @@ export class FirecrackerVsockClient {
         pending.timeout = setTimeout(() => {
           pending.hostTimedOut = true;
           void this.send({
-            version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+            version: GUEST_PROTOCOL_VERSION,
             type: 'cancel',
             requestId,
             reason: `host timeout after ${request.timeoutMs}ms`,
@@ -178,7 +181,7 @@ export class FirecrackerVsockClient {
           pending.cancellation = setTimeout(() => {
             if (this.pending !== pending) return;
             this.completePending({
-              version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+              version: GUEST_PROTOCOL_VERSION,
               type: 'result',
               requestId,
               exitCode: 124,
@@ -194,22 +197,22 @@ export class FirecrackerVsockClient {
   }
 
   async writeStdin(data: Buffer, requestId = this.pending?.requestId): Promise<void> {
-    if (!requestId) throw new Error('No active Firecracker guest request');
-    for (let offset = 0; offset < data.length; offset += FIRECRACKER_MAX_STREAM_CHUNK_BYTES) {
+    if (!requestId) throw new Error('No active guest request');
+    for (let offset = 0; offset < data.length; offset += GUEST_MAX_STREAM_CHUNK_BYTES) {
       await this.send({
-        version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+        version: GUEST_PROTOCOL_VERSION,
         type: 'stdin',
         requestId,
-        data: data.subarray(offset, offset + FIRECRACKER_MAX_STREAM_CHUNK_BYTES)
+        data: data.subarray(offset, offset + GUEST_MAX_STREAM_CHUNK_BYTES)
           .toString('base64'),
       });
     }
   }
 
   endStdin(requestId = this.pending?.requestId): Promise<void> {
-    if (!requestId) return Promise.reject(new Error('No active Firecracker guest request'));
+    if (!requestId) return Promise.reject(new Error('No active guest request'));
     return this.send({
-      version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+      version: GUEST_PROTOCOL_VERSION,
       type: 'stdin',
       requestId,
       eof: true,
@@ -217,9 +220,9 @@ export class FirecrackerVsockClient {
   }
 
   cancel(reason = 'host cancellation', requestId = this.pending?.requestId): Promise<void> {
-    if (!requestId) return Promise.reject(new Error('No active Firecracker guest request'));
+    if (!requestId) return Promise.reject(new Error('No active guest request'));
     return this.send({
-      version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+      version: GUEST_PROTOCOL_VERSION,
       type: 'cancel',
       requestId,
       reason,
@@ -227,12 +230,12 @@ export class FirecrackerVsockClient {
   }
 
   resize(columns: number, rows: number, requestId = this.pending?.requestId): Promise<void> {
-    if (!requestId) return Promise.reject(new Error('No active Firecracker guest request'));
+    if (!requestId) return Promise.reject(new Error('No active guest request'));
     if (!this.ready?.capabilities.resize) {
-      return Promise.reject(new Error('Firecracker guest supervisor does not support TTY resize'));
+      return Promise.reject(new Error('guest supervisor does not support TTY resize'));
     }
     return this.send({
-      version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+      version: GUEST_PROTOCOL_VERSION,
       type: 'resize',
       requestId,
       columns,
@@ -242,17 +245,17 @@ export class FirecrackerVsockClient {
 
   async shutdown(): Promise<void> {
     if (!this.socket) return;
-    if (this.pending) throw new Error('Cannot shut down Firecracker guest while a request is running');
+    if (this.pending) throw new Error('Cannot shut down guest while a request is running');
     const requestId = 'shutdown';
     const acknowledgment = withTimeout(
       new Promise<void>((resolve, reject) => {
         this.shutdownWaiter = { resolve, reject };
       }),
       this.connectTimeoutMs,
-      `Firecracker guest shutdown acknowledgment timed out after ${this.connectTimeoutMs}ms`,
+      `guest shutdown acknowledgment timed out after ${this.connectTimeoutMs}ms`,
     );
     await this.send({
-      version: FIRECRACKER_GUEST_PROTOCOL_VERSION,
+      version: GUEST_PROTOCOL_VERSION,
       type: 'shutdown',
       requestId,
     });
@@ -271,14 +274,14 @@ export class FirecrackerVsockClient {
       let protocolData = chunk;
       if (!this.handshakeComplete) {
         this.handshakeBuffer = Buffer.concat([this.handshakeBuffer, chunk]);
-        if (this.handshakeBuffer.length > FIRECRACKER_VSOCK_HANDSHAKE_LIMIT) {
-          throw new Error('Firecracker vsock CONNECT response exceeded 128 bytes');
+        if (this.handshakeBuffer.length > GUEST_VSOCK_HANDSHAKE_LIMIT) {
+          throw new Error('vsock CONNECT response exceeded 128 bytes');
         }
         const newline = this.handshakeBuffer.indexOf(0x0a);
         if (newline === -1) return;
         const response = this.handshakeBuffer.subarray(0, newline).toString('ascii');
         if (!/^OK(?: \d+)?$/.test(response)) {
-          throw new Error(`Firecracker vsock CONNECT failed: ${response}`);
+          throw new Error(`vsock CONNECT failed: ${response}`);
         }
         this.handshakeComplete = true;
         protocolData = this.handshakeBuffer.subarray(newline + 1);
@@ -292,23 +295,23 @@ export class FirecrackerVsockClient {
       if (this.decoder.pendingBytes > 0) {
         this.frameReadTimeout = setTimeout(() => {
           this.fail(new Error(
-            `Firecracker guest frame read timed out after ${this.readTimeoutMs}ms`,
+            `guest frame read timed out after ${this.readTimeoutMs}ms`,
           ));
         }, this.readTimeoutMs);
       }
     }).catch((error) => this.fail(toError(error)));
   }
 
-  private async handleFrame(frame: FirecrackerGuestFrame): Promise<void> {
+  private async handleFrame(frame: GuestProtocolFrame): Promise<void> {
     if (frame.type === 'ready') {
-      if (this.ready) throw new FirecrackerProtocolError('invalid_frame', 'Duplicate ready frame');
+      if (this.ready) throw new GuestProtocolError('invalid_frame', 'Duplicate ready frame');
       this.ready = frame;
       this.readyWaiter?.resolve(frame);
       this.readyWaiter = undefined;
       return;
     }
     if (frame.type === 'error') {
-      const error = new FirecrackerGuestError(frame);
+      const error = new GuestExecutionError(frame);
       if (this.pending?.requestId === frame.requestId) {
         this.rejectPending(error);
       } else {
@@ -332,23 +335,23 @@ export class FirecrackerVsockClient {
       this.shutdownWaiter = undefined;
       return;
     }
-    throw new FirecrackerProtocolError(
+    throw new GuestProtocolError(
       'invalid_frame',
-      `Unexpected ${frame.type} frame from Firecracker guest`,
+      `Unexpected ${frame.type} frame from guest`,
     );
   }
 
   private requirePending(requestId: string): PendingExecution {
     if (!this.pending || this.pending.requestId !== requestId) {
-      throw new FirecrackerProtocolError(
+      throw new GuestProtocolError(
         'request_not_found',
-        `Unexpected Firecracker guest request id: ${requestId}`,
+        `Unexpected guest request id: ${requestId}`,
       );
     }
     return this.pending;
   }
 
-  private completePending(frame: FirecrackerResultFrame): void {
+  private completePending(frame: GuestResultFrame): void {
     const pending = this.requirePending(frame.requestId);
     clearTimeout(pending.timeout);
     clearTimeout(pending.cancellation);
@@ -379,22 +382,22 @@ export class FirecrackerVsockClient {
     pending.reject(error);
   }
 
-  private send(frame: FirecrackerGuestFrame): Promise<void> {
+  private send(frame: GuestProtocolFrame): Promise<void> {
     if (!this.handshakeComplete) {
-      return Promise.reject(new Error('Firecracker vsock CONNECT handshake is not complete'));
+      return Promise.reject(new Error('vsock CONNECT handshake is not complete'));
     }
-    return this.writeRaw(encodeFirecrackerFrame(frame));
+    return this.writeRaw(encodeGuestFrame(frame));
   }
 
   private writeRaw(data: Buffer): Promise<void> {
     const socket = this.socket;
     if (!socket || socket.destroyed || !socket.writable) {
-      return Promise.reject(new Error('Firecracker guest connection is not writable'));
+      return Promise.reject(new Error('guest connection is not writable'));
     }
     return new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         reject(new Error(
-          `Firecracker guest write timed out after ${this.writeTimeoutMs}ms`,
+          `guest write timed out after ${this.writeTimeoutMs}ms`,
         ));
         socket.destroy();
       }, this.writeTimeoutMs);
@@ -420,11 +423,11 @@ export class FirecrackerVsockClient {
   private onClose(): void {
     if (this.pending) {
       this.rejectPending(new Error(
-        `Firecracker guest disconnected while request ${this.pending.requestId} was running`,
+        `guest disconnected while request ${this.pending.requestId} was running`,
       ));
     }
     if (!this.ready) {
-      this.readyWaiter?.reject(new Error('Firecracker guest disconnected before readiness'));
+      this.readyWaiter?.reject(new Error('guest disconnected before readiness'));
       this.readyWaiter = undefined;
     }
   }

--- a/src/microvm/workspace.test.ts
+++ b/src/microvm/workspace.test.ts
@@ -3,24 +3,24 @@ import { createHash } from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import {
-  FIRECRACKER_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
-  FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES,
-  FirecrackerWorkspaceImage,
+  MICROVM_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
+  MICROVM_MIN_WORKSPACE_IMAGE_BYTES,
+  MicrovmWorkspaceImage,
   assertNoWorkspaceConflicts,
-  buildFirecrackerWorkspaceManifest,
-  calculateFirecrackerWorkspaceImageBytes,
-  type FirecrackerWorkspaceImageDependencies,
-} from './workspace-image';
+  buildMicrovmWorkspaceManifest,
+  calculateMicrovmWorkspaceImageBytes,
+  type MicrovmWorkspaceImageDependencies,
+} from './workspace';
 
-describe('Firecracker workspace images', () => {
+describe('microVM workspace images', () => {
   it('sizes images with headroom, block alignment, minimum, and cap', () => {
-    expect(calculateFirecrackerWorkspaceImageBytes(0))
-      .toBe(FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES);
-    expect(calculateFirecrackerWorkspaceImageBytes(512 * 1024 * 1024) % 4096).toBe(0);
-    expect(() => calculateFirecrackerWorkspaceImageBytes(
-      FIRECRACKER_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
+    expect(calculateMicrovmWorkspaceImageBytes(0))
+      .toBe(MICROVM_MIN_WORKSPACE_IMAGE_BYTES);
+    expect(calculateMicrovmWorkspaceImageBytes(512 * 1024 * 1024) % 4096).toBe(0);
+    expect(() => calculateMicrovmWorkspaceImageBytes(
+      MICROVM_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
     )).toThrow(/exceeding cap/);
-    expect(() => calculateFirecrackerWorkspaceImageBytes(0, 1024)).toThrow(/cap/);
+    expect(() => calculateMicrovmWorkspaceImageBytes(0, 1024)).toThrow(/cap/);
   });
 
   it('preserves hidden files, modes, and safe symlinks while excluding credentials', async () => {
@@ -40,12 +40,12 @@ describe('Firecracker workspace images', () => {
     await fs.writeFile(baseRootfs, 'rootfs');
     await fs.writeFile(supervisor, 'binary');
     const commands: Array<{ command: string; args: readonly string[] }> = [];
-    const dependencies: FirecrackerWorkspaceImageDependencies = {
+    const dependencies: MicrovmWorkspaceImageDependencies = {
       runTool: jest.fn(async (command, args) => {
         commands.push({ command, args });
       }),
     };
-    const image = new FirecrackerWorkspaceImage({
+    const image = new MicrovmWorkspaceImage({
       runId: 'run-1',
       workDir: root,
       workspacePath: workspace,
@@ -58,7 +58,7 @@ describe('Firecracker workspace images', () => {
     }, dependencies);
 
     const prepared = await image.prepare();
-    expect(prepared.imageBytes).toBe(FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES);
+    expect(prepared.imageBytes).toBe(MICROVM_MIN_WORKSPACE_IMAGE_BYTES);
     expect((await fs.stat(prepared.workspaceImagePath)).mode & 0o777).toBe(0o600);
     expect(await fs.readFile(
       path.join(image.stagingDirectory, 'workspace', '.hidden'),
@@ -90,7 +90,7 @@ describe('Firecracker workspace images', () => {
     const workspace = path.join(root, 'source');
     await fs.mkdir(workspace);
     await fs.symlink('../outside', path.join(workspace, 'escape'));
-    await expect(buildFirecrackerWorkspaceManifest(workspace))
+    await expect(buildMicrovmWorkspaceManifest(workspace))
       .rejects.toThrow(/escapes/);
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -152,14 +152,14 @@ describe('Firecracker workspace images', () => {
     await fs.writeFile(path.join(root, 'base.ext4'), 'rootfs');
     await fs.writeFile(path.join(root, 'supervisor'), 'binary');
     let e2fsckCalls = 0;
-    const dependencies: FirecrackerWorkspaceImageDependencies = {
+    const dependencies: MicrovmWorkspaceImageDependencies = {
       runTool: jest.fn(async (command) => {
         if (command === 'e2fsck' && ++e2fsckCalls > 1) {
           throw new Error('corrupt image');
         }
       }),
     };
-    const image = new FirecrackerWorkspaceImage({
+    const image = new MicrovmWorkspaceImage({
       runId: 'run-2',
       workDir: root,
       workspacePath: workspace,
@@ -188,7 +188,7 @@ describe('Firecracker workspace images', () => {
     await fs.writeFile(path.join(root, 'base.ext4'), 'rootfs');
     await fs.writeFile(path.join(root, 'supervisor'), 'binary');
     const rsyncCalls: string[][] = [];
-    const image = new FirecrackerWorkspaceImage({
+    const image = new MicrovmWorkspaceImage({
       runId: 'run-3',
       workDir: root,
       workspacePath: workspace,

--- a/src/microvm/workspace.ts
+++ b/src/microvm/workspace.ts
@@ -2,20 +2,29 @@ import { createHash } from 'crypto';
 import { createReadStream, promises as fs, type Stats } from 'fs';
 import * as path from 'path';
 import execa from 'execa';
-import type { FirecrackerHostToolPaths } from './preflight';
 import {
   CREDENTIAL_ENTRIES,
   HOME_TOOL_SUBDIRS,
 } from '../config/mount-policy';
 
 const MIB = 1024 * 1024;
-export const FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES = 256 * MIB;
-export const FIRECRACKER_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES = 8 * 1024 * MIB;
-const FIRECRACKER_WORKSPACE_IMAGE_HEADROOM_BYTES = 128 * MIB;
-const FIRECRACKER_WORKSPACE_BLOCK_BYTES = 4096;
-const FIRECRACKER_E2FSCK_REPAIR_EXIT_CODE = 1;
+export const MICROVM_MIN_WORKSPACE_IMAGE_BYTES = 256 * MIB;
+export const MICROVM_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES = 8 * 1024 * MIB;
+const WORKSPACE_IMAGE_HEADROOM_BYTES = 128 * MIB;
+const WORKSPACE_BLOCK_BYTES = 4096;
+const E2FSCK_REPAIR_EXIT_CODE = 1;
 
-export interface FirecrackerWorkspaceImageConfig {
+/** Minimal host tool paths this module needs; a structural subset so callers
+ * (e.g. Firecracker's preflight-derived tool paths) can pass their own
+ * richer tool-path record without this module depending on it. */
+export interface MicrovmWorkspaceHostTools {
+  readonly mke2fs: string;
+  readonly debugfs: string;
+  readonly e2fsck: string;
+  readonly rsync: string;
+}
+
+export interface MicrovmWorkspaceImageConfig {
   readonly runId: string;
   readonly workDir: string;
   readonly workspacePath: string;
@@ -28,7 +37,7 @@ export interface FirecrackerWorkspaceImageConfig {
   readonly gid: number;
 }
 
-export interface FirecrackerWorkspaceManifestEntry {
+export interface MicrovmWorkspaceManifestEntry {
   readonly type: 'file' | 'directory' | 'symlink';
   readonly mode: number;
   readonly uid: number;
@@ -38,16 +47,16 @@ export interface FirecrackerWorkspaceManifestEntry {
   readonly target?: string;
 }
 
-export type FirecrackerWorkspaceManifest = ReadonlyMap<
+export type MicrovmWorkspaceManifest = ReadonlyMap<
   string,
-  FirecrackerWorkspaceManifestEntry
+  MicrovmWorkspaceManifestEntry
 >;
 
-export interface FirecrackerWorkspaceImageDependencies {
+export interface MicrovmWorkspaceImageDependencies {
   runTool(command: string, args: readonly string[]): Promise<void>;
 }
 
-const defaultDependencies: FirecrackerWorkspaceImageDependencies = {
+const defaultDependencies: MicrovmWorkspaceImageDependencies = {
   runTool: async (command, args) => {
     const result = await execa(command, [...args], {
       reject: false,
@@ -57,7 +66,7 @@ const defaultDependencies: FirecrackerWorkspaceImageDependencies = {
     if (result.exitCode === 0) return;
     if (
       (command === 'e2fsck' || command.endsWith('/e2fsck')) &&
-      result.exitCode === FIRECRACKER_E2FSCK_REPAIR_EXIT_CODE
+      result.exitCode === E2FSCK_REPAIR_EXIT_CODE
     ) return;
     throw new Error(
       `${command} exited with code ${result.exitCode}: ` +
@@ -66,31 +75,31 @@ const defaultDependencies: FirecrackerWorkspaceImageDependencies = {
   },
 };
 
-export interface FirecrackerWorkspacePreparation {
+export interface MicrovmWorkspacePreparation {
   readonly workspaceImagePath: string;
   readonly rootfsImagePath: string;
   readonly imageBytes: number;
-  readonly originalManifest: FirecrackerWorkspaceManifest;
+  readonly originalManifest: MicrovmWorkspaceManifest;
 }
 
 /**
  * Owns the host-only population and post-stop extraction of one writable image.
  */
-export class FirecrackerWorkspaceImage {
+export class MicrovmWorkspaceImage {
   readonly runDirectory: string;
   readonly stagingDirectory: string;
   readonly workspaceImagePath: string;
   readonly rootfsImagePath: string;
   readonly recoveryImagePath: string;
-  private originalManifest: FirecrackerWorkspaceManifest | undefined;
+  private originalManifest: MicrovmWorkspaceManifest | undefined;
   private prepared = false;
   private extractionSucceeded = false;
   private recoveryPreserved = false;
 
   constructor(
-    private readonly config: FirecrackerWorkspaceImageConfig,
-    private readonly dependencies: FirecrackerWorkspaceImageDependencies = defaultDependencies,
-    private readonly tools?: Pick<FirecrackerHostToolPaths, 'mke2fs' | 'debugfs' | 'e2fsck' | 'rsync'>,
+    private readonly config: MicrovmWorkspaceImageConfig,
+    private readonly dependencies: MicrovmWorkspaceImageDependencies = defaultDependencies,
+    private readonly tools?: MicrovmWorkspaceHostTools,
   ) {
     assertSafeRunId(config.runId);
     this.runDirectory = path.join(config.workDir, 'firecracker-images', config.runId);
@@ -111,8 +120,8 @@ export class FirecrackerWorkspaceImage {
     return this.dependencies.runTool(this.tools?.[command] ?? command, args);
   }
 
-  async prepare(): Promise<FirecrackerWorkspacePreparation> {
-    if (this.prepared) throw new Error('Firecracker workspace image is already prepared');
+  async prepare(): Promise<MicrovmWorkspacePreparation> {
+    if (this.prepared) throw new Error('microVM workspace image is already prepared');
     await fs.mkdir(path.join(this.stagingDirectory, 'workspace'), {
       recursive: true,
       mode: 0o700,
@@ -134,7 +143,7 @@ export class FirecrackerWorkspaceImage {
     try {
       await fs.lstat(path.join(this.config.workspacePath, '.awf-home'));
       throw new Error(
-        'Workspace contains reserved Firecracker guest home path: .awf-home',
+        'Workspace contains reserved microVM guest home path: .awf-home',
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
@@ -147,12 +156,12 @@ export class FirecrackerWorkspaceImage {
       this.config.gid,
     );
     await this.copyAllowedHomeState();
-    this.originalManifest = await buildFirecrackerWorkspaceManifest(this.config.workspacePath);
+    this.originalManifest = await buildMicrovmWorkspaceManifest(this.config.workspacePath);
 
     const imageRoot = path.join(this.stagingDirectory, 'workspace');
     const stagingUsage = await calculateTreeUsage(imageRoot);
-    const imageBytes = calculateFirecrackerWorkspaceImageBytes(
-      stagingUsage.bytes + stagingUsage.entries * FIRECRACKER_WORKSPACE_BLOCK_BYTES,
+    const imageBytes = calculateMicrovmWorkspaceImageBytes(
+      stagingUsage.bytes + stagingUsage.entries * WORKSPACE_BLOCK_BYTES,
       this.config.maxImageBytes,
     );
     const inodeCount = Math.max(8192, Math.ceil(stagingUsage.entries * 1.25) + 1024);
@@ -166,11 +175,11 @@ export class FirecrackerWorkspaceImage {
       '-t', 'ext4',
       '-F',
       '-q',
-      '-b', String(FIRECRACKER_WORKSPACE_BLOCK_BYTES),
+      '-b', String(WORKSPACE_BLOCK_BYTES),
       '-N', String(inodeCount),
       '-d', imageRoot,
       this.workspaceImagePath,
-      String(imageBytes / FIRECRACKER_WORKSPACE_BLOCK_BYTES),
+      String(imageBytes / WORKSPACE_BLOCK_BYTES),
     ]);
 
     await this.prepareRootfs();
@@ -184,11 +193,11 @@ export class FirecrackerWorkspaceImage {
   }
 
   /**
-   * Must only be called after the Firecracker process has terminated.
+   * Must only be called after the microVM process has terminated.
    */
   async extractAfterStop(changedImagePath = this.workspaceImagePath): Promise<void> {
     if (!this.prepared || !this.originalManifest) {
-      throw new Error('Firecracker workspace image has not been prepared');
+      throw new Error('microVM workspace image has not been prepared');
     }
     if (this.extractionSucceeded) return;
     const extractionDirectory = path.join(this.runDirectory, 'extracted');
@@ -210,15 +219,15 @@ export class FirecrackerWorkspaceImage {
         force: true,
       });
       const guestWorkspace = extractionDirectory;
-      const guestManifest = await buildFirecrackerWorkspaceManifest(guestWorkspace);
-      const currentManifest = await buildFirecrackerWorkspaceManifest(this.config.workspacePath);
+      const guestManifest = await buildMicrovmWorkspaceManifest(guestWorkspace);
+      const currentManifest = await buildMicrovmWorkspaceManifest(this.config.workspacePath);
       assertNoWorkspaceConflicts(this.originalManifest, guestManifest, currentManifest);
       await this.applyWorkspaceUpdateAtomically(guestWorkspace, guestManifest);
       this.extractionSucceeded = true;
     } catch (error) {
       await this.preserveRecoveryImage(changedImagePath);
       throw new Error(
-        `Firecracker workspace copy-back failed; changed image preserved at ` +
+        `microVM workspace copy-back failed; changed image preserved at ` +
         `${this.recoveryImagePath}: ${formatError(error)}`,
       );
     }
@@ -273,15 +282,15 @@ export class FirecrackerWorkspaceImage {
   }
 
   private async prepareRootfs(): Promise<void> {
-    await assertRegularFile(this.config.baseRootfsPath, 'Firecracker base rootfs');
-    await assertRegularFile(this.config.supervisorBinaryPath, 'Firecracker guest supervisor');
+    await assertRegularFile(this.config.baseRootfsPath, 'microVM base rootfs');
+    await assertRegularFile(this.config.supervisorBinaryPath, 'guest supervisor');
     if (!/^[A-Fa-f0-9]{64}$/.test(this.config.supervisorSha256)) {
-      throw new Error('Firecracker guest supervisor SHA-256 must be 64 hexadecimal characters');
+      throw new Error('guest supervisor SHA-256 must be 64 hexadecimal characters');
     }
     const actual = await sha256File(this.config.supervisorBinaryPath);
     if (actual !== this.config.supervisorSha256.toLowerCase()) {
       throw new Error(
-        `Firecracker guest supervisor SHA-256 mismatch: expected ` +
+        `guest supervisor SHA-256 mismatch: expected ` +
         `${this.config.supervisorSha256.toLowerCase()}, got ${actual}`,
       );
     }
@@ -323,7 +332,7 @@ export class FirecrackerWorkspaceImage {
 
   private async applyWorkspaceUpdateAtomically(
     guestWorkspace: string,
-    guestManifest: FirecrackerWorkspaceManifest,
+    guestManifest: MicrovmWorkspaceManifest,
   ): Promise<void> {
     const workspaceParent = path.dirname(this.config.workspacePath);
     const workspaceName = path.basename(this.config.workspacePath);
@@ -345,9 +354,9 @@ export class FirecrackerWorkspaceImage {
       `${guestWorkspace}${path.sep}`,
       `${mergeDirectory}${path.sep}`,
     ]);
-    const stagedManifest = await buildFirecrackerWorkspaceManifest(mergeDirectory);
+    const stagedManifest = await buildMicrovmWorkspaceManifest(mergeDirectory);
     assertExactWorkspaceManifest(guestManifest, stagedManifest, 'staged workspace');
-    const latestManifest = await buildFirecrackerWorkspaceManifest(this.config.workspacePath);
+    const latestManifest = await buildMicrovmWorkspaceManifest(this.config.workspacePath);
     assertNoWorkspaceConflicts(this.originalManifest!, guestManifest, latestManifest);
 
     let backupPending = false;
@@ -375,39 +384,39 @@ export class FirecrackerWorkspaceImage {
   }
 }
 
-export function calculateFirecrackerWorkspaceImageBytes(
+export function calculateMicrovmWorkspaceImageBytes(
   contentBytes: number,
-  maximumBytes = FIRECRACKER_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
+  maximumBytes = MICROVM_DEFAULT_MAX_WORKSPACE_IMAGE_BYTES,
 ): number {
   if (!Number.isSafeInteger(contentBytes) || contentBytes < 0) {
-    throw new Error(`Invalid Firecracker workspace content size: ${contentBytes}`);
+    throw new Error(`Invalid microVM workspace content size: ${contentBytes}`);
   }
   if (
     !Number.isSafeInteger(maximumBytes) ||
-    maximumBytes < FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES
+    maximumBytes < MICROVM_MIN_WORKSPACE_IMAGE_BYTES
   ) {
     throw new Error(
-      `Firecracker workspace image cap must be at least ` +
-      `${FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES} bytes`,
+      `microVM workspace image cap must be at least ` +
+      `${MICROVM_MIN_WORKSPACE_IMAGE_BYTES} bytes`,
     );
   }
   const withHeadroom = Math.ceil(contentBytes * 1.25) +
-    FIRECRACKER_WORKSPACE_IMAGE_HEADROOM_BYTES;
-  const requested = Math.max(FIRECRACKER_MIN_WORKSPACE_IMAGE_BYTES, withHeadroom);
-  const aligned = Math.ceil(requested / FIRECRACKER_WORKSPACE_BLOCK_BYTES) *
-    FIRECRACKER_WORKSPACE_BLOCK_BYTES;
+    WORKSPACE_IMAGE_HEADROOM_BYTES;
+  const requested = Math.max(MICROVM_MIN_WORKSPACE_IMAGE_BYTES, withHeadroom);
+  const aligned = Math.ceil(requested / WORKSPACE_BLOCK_BYTES) *
+    WORKSPACE_BLOCK_BYTES;
   if (aligned > maximumBytes) {
     throw new Error(
-      `Firecracker workspace requires ${aligned} bytes, exceeding cap ${maximumBytes}`,
+      `microVM workspace requires ${aligned} bytes, exceeding cap ${maximumBytes}`,
     );
   }
   return aligned;
 }
 
-export async function buildFirecrackerWorkspaceManifest(
+export async function buildMicrovmWorkspaceManifest(
   root: string,
-): Promise<FirecrackerWorkspaceManifest> {
-  const manifest = new Map<string, FirecrackerWorkspaceManifestEntry>();
+): Promise<MicrovmWorkspaceManifest> {
+  const manifest = new Map<string, MicrovmWorkspaceManifestEntry>();
   await walkSafeTree(root, root, async (absolutePath, relativePath, stat) => {
     if (relativePath === '') return;
     const mode = stat.mode & 0o7777;
@@ -443,9 +452,9 @@ export async function buildFirecrackerWorkspaceManifest(
 }
 
 export function assertNoWorkspaceConflicts(
-  original: FirecrackerWorkspaceManifest,
-  guest: FirecrackerWorkspaceManifest,
-  current: FirecrackerWorkspaceManifest,
+  original: MicrovmWorkspaceManifest,
+  guest: MicrovmWorkspaceManifest,
+  current: MicrovmWorkspaceManifest,
 ): void {
   const paths = new Set([...original.keys(), ...guest.keys(), ...current.keys()]);
   const conflicts: string[] = [];
@@ -520,7 +529,7 @@ async function walkSafeTree(
     if (stat.isSymbolicLink()) {
       const target = await fs.readlink(current);
       if (path.isAbsolute(target)) {
-        throw new Error(`Absolute symlink is not safe for Firecracker workspace: ${current}`);
+        throw new Error(`Absolute symlink is not safe for microVM workspace: ${current}`);
       }
       assertContained(
         resolvedSafetyRoot,
@@ -528,7 +537,7 @@ async function walkSafeTree(
         `symlink target for ${current}`,
       );
     } else if (!stat.isFile() && !stat.isDirectory()) {
-      throw new Error(`Special filesystem entry is not safe for Firecracker workspace: ${current}`);
+      throw new Error(`Special filesystem entry is not safe for microVM workspace: ${current}`);
     }
     const result = await visitor(current, relativePath, stat);
     if (!stat.isDirectory() || result === 'skip') return;
@@ -551,15 +560,15 @@ async function calculateTreeUsage(root: string): Promise<{ bytes: number; entrie
 }
 
 function entriesEqual(
-  left: FirecrackerWorkspaceManifestEntry | undefined,
-  right: FirecrackerWorkspaceManifestEntry | undefined,
+  left: MicrovmWorkspaceManifestEntry | undefined,
+  right: MicrovmWorkspaceManifestEntry | undefined,
 ): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function assertExactWorkspaceManifest(
-  expected: FirecrackerWorkspaceManifest,
-  actual: FirecrackerWorkspaceManifest,
+  expected: MicrovmWorkspaceManifest,
+  actual: MicrovmWorkspaceManifest,
   label: string,
 ): void {
   const mismatches: string[] = [];
@@ -571,7 +580,7 @@ function assertExactWorkspaceManifest(
   }
   if (mismatches.length > 0) {
     throw new Error(
-      `Firecracker ${label} diverged during staging at ${mismatches.slice(0, 20).join(', ')}` +
+      `microVM ${label} diverged during staging at ${mismatches.slice(0, 20).join(', ')}` +
       (mismatches.length > 20 ? ` and ${mismatches.length - 20} more paths` : ''),
     );
   }
@@ -590,13 +599,13 @@ function assertContained(root: string, candidate: string, label: string): void {
 
 function assertSafeRunId(runId: string): void {
   if (!/^[A-Za-z0-9-]{1,64}$/.test(runId)) {
-    throw new Error(`Unsafe Firecracker workspace run id: ${runId}`);
+    throw new Error(`Unsafe microVM workspace run id: ${runId}`);
   }
 }
 
 function assertDebugfsOperand(value: string, label: string): void {
   if (/[\s"'\\;`\r\n]/.test(value)) {
-    throw new Error(`Firecracker ${label} is unsafe for debugfs commands: ${value}`);
+    throw new Error(`microVM ${label} is unsafe for debugfs commands: ${value}`);
   }
 }
 
@@ -621,13 +630,13 @@ async function applySafeOwnership(
     uid > 0xffff_ffff ||
     gid > 0xffff_ffff
   ) {
-    throw new Error(`Invalid Firecracker workspace identity: ${uid}:${gid}`);
+    throw new Error(`Invalid microVM workspace identity: ${uid}:${gid}`);
   }
   const currentUid = process.getuid?.();
   const currentGid = process.getgid?.();
   if (currentUid !== 0 && (currentUid !== uid || currentGid !== gid)) {
     throw new Error(
-      `Cannot map Firecracker workspace ownership to ${uid}:${gid} as ` +
+      `Cannot map microVM workspace ownership to ${uid}:${gid} as ` +
       `${String(currentUid)}:${String(currentGid)}`,
     );
   }


### PR DESCRIPTION
## Summary

This is **layer 1 (bottom)** of a greenfield PR stack that will eventually add Cloud Hypervisor support. It is purely a **behavior-preserving refactor**: it extracts the Firecracker-independent host modules into a new `src/microvm/` area so a future VMM backend can reuse them without depending on Firecracker-specific code. **No Cloud Hypervisor support is added in this PR.**

## What moved

| Old (`src/firecracker/`) | New (`src/microvm/`) | Notes |
|---|---|---|
| `infrastructure.ts` | `infrastructure.ts` | Docker Compose network/bridge discovery. `resolveFirecrackerInfrastructure` → `resolveMicrovmInfrastructure`, `FirecrackerInfrastructureSnapshot` → `MicrovmInfrastructureSnapshot` |
| `network.ts` | `network.ts` | Network namespace/veth/TAP/nftables planning + lifecycle. `FirecrackerNetworkManager` → `MicrovmNetworkManager`, `FirecrackerLinuxNetworkCommands` → `LinuxNetworkCommands`, `createFirecrackerNetworkPlan` → `createMicrovmNetworkPlan`, etc. |
| `workspace-image.ts` | `workspace.ts` | ext4 workspace image build/manifest/copy-back/conflict recovery. `FirecrackerWorkspaceImage` → `MicrovmWorkspaceImage` |
| `vsock-protocol.ts` | `guest-protocol.ts` | AWF framed guest-supervisor protocol (transport-independent). `FirecrackerGuestFrame` → `GuestProtocolFrame`, `FirecrackerProtocolError` → `GuestProtocolError`, etc. |
| `vsock-client.ts` | `vsock-client.ts` | Host-side vsock/UDS client speaking the framed protocol. `FirecrackerVsockClient` → `MicrovmVsockClient`, `FirecrackerGuestExecutionRequest/Result` → `GuestExecutionRequest/Result` |

Genuinely Firecracker-specific code **stays** in `src/firecracker/`: the HTTP API client (`api-client.ts`), jailer/binary preflight validation (`preflight.ts`), CLI runtime validation (`runtime-validation.ts`), and the process orchestrator (`manager.ts`), which now imports from `src/microvm/`.

## Behavior-preservation details

- Symbols were renamed away from "Firecracker" **only** where the concept is actually VMM-neutral. The jailer-specific `jailerUid`/`jailerGid` plan fields became the generic `tapOwnerUid`/`tapOwnerGid` since they really describe tap-device ownership, not a jailer concept — this is the one non-cosmetic rename and it's a straight one-to-one field rename with no logic change.
- The network plan's `networkInterface` field (tap device descriptor) and all on-disk path literals (e.g. `firecracker-images`, `.awf-firecracker-recovery`) are left **byte-for-byte identical** to avoid any behavior change (namespace/interface naming, recovery paths, etc. are untouched).
- `src/microvm/*` modules no longer import types from `src/firecracker/*` (dependency direction now flows firecracker → microvm, not the reverse); each defines its own small structural type (`MicrovmNetworkHostTools`, `MicrovmWorkspaceHostTools`, `MicrovmTapInterface`) that Firecracker's richer types satisfy structurally.
- The Go guest supervisor (`guest/firecracker-supervisor/`) is left in place — moving/renaming it risked destabilizing its build and the CI workflows that reference it by path. Instead, added a doc comment in `protocol.go` establishing that it already speaks the same VMM-neutral protocol as `src/microvm/guest-protocol.ts`, as the compatibility boundary a future guest build can reuse.

## Validation

- `npx jest` — **296 suites / 4664 tests passing** (all moved test files updated in lockstep with their renamed symbols)
- `npx tsc --noEmit` — clean
- `npx tsc` full build — clean
- `go build ./...` and `go test ./...` in `guest/firecracker-supervisor` — passing (verifying the doc-only comment didn't affect the artifact build)

Note: `npm run lint` (eslint) could not be run in this sandbox because eslint 10.8.1 isn't available on the registry mirror reachable from this environment — this is an environment limitation, not related to the change. TypeScript compilation and the full test suite are clean.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>