### PR TITLE
ci: add Cloud Hypervisor live-KVM integration

### DIFF
--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -47,6 +47,16 @@ jobs:
           go-version: '1.25.0'
           cache-dependency-path: guest/firecracker-supervisor/go.mod
 
+      - name: Run guest supervisor unit tests
+        working-directory: guest/firecracker-supervisor
+        # guest/firecracker-supervisor is shared, unmodified, between the
+        # Firecracker and Cloud Hypervisor backends (see build.sh above).
+        # Running its unit tests here (not just building it) catches
+        # defects like an incorrect syscall.Mount() fstype before they
+        # only surface as a guest kernel panic during the live-KVM job
+        # below, which is much slower to diagnose.
+        run: go test ./...
+
       - name: Install deterministic guest build prerequisites
         run: |
           sudo apt-get update

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -169,7 +169,7 @@ jobs:
           # job log for fast triage, in addition to the uploaded artifact.
           # Redact the test-only secret sentinel defensively, matching the
           # scan the next step performs on the copied artifact.
-          for f in "$RUNNER_TEMP"/awf-cloud-hypervisor-live/*/audit/cloud-hypervisor/{serial.log,cloud-hypervisor.log,network-diagnostics.txt}; do
+          for f in "$RUNNER_TEMP"/awf-cloud-hypervisor-live/*/audit/cloud-hypervisor/{serial.log,cloud-hypervisor.log,network-diagnostics.txt,vm-info.json,counters.json}; do
             [ -f "$f" ] || continue
             echo "--- $f ---"
             sed 's/awf-cloud-hypervisor-real-secret-do-not-expose/[REDACTED]/g' "$f"

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -254,8 +254,20 @@ jobs:
             echo "::error::Cloud Hypervisor namespace residue remains after cleanup"
             exit 1
           fi
+          # /sys/fs/cgroup/awf-cloud-hypervisor is a parent cgroup that
+          # persists across the whole job; only per-run sub-cgroups are
+          # created one level inside it (see cgroupPath in
+          # src/cloud-hypervisor/manager.ts). Any cgroup v2 directory --
+          # including this parent itself -- always contains standard
+          # controller interface files (cpu.max, memory.max,
+          # cgroup.controllers, ...) simply by virtue of existing;
+          # matching all entries here (not just directories) made this
+          # check a guaranteed false positive the moment the live-KVM job
+          # ever actually completed successfully. See the identical fix
+          # in scripts/ci/cloud-hypervisor-live-smoke.sh's own
+          # assert_no_residue for the same root cause.
           if [ -d /sys/fs/cgroup/awf-cloud-hypervisor ] && \
-             [ -n "$(sudo find /sys/fs/cgroup/awf-cloud-hypervisor -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then
+             [ -n "$(sudo find /sys/fs/cgroup/awf-cloud-hypervisor -mindepth 1 -maxdepth 1 -type d 2>/dev/null)" ]; then
             echo "::error::Cloud Hypervisor cgroup residue remains after cleanup"
             exit 1
           fi

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -184,12 +184,22 @@ jobs:
           rm -rf "$destination"
           mkdir -p "$destination"
           if [ -d "$source_root" ]; then
+            # --keep-containers (the keep-containers/preserve-diagnostics
+            # live case) intentionally leaves its own work/audit files
+            # root-owned (they are written by the CLI process, itself run
+            # via sudo, and deliberately never cleaned up so the case's own
+            # assertions can inspect them afterward). Every other case's
+            # files are owned by the runner user and readable without
+            # sudo, but find/cp must run as root here to reach the
+            # keep-containers case's own preserved files too -- reading a
+            # root-owned file as the runner user is a permission error,
+            # not evidence of a missing file.
             while IFS= read -r -d '' file; do
               relative=${file#"$source_root/"}
               mkdir -p "$destination/$(dirname "$relative")"
-              cp "$file" "$destination/$relative"
+              sudo cp "$file" "$destination/$relative"
             done < <(
-              find "$source_root" -type f \
+              sudo find "$source_root" -type f \
                 \( -path '*/audit/*' \
                 -o -path '*/proxy-logs/*' \
                 -o -name 'stdout.log' \
@@ -197,6 +207,12 @@ jobs:
                 -print0
             )
           fi
+          # Hand ownership of the copied destination tree back to the
+          # runner user: sudo cp above creates new destination files as
+          # root, which the secret-sentinel scan below and the later
+          # upload-artifact step (both running as the runner user, not
+          # root) need to be able to read.
+          sudo chown -R "$(id -u):$(id -g)" "$destination"
           # awf-resolved-config.json's agentCommand field always contains the
           # smoke test's own shell command verbatim -- and this specific
           # command (the api-proxy-reflect case) intentionally references

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -102,7 +102,11 @@ jobs:
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'cloud-hypervisor-kvm'))
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    # 15 cases, each with up to a 90s boot budget and (since the guest
+    # connectivity probe raised its own timeout for the same nested-KVM
+    # scheduling reasons) up to a further 90s probe budget in the worst
+    # case; 60 minutes leaves headroom without masking a genuine hang.
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -143,6 +143,24 @@ jobs:
           ./scripts/ci/cloud-hypervisor-live-smoke.sh \
             "$RUNNER_TEMP/cloud-hypervisor-test-x86_64"
 
+      - name: Print guest boot diagnostics on failure
+        if: failure()
+        run: |
+          set -uo pipefail
+          # Cloud Hypervisor's own collectDiagnostics() runs before the run
+          # directory is torn down on a startup failure (see
+          # src/cloud-hypervisor-runtime-backend.ts), so the guest serial
+          # console and Cloud Hypervisor log land under each case's
+          # audit/cloud-hypervisor/ directory. Print them directly in the
+          # job log for fast triage, in addition to the uploaded artifact.
+          # Redact the test-only secret sentinel defensively, matching the
+          # scan the next step performs on the copied artifact.
+          for f in "$RUNNER_TEMP"/awf-cloud-hypervisor-live/*/audit/cloud-hypervisor/{serial.log,cloud-hypervisor.log}; do
+            [ -f "$f" ] || continue
+            echo "--- $f ---"
+            sed 's/awf-cloud-hypervisor-real-secret-do-not-expose/[REDACTED]/g' "$f"
+          done
+
       - name: Collect redacted diagnostics
         if: always()
         run: |

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -1,0 +1,195 @@
+name: Cloud Hypervisor Preview Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_live_kvm:
+        description: Run the live KVM job on GitHub-hosted x64 Ubuntu 24.04
+        required: true
+        type: boolean
+        default: true
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - '.github/workflows/test-cloud-hypervisor.yml'
+      - 'guest/cloud-hypervisor/**'
+      - 'guest/firecracker-supervisor/**'
+      - 'src/cloud-hypervisor/**'
+      - 'src/cloud-hypervisor-runtime-backend.ts'
+      - 'src/cloud-hypervisor-runtime-backend.test.ts'
+      - 'src/microvm/**'
+      - 'src/types/runtime-options.ts'
+      - 'scripts/ci/cloud-hypervisor-*.sh'
+      - 'docs/cloud-hypervisor-foundation.md'
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: cloud-hypervisor-preview-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-test-artifacts:
+    name: Build deterministic test guest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.0'
+          cache-dependency-path: guest/firecracker-supervisor/go.mod
+
+      - name: Install deterministic guest build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            bc \
+            binutils \
+            bison \
+            build-essential \
+            ca-certificates \
+            cpio \
+            e2fsprogs \
+            file \
+            flex \
+            libelf-dev \
+            libssl-dev \
+            rsync \
+            xz-utils
+
+      - name: Build and verify pinned artifacts
+        run: |
+          ./guest/cloud-hypervisor/build-test-artifacts.sh
+          ./guest/cloud-hypervisor/verify-test-artifacts.sh \
+            release/cloud-hypervisor-test-x86_64
+
+      - name: Attest guest artifact provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release/cloud-hypervisor-test-x86_64/awf-cloud-hypervisor-test-x86_64.tar.gz
+
+      - name: Upload guest artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: cloud-hypervisor-test-x86_64
+          path: release/cloud-hypervisor-test-x86_64/
+          if-no-files-found: error
+          retention-days: 7
+
+  live-kvm:
+    name: Live Cloud Hypervisor KVM smoke/security
+    needs: build-test-artifacts
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.run_live_kvm) ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'cloud-hypervisor-kvm'))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Download verified guest artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloud-hypervisor-test-x86_64
+          path: ${{ runner.temp }}/cloud-hypervisor-test-x86_64
+
+      - name: Grant workflow user access to KVM
+        run: |
+          if [ -e /dev/kvm ]; then
+            sudo chmod 666 /dev/kvm
+          fi
+
+      - name: Verify capable host and artifact digests
+        run: |
+          ./scripts/ci/cloud-hypervisor-host-preflight.sh \
+            "$RUNNER_TEMP/cloud-hypervisor-test-x86_64"
+
+      - name: Install, build, and prepare infrastructure images
+        run: |
+          npm ci
+          npm run build
+          docker build -t ghcr.io/github/gh-aw-firewall/squid:latest containers/squid
+          docker build -t ghcr.io/github/gh-aw-firewall/api-proxy:latest containers/api-proxy
+
+      - name: Run live fail-closed smoke/security coverage
+        run: |
+          ./scripts/ci/cloud-hypervisor-live-smoke.sh \
+            "$RUNNER_TEMP/cloud-hypervisor-test-x86_64"
+
+      - name: Collect redacted diagnostics
+        if: always()
+        run: |
+          set -euo pipefail
+          source_root="$RUNNER_TEMP/awf-cloud-hypervisor-live"
+          destination="$RUNNER_TEMP/cloud-hypervisor-diagnostics-safe"
+          rm -rf "$destination"
+          mkdir -p "$destination"
+          if [ -d "$source_root" ]; then
+            while IFS= read -r -d '' file; do
+              relative=${file#"$source_root/"}
+              mkdir -p "$destination/$(dirname "$relative")"
+              cp "$file" "$destination/$relative"
+            done < <(
+              find "$source_root" -type f \
+                \( -path '*/audit/*' \
+                -o -path '*/proxy-logs/*' \
+                -o -name 'stdout.log' \
+                -o -name 'stderr.log' \) \
+                -print0
+            )
+          fi
+          if grep -R --binary-files=without-match \
+            -F 'awf-cloud-hypervisor-real-secret-do-not-expose' \
+            "$destination"; then
+            echo "::error::Secret sentinel found in diagnostic artifacts"
+            rm -rf "$destination"
+            exit 1
+          fi
+
+      - name: Upload actionable diagnostics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: cloud-hypervisor-live-diagnostics
+          path: ${{ runner.temp }}/cloud-hypervisor-diagnostics-safe/
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Enforce final residue cleanup
+        if: always()
+        run: |
+          set -euo pipefail
+          while read -r namespace _; do
+            case "$namespace" in
+              awffc-*) sudo ip netns delete "$namespace" ;;
+            esac
+          done < <(sudo ip netns list)
+          if sudo ip netns list | grep -q '^awffc-'; then
+            echo "::error::Cloud Hypervisor namespace residue remains after cleanup"
+            exit 1
+          fi
+          if [ -d /sys/fs/cgroup/awf-cloud-hypervisor ] && \
+             [ -n "$(sudo find /sys/fs/cgroup/awf-cloud-hypervisor -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then
+            echo "::error::Cloud Hypervisor cgroup residue remains after cleanup"
+            exit 1
+          fi
+          if pgrep -f 'cloud-hypervisor --api-socket' >/dev/null 2>&1; then
+            echo "::error::Cloud Hypervisor process residue remains after cleanup"
+            exit 1
+          fi

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -197,8 +197,19 @@ jobs:
                 -print0
             )
           fi
+          # awf-resolved-config.json's agentCommand field always contains the
+          # smoke test's own shell command verbatim -- and this specific
+          # command (the api-proxy-reflect case) intentionally references
+          # the sentinel string itself as the pattern it greps for, to
+          # assert the sentinel is absent from `env`. That is expected,
+          # self-referential test source text, not a leak of the sentinel
+          # *value* into somewhere it shouldn't be (guest console output,
+          # network captures, proxy logs, etc. are all still fully scanned
+          # below) -- so this one, known, always-matching file is excluded
+          # from the scan rather than silently disabling it everywhere.
           if grep -R --binary-files=without-match \
             -F 'awf-cloud-hypervisor-real-secret-do-not-expose' \
+            --exclude='awf-resolved-config.json' \
             "$destination"; then
             echo "::error::Secret sentinel found in diagnostic artifacts"
             rm -rf "$destination"

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -109,6 +109,17 @@ jobs:
           name: cloud-hypervisor-test-x86_64
           path: ${{ runner.temp }}/cloud-hypervisor-test-x86_64
 
+      - name: Restore artifact executable permissions
+        run: |
+          # actions/upload-artifact + actions/download-artifact do not
+          # reliably preserve the executable bit on binary files (a known
+          # GitHub Actions artifact limitation). Digest verification below
+          # still proves file integrity; this only restores the mode bits
+          # needed to exec the pinned, already-verified binaries.
+          chmod 0755 \
+            "$RUNNER_TEMP/cloud-hypervisor-test-x86_64/cloud-hypervisor" \
+            "$RUNNER_TEMP/cloud-hypervisor-test-x86_64/awf-supervisor"
+
       - name: Grant workflow user access to KVM
         run: |
           if [ -e /dev/kvm ]; then

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -165,7 +165,7 @@ jobs:
           # job log for fast triage, in addition to the uploaded artifact.
           # Redact the test-only secret sentinel defensively, matching the
           # scan the next step performs on the copied artifact.
-          for f in "$RUNNER_TEMP"/awf-cloud-hypervisor-live/*/audit/cloud-hypervisor/{serial.log,cloud-hypervisor.log}; do
+          for f in "$RUNNER_TEMP"/awf-cloud-hypervisor-live/*/audit/cloud-hypervisor/{serial.log,cloud-hypervisor.log,network-diagnostics.txt}; do
             [ -f "$f" ] || continue
             echo "--- $f ---"
             sed 's/awf-cloud-hypervisor-real-secret-do-not-expose/[REDACTED]/g' "$f"

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -156,8 +156,16 @@ jobs:
                 -print0
             )
           fi
+          # See the identical comment in test-cloud-hypervisor.yml:
+          # awf-resolved-config.json's agentCommand field always contains
+          # the smoke test's own shell command verbatim, which for the
+          # api-proxy-reflect case intentionally references the sentinel
+          # string itself as the pattern it greps for -- expected,
+          # self-referential test source text, not a leak of the sentinel
+          # value elsewhere (still fully scanned below).
           if grep -R --binary-files=without-match \
             -F 'awf-firecracker-real-secret-do-not-expose' \
+            --exclude='awf-resolved-config.json' \
             "$destination"; then
             echo "::error::Secret sentinel found in diagnostic artifacts"
             rm -rf "$destination"

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -98,6 +98,19 @@ jobs:
           name: firecracker-test-x86_64
           path: ${{ runner.temp }}/firecracker-test-x86_64
 
+      - name: Restore artifact executable permissions
+        run: |
+          # actions/upload-artifact + actions/download-artifact do not
+          # reliably preserve the executable bit on binary files (a known
+          # GitHub Actions artifact limitation). Digest verification in the
+          # preflight step below still proves file integrity; this only
+          # restores the mode bits needed to exec the pinned, already-
+          # verified binaries.
+          chmod 0755 \
+            "$RUNNER_TEMP/firecracker-test-x86_64/firecracker" \
+            "$RUNNER_TEMP/firecracker-test-x86_64/jailer" \
+            "$RUNNER_TEMP/firecracker-test-x86_64/awf-firecracker-supervisor"
+
       - name: Grant workflow user access to KVM
         run: |
           if [ -e /dev/kvm ]; then

--- a/.github/workflows/test-firecracker.yml
+++ b/.github/workflows/test-firecracker.yml
@@ -143,12 +143,17 @@ jobs:
           rm -rf "$destination"
           mkdir -p "$destination"
           if [ -d "$source_root" ]; then
+            # See the identical comment in test-cloud-hypervisor.yml:
+            # --keep-containers intentionally leaves its own work/audit
+            # files root-owned (written by the CLI process via sudo, never
+            # cleaned up so the case's own assertions can inspect them
+            # afterward), so find/cp must run as root here too.
             while IFS= read -r -d '' file; do
               relative=${file#"$source_root/"}
               mkdir -p "$destination/$(dirname "$relative")"
-              cp "$file" "$destination/$relative"
+              sudo cp "$file" "$destination/$relative"
             done < <(
-              find "$source_root" -type f \
+              sudo find "$source_root" -type f \
                 \( -path '*/audit/*' \
                 -o -path '*/proxy-logs/*' \
                 -o -name 'stdout.log' \
@@ -156,6 +161,12 @@ jobs:
                 -print0
             )
           fi
+          # Hand ownership of the copied destination tree back to the
+          # runner user: sudo cp above creates new destination files as
+          # root, which the secret-sentinel scan below and the later
+          # upload-artifact step (both running as the runner user) need to
+          # be able to read.
+          sudo chown -R "$(id -u):$(id -g)" "$destination"
           # See the identical comment in test-cloud-hypervisor.yml:
           # awf-resolved-config.json's agentCommand field always contains
           # the smoke test's own shell command verbatim, which for the

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ paper-data/.gh-aw-skip-cache.json
 
 # Python bytecode from local enclave-bootstrap syntax checks
 __pycache__/
+
+# Local `go build`/`go vet` output for the guest supervisor module
+# (built binary shares its directory's module name with no extension,
+# easy to accidentally leave behind after a local build/test cycle)
+/guest/firecracker-supervisor/firecracker-supervisor

--- a/docs/INTEGRATION-TESTS.md
+++ b/docs/INTEGRATION-TESTS.md
@@ -282,7 +282,7 @@ cases:
 | `partial-start-cleanup` | Corrupt rootfs causes clean failure; no residue |
 | `cancellation` | `SIGTERM` cleans up residue within a non-flaky time ceiling; exits 143 |
 | `keep` | `--keep-containers` preserves namespace/run-directory; diagnostics ≤1 MiB |
-| `security-assertions` **(CH-only)** | Live jailer-replacement boundary: non-root uid, empty `CapEff`, `no_new_privs`, active seccomp filter, per-run cgroup membership/bounded memory, `landlock_enable` + exactly-minimal disk/net/vsock topology via `vm.info` |
+| `security-assertions` **(CH-only)** | Live jailer-replacement boundary: non-root uid, `CapEff` limited to `CAP_NET_ADMIN` alone, `no_new_privs`, active seccomp filter, per-run cgroup membership/bounded memory, `landlock_enable` + exactly-minimal disk/net/vsock topology via `vm.info` |
 
 After every case, the suite asserts no `awffc-*` namespaces, `fch*`/`fcn*`/`fct*`
 interfaces (shared naming with Firecracker), `awf-cloud-hypervisor` cgroup

--- a/docs/INTEGRATION-TESTS.md
+++ b/docs/INTEGRATION-TESTS.md
@@ -235,3 +235,59 @@ Live assertions (see `scripts/ci/firecracker-live-smoke.sh`):
 After every case, the suite asserts no `awffc-*` namespaces or Firecracker
 interface residue remain. See [Firecracker integration (preview)](../docs/firecracker-integration.md#part-14--ci-workflow)
 for the full CI workflow specification.
+
+## Cloud Hypervisor preview integration tests
+
+The Cloud Hypervisor backend has its own separate CI workflow
+(`test-cloud-hypervisor.yml`), structurally identical to Firecracker's above
+but scoped to Cloud Hypervisor paths and **GitHub-hosted Ubuntu x86_64
+runners only** (self-hosted runners are explicitly rejected, unlike
+Firecracker's preview).
+
+**Trigger:** `workflow_dispatch`, or pull request open/synchronize/reopen/label
+scoped to `guest/cloud-hypervisor/**`, `src/cloud-hypervisor/**`,
+`src/microvm/**`, and the related scripts/docs/workflow files. Only label
+`cloud-hypervisor-kvm` enables the live job. It does **not** run on push or
+schedule.
+
+**Build job** (`ubuntu-24.04`): Builds deterministic guest artifacts — Cloud
+Hypervisor v53.0 binary, the same pinned Linux 6.1.141 kernel config
+Firecracker uses, BusyBox 1.36.1 rootfs, and the shared AWF guest supervisor —
+from pinned, SHA-256 verified sources. Attests provenance. Uploads as a
+7-day workflow artifact (`cloud-hypervisor-test-x86_64`).
+
+**Live job** (`ubuntu-24.04`): Downloads the build artifact, verifies all four
+SHA-256 digests plus GitHub-hosted-only host eligibility (`GITHUB_ACTIONS`,
+`RUNNER_ENVIRONMENT`, `ImageOS`) and Landlock LSM availability, then runs the
+live smoke/security suite. The preflight requires usable KVM and fails closed
+if `/dev/kvm` or another required host capability is unavailable.
+
+Live assertions (see `scripts/ci/cloud-hypervisor-live-smoke.sh`) reproduce
+Firecracker's full 13-case contract verbatim, plus two Cloud Hypervisor-only
+cases:
+
+| Case | What it proves |
+|------|---------------|
+| `allowed-https` | Allowed domains reach the internet through Squid |
+| `blocked-domain` | Non-allowlisted domains are blocked |
+| `direct-egress` | Bypassing proxy env vars does not enable direct egress |
+| `arbitrary-tcp` | Raw TCP to arbitrary IPs is blocked |
+| `dns-denial` | Direct DNS (8.8.8.8:53) is blocked from the guest |
+| `metadata-denial` | Instance metadata IP (`169.254.169.254`) is unreachable |
+| `api-proxy-reflect` | API proxy `/reflect` reachable; secret sentinel not in output |
+| `workspace-copyback` | Guest file writes, permission changes, and symlinks survive copy-back |
+| `exit-code` | Agent exit code propagates faithfully (37 → 37) |
+| `timeout-124` | Timed-out agent exits 124 |
+| `device-assumptions` **(CH-only)** | `/dev/vda`/`/dev/vdb` and `eth0` guest device assumptions hold |
+| `partial-start-cleanup` | Corrupt rootfs causes clean failure; no residue |
+| `cancellation` | `SIGTERM` cleans up residue within a non-flaky time ceiling; exits 143 |
+| `keep` | `--keep-containers` preserves namespace/run-directory; diagnostics ≤1 MiB |
+| `security-assertions` **(CH-only)** | Live jailer-replacement boundary: non-root uid, empty `CapEff`, `no_new_privs`, active seccomp filter, per-run cgroup membership/bounded memory, `landlock_enable` + exactly-minimal disk/net/vsock topology via `vm.info` |
+
+After every case, the suite asserts no `awffc-*` namespaces, `fch*`/`fcn*`/`fct*`
+interfaces (shared naming with Firecracker), `awf-cloud-hypervisor` cgroup
+entries, or `cloud-hypervisor` processes remain. The secret sentinel
+(`awf-cloud-hypervisor-real-secret-do-not-expose`, distinct from
+Firecracker's) is scanned for in the same way. See
+[Cloud Hypervisor integration (preview)](../docs/cloud-hypervisor-foundation.md#part-14--ci-workflow)
+for the full CI workflow specification.

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -111,6 +111,17 @@ for the guest artifact build/verification pipeline. See
 [docs/cloud-hypervisor-foundation.md](./cloud-hypervisor-foundation.md) for
 the full architecture and security-boundary writeup.
 
+Release test artifacts (`cloud-hypervisor-test-x86_64`) are x86_64
+test/preview artifacts built and verified by
+[`test-cloud-hypervisor.yml`](../.github/workflows/test-cloud-hypervisor.yml),
+which also runs the live-KVM parity/security smoke suite
+(`scripts/ci/cloud-hypervisor-live-smoke.sh`) on GitHub-hosted Ubuntu x86_64
+runners when triggered by manual dispatch or the `cloud-hypervisor-kvm` pull
+request label. They are published as workflow artifacts, but are not
+production defaults and are never auto-downloaded. See
+[docs/cloud-hypervisor-foundation.md](./cloud-hypervisor-foundation.md#part-14--ci-workflow)
+for the complete CI workflow specification and troubleshooting reference.
+
 ## 5. CLI Mapping
 
 *This section is normative.*

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -12,10 +12,15 @@ are rejected, unlike Firecracker's preview), and is otherwise fail-closed.
 Firecracker continues to work unchanged and is unaffected by this backend.
 :::
 
-This is **stack layer 3** of a 4-layer PR stack: it builds a complete,
+This document originated as **stack layer 3**, which built a complete,
 runnable Cloud Hypervisor microVM backend on top of the layer 1 VMM-neutral
 `src/microvm/` primitives and the layer 2 configuration/artifact/preflight
-foundation. Layer 4 adds the live-KVM GitHub Actions CI workflow.
+foundation. **Stack layer 4** (this layer) adds the live-KVM GitHub Actions
+CI workflow (`test-cloud-hypervisor.yml`, Part 14), the parity/security
+smoke suite (`scripts/ci/cloud-hypervisor-live-smoke.sh`), and this
+documentation update; Firecracker remains present and unaffected. Firecracker
+removal, if it ever happens, is an explicit later layer and is out of scope
+here.
 
 ## Part 1 — What Cloud Hypervisor adds and why it is a preview
 
@@ -38,8 +43,8 @@ isolation), different VMM implementation and host launch strategy.
   boundary: network-namespace join, non-root privilege drop, and
   kernel-enforced Landlock filesystem confinement (see Part 3).
 - The live-KVM GitHub Actions workflow that exercises this backend end to
-  end on real hardware is a later layer; this layer's validation is unit
-  tests plus static analysis only (see Part 15).
+  end on real hardware is `test-cloud-hypervisor.yml` (Part 14), added in
+  stack layer 4 alongside the parity/security smoke suite.
 
 ### Comparison with Firecracker
 
@@ -320,30 +325,249 @@ config-file/CLI mapping.
   non-Ubuntu/non-x86_64 hosts are explicitly rejected.
 - **No TTY, DinD, host access, extra volume mounts, enclaves, or topology
   peers** — same restrictions as Firecracker's preview.
-- **No live-KVM GitHub Actions workflow yet.** This layer's validation is
-  unit tests, `tsc --noEmit`, and the existing Firecracker live-KVM
-  workflow (unaffected). A dedicated Cloud Hypervisor live-KVM smoke test
-  is a later layer's responsibility — see Part 15.
+- **No vhost-net/vhost-user and no throughput claims.** The performance
+  baselines in Part 14 measure boot/readiness latency and cgroup-bounded
+  memory overhead only; this preview makes no network throughput guarantees.
+- **Firecracker is unaffected and remains supported.** Removing Firecracker
+  is an explicit later layer, not this one.
 
-## Part 15 — Validation performed in this layer
+## Part 14 — CI workflow
+
+The Cloud Hypervisor preview has its own dedicated CI workflow,
+[`test-cloud-hypervisor.yml`](../.github/workflows/test-cloud-hypervisor.yml),
+structurally mirroring
+[Firecracker's `test-firecracker.yml`](./firecracker-integration.md#part-14--ci-workflow)
+but adapted for this backend's GitHub-hosted-only support statement and
+jailer-free launcher.
+
+### Trigger conditions
+
+The workflow triggers **only** on:
+
+- `workflow_dispatch` — manual trigger; `run_live_kvm: false` validates the
+  deterministic artifact build without queueing the KVM job.
+- A pull request open, synchronize, or reopen event, **scoped to paths**
+  under `guest/cloud-hypervisor/`, `guest/firecracker-supervisor/` (shared
+  guest supervisor), `src/cloud-hypervisor/`,
+  `src/cloud-hypervisor-runtime-backend.ts`, `src/microvm/`,
+  `scripts/ci/cloud-hypervisor-*.sh`, this document, and the workflow file
+  itself — builds and verifies the deterministic guest artifacts on
+  `ubuntu-24.04`.
+- A pull request being **labeled** with `cloud-hypervisor-kvm` additionally
+  enables the live KVM job.
+
+It does **not** run on push or schedule. The path scoping keeps CI cost
+proportional to actual changes to this preview instead of running on every
+unrelated pull request.
+
+### Jobs
+
+#### `build-test-artifacts` (runs on `ubuntu-24.04`, no KVM required)
+
+1. Checks out the repository and sets up Go 1.25.0 (cache keyed on the
+   shared `guest/firecracker-supervisor/go.mod`).
+2. Installs the same deterministic kernel-build prerequisites Firecracker's
+   job uses (`bc`, `binutils`, `bison`, `build-essential`, `cpio`,
+   `e2fsprogs`, `file`, `flex`, `libelf-dev`, `libssl-dev`, `rsync`,
+   `xz-utils`) — both backends build the identical pinned kernel config.
+3. Runs `guest/cloud-hypervisor/build-test-artifacts.sh` — downloads Cloud
+   Hypervisor v53.0 (SHA-256 verified), Linux 6.1.141 (SHA-256 verified),
+   BusyBox 1.36.1 (SHA-256 verified), and a pinned CA bundle; builds the
+   kernel, BusyBox, and shared supervisor; creates the rootfs; produces
+   `SHA256SUMS`, `manifest.json`, and `sbom.spdx.json`; archives everything
+   as `release/cloud-hypervisor-test-x86_64/awf-cloud-hypervisor-test-x86_64.tar.gz`.
+4. Runs `guest/cloud-hypervisor/verify-test-artifacts.sh` against the output.
+5. Attests artifact provenance via `actions/attest-build-provenance`.
+6. Uploads `release/cloud-hypervisor-test-x86_64/` as artifact
+   `cloud-hypervisor-test-x86_64` with 7-day retention.
+
+#### `live-kvm` (runs on `ubuntu-24.04`)
+
+Gated on manual dispatch (`run_live_kvm: true`) or the `cloud-hypervisor-kvm`
+pull request label — never on unlabeled pull requests, push, or schedule.
+Its preflight fails closed (does not silently skip) if the runner lacks
+usable KVM or any other required host capability.
+
+1. Downloads the `cloud-hypervisor-test-x86_64` artifact from the build job.
+2. Runs `scripts/ci/cloud-hypervisor-host-preflight.sh` — verifies Linux,
+   x86_64, GitHub-hosted-only host eligibility (`GITHUB_ACTIONS`,
+   `RUNNER_ENVIRONMENT`, `ImageOS`), `/dev/kvm`, required host tools
+   including `setpriv`, Landlock LSM availability, the Cloud Hypervisor
+   version string, and all four SHA-256 digests via
+   `sha256sum --check --strict SHA256SUMS`.
+3. Installs NPM dependencies, builds the AWF distribution, and builds the
+   Squid and API proxy container images locally.
+4. Runs `scripts/ci/cloud-hypervisor-live-smoke.sh` — the live test suite.
+5. Collects redacted diagnostics (audit, proxy-logs, stdout/stderr) and
+   scans for the secret sentinel before uploading, unconditionally
+   (`if: always()`).
+6. Enforces final residue cleanup — network namespaces, the
+   `awf-cloud-hypervisor` cgroup tree, and any lingering `cloud-hypervisor`
+   process — unconditionally (`if: always()`).
+
+### Live smoke test assertions
+
+`cloud-hypervisor-live-smoke.sh` reproduces
+[Firecracker's full 13-case contract](./firecracker-integration.md#live-smoke-test-assertions)
+verbatim (same case names, same expected exit codes, same assertions), then
+adds two Cloud Hypervisor-specific cases:
+
+| Case | Expected exit | Assertion |
+|------|--------------|-----------|
+| `allowed-https` | 0 | `wget https://example.com` succeeds and returns "Example Domain" |
+| `blocked-domain` | 0 | `wget https://github.com` fails (not in `--allow-domains`) |
+| `direct-egress` | 0 | Unsets proxy vars; direct `wget` fails |
+| `arbitrary-tcp` | 0 | `nc -z 1.1.1.1 443` fails |
+| `dns-denial` | 0 | `nslookup example.com 8.8.8.8` fails |
+| `metadata-denial` | 0 | Unsets proxy vars; `wget http://169.254.169.254/latest/meta-data/` fails |
+| `api-proxy-reflect` | 0 | API proxy `/reflect` reachable; secret sentinel absent from guest `env` |
+| `workspace-copyback` | 0 | Guest writes, `chmod 755`, and a symlink all survive copy-back |
+| `exit-code` | 37 | `exit 37` propagates as AWF exit code 37 |
+| `timeout-124` | 124 | `sleep 90` with `--agent-timeout 1` exits 124 |
+| `device-assumptions` **(new)** | 0 | `/dev/vda` and `/dev/vdb` are block devices; `eth0` exists |
+| `partial-start-cleanup` | 1 | Corrupt rootfs (valid digest, invalid content) fails cleanly; no residue |
+| `cancellation` | 143 | `SIGTERM` after namespace appears cleans up; cleanup time is measured against a non-flaky ceiling |
+| `keep` (keep mode) | 0 | `--keep-containers` preserves namespace/run-directory/diagnostics; all bounded ≤1 MiB |
+| `security-assertions` **(new)** | 143 | See below |
+
+The `security-assertions` case starts a long-lived guest command, then —
+while the VM is live — inspects the host-visible Cloud Hypervisor process
+and its own `vm.info` response to prove the launcher's jailer-replacement
+boundary (Part 3) live, not just at the argv-construction unit-test level:
+
+- **Non-root identity**: `/proc/<pid>` is not owned by uid 0.
+- **Empty effective capability set**: `/proc/<pid>/status`'s `CapEff` is
+  all-zero.
+- **`no_new_privs` is set**: `NoNewPrivs: 1`.
+- **Active seccomp filter**: `Seccomp: 2` (filter mode), confirming
+  `--seccomp true` is in effect.
+- **Cgroup membership and bounded limits**: the process's PID appears in
+  `/sys/fs/cgroup/awf-cloud-hypervisor/<runId>/cgroup.procs`; `memory.max`
+  (or the cgroup v1 equivalent) is a bounded positive number; live
+  `memory.current` usage is greater than zero and does not exceed it (the
+  "bounded memory overhead" baseline from Part 4/9).
+- **`landlock_enable` reflected in `vm.create`** and an **exactly-minimal
+  device set**: querying the Cloud Hypervisor process's own
+  `GET /api/v1/vm.info` over its private Unix domain socket confirms
+  exactly two disks (rootfs, workspace), exactly one net device, and a
+  vsock device — proving the host-only API socket path is never wired to
+  the guest as any device (structurally, not just by absence of a mount).
+
+Boot/readiness and cleanup-time are measured as non-flaky regression
+baselines (generous ceilings tuned for shared GitHub-hosted runners, not
+tight performance targets): the `allowed-https` case's total wall time is
+checked against a 90-second boot+readiness+run+cleanup ceiling, and the
+`cancellation` case's SIGTERM-to-clean-residue time is checked against a
+20-second ceiling.
+
+### Secret sentinel check
+
+All smoke test cases set
+`OPENAI_API_KEY=awf-cloud-hypervisor-real-secret-do-not-expose` (a value
+distinct from Firecracker's sentinel so the two suites' diagnostics never
+cross-contaminate if run in the same job). After each run, the test scans
+`stdout.log`, `audit/`, and `proxy-logs/` for this sentinel string.
+
+### Shared vs. backend-specific residue naming
+
+`src/microvm/network.ts` is VMM-neutral and used unmodified by both
+backends (Part 2), so the network namespace (`awffc-*`) and veth/TAP
+(`fch*`/`fcn*`/`fct*`) residue checks are intentionally identical to
+Firecracker's — this is shared infrastructure, not a Cloud Hypervisor gap.
+The cgroup path (`/sys/fs/cgroup/awf-cloud-hypervisor/<runId>`) and process
+name (`cloud-hypervisor`) residue checks are Cloud Hypervisor-specific.
+
+## Part 15 — Troubleshooting
+
+Most preflight, boot, and cleanup failure modes are identical to
+Firecracker's — see
+[Firecracker's Part 15](./firecracker-integration.md#part-15--troubleshooting)
+for the general shape of each failure (host tool missing, digest mismatch,
+API timeout, guest connectivity probe failure, Docker infrastructure not
+cleaned up, workspace copy-back recovery via `debugfs`). This section covers
+only what differs for Cloud Hypervisor.
+
+**`Cloud Hypervisor is supported only on GitHub-hosted runners, not self-hosted`**
+
+Unlike Firecracker's preview, this backend rejects self-hosted runners
+outright (`src/cloud-hypervisor/host-eligibility.ts`). There is no flag to
+override this; run on a GitHub-hosted Ubuntu x86_64 runner instead.
+
+**`Cloud Hypervisor requires a GitHub-hosted Ubuntu runner image`**
+
+`ImageOS` did not start with `ubuntu` — you are likely on a non-Ubuntu
+GitHub-hosted image (e.g. Windows or macOS runners, which also lack
+`/dev/kvm`). Use an `ubuntu-24.04` (or later) runner.
+
+**`Cloud Hypervisor is pinned to v53.0; found v<other>`**
+
+The Cloud Hypervisor binary is not v53.0. Do not bypass the version check;
+obtain the pinned release.
+
+**`host tool "setpriv" was not found on PATH`**
+
+Install `util-linux` (`setpriv` ships in it; standard on Ubuntu, so this
+should not occur on a genuine GitHub-hosted Ubuntu runner).
+
+**`The running kernel does not report Landlock in /sys/kernel/security/lsm`**
+
+Landlock requires Linux 5.13+ with `CONFIG_SECURITY_LANDLOCK=y` and the LSM
+enabled at boot (`lsm=landlock,...` on the kernel cmdline, or Landlock
+included in the distribution default). GitHub-hosted Ubuntu 24.04 runners
+ship this by default; a custom or older kernel may not.
+
+**`Cloud Hypervisor requires a non-root target uid/gid`**
+
+Same as Firecracker's jailer requirement: run through `sudo` from a
+non-root account so `SUDO_UID`/`SUDO_GID` are set — see
+[Firecracker's Part 15](./firecracker-integration.md#preflight-failures).
+
+**Namespace, cgroup, and process residue after a failed run:**
+
+```bash
+# List namespace residue (shared naming with Firecracker)
+sudo ip netns list | grep awffc
+
+# Remove all AWF microVM namespaces
+sudo ip netns list | awk '/^awffc-/{print $1}' | \
+  xargs -r -I{} sudo ip netns delete {}
+
+# List and remove Cloud Hypervisor-specific cgroup residue
+sudo find /sys/fs/cgroup/awf-cloud-hypervisor -mindepth 1 -maxdepth 1
+sudo rmdir /sys/fs/cgroup/awf-cloud-hypervisor/<runId>
+
+# Find a lingering Cloud Hypervisor process (do not blindly pkill by name;
+# confirm the PID belongs to an AWF run before terminating it)
+pgrep -af 'cloud-hypervisor --api-socket'
+```
+
+**Run directory residue (only if stop failed):**
+
+```bash
+ls /tmp/awf-*/cloud-hypervisor-run/ 2>/dev/null
+sudo rm -rf /tmp/awf-<timestamp>/cloud-hypervisor-run/cloud-hypervisor/<runId>
+```
+
+## Part 16 — Validation performed in this layer
 
 - `tsc --noEmit -p tsconfig.check.json`: clean.
-- Full Jest suite: all suites passing, including new coverage for the API
-  client (typed requests, chained-error parsing, timeout/size bounds),
+- Full Jest suite: all suites passing, including layer 3's API client,
   launcher (argv construction, kvm-gid retention, Landlock rule
-  computation, cgroup v2 subtree_control delegation ordering and rmdir-only
-  cleanup), manager (launch, partial-start rollback, workspace/vsock
-  lifecycle, keep-mode preservation, termination-confirmation retry,
-  natural-exit wait, `vm.create` failure rollback, signal-exit fast-fail,
-  bounded diagnostics with `vm.counters`), backend (host-eligibility gating,
-  stdin serialization, TTY rejection, credential-safe environment,
-  cancellation), and runtime registration/preview-gate wiring.
-- No new shell scripts were introduced — the launcher builds argv arrays
-  passed directly to `execa`; there is nothing to `shellcheck`/`bash -n`.
+  computation, cgroup v2 `subtree_control` delegation ordering and
+  rmdir-only cleanup), manager, backend, and runtime-registration coverage,
+  plus new layer 4 coverage for the CI workflow's YAML structure (triggers,
+  permissions, concurrency, job gating, path scoping) and the new
+  `scripts/ci/cloud-hypervisor-*.sh` scripts' behavior (13-case parity with
+  Firecracker, device-assumption and security-assertion coverage, distinct
+  secret sentinel, shared-vs-specific residue naming, digest flag wiring).
+- `bash -n` and `shellcheck` (severity=error) on both new scripts, plus
+  `bash -n` on every `run:` block in the new workflow YAML.
 - `guest/firecracker-supervisor` Go tests (`go vet`, `go test`): unaffected,
   confirming the shared guest supervisor still works for both backends.
-- **Not performed in this layer**: an actual boot on real KVM hardware.
-  This environment has no `/dev/kvm` and no built Cloud Hypervisor guest
-  artifacts, so a live smoke test would be faked, not validated. This is
-  explicitly deferred to the layer that adds the dedicated live-KVM GitHub
-  Actions workflow.
+- **Live-KVM validation**: the `test-cloud-hypervisor.yml` workflow's
+  `live-kvm` job runs the full smoke/security suite on real GitHub-hosted
+  KVM hardware when triggered (manual dispatch or the
+  `cloud-hypervisor-kvm` pull request label). This development environment
+  has no `/dev/kvm`, so the suite's actual pass/fail status must be
+  confirmed from the workflow run itself rather than reproduced locally.
+

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -546,12 +546,24 @@ vsock-over-UDS multiplexer closes the host-facing connection immediately if
 the guest hasn't yet started listening on the target vsock port (kernel
 boot + guest supervisor startup take a variable, host-load-dependent amount
 of time). `CloudHypervisorManager.startInstance()` retries the connect with
-a fresh client every 250 ms for up to 20 seconds before surfacing the error;
+a fresh client every 250 ms for up to 90 seconds before surfacing the error;
 seeing it in this error message means that entire retry budget was
 exhausted. If it persists, check the guest serial console log
 (`<auditDir>/cloud-hypervisor/serial.log`) for a kernel panic or a
 supervisor startup failure rather than assuming it is purely a timing
 issue.
+
+The 90-second budget is deliberately generous, not a tight few-second
+timeout. Live validation on GitHub-hosted Ubuntu runners showed the guest
+kernel's own boot-log clock advancing far slower than host wall-clock time
+during early PCI/virtio device enumeration — multiple seconds of real
+elapsed time per device, with Cloud Hypervisor's own log reporting
+`Running under nested virtualisation. Hypervisor string: Microsoft Hv`.
+This is consistent with the extra vCPU-scheduling overhead of nested KVM on
+these runners, not a guest crash or hang. A short budget would abort a
+guest that is merely slow to be scheduled. This matches the smoke test's
+own boot-readiness ceiling (`BOOT_READINESS_CEILING_MS` in
+`cloud-hypervisor-live-smoke.sh`).
 
 When `--diagnostic-logs` is set, `CloudHypervisorRuntimeBackend.start()`'s
 failure path collects diagnostics via a `beforeCleanup` hook passed to

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -72,14 +72,20 @@ isolation), different VMM implementation and host launch strategy.
    for the secure host launch:
    - `buildCloudHypervisorLaunchCommand()` builds the exact argv AWF spawns:
      `ip netns exec <namespace> setpriv --reuid=<uid> --regid=<gid>
-     --groups=<kvm-gid> --no-new-privs --inh-caps=-all --bounding-set=-all
+     --groups=<kvm-gid> --no-new-privs --inh-caps=-all,+net_admin
+     --bounding-set=-all,+net_admin --ambient-caps=+net_admin
      -- cloud-hypervisor --api-socket path=<path> --log-file <path> -v
      --seccomp true`. `--groups=<kvm-gid>` replaces the operator's full
      supplementary group list with only the group that owns `/dev/kvm`
      (resolved by preflight) — a blanket `--clear-groups` would also drop
-     kvm-group access and make every real launch fail with EACCES. No
-     shell is ever invoked — this argv is passed directly to `execa`,
-     never interpolated into a shell string.
+     kvm-group access and make every real launch fail with EACCES. The
+     capability set is empty except for `CAP_NET_ADMIN`, retained via the
+     bounding, inheritable, and ambient sets together — Cloud Hypervisor's
+     virtio-net backend needs it to finish configuring the already-created,
+     already-owned TAP device (`vm.boot` otherwise fails with "Failed to
+     read the TAP flags from sysfs: Permission denied"). No shell is ever
+     invoked — this argv is passed directly to `execa`, never interpolated
+     into a shell string.
    - `computeCloudHypervisorLandlockRules()` computes the minimal
      `landlock_rules` list sent in the `vm.create` payload.
    - `CloudHypervisorCgroup` manages a cgroup v2 hierarchy: it enables
@@ -134,7 +140,7 @@ MicrovmWorkspaceImage.prepare() (workspace + rootfs staging — shared with Fire
     ↓
 private run directory under /run/awf-cloud-hypervisor (0711 ancestors, 0700 leaf owned by the non-root identity) + per-run cgroup v2 (subtree_control delegated root→parent→leaf)
     ↓
-buildCloudHypervisorLaunchCommand() → ip netns exec → setpriv --groups=<kvm-gid> → cloud-hypervisor --api-socket ... --seccomp true (minimal PATH-only environment)
+buildCloudHypervisorLaunchCommand() → ip netns exec → setpriv --groups=<kvm-gid> --ambient-caps=+net_admin → cloud-hypervisor --api-socket ... --seccomp true (minimal PATH-only environment)
     ↓
 wait for API socket → vmm.ping → vm.create (landlock_enable: true, minimal landlock_rules)
     ↓
@@ -160,15 +166,22 @@ boundary:
    intermediate fork — the resulting process keeps the PID the host
    observes for cgroup assignment.
 2. **Privilege drop.** `setpriv --reuid=<uid> --regid=<gid>
-   --groups=<kvm-gid> --no-new-privs --inh-caps=-all --bounding-set=-all`
+   --groups=<kvm-gid> --no-new-privs --inh-caps=-all,+net_admin
+   --bounding-set=-all,+net_admin --ambient-caps=+net_admin`
    execs Cloud Hypervisor as the same non-root operator identity
-   Firecracker's jailer targets (`SUDO_UID`/`SUDO_GID`), with an empty
-   capability bounding set and `no_new_privs` set, before any guest code
-   runs. `--groups=<kvm-gid>` replaces the operator's supplementary group
+   Firecracker's jailer targets (`SUDO_UID`/`SUDO_GID`), with `no_new_privs`
+   set and an otherwise-empty capability set before any guest code runs.
+   `--groups=<kvm-gid>` replaces the operator's supplementary group
    list with only the group that owns `/dev/kvm` (resolved by preflight);
    a blanket `--clear-groups` would also drop that membership and make
    every real launch fail opening `/dev/kvm` even though root-run
-   preflight passed.
+   preflight passed. The capability set retains exactly one exception,
+   `CAP_NET_ADMIN` — via the bounding, inheritable, and ambient sets
+   together, so it survives the uid change and `execve()` of a plain,
+   non-file-capability binary even under `--no-new-privs` — because Cloud
+   Hypervisor's virtio-net backend needs it to finish configuring the
+   already-created, already-owned TAP device; without it, `vm.boot` fails
+   with "Failed to read the TAP flags from sysfs: Permission denied".
 3. **Filesystem confinement.** In place of jailer's userspace chroot, AWF
    combines:
    - a **private run directory** under `/run/awf-cloud-hypervisor/<binary>/<runId>/`
@@ -241,7 +254,7 @@ Same as Firecracker (`ip`, `nft`, `sysctl`, `mke2fs`, `debugfs`, `e2fsck`,
 
 | Tool | Purpose |
 |------|---------|
-| `setpriv` | Drops to the non-root operator uid/gid with an empty capability set before Cloud Hypervisor execs (util-linux; standard on Ubuntu) |
+| `setpriv` | Drops to the non-root operator uid/gid before Cloud Hypervisor execs, retaining only `CAP_NET_ADMIN` (util-linux; standard on Ubuntu) |
 
 ### Operator account
 
@@ -436,16 +449,19 @@ and its own `vm.info` response to prove the launcher's jailer-replacement
 boundary (Part 3) live, not just at the argv-construction unit-test level:
 
 - **Non-root identity**: `/proc/<pid>` is not owned by uid 0.
-- **Empty effective capability set**: `/proc/<pid>/status`'s `CapEff` is
-  all-zero.
+- **Minimal effective capability set**: `/proc/<pid>/status`'s `CapEff` is
+  exactly `0000000000001000` — `CAP_NET_ADMIN` alone (needed for Cloud
+  Hypervisor's virtio-net backend to finish configuring the already-owned
+  TAP device; see Part 3) and nothing else.
 - **`no_new_privs` is set**: `NoNewPrivs: 1`.
 - **Active seccomp filter**: `Seccomp: 2` (filter mode), confirming
   `--seccomp true` is in effect.
 - **Cgroup membership and bounded limits**: the process's PID appears in
   `/sys/fs/cgroup/awf-cloud-hypervisor/<runId>/cgroup.procs`; `memory.max`
-  (or the cgroup v1 equivalent) is a bounded positive number; live
-  `memory.current` usage is greater than zero and does not exceed it (the
-  "bounded memory overhead" baseline from Part 4/9).
+  is a bounded positive number (cgroup v1 hosts are rejected outright by
+  preflight, so there is no v1 fallback to check); live `memory.current`
+  usage is greater than zero and does not exceed it (the "bounded memory
+  overhead" baseline from Part 4/9).
 - **`landlock_enable` reflected in `vm.create`** and an **exactly-minimal
   device set**: querying the Cloud Hypervisor process's own
   `GET /api/v1/vm.info` over its private Unix domain socket confirms

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -591,6 +591,31 @@ before the process is terminated at all — can observe a still-empty
 `serial.log` even when the guest did write to its console before crashing
 or hanging.
 
+**Guest kernel panics with `Attempted to kill init!` on every boot (fixed;
+historical)**
+
+Once the two boot-timing issues above were resolved, live-KVM validation
+uncovered the real underlying blocker: the guest kernel's serial console
+showed `Run /sbin/awf-supervisor as init process` immediately followed by
+`firecracker-supervisor: mount workspace: no such device` and a kernel
+panic. `mountWorkspace()` in
+`guest/firecracker-supervisor/runtime_linux.go` called
+`syscall.Mount(device, mount, "", 0, "")` — an **empty filesystem type**.
+An empty fstype is only valid for bind/remount mounts (`MS_BIND`/
+`MS_REMOUNT`); a fresh mount of a raw block device with an empty fstype
+fails with `ENODEV` ("no such device"), even though the device itself
+exists and is a valid block device. The workspace image is always
+formatted `ext4` (see `src/microvm/workspace.ts`'s `mkfs -t ext4`), so this
+was fixed by passing `"ext4"` explicitly. This guest supervisor binary is
+shared, unmodified, between the Firecracker and Cloud Hypervisor backends
+(see Part 2), so this was a genuine, pre-existing production defect
+affecting **both** backends, not something specific to this preview — any
+real guest boot exercising the workspace mount would have hit it. A
+regression test (`TestWorkspaceMountArgsUseExt4Filesystem` in
+`runtime_linux_test.go`) and a CI step running `go test ./...` for this
+package (see Part 14) now guard against a regression of this specific
+class of bug.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -771,6 +771,23 @@ fix:
   device config (`CloudHypervisorManager.buildVmConfig()`) rather than
   relying on Cloud Hypervisor's own defaults.
 
+**Update**: neither of the two changes above resolved it. A follow-up live
+run with both applied showed the *identical* pattern — `ct state invalid`
+still at zero hits (ruling out conntrack-invalid marking) and the return
+accept rule still at zero hits (ruling out the offload/checksum theory,
+since disabling all three offloads made no observable difference). Since
+the microVM's own nftables table shows no rule matching the return traffic
+at all (neither accepting nor dropping it), the packets may never be
+reaching this bridge/veth from Squid's side in the first place, or may be
+handled entirely by a *different* ruleset before ever reaching this one.
+`captureHostBridgeDiagnostics()` was extended to also capture the
+host/default-namespace `nft -a list ruleset` and `iptables -S` — Docker
+manages its own iptables/nftables rules for its bridge networks in that
+same root namespace, entirely separate from (and evaluated in addition
+to) the microVM's own table, and could independently drop or redirect
+traffic on this shared bridge in a way the microVM's own counters would
+never reveal. This is the next concrete lead to check against a live run.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -591,6 +591,24 @@ before the process is terminated at all — can observe a still-empty
 `serial.log` even when the guest did write to its console before crashing
 or hanging.
 
+`CloudHypervisorRuntimeBackend.collectDiagnostics()` is idempotent
+(collects at most once per instance): the CLI's own generic cleanup path
+(`buildCleanupFn` in `commands/main-action.ts`) unconditionally calls
+`externalRuntimeBackend.collectDiagnostics()` again during shutdown,
+regardless of whether `start()`'s failure path already collected
+diagnostics via the `beforeCleanup` hook above. Without the idempotency
+guard, that second, redundant call ran *after* `stop()` had already torn
+down the network/cgroup, silently clobbering the earlier, more useful
+snapshot with an empty/unavailable one (observed live:
+`network-diagnostics.txt` regressing from real content to "network
+namespace not set up" between two collectDiagnostics() calls in the same
+failed run). Likewise, `start()`'s failure path now marks the backend
+`stopped` once its own internal `manager.stop()` call succeeds, so that
+same generic cleanup path's `externalRuntimeBackend.stop()` call becomes a
+no-op instead of invoking `manager.stop()` a second, redundant time (a
+failed internal stop deliberately leaves `stopped` false, so the outer
+cleanup path still gets a genuine retry attempt).
+
 **Guest kernel panics with `Attempted to kill init!` on every boot (fixed;
 historical)**
 

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -788,6 +788,43 @@ to) the microVM's own table, and could independently drop or redirect
 traffic on this shared bridge in a way the microVM's own counters would
 never reveal. This is the next concrete lead to check against a live run.
 
+**Update**: a follow-up live run's host-level ruleset showed Docker's
+`DOCKER-ISOLATION-STAGE-1`/`DOCKER-FORWARD` chains present for the
+infrastructure bridge (confirmed as ours by its subnet-based isolation
+rule, `ip saddr != 172.30.0.0/24 ... drop`, matching AWF's real subnet),
+but neither of its two explicit anti-cross-network drop rules showed any
+hits (0/0), and the one same-bridge accept rule
+(`iifname X oifname X accept`, matching guest↔Squid intra-bridge traffic)
+also showed exactly zero hits across the whole run — inconclusive on its
+own, since 0 hits doesn't distinguish "never reached this rule" from
+"reached but something upstream already handled it".
+
+Given Firecracker uses this exact same shared netns/bridge/nftables/veth
+code and its own live-KVM CI is green, the bridge/Docker-isolation path
+itself is very unlikely to be broken in a way specific to this scenario.
+The next most likely explanation, consistent with everything observed so
+far (guest boot needing a 90s budget for what should be sub-second AP
+bring-up; the connectivity probe needing the same generous budget with
+only marginal improvement from 5s→90s; a bare handful of tap packets
+relayed regardless of how long the test waits): `CloudHypervisorCgroup`
+sized the CPU quota as exactly "1 CPU per configured vCPU"
+(`vcpuCount * CGROUP_V2_PERIOD_US`), but Cloud Hypervisor's own I/O,
+virtio device emulation (including the tap fd read/write loop for the
+guest's network device), and API threads all run in that *same* cgroup as
+the vCPU thread(s) and compete for the *same* quota. Under nested KVM on
+GitHub-hosted runners (where vCPU exits are unusually expensive), the
+vCPU thread alone can consume most of an already-tight, vCPU-only-sized
+quota, starving the VMM's own non-vCPU threads (including the one
+relaying guest network I/O) of their share — independent of wall-clock
+timeout length, matching why raising timeouts alone barely helped.
+
+Added a fixed `CGROUP_CPU_HEADROOM_QUOTA_US` (one additional full
+CPU-equivalent, `100_000`us per period) on top of the per-vCPU quota,
+mirroring the existing `CGROUP_MEMORY_HEADROOM_MIB` pattern for the same
+"VMM overhead needs room beyond what's sized for the guest alone" reason.
+Not yet confirmed as the fix — the next live run will show whether guest
+network I/O throughput changes.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -645,6 +645,20 @@ Same as Firecracker's jailer requirement: run through `sudo` from a
 non-root account so `SUDO_UID`/`SUDO_GID` are set — see
 [Firecracker's Part 15](./firecracker-integration.md#preflight-failures).
 
+**Cgroup residue remains after cleanup (fixed; historical)**
+
+Live-KVM validation observed `Cloud Hypervisor cgroup residue remains
+after cleanup` following a guest-connectivity-probe failure and immediate
+teardown. `CloudHypervisorCgroup.cleanup()` called `rmdir()` on the leaf
+cgroup exactly once; cgroup v2 rejects `rmdir()` on a non-empty cgroup
+with `EBUSY` not only while a process is still a live member, but also for
+a short window *after* that process has fully exited — the memory
+controller's charge-migration teardown can lag process-exit by a handful
+of milliseconds under load, even though `stop()` only calls `cleanup()`
+once process termination is already confirmed. Fixed by retrying `rmdir()`
+on `EBUSY` for up to 5 seconds (100ms interval) before giving up; any
+other error (e.g. `EACCES`) still fails immediately, unretried.
+
 **Namespace, cgroup, and process residue after a failed run:**
 
 ```bash

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -657,6 +657,43 @@ rootfs build; it was not modified here (out of scope for this layer), but
 is very likely affected identically on any real Firecracker live-KVM run
 against this rootfs — see the layer 4 completion handoff.
 
+**Guest boots and gets a valid IP, but all TCP connections to Squid/API
+proxy time out (fixed; historical)**
+
+Once the defects above were fixed, the guest reliably booted with a
+correctly-configured `eth0` IP and default route, but every connection to
+Squid or the API proxy still timed out. Live diagnostics (`nft list
+ruleset` + `ip -s link show` inside the microVM's network namespace,
+captured before teardown — see `network-diagnostics.txt` above) showed the
+*host-side TAP device* with an asymmetric packet count: ~10 RX packets
+(guest-to-host — working) but only 1 TX packet (host-to-guest — stalled),
+even though 20+ response packets had already arrived on the host-side veth
+from Squid. Traffic was reaching the host and being correctly forwarded by
+nftables, but Cloud Hypervisor was not relaying it back into the guest.
+
+Root cause: Cloud Hypervisor's own tap handling (`Tap::open_named()` in
+`net_util/src/tap.rs`) always re-opens its tap file descriptor requesting
+`IFF_VNET_HDR` (a `struct virtio_net_hdr` prefix on every frame). The
+shared TAP-creation code in `src/microvm/network.ts` (`ip tuntap add ...
+mode tap`, used unmodified by both Firecracker and Cloud Hypervisor) never
+requested that feature at *creation* time. When Cloud Hypervisor's re-open
+requests a frame layout the tap wasn't created to support, the host kernel
+and Cloud Hypervisor disagree on frame layout specifically for the
+host-to-guest direction — guest-to-host traffic (and the entire host-side
+veth/nftables layer) keeps working normally, masking the problem as a
+"the guest just isn't receiving responses" mystery rather than an obvious
+hard failure.
+
+Fixed by adding a `tapVnetHdr` field to `MicrovmNetworkPlanOptions`/
+`MicrovmNetworkPlan` (defaulting to `false`, preserving Firecracker's
+existing, unaffected behavior exactly), which conditionally appends
+`vnet_hdr` to the `ip tuntap add` invocation. `CloudHypervisorManager`
+opts in explicitly (`tapVnetHdr: true`) when building its network plan;
+Firecracker's own manager does not (Firecracker's tap handling does not
+request `IFF_VNET_HDR`, so creating the tap with that feature available
+would have been a no-op for Firecracker, but changing shared, working
+code without a concrete reason is unnecessary risk).
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -694,6 +694,24 @@ request `IFF_VNET_HDR`, so creating the tap with that feature available
 would have been a no-op for Firecracker, but changing shared, working
 code without a concrete reason is unnecessary risk).
 
+**Guest connectivity probe still times out even with a fully-correct
+network path (fixed; historical)**
+
+After the `vnet_hdr` fix above, live network diagnostics conclusively
+showed the tap/nftables/MAC path working correctly — Squid's response
+packets reached the host-side veth — yet
+`probeGuestConnectivity()`'s `nc -z -w 5` inside the guest still timed out.
+This is the same nested-virtualization vCPU-scheduling phenomenon
+documented for guest boot above (see
+`CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS`): the guest's vCPU can be
+scheduled so rarely that a short-lived command doesn't get enough real CPU
+time to complete a `connect()` within a tight budget, even though nothing
+about the network path itself is broken. Raised `nc`'s own timeout to 60s,
+`wget`'s to 20s, and the overall guest-exec budget
+(`CLOUD_HYPERVISOR_PROBE_TIMEOUT_MS`) to 90s to match the same
+nested-KVM-tolerant convention used elsewhere, and increased the live-KVM
+workflow job's `timeout-minutes` accordingly.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -553,17 +553,31 @@ exhausted. If it persists, check the guest serial console log
 supervisor startup failure rather than assuming it is purely a timing
 issue.
 
-The 90-second budget is deliberately generous, not a tight few-second
-timeout. Live validation on GitHub-hosted Ubuntu runners showed the guest
-kernel's own boot-log clock advancing far slower than host wall-clock time
-during early PCI/virtio device enumeration — multiple seconds of real
-elapsed time per device, with Cloud Hypervisor's own log reporting
-`Running under nested virtualisation. Hypervisor string: Microsoft Hv`.
-This is consistent with the extra vCPU-scheduling overhead of nested KVM on
-these runners, not a guest crash or hang. A short budget would abort a
-guest that is merely slow to be scheduled. This matches the smoke test's
-own boot-readiness ceiling (`BOOT_READINESS_CEILING_MS` in
-`cloud-hypervisor-live-smoke.sh`).
+**Known GitHub-hosted-runner limitation: multi-vCPU guest boot can stall
+for 90+ seconds under nested virtualization.** Live validation captured a
+guest boot that made no further progress for 90+ real seconds immediately
+after its serial console logged `kvm-guest: setup PV IPIs` at kernel
+virtual time ~0.13s — the point where a guest with more than one vCPU
+begins bringing up its secondary (AP) CPUs via inter-processor interrupts
+(INIT-SIPI-SIPI). GitHub-hosted runners execute Cloud Hypervisor under
+*nested* virtualization (its own log reports `Running under nested
+virtualisation. Hypervisor string: Microsoft Hv` there); local
+APIC/IPI virtualization for a nested (L2) guest is not hardware-accelerated
+the way it is for an L1 guest on this class of infrastructure, so every
+AP-bring-up step traps all the way up to the L0 host and back — a
+well-documented, order-of-magnitude nested-KVM SMP penalty, not a Cloud
+Hypervisor or AWF defect. A single-vCPU guest never reaches that code path
+at all and boots in the expected sub-second-to-few-seconds range even
+nested. `scripts/ci/cloud-hypervisor-live-smoke.sh` therefore passes
+`--cloud-hypervisor-vcpus 1`; the default (`--cloud-hypervisor-vcpus`,
+default 2, see `docs/awf-config-spec.md`) is unchanged for other
+environments, but operators running this preview on similarly nested
+infrastructure (self-managed nested-KVM CI, for example) should expect the
+same AP-bring-up penalty at more than one vCPU and may need to raise
+`CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS` further or pin to a single vCPU.
+The 90-second retry budget above remains a deliberately generous safety
+margin for ordinary boot-timing variance (kernel decompression + supervisor
+startup), independent of this specific SMP pathology.
 
 When `--diagnostic-logs` is set, `CloudHypervisorRuntimeBackend.start()`'s
 failure path collects diagnostics via a `beforeCleanup` hook passed to

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -737,6 +737,40 @@ about the network path itself is broken. Raised `nc`'s own timeout to 60s,
 nested-KVM-tolerant convention used elsewhere, and increased the live-KVM
 workflow job's `timeout-minutes` accordingly.
 
+**Guest→Squid packets forwarded but the return path never matches
+`established,related` (under investigation)**
+
+With per-rule nftables counters added (see the diagnostics-lifecycle entry
+above), a live run showed the guest→Squid forward-chain rule matching real
+traffic (`counter packets 6 bytes 360 accept`, from `nc`'s own SYN
+retransmissions over its 60s budget), while the return-path accept rule
+(`ether daddr <guestMac> ip daddr <guestIp> ct state established,related
+accept`) stayed at **zero** hits, and none of the anti-spoof drop rules
+matched either. This rules out both a misconfigured anti-spoof rule and a
+`vnet_hdr`/tap-negotiation failure (both would show up as counter hits
+somewhere); the traffic leaves the guest and is accepted outbound, but
+Squid's reply is never recognized as belonging to that connection.
+
+Two changes were made to narrow this further, not yet confirmed as the
+fix:
+- Added a `counter` to the chain's very first rule, `ct state invalid
+  drop` — previously uncounted, so a reply being marked "invalid" by
+  conntrack (and dropped before ever reaching the return-path accept rule)
+  would have been invisible. If this rule's counter is nonzero on the next
+  live run, that is the confirmed root cause.
+- Cloud Hypervisor's virtio-net device defaults all three offloads
+  (`offload_tso`, `offload_ufo`, `offload_csum`) to enabled (confirmed via
+  `vm.info`'s `net[0]` config, now captured in `vm-info.json`). This
+  network path is a fully-software bridge/veth/tap chain with no real NIC
+  downstream to finish partially-offloaded (unchecksummed /
+  not-yet-segmented) frames; conntrack's TCP state tracking needs a valid,
+  fully-computed checksum to correctly parse segment flags/sequence
+  numbers, so an offloaded-but-never-finished checksum is a plausible
+  cause for exactly this "accepted outbound, reply never tracked as
+  established" symptom. All three are now explicitly disabled in the net
+  device config (`CloudHypervisorManager.buildVmConfig()`) rather than
+  relying on Cloud Hypervisor's own defaults.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -553,6 +553,18 @@ exhausted. If it persists, check the guest serial console log
 supervisor startup failure rather than assuming it is purely a timing
 issue.
 
+When `--diagnostic-logs` is set, `CloudHypervisorRuntimeBackend.start()`'s
+failure path collects diagnostics via a `beforeCleanup` hook passed to
+`CloudHypervisorManager.stop()`, invoked after the Cloud Hypervisor process
+is confirmed terminated but before `stop()` removes the private run
+directory those diagnostic files live in. This ordering matters: Cloud
+Hypervisor does not guarantee flushing buffered guest serial console
+output to disk until its own process actually exits (`vmm.shutdown()`
+alone is not sufficient), so collecting diagnostics any earlier — e.g.
+before the process is terminated at all — can observe a still-empty
+`serial.log` even when the guest did write to its console before crashing
+or hanging.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -616,6 +616,29 @@ regression test (`TestWorkspaceMountArgsUseExt4Filesystem` in
 package (see Part 14) now guard against a regression of this specific
 class of bug.
 
+**`Cloud Hypervisor guest connectivity probe failed with exit code 127`
+(fixed; historical)**
+
+`CloudHypervisorRuntimeBackend.probeGuestConnectivity()` originally shelled
+out to `curl` inside the guest to verify Squid and (if enabled) API proxy
+reachability before declaring the microVM ready. The guest rootfs used for
+this backend's own live-KVM validation is a minimal BusyBox userland (see
+`guest/cloud-hypervisor/build-test-artifacts.sh`) that provides `wget` and
+`nc` but not `curl` — exit code 127 is the shell's "command not found".
+Fixed by switching the Squid reachability check to `nc -z` (a raw TCP
+check; a non-proxy-style HTTP request to Squid's own port intentionally
+returns a 4xx error page by Squid's design, which BusyBox `wget`, unlike
+`curl` without `--fail`, treats as a script failure by default — so `nc -z`
+avoids that mismatch entirely) and the API proxy `/reflect` check to
+`wget` with the guest's proxy environment variables unset for that one
+request (matching the smoke test's own `api-proxy-reflect` case, and
+replacing `curl --noproxy '*'`, which BusyBox `wget` has no equivalent
+flag for). **Note:** `FirecrackerRuntimeBackend.probeGuestConnectivity()`
+has the identical `curl`-based implementation and shares this same guest
+rootfs build; it was not modified here (out of scope for this layer), but
+is very likely affected identically on any real Firecracker live-KVM run
+against this rootfs — see the layer 4 completion handoff.
+
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 
 Same as Firecracker's jailer requirement: run through `sudo` from a

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -104,7 +104,8 @@ isolation), different VMM implementation and host launch strategy.
    `src/microvm/network.ts` unchanged) → workspace image preparation
    (reusing `src/microvm/workspace.ts` unchanged) → private run-directory
    staging → cgroup setup → launch → API-socket readiness → `vm.create` →
-   (later) `vm.boot` → VSOCK guest-supervisor connect (reusing
+   (later) `vm.boot` → VSOCK guest-supervisor connect, retried with a fresh
+   client on the guest-boot-timing race documented in Part 3 (reusing
    `src/microvm/vsock-client.ts` and `guest-protocol.ts` unchanged) →
    execution → graceful `vm.shutdown`/`vmm.shutdown` → process termination
    → workspace extraction → network/cgroup/run-directory cleanup, with
@@ -144,7 +145,7 @@ buildCloudHypervisorLaunchCommand() → ip netns exec → setpriv --groups=<kvm-
     ↓
 wait for API socket → vmm.ping → vm.create (landlock_enable: true, minimal landlock_rules)
     ↓
-CloudHypervisorRuntimeBackend.start(): vm.boot → VSOCK connect (CID 3, CONNECT <port>\n) → Squid/API-proxy connectivity probe
+CloudHypervisorRuntimeBackend.start(): vm.boot → VSOCK connect (CID 3, CONNECT <port>\n, retried on the guest-boot-timing race — see Part 3) → Squid/API-proxy connectivity probe
     ↓
 Agent command executes inside the guest via the VSOCK guest-protocol transport (unchanged)
     ↓
@@ -537,6 +538,20 @@ Landlock requires Linux 5.13+ with `CONFIG_SECURITY_LANDLOCK=y` and the LSM
 enabled at boot (`lsm=landlock,...` on the kernel cmdline, or Landlock
 included in the distribution default). GitHub-hosted Ubuntu 24.04 runners
 ship this by default; a custom or older kernel may not.
+
+**`guest disconnected before readiness` on `startInstance()`**
+
+This is expected transient behavior, not a bug: Cloud Hypervisor's own
+vsock-over-UDS multiplexer closes the host-facing connection immediately if
+the guest hasn't yet started listening on the target vsock port (kernel
+boot + guest supervisor startup take a variable, host-load-dependent amount
+of time). `CloudHypervisorManager.startInstance()` retries the connect with
+a fresh client every 250 ms for up to 20 seconds before surfacing the error;
+seeing it in this error message means that entire retry budget was
+exhausted. If it persists, check the guest serial console log
+(`<auditDir>/cloud-hypervisor/serial.log`) for a kernel panic or a
+supervisor startup failure rather than assuming it is purely a timing
+issue.
 
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -197,7 +197,13 @@ boundary:
      `vm.create` payload with a minimal `landlock_rules` list (kernel image
      read-only; rootfs, workspace, and the run directory read-write;
      `/dev/kvm` and `/dev/net/tun` read-write for KVM ioctls and TAP
-     attachment). Any path not listed becomes inaccessible to the Cloud
+     attachment; the TAP's own `/sys/class/net/<tapName>` directory
+     read-only, for the world-readable `tun_flags` sysfs attribute Cloud
+     Hypervisor's virtio-net setup reads to detect multi-queue support —
+     without this rule Landlock itself blocks that read, surfacing as
+     `vm.boot` failing with "Failed to read the TAP flags from sysfs:
+     Permission denied" even though ordinary Unix file permissions would
+     have allowed it). Any path not listed becomes inaccessible to the Cloud
      Hypervisor process the instant Landlock is enabled — enforced by the
      kernel, not a userspace boundary a compromised process could bypass.
    - Cloud Hypervisor's own **default seccomp filter** (`--seccomp true`,

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -822,8 +822,47 @@ Added a fixed `CGROUP_CPU_HEADROOM_QUOTA_US` (one additional full
 CPU-equivalent, `100_000`us per period) on top of the per-vCPU quota,
 mirroring the existing `CGROUP_MEMORY_HEADROOM_MIB` pattern for the same
 "VMM overhead needs room beyond what's sized for the guest alone" reason.
-Not yet confirmed as the fix — the next live run will show whether guest
-network I/O throughput changes.
+
+**Update — root cause confirmed and fixed.** Neither the CPU headroom
+change nor any of the previous attempts changed the observable pattern:
+`ct state invalid` and the return-path accept rule both stayed at exactly
+zero hits, run after run, and the guest's outbound packet count (6
+packets from `nc`'s own SYN-retry schedule) was identical regardless of
+CPU quota, offloads, or `vnet_hdr`. That consistency was itself the clue:
+this was never a scheduling/timing artifact.
+
+Squid's own `access.log` (captured in the diagnostics artifact) settled
+it conclusively: it showed **zero** connection attempts from the guest's
+address, across the entire test run — while genuine container-to-container
+traffic on the exact same bridge (the API proxy reaching Squid) worked
+fine. The microVM's own nftables table showed the outbound packet being
+accepted (leaving via the host-side veth), but it never arrived at Squid.
+
+Root cause: Docker's host-level `DOCKER-FORWARD` chain includes a
+generic same-bridge accept rule (`iifname <bridge> oifname <bridge>
+accept`) intended to permit intra-bridge traffic, but it never matched
+traffic to/from our manually-injected (non-Docker-managed) veth on this
+GitHub-hosted runner's Docker/kernel/nftables combination — silently
+falling through to the `FORWARD` chain's default-drop policy. Real
+Docker-managed containers on the same bridge are unaffected (Docker
+grants them rules of their own that an externally-injected veth never
+receives).
+
+Fixed by inserting a scoped `ACCEPT` rule directly into Docker's
+`DOCKER-USER` chain (which Docker evaluates *before* its own isolation
+logic) — `-i <bridge> -o <bridge> -j ACCEPT`, both interfaces required to
+be this exact per-run bridge. This is the same `DOCKER-USER`
+customization point AWF's own container-based sandbox mode already uses
+(`src/host-iptables-chain.ts`), just scoped for the microVM
+network-isolation path instead. Inserted right after the host veth joins
+the bridge in `MicrovmNetworkManager.setup()`, and removed in `cleanup()`
+(tolerant of it already being gone). Scoped to exactly this per-run
+bridge (Docker Compose assigns a unique bridge name per invocation) with
+both interfaces required to match, so it does not weaken isolation for
+any other bridge/network on the host, and it does not bypass the
+microVM's own in-namespace nftables allowlist — that allowlist still
+governs what the guest can send in the first place; this rule only fixes
+the Docker-level pass-through for traffic that has already cleared it.
 
 **`Cloud Hypervisor requires a non-root target uid/gid`**
 

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -609,6 +609,31 @@ no-op instead of invoking `manager.stop()` a second, redundant time (a
 failed internal stop deliberately leaves `stopped` false, so the outer
 cleanup path still gets a genuine retry attempt).
 
+The same "API socket only responsive before shutdown, files only flushed
+after shutdown" tension applies to `vm.info`/`vm.counters`, not just the
+serial console: `CloudHypervisorManager.stop()` snapshots both *before*
+calling `vmm.shutdown()` (stored as `lastVmInfo`/`lastVmCounters`), since a
+live call from inside `collectDiagnostics()` (invoked later, via
+`beforeCleanup`, after the process has already been asked to exit) would
+always fail against an already-unresponsive socket. `collectDiagnostics()`
+prefers this snapshot and only falls back to a live call when invoked
+directly outside of `stop()` (e.g. via `--diagnostic-logs` without a
+failure). Written to `vm-info.json` alongside the existing
+`counters.json`.
+
+`CloudHypervisorManager.collectDiagnostics()`'s host-side network capture
+(`network-diagnostics.txt`) now includes, in addition to `nft list
+ruleset` and `ip -s link show`: `nft -a list ruleset` (rule handles, plus
+per-rule hit counters — `generateMicrovmNftRuleset()` attaches a `counter`
+object to every forward-chain rule purely for this diagnostic visibility;
+it does not change any accept/drop decision), `ip -d link show`, `ip route
+show`, `ip neigh show` (inside the microVM's own namespace), and a
+separate host-side (outside any namespace) `bridge fdb show` for the
+infrastructure bridge Squid/API-proxy containers are attached to — MAC
+learning for that traffic happens on the bridge, not inside the
+namespace. The guest-side capture (`probeGuestConnectivity()`'s failure
+path) also now includes `ip neigh show` to confirm ARP resolution.
+
 **Guest kernel panics with `Attempted to kill init!` on every boot (fixed;
 historical)**
 

--- a/guest/cloud-hypervisor/build-test-artifacts.sh
+++ b/guest/cloud-hypervisor/build-test-artifacts.sh
@@ -151,6 +151,18 @@ done
 # BusyBox 1.36.1 tc depends on CBQ UAPI definitions removed from newer build hosts.
 # The minimal guest never uses traffic control; AWF enforces policy in the host netns.
 disable_busybox_option TC
+# FEATURE_WGET_OPENSSL defaults to enabled and, when active, makes wget
+# handle every https:// URL by shelling out directly to
+# `openssl s_client -connect <hostname>:443` -- entirely bypassing wget's
+# own HTTP(S)_PROXY-aware connection logic. That requires the guest to
+# resolve DNS and reach arbitrary hosts on port 443 directly, both of
+# which this network policy deliberately blocks (the guest is only ever
+# supposed to reach Squid/API-proxy on their fixed IPs; Squid alone
+# resolves/enforces the allowed-domain list). Disabling this makes wget
+# fall back to FEATURE_WGET_HTTPS's internal TLS code, which correctly
+# tunnels through HTTPS_PROXY/https_proxy via a CONNECT request using the
+# hostname string, never needing guest-side DNS resolution at all.
+disable_busybox_option FEATURE_WGET_OPENSSL
 make -C "$busybox_dir" -j"$JOBS"
 
 # The AWF guest supervisor is intentionally VMM-neutral (see

--- a/guest/firecracker-supervisor/runtime_linux.go
+++ b/guest/firecracker-supervisor/runtime_linux.go
@@ -115,8 +115,14 @@ func mountProc() error {
 	return nil
 }
 
+// syncFilesystems is a package-level indirection over syscall.Sync so the
+// shutdown request handler's ordering (sync happens-before acknowledging
+// the request to the host) can be verified in a unit test without
+// depending on real kernel state.
+var syncFilesystems = syscall.Sync
+
 func shutdownGuest(config bootConfig) error {
-	syscall.Sync()
+	syncFilesystems()
 	if err := syscall.Unmount(config.WorkspaceMount, 0); err != nil {
 		return fmt.Errorf("unmount workspace: %w", err)
 	}
@@ -248,6 +254,20 @@ func serveClient(connection *os.File, config bootConfig) bool {
 		case "resize":
 			s.sendError(frame.RequestID, errorTTYUnsupported, "TTY and resize are unsupported")
 		case "shutdown":
+			// syncFilesystems (syscall.Sync in production) must complete
+			// *before* acknowledging this request: once the host receives
+			// "shutting_down" it proceeds to call Cloud Hypervisor's own
+			// vm.shutdown/vmm.shutdown API, which can tear the VM down
+			// quickly enough to race ahead of shutdownGuest()'s own
+			// sync()+unmount() below (that pair only runs *after*
+			// serveClient returns to its caller). Any writes still sitting
+			// in this guest's page cache -- e.g. the agent command's own
+			// workspace writes, which have no reason to have called
+			// fsync() themselves -- could be lost before they ever reach
+			// the workspace block device, silently discarding the user's
+			// own command output from the host-side copy-back. Sync is
+			// safe to call unconditionally and idempotently here.
+			syncFilesystems()
 			_ = s.send(newFrame("shutting_down", frame.RequestID))
 			s.stopActive()
 			return true

--- a/guest/firecracker-supervisor/runtime_linux.go
+++ b/guest/firecracker-supervisor/runtime_linux.go
@@ -126,6 +126,15 @@ func shutdownGuest(config bootConfig) error {
 	return nil
 }
 
+const workspaceFilesystemType = "ext4"
+
+// workspaceMountArgs computes the syscall.Mount() arguments for the
+// workspace device. Split out from mountWorkspace so it can be unit-tested
+// without requiring root/CAP_SYS_ADMIN to actually perform a mount.
+func workspaceMountArgs(config bootConfig) (source, target, fstype string, flags uintptr) {
+	return config.WorkspaceDevice, config.WorkspaceMount, workspaceFilesystemType, 0
+}
+
 func mountWorkspace(config bootConfig) error {
 	info, err := os.Stat(config.WorkspaceDevice)
 	if err != nil {
@@ -137,7 +146,19 @@ func mountWorkspace(config bootConfig) error {
 	if err := os.MkdirAll(config.WorkspaceMount, 0755); err != nil {
 		return fmt.Errorf("create workspace mount: %w", err)
 	}
-	if err := syscall.Mount(config.WorkspaceDevice, config.WorkspaceMount, "", 0, ""); err != nil {
+	// The workspace image is always formatted as ext4 by
+	// MicrovmWorkspaceImage (mkfs -t ext4; see src/microvm/workspace.ts),
+	// matching the root filesystem's `rootfstype=ext4` kernel cmdline
+	// parameter. An empty fstype string is only valid for bind/remount
+	// mounts (MS_BIND/MS_REMOUNT); passing it here for a fresh mount from a
+	// raw block device instead failed with ENODEV ("no such device"),
+	// which made this supervisor's init process return an error and the
+	// kernel panic with "Attempted to kill init!" on every single guest
+	// boot. Discovered via live-KVM validation (a genuine, pre-existing
+	// defect shared by both the Firecracker and Cloud Hypervisor backends,
+	// since they share this guest supervisor binary).
+	source, target, fstype, flags := workspaceMountArgs(config)
+	if err := syscall.Mount(source, target, fstype, flags, ""); err != nil {
 		return fmt.Errorf("mount workspace: %w", err)
 	}
 	return nil

--- a/guest/firecracker-supervisor/runtime_linux_test.go
+++ b/guest/firecracker-supervisor/runtime_linux_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -53,5 +54,63 @@ func TestWorkspaceMountArgsUseExt4Filesystem(t *testing.T) {
 	}
 	if flags != 0 {
 		t.Fatalf("unexpected mount flags: got %d want 0", flags)
+	}
+}
+
+func TestShutdownRequestSyncsBeforeAcknowledging(t *testing.T) {
+	// Regression test: a live-KVM investigation found the workspace-
+	// copyback smoke case's own newly-written file missing entirely from
+	// the host-side copy-back, despite the guest agent command completing
+	// successfully. Root cause: serveClient's "shutdown" case previously
+	// sent the "shutting_down" acknowledgment *before* shutdownGuest()'s
+	// own syscall.Sync()+unmount() ran (that pair only executes after
+	// serveClient returns to its caller). Once the host receives that
+	// acknowledgment it proceeds to call Cloud Hypervisor's own
+	// vm.shutdown/vmm.shutdown API, which can tear the VM down before the
+	// guest ever gets to flush its page cache to the workspace block
+	// device -- silently discarding writes the agent command made (e.g.
+	// via a plain `printf > file` with no explicit fsync of its own).
+	//
+	// This exercises serveClient itself end-to-end over a real, connected
+	// socketpair (matching its *os.File parameter type) and asserts that
+	// syncFilesystems is called strictly before the "shutting_down" frame
+	// is observed on the wire.
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	serverEnd := os.NewFile(uintptr(fds[0]), "server")
+	testEnd := os.NewFile(uintptr(fds[1]), "test")
+	defer serverEnd.Close()
+	defer testEnd.Close()
+
+	var syncCalled, syncCalledBeforeShutdownFrame bool
+	originalSync := syncFilesystems
+	syncFilesystems = func() { syncCalled = true }
+	defer func() { syncFilesystems = originalSync }()
+
+	done := make(chan bool, 1)
+	go func() { done <- serveClient(serverEnd, bootConfig{}) }()
+
+	// Discard the initial "ready" frame serveClient sends on connect.
+	if _, err := ReadFrame(testEnd); err != nil {
+		t.Fatalf("read ready frame: %v", err)
+	}
+	if err := WriteFrame(testEnd, newFrame("shutdown", "req-1")); err != nil {
+		t.Fatalf("write shutdown frame: %v", err)
+	}
+	reply, err := ReadFrame(testEnd)
+	if err != nil {
+		t.Fatalf("read shutting_down frame: %v", err)
+	}
+	syncCalledBeforeShutdownFrame = syncCalled
+	if reply.Type != "shutting_down" {
+		t.Fatalf("reply type mismatch: got %q want %q", reply.Type, "shutting_down")
+	}
+	if !syncCalledBeforeShutdownFrame {
+		t.Fatal("syncFilesystems must be called before the shutting_down acknowledgment is sent")
+	}
+	if shouldShutdown := <-done; !shouldShutdown {
+		t.Fatal("serveClient should report shutdown requested")
 	}
 }

--- a/guest/firecracker-supervisor/runtime_linux_test.go
+++ b/guest/firecracker-supervisor/runtime_linux_test.go
@@ -28,3 +28,30 @@ func TestResolveCommandRejectsRelativeExecutablePath(t *testing.T) {
 		t.Fatal("expected relative executable path to fail")
 	}
 }
+
+func TestWorkspaceMountArgsUseExt4Filesystem(t *testing.T) {
+	// Regression test: the workspace device is always formatted as ext4
+	// (see src/microvm/workspace.ts's `mkfs -t ext4`), but mountWorkspace()
+	// previously passed an empty fstype string to syscall.Mount(), which
+	// is only valid for bind/remount mounts (MS_BIND/MS_REMOUNT). For a
+	// fresh mount of a raw block device this fails with ENODEV ("no such
+	// device"), which made the guest supervisor's init process return an
+	// error and the kernel panic with "Attempted to kill init!" on every
+	// single guest boot — discovered via live-KVM validation, a genuine,
+	// pre-existing defect shared by both the Firecracker and Cloud
+	// Hypervisor backends (they share this guest supervisor binary).
+	config := bootConfig{WorkspaceDevice: "/dev/vdb", WorkspaceMount: "/workspace"}
+	source, target, fstype, flags := workspaceMountArgs(config)
+	if source != config.WorkspaceDevice {
+		t.Fatalf("source mismatch: got %s want %s", source, config.WorkspaceDevice)
+	}
+	if target != config.WorkspaceMount {
+		t.Fatalf("target mismatch: got %s want %s", target, config.WorkspaceMount)
+	}
+	if fstype != "ext4" {
+		t.Fatalf("fstype mismatch: got %q want %q (empty string is ENODEV for a fresh block-device mount)", fstype, "ext4")
+	}
+	if flags != 0 {
+		t.Fatalf("unexpected mount flags: got %d want 0", flags)
+	}
+}

--- a/guest/firecracker/build-test-artifacts.sh
+++ b/guest/firecracker/build-test-artifacts.sh
@@ -134,6 +134,18 @@ done
 # BusyBox 1.36.1 tc depends on CBQ UAPI definitions removed from newer build hosts.
 # The minimal guest never uses traffic control; AWF enforces policy in the host netns.
 disable_busybox_option TC
+# FEATURE_WGET_OPENSSL defaults to enabled and, when active, makes wget
+# handle every https:// URL by shelling out directly to
+# `openssl s_client -connect <hostname>:443` -- entirely bypassing wget's
+# own HTTP(S)_PROXY-aware connection logic. That requires the guest to
+# resolve DNS and reach arbitrary hosts on port 443 directly, both of
+# which this network policy deliberately blocks (the guest is only ever
+# supposed to reach Squid/API-proxy on their fixed IPs; Squid alone
+# resolves/enforces the allowed-domain list). Disabling this makes wget
+# fall back to FEATURE_WGET_HTTPS's internal TLS code, which correctly
+# tunnels through HTTPS_PROXY/https_proxy via a CONNECT request using the
+# hostname string, never needing guest-side DNS resolution at all.
+disable_busybox_option FEATURE_WGET_OPENSSL
 make -C "$busybox_dir" -j"$JOBS"
 
 supervisor="$OUTPUT/awf-firecracker-supervisor"

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -131,6 +131,17 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain('--cloud-hypervisor-supervisor-sha256');
   });
 
+  it('explicitly passes --network-isolation (commander resolves the paired option to undefined by default)', () => {
+    // Regression test: discovered via a live workflow_dispatch run —
+    // assertCloudHypervisorRuntimeCompatibility() requires a strictly
+    // truthy config.networkIsolation, but the --network-isolation/
+    // --no-network-isolation commander.js option pair resolves to
+    // `undefined` (not `true`) when neither flag is passed on the CLI,
+    // despite the CLI help text describing it as "enabled by default".
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    expect(source).toMatch(/COMMON=\(\n(?:.*\n)*?\s*--network-isolation\n/);
+  });
+
   (shellcheckAvailable() ? it : it.skip)('has no new shellcheck errors beyond the Firecracker baseline', () => {
     expect(() =>
       execFileSync('shellcheck', ['--severity=error', smokePath]),

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -1,0 +1,160 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+const preflightPath = path.resolve(__dirname, 'cloud-hypervisor-host-preflight.sh');
+const smokePath = path.resolve(__dirname, 'cloud-hypervisor-live-smoke.sh');
+const firecrackerPreflightPath = path.resolve(__dirname, 'firecracker-host-preflight.sh');
+const firecrackerSmokePath = path.resolve(__dirname, 'firecracker-live-smoke.sh');
+
+function shellcheckAvailable(): boolean {
+  try {
+    execFileSync('shellcheck', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('cloud-hypervisor-host-preflight.sh', () => {
+  it('passes bash syntax check', () => {
+    expect(() => execFileSync('bash', ['-n', preflightPath])).not.toThrow();
+  });
+
+  it('fails closed with a usage message when no artifact directory is given', () => {
+    expect(() =>
+      execFileSync('bash', [preflightPath], { stdio: 'pipe' }),
+    ).toThrow();
+  });
+
+  it('enforces GitHub-hosted-only host eligibility ahead of live capability checks', () => {
+    const source = fs.readFileSync(preflightPath, 'utf-8');
+    expect(source).toContain('GITHUB_ACTIONS');
+    expect(source).toContain('RUNNER_ENVIRONMENT');
+    expect(source).toContain('github-hosted');
+    expect(source).toContain('ImageOS');
+  });
+
+  it('requires setpriv (the launcher jailer replacement) and does not check a jailer binary version', () => {
+    const source = fs.readFileSync(preflightPath, 'utf-8');
+    expect(source).toContain('setpriv');
+    expect(source).not.toContain('jailer --version');
+    expect(source).not.toMatch(/\$ARTIFACT_DIR\/jailer/);
+  });
+
+  it('checks for Landlock LSM support and pins Cloud Hypervisor v53.0', () => {
+    const source = fs.readFileSync(preflightPath, 'utf-8');
+    expect(source).toContain('/sys/kernel/security/lsm');
+    expect(source).toContain('landlock');
+    expect(source).toContain("'53.0'");
+  });
+
+  it('verifies artifact digests via sha256sum --check --strict', () => {
+    const source = fs.readFileSync(preflightPath, 'utf-8');
+    expect(source).toContain('sha256sum --check --strict SHA256SUMS');
+  });
+
+  (shellcheckAvailable() ? it : it.skip)('has no shellcheck errors', () => {
+    expect(() =>
+      execFileSync('shellcheck', ['--severity=error', preflightPath]),
+    ).not.toThrow();
+  });
+});
+
+describe('cloud-hypervisor-live-smoke.sh', () => {
+  it('passes bash syntax check', () => {
+    expect(() => execFileSync('bash', ['-n', smokePath])).not.toThrow();
+  });
+
+  it('reproduces the full 13-case Firecracker behavioral/security contract', () => {
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    const requiredCases = [
+      'allowed-https',
+      'blocked-domain',
+      'direct-egress',
+      'arbitrary-tcp',
+      'dns-denial',
+      'metadata-denial',
+      'api-proxy-reflect',
+      'workspace-copyback',
+      'exit-code',
+      'timeout-124',
+      'partial-start-cleanup',
+    ];
+    for (const name of requiredCases) {
+      expect(source).toContain(`run_case ${name}`);
+    }
+    // cancellation and keep are hand-rolled blocks (not run_case) in both scripts.
+    expect(source).toContain('cancel_work=');
+    expect(source).toContain('keep_work=');
+  });
+
+  it('adds Cloud Hypervisor-specific device-assumption and security-assertion coverage', () => {
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    expect(source).toContain('run_case device-assumptions');
+    expect(source).toContain('/dev/vda');
+    expect(source).toContain('/dev/vdb');
+    expect(source).toContain('eth0');
+    expect(source).toContain('sec_work=');
+    expect(source).toContain('CapEff');
+    expect(source).toContain('NoNewPrivs');
+    expect(source).toContain('Seccomp');
+    expect(source).toContain('landlock_enable');
+    expect(source).toContain('cgroup.procs');
+  });
+
+  it('measures non-flaky boot-readiness and cleanup-time baselines', () => {
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    expect(source).toContain('BOOT_READINESS_CEILING_MS');
+    expect(source).toContain('CLEANUP_CEILING_MS');
+    expect(source).not.toMatch(/vhost-net|vhost-user/);
+  });
+
+  it('uses a Cloud Hypervisor-distinct secret sentinel and scans for leaks', () => {
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    expect(source).toContain('awf-cloud-hypervisor-real-secret-do-not-expose');
+  });
+
+  it('checks netns/veth/TAP residue (shared with Firecracker) plus Cloud Hypervisor-specific cgroup/process residue', () => {
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    expect(source).toContain("grep -q '^awffc-'");
+    expect(source).toContain('(fch|fcn|fct)');
+    expect(source).toContain('CGROUP_ROOT');
+    expect(source).toContain("pgrep -f 'cloud-hypervisor --api-socket'");
+  });
+
+  it('passes the pinned artifact digests as distinct --cloud-hypervisor-*-sha256 flags', () => {
+    const source = fs.readFileSync(smokePath, 'utf-8');
+    expect(source).toContain('--cloud-hypervisor-binary-sha256');
+    expect(source).toContain('--cloud-hypervisor-kernel-sha256');
+    expect(source).toContain('--cloud-hypervisor-rootfs-sha256');
+    expect(source).toContain('--cloud-hypervisor-supervisor-sha256');
+  });
+
+  (shellcheckAvailable() ? it : it.skip)('has no new shellcheck errors beyond the Firecracker baseline', () => {
+    expect(() =>
+      execFileSync('shellcheck', ['--severity=error', smokePath]),
+    ).not.toThrow();
+  });
+});
+
+describe('parity with the Firecracker live-smoke conventions', () => {
+  it('both Firecracker and Cloud Hypervisor scripts define the same run_case/assert_no_residue helpers', () => {
+    const firecracker = fs.readFileSync(firecrackerSmokePath, 'utf-8');
+    const cloudHypervisor = fs.readFileSync(smokePath, 'utf-8');
+    for (const helper of ['run_case()', 'assert_no_residue()']) {
+      expect(firecracker).toContain(helper);
+      expect(cloudHypervisor).toContain(helper);
+    }
+  });
+
+  it('both preflight scripts fail closed on missing Linux/x86_64/KVM host requirements', () => {
+    const firecracker = fs.readFileSync(firecrackerPreflightPath, 'utf-8');
+    const cloudHypervisor = fs.readFileSync(preflightPath, 'utf-8');
+    for (const script of [firecracker, cloudHypervisor]) {
+      expect(script).toContain('/dev/kvm');
+      expect(script).toContain('x86_64');
+      expect(script).toContain('set -euo pipefail');
+    }
+  });
+});

--- a/scripts/ci/cloud-hypervisor-host-preflight.sh
+++ b/scripts/ci/cloud-hypervisor-host-preflight.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail-closed CI host preflight for the Cloud Hypervisor live-KVM job.
+#
+# Mirrors scripts/ci/firecracker-host-preflight.sh's checks (Linux/x86_64,
+# /dev/kvm, kernel controls, cgroup hierarchy, required host tools, docker,
+# artifact digests), with two Cloud Hypervisor-specific differences:
+#   1. GitHub-hosted-only host eligibility is enforced here too (this
+#      backend rejects self-hosted runners, unlike Firecracker's preview —
+#      see src/cloud-hypervisor/host-eligibility.ts), so a misconfigured
+#      self-hosted runner fails fast in CI instead of failing later inside
+#      the CLI.
+#   2. `setpriv` is required (the launcher's jailer replacement — see
+#      src/cloud-hypervisor/launcher.ts) and there is no jailer binary to
+#      version-check.
+
+ARTIFACT_DIR=${1:?usage: cloud-hypervisor-host-preflight.sh ARTIFACT_DIR}
+
+fail() {
+  echo "::error title=Cloud Hypervisor host preflight::$*" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = Linux ] || fail "Linux is required; macOS and Windows are unsupported."
+[ "$(uname -m)" = x86_64 ] || fail "This CI artifact set requires an x86_64 host."
+
+# GitHub-hosted-only host eligibility (mirrors
+# src/cloud-hypervisor/host-eligibility.ts::evaluateGithubHostedRunnerEligibility).
+[ "${GITHUB_ACTIONS:-}" = true ] \
+  || fail "Cloud Hypervisor is supported only inside GitHub Actions runs (GITHUB_ACTIONS != \"true\")."
+[ "${RUNNER_ENVIRONMENT:-}" = github-hosted ] \
+  || fail "Cloud Hypervisor is supported only on GitHub-hosted runners, not self-hosted (RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT:-unset})."
+case "${ImageOS:-}" in
+  ubuntu*) : ;;
+  *) fail "Cloud Hypervisor requires a GitHub-hosted Ubuntu runner image (ImageOS=${ImageOS:-unset})." ;;
+esac
+
+[ -c /dev/kvm ] || fail "/dev/kvm is missing; use a KVM-capable host."
+[ -r /dev/kvm ] && [ -w /dev/kvm ] \
+  || fail "/dev/kvm must be readable and writable by the workflow user."
+
+for control in \
+  /proc/sys/net/ipv4/ip_forward \
+  /proc/sys/net/ipv6/conf/all/disable_ipv6 \
+  /proc/sys/kernel/seccomp/actions_avail; do
+  [ -r "$control" ] || fail "Required host kernel control is unavailable: $control"
+done
+[ -r /sys/fs/cgroup/cgroup.controllers ] || [ -w /sys/fs/cgroup ] \
+  || fail "A usable cgroup v1 or v2 hierarchy is required to bound the Cloud Hypervisor process."
+
+for tool in nft ip sysctl mke2fs debugfs e2fsck rsync setpriv docker sha256sum timeout curl; do
+  command -v "$tool" >/dev/null || fail "Required host tool is missing: $tool"
+done
+command -v sudo >/dev/null || fail "Passwordless sudo is required for the netns-join/privilege-drop launcher."
+sudo -n true || fail "Passwordless sudo is required for the netns-join/privilege-drop launcher."
+docker info >/dev/null || fail "A host-visible Docker Engine is required."
+docker compose version >/dev/null || fail "Docker Compose v2 is required."
+
+# Kernel LSM support for Landlock, the filesystem-confinement boundary the
+# launcher relies on in place of a jailer chroot (see
+# src/cloud-hypervisor/launcher.ts).
+if [ -r /sys/kernel/security/lsm ]; then
+  grep -Fq landlock /sys/kernel/security/lsm \
+    || fail "The running kernel does not report Landlock in /sys/kernel/security/lsm."
+else
+  fail "/sys/kernel/security/lsm is unavailable; cannot confirm Landlock LSM support."
+fi
+
+"$ARTIFACT_DIR/cloud-hypervisor" --version | grep -Fq '53.0' \
+  || fail "Cloud Hypervisor v53.0 is required."
+(
+  cd "$ARTIFACT_DIR"
+  sha256sum --check --strict SHA256SUMS
+) || fail "Artifact digest verification failed."
+
+echo "Cloud Hypervisor host preflight passed on GitHub-hosted Ubuntu x86_64 with accessible KVM."

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -17,10 +17,11 @@ set -euo pipefail
 #   - security-assertions: while a run is live, inspects the host-visible
 #     Cloud Hypervisor process and its own vm.info response to confirm the
 #     launcher's jailer-replacement boundary (netns join, non-root identity,
-#     empty capability set, no_new_privs, active seccomp filter, per-run
-#     cgroup membership/limits, landlock_enable reflected in vm.create, and
-#     an exactly-minimal disk/net/vsock device set with no path to the
-#     host-only API socket) — see src/cloud-hypervisor/launcher.ts.
+#     capability set limited to CAP_NET_ADMIN alone, no_new_privs, active
+#     seccomp filter, per-run cgroup membership/limits, landlock_enable
+#     reflected in vm.create, and an exactly-minimal disk/net/vsock device
+#     set with no path to the host-only API socket) — see
+#     src/cloud-hypervisor/launcher.ts.
 #
 # NOTE on shared namespace/interface naming: src/microvm/network.ts is
 # VMM-neutral and used unmodified by both the Firecracker and Cloud
@@ -282,10 +283,11 @@ assert_no_residue
 # --- Cloud Hypervisor-specific live security assertions -------------------
 #
 # Reproduces the launcher's jailer-replacement boundary live, while a run is
-# in flight: netns-join + non-root privilege drop + empty capability set +
-# no_new_privs + active seccomp filter + per-run cgroup membership/limits +
-# landlock_enable reflected in vm.create + an exactly-minimal disk/net/vsock
-# device set (see src/cloud-hypervisor/launcher.ts and manager.ts).
+# in flight: netns-join + non-root privilege drop + capability set limited
+# to CAP_NET_ADMIN alone + no_new_privs + active seccomp filter + per-run
+# cgroup membership/limits + landlock_enable reflected in vm.create + an
+# exactly-minimal disk/net/vsock device set (see
+# src/cloud-hypervisor/launcher.ts and manager.ts).
 sec_work="$RUN_ROOT/security/work"
 sec_workspace="$RUN_ROOT/security/workspace"
 sec_audit="$RUN_ROOT/security/audit"
@@ -341,10 +343,13 @@ proc_uid=$(sudo stat -c %u "/proc/$vmm_pid" 2>/dev/null || echo "")
 [ -n "$proc_uid" ] || fail_security "could not stat /proc/$vmm_pid"
 [ "$proc_uid" != "0" ] || fail_security "Cloud Hypervisor process is running as root"
 
-# Empty effective capability set (setpriv --inh-caps=-all --bounding-set=-all).
+# Capability set limited to CAP_NET_ADMIN alone (setpriv --inh-caps=-all,
+# +net_admin --bounding-set=-all,+net_admin --ambient-caps=+net_admin).
+# CAP_NET_ADMIN's bit is 12, so the expected 64-bit CapEff bitmask is
+# exactly 0x1000: 0000000000001000.
 cap_eff=$(sudo awk '/^CapEff:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")
-[ "$cap_eff" = "0000000000000000" ] \
-  || fail_security "process retains effective capabilities: ${cap_eff:-unknown}"
+[ "$cap_eff" = "0000000000001000" ] \
+  || fail_security "process capability set is not exactly CAP_NET_ADMIN: ${cap_eff:-unknown}"
 
 # no_new_privs set (setpriv --no-new-privs).
 no_new_privs=$(sudo awk '/^NoNewPrivs:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -327,6 +327,7 @@ keep_work="$RUN_ROOT/keep/work"
 keep_workspace="$RUN_ROOT/keep/workspace"
 keep_audit="$RUN_ROOT/keep/audit"
 mkdir -p "$keep_work" "$keep_workspace" "$keep_audit"
+set +e
 (
   export GITHUB_WORKSPACE="$keep_workspace"
   export OPENAI_API_KEY="$SECRET_SENTINEL"
@@ -337,6 +338,18 @@ mkdir -p "$keep_work" "$keep_workspace" "$keep_audit"
     --audit-dir "$keep_audit" \
     -- 'true'
 ) >"$RUN_ROOT/keep/stdout.log" 2>"$RUN_ROOT/keep/stderr.log"
+keep_status=$?
+set -e
+if [ "$keep_status" -ne 0 ]; then
+  # Unlike run_case, this invocation is not wrapped by a helper that
+  # tails its own log on failure, so under `set -e` a non-zero exit here
+  # previously aborted the whole suite silently -- both log files were
+  # redirected to disk but never echoed to the job log, and were only
+  # visible (if at all) via the uploaded diagnostics artifact.
+  echo "keep-containers invocation: expected exit 0, got $keep_status" >&2
+  tail -200 "$RUN_ROOT/keep/stderr.log" >&2
+  exit 1
+fi
 sudo ip netns list | grep -q '^awffc-' || {
   echo "keep mode did not preserve the run network namespace" >&2
   exit 1

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -96,8 +96,17 @@ assert_no_residue() {
     echo "Cloud Hypervisor veth/TAP residue detected" >&2
     return 1
   fi
-  if [ -d "$CGROUP_ROOT" ] && [ -n "$(sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then
-    sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 >&2
+  # $CGROUP_ROOT (.../awf-cloud-hypervisor) is a *parent* cgroup that
+  # persists across runs; only per-run sub-cgroups live one level
+  # inside it (see cgroupPath in src/cloud-hypervisor/manager.ts). Any
+  # cgroup v2 directory -- including this parent itself -- always
+  # contains standard controller interface files (cpu.max, memory.max,
+  # cgroup.controllers, ...) simply by virtue of existing; matching all
+  # entries here (not just directories) made this check a permanent
+  # false positive the moment it was ever actually reached, regardless
+  # of whether a real leftover per-run cgroup was present.
+  if [ -d "$CGROUP_ROOT" ] && [ -n "$(sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)" ]; then
+    sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 -type d >&2
     echo "Cloud Hypervisor cgroup residue detected" >&2
     return 1
   fi

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -165,12 +165,23 @@ assert_no_residue
 # Best-effort, bounded packet capture across the first live case only (never
 # a persistent/always-on capture): the live-KVM connectivity investigation
 # has confirmed ARP round-trips and per-rule nftables accept counters for
-# the guest's outbound SYN, but has not yet directly observed the actual
-# frames in flight on the shared bridge. `-i any` (all interfaces, since the
-# per-run bridge/veth names are only known once the CLI creates them) keeps
-# this decisive without needing to thread bridge naming into this script.
-# Failure to start tcpdump (not installed, insufficient privilege) must
-# never fail the suite -- this is diagnostics, not a behavioral assertion.
+# the guest's outbound SYN, has proven (via a host-side capture) that
+# Squid's SYN-ACK reply reaches this run's host-side veth peer, and has
+# ruled out rp_filter and a missing prerouting nat hook as the reason it
+# never reaches this namespace's own forward-chain counters. The remaining
+# question is whether the reply actually crosses into the per-run network
+# namespace (via the veth pair) and reaches nftables evaluation there, or
+# is lost at that boundary -- an in-namespace capture, taken alongside the
+# existing host-side one, is the only way to observe that directly. The
+# namespace only exists for the lifetime of a single run_case's CLI
+# invocation and its name is not known ahead of time, so a short background
+# poll picks it up the moment it appears.
+#
+# `-i any` (all interfaces, since the per-run bridge/veth names are only
+# known once the CLI creates them) keeps both captures decisive without
+# needing to thread naming into this script. Failure to start tcpdump (not
+# installed, insufficient privilege, namespace never appears) must never
+# fail the suite -- this is diagnostics, not a behavioral assertion.
 tcpdump_pid=
 tcpdump_out="$RUN_ROOT/allowed-https/audit/tcpdump.pcap"
 mkdir -p "$(dirname "$tcpdump_out")"
@@ -179,6 +190,22 @@ if command -v tcpdump >/dev/null 2>&1; then
     'port 3128 or arp or icmp' >/dev/null 2>&1 &
   tcpdump_pid=$!
   sleep 1
+fi
+
+ns_tcpdump_out="$RUN_ROOT/allowed-https/audit/tcpdump-namespace.pcap"
+ns_watcher_pid=
+if command -v tcpdump >/dev/null 2>&1; then
+  (
+    for _ in $(seq 1 200); do
+      ns=$(sudo ip netns list 2>/dev/null | awk '{print $1}' | grep -m1 '^awffc-' || true)
+      if [ -n "$ns" ]; then
+        exec sudo ip netns exec "$ns" tcpdump -i any -w "$ns_tcpdump_out" \
+          'port 3128 or arp or icmp' >/dev/null 2>&1
+      fi
+      sleep 0.05
+    done
+  ) &
+  ns_watcher_pid=$!
 fi
 
 boot_start_ns=$(date +%s%N)
@@ -190,6 +217,12 @@ if [ -n "$tcpdump_pid" ]; then
   sudo kill "$tcpdump_pid" >/dev/null 2>&1 || true
   wait "$tcpdump_pid" 2>/dev/null || true
   sudo chmod 0644 "$tcpdump_out" 2>/dev/null || true
+fi
+if [ -n "$ns_watcher_pid" ]; then
+  sudo pkill -f "tcpdump -i any -w $ns_tcpdump_out" >/dev/null 2>&1 || true
+  kill "$ns_watcher_pid" >/dev/null 2>&1 || true
+  wait "$ns_watcher_pid" 2>/dev/null || true
+  sudo chmod 0644 "$ns_tcpdump_out" 2>/dev/null || true
 fi
 
 boot_ms=$(( (boot_end_ns - boot_start_ns) / 1000000 ))

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -510,8 +510,14 @@ esac
 #
 # The expected TAP name is derived exactly like
 # createMicrovmNetworkPlan() (src/microvm/network.ts): `fct` + the first 12
-# hex characters of sha256(runId).
-expected_tap="fct$(printf '%s' "$run_id" | sha256sum | cut -c1-12)"
+# hex characters of sha256(runId). The per-run network namespace shares
+# the same token (`awffc-` + token) and is where the TAP device actually
+# lives -- checking for it in the root/default namespace, which is what
+# actually hosts this script, would never find a namespace-scoped
+# interface regardless of whether it truly exists.
+run_token=$(printf '%s' "$run_id" | sha256sum | cut -c1-12)
+expected_tap="fct$run_token"
+expected_namespace="awffc-$run_token"
 expected_rootfs_path="$run_directory/rootfs.ext4"
 expected_workspace_path="$run_directory/workspace.ext4"
 expected_vsock_socket="$run_directory/awf-vsock.socket"
@@ -598,9 +604,13 @@ node -e '
   || fail_security "vm.info device-topology assertion failed: $vm_info"
 
 # Cross-check the expected TAP interface actually exists on the host (not
-# just referenced in the VMM's own self-reported config).
-sudo ip link show "$expected_tap" >/dev/null 2>&1 \
-  || fail_security "expected TAP interface $expected_tap not found on host"
+# just referenced in the VMM's own self-reported config). The TAP device
+# is namespace-scoped -- it lives inside the per-run network namespace
+# created by MicrovmNetworkManager.setup(), not the root/default
+# namespace this script itself runs in -- so it must be checked via
+# `ip netns exec`, not a bare `ip link show`.
+sudo ip netns exec "$expected_namespace" ip link show "$expected_tap" >/dev/null 2>&1 \
+  || fail_security "expected TAP interface $expected_tap not found in namespace $expected_namespace"
 
 kill -TERM "$sec_pid"
 set +e

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -51,6 +51,12 @@ digest() {
 COMMON=(
   --container-runtime cloud-hypervisor
   --cloud-hypervisor-preview
+  # Explicit, even though --network-isolation is documented as "enabled by
+  # default": the paired --network-isolation/--no-network-isolation
+  # commander.js options resolve to `undefined` (not `true`) when neither
+  # flag is passed, and assertCloudHypervisorRuntimeCompatibility() requires
+  # a strictly truthy value. Discovered via a live workflow_dispatch run.
+  --network-isolation
   --cloud-hypervisor-binary "$ARTIFACT_DIR/cloud-hypervisor"
   --cloud-hypervisor-kernel "$ARTIFACT_DIR/vmlinux.bin"
   --cloud-hypervisor-rootfs "$ARTIFACT_DIR/rootfs.ext4"
@@ -85,9 +91,9 @@ assert_no_residue() {
     echo "Cloud Hypervisor process residue detected" >&2
     return 1
   fi
-  if sudo find /tmp -maxdepth 4 -type d -name 'cloud-hypervisor-run' 2>/dev/null \
-    | xargs -r -I{} sudo find {} -mindepth 1 -maxdepth 3 -print 2>/dev/null \
+  if sudo find /run/awf-cloud-hypervisor -mindepth 2 2>/dev/null \
     | grep -q .; then
+    sudo find /run/awf-cloud-hypervisor -mindepth 2 >&2
     echo "Cloud Hypervisor run-directory residue detected" >&2
     return 1
   fi
@@ -123,6 +129,10 @@ run_case() {
   if [ "$status" -ne "$expected" ]; then
     echo "case $name: expected exit $expected, got $status" >&2
     tail -200 "$RUN_ROOT/$name/stderr.log" >&2
+    if sudo docker network inspect awf-net >/dev/null 2>&1; then
+      echo "--- docker network inspect awf-net (diagnostic) ---" >&2
+      sudo docker network inspect awf-net >&2
+    fi
     return 1
   fi
   if grep -R --binary-files=without-match -F "$SECRET_SENTINEL" \
@@ -240,7 +250,14 @@ sudo ip netns list | grep -q '^awffc-' || {
   echo "keep mode did not preserve the run network namespace" >&2
   exit 1
 }
-test -d "$keep_work/cloud-hypervisor-run"
+sudo test -d /run/awf-cloud-hypervisor || {
+  echo "keep mode did not preserve the private run-directory root" >&2
+  exit 1
+}
+sudo find /run/awf-cloud-hypervisor -mindepth 2 -maxdepth 2 -type d 2>/dev/null | grep -q . || {
+  echo "keep mode did not preserve the run directory" >&2
+  exit 1
+}
 test -f "$keep_audit/cloud-hypervisor/network-plan.json"
 test -f "$keep_audit/cloud-hypervisor/cloud-hypervisor.log"
 find "$keep_audit/cloud-hypervisor" -type f -size +1048576c -print -quit \
@@ -255,6 +272,11 @@ while read -r namespace _; do
   esac
 done < <(sudo ip netns list)
 sudo docker compose -f "$keep_work/docker-compose.yml" down --volumes --remove-orphans
+# --keep-containers intentionally preserves the private run directory (see
+# CLOUD_HYPERVISOR_RUN_ROOT in src/cloud-hypervisor/manager.ts); clean it up
+# here so assert_no_residue below reflects steady-state, not this case's
+# deliberate preservation.
+sudo find /run/awf-cloud-hypervisor -mindepth 2 -maxdepth 2 -type d -exec rm -rf {} +
 assert_no_residue
 
 # --- Cloud Hypervisor-specific live security assertions -------------------
@@ -281,7 +303,7 @@ sec_pid=$!
 
 api_socket=""
 for _ in $(seq 1 60); do
-  api_socket=$(sudo find "$sec_work/cloud-hypervisor-run" -name api.socket 2>/dev/null | head -1)
+  api_socket=$(sudo find /run/awf-cloud-hypervisor -name api.socket 2>/dev/null | head -1)
   [ -n "$api_socket" ] && break
   sleep 1
 done
@@ -293,16 +315,11 @@ if [ -z "$api_socket" ]; then
 fi
 run_directory=$(dirname "$api_socket")
 run_id=$(basename "$run_directory")
-# Cgroup root matches whichever hierarchy preflight detected (GitHub-hosted
-# Ubuntu runners use cgroup v2 exclusively per docs/cloud-hypervisor-foundation.md
-# Part 6, but this is discovered rather than assumed for robustness).
-if sudo test -d "$CGROUP_ROOT/$run_id"; then
-  cgroup_path="$CGROUP_ROOT/$run_id"
-elif sudo test -d "/sys/fs/cgroup/memory/awf-cloud-hypervisor/$run_id"; then
-  cgroup_path="/sys/fs/cgroup/memory/awf-cloud-hypervisor/$run_id"
-else
-  cgroup_path="$CGROUP_ROOT/$run_id"
-fi
+# GitHub-hosted Ubuntu runners (this backend's only supported host) run
+# cgroup v2 exclusively; runCloudHypervisorPreflight rejects v1-only hosts
+# outright (see src/cloud-hypervisor/preflight.ts), so the cgroup path is
+# always under the v2 unified hierarchy.
+cgroup_path="$CGROUP_ROOT/$run_id"
 
 fail_security() {
   echo "security-assertions: $*" >&2
@@ -339,54 +356,108 @@ seccomp_mode=$(sudo awk '/^Seccomp:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/n
 
 # Per-run cgroup membership and non-trivial, bounded limits.
 sudo test -f "$cgroup_path/cgroup.procs" || fail_security "cgroup.procs missing at $cgroup_path"
-if sudo test -f "$cgroup_path/memory.max"; then
-  memory_max=$(sudo cat "$cgroup_path/memory.max")
-  case "$memory_max" in
-    ''|*[!0-9]*) fail_security "memory.max is not a bounded numeric value: $memory_max" ;;
-  esac
-  memory_current=$(sudo cat "$cgroup_path/memory.current" 2>/dev/null || echo 0)
-  case "$memory_current" in
-    ''|*[!0-9]*) fail_security "memory.current is not numeric: $memory_current" ;;
-  esac
-  [ "$memory_current" -gt 0 ] || fail_security "memory.current reports zero usage; cgroup accounting looks inactive"
-  [ "$memory_current" -le "$memory_max" ] || fail_security "memory.current ($memory_current) exceeds memory.max ($memory_max)"
-elif sudo test -f "$cgroup_path/memory.limit_in_bytes"; then
-  memory_max=$(sudo cat "$cgroup_path/memory.limit_in_bytes")
-  case "$memory_max" in
-    ''|*[!0-9]*) fail_security "memory.limit_in_bytes is not a bounded numeric value: $memory_max" ;;
-  esac
-else
-  fail_security "no memory limit file found under $cgroup_path (neither cgroup v2 nor v1)"
-fi
+sudo test -f "$cgroup_path/memory.max" || fail_security "memory.max missing at $cgroup_path (cgroup v2 controller delegation may have failed)"
+memory_max=$(sudo cat "$cgroup_path/memory.max")
+case "$memory_max" in
+  ''|*[!0-9]*) fail_security "memory.max is not a bounded numeric value: $memory_max" ;;
+esac
+memory_current=$(sudo cat "$cgroup_path/memory.current" 2>/dev/null || echo 0)
+case "$memory_current" in
+  ''|*[!0-9]*) fail_security "memory.current is not numeric: $memory_current" ;;
+esac
+[ "$memory_current" -gt 0 ] || fail_security "memory.current reports zero usage; cgroup accounting looks inactive"
+[ "$memory_current" -le "$memory_max" ] || fail_security "memory.current ($memory_current) exceeds memory.max ($memory_max)"
 
 # vm.info reflects landlock_enable and an exactly-minimal, expected device
 # topology (rootfs+workspace disks, single net device, vsock) — proving the
-# host-only API socket is never exposed to the guest as any device.
-vm_info=$(sudo curl --silent --show-error --max-time 5 --unix-socket "$api_socket" \
-  http://localhost/api/v1/vm.info) || fail_security "vm.info request failed"
+# host-only API socket is never exposed to the guest as any device. Poll
+# until vm.info reports state "Running": the API socket appears before
+# vm.create/vm.boot (manager.ts), so a one-shot request here would race
+# startup and could fail on a valid but slower runner; polling for "Running"
+# also proves these assertions inspect a live VM, not merely a launched VMM.
+#
+# The expected TAP name is derived exactly like
+# createMicrovmNetworkPlan() (src/microvm/network.ts): `fct` + the first 12
+# hex characters of sha256(runId).
+expected_tap="fct$(printf '%s' "$run_id" | sha256sum | cut -c1-12)"
+expected_rootfs_path="$run_directory/rootfs.ext4"
+expected_workspace_path="$run_directory/workspace.ext4"
+expected_vsock_socket="$run_directory/awf-vsock.socket"
+
+vm_info=""
+for _ in $(seq 1 30); do
+  candidate=$(sudo curl --silent --show-error --max-time 5 --unix-socket "$api_socket" \
+    http://localhost/api/v1/vm.info) || fail_security "vm.info request failed"
+  if printf '%s' "$candidate" | grep -Eq '"state" *: *"Running"'; then
+    vm_info=$candidate
+    break
+  fi
+  sleep 1
+done
+[ -n "$vm_info" ] || fail_security "vm.info never reported state \"Running\" within the poll window"
+
 node -e '
-  const info = JSON.parse(process.argv[1]);
+  const [
+    infoJson, expectedTap, expectedRootfsPath, expectedWorkspacePath, expectedVsockSocket,
+  ] = process.argv.slice(1);
+  const info = JSON.parse(infoJson);
+  if (info.state !== "Running") {
+    throw new Error("expected vm.info state \"Running\", got " + JSON.stringify(info.state));
+  }
   const config = info.config || {};
+
+  // Reject any unexpected top-level device-bearing config field (e.g. a
+  // virtio-fs, pmem, vdpa, or VFIO device this preview never configures) —
+  // not just count the devices we do expect.
+  const allowedKeys = new Set([
+    "cpus", "memory", "payload", "disks", "net", "rng", "serial", "console",
+    "vsock", "watchdog", "landlock_enable", "landlock_rules",
+  ]);
+  for (const key of Object.keys(config)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error("unexpected device-bearing vm.info config field: " + key);
+    }
+  }
+
   if (config.landlock_enable !== true) {
     throw new Error("landlock_enable is not true in vm.info: " + JSON.stringify(config.landlock_enable));
   }
+
   const disks = config.disks || [];
   if (disks.length !== 2) {
     throw new Error("expected exactly 2 disks (rootfs, workspace), got " + disks.length);
   }
-  const net = config.net || [];
-  if (net.length !== 1) {
-    throw new Error("expected exactly 1 net device, got " + net.length);
+  const [rootfsDisk, workspaceDisk] = disks;
+  if (rootfsDisk.id !== "rootfs" || rootfsDisk.path !== expectedRootfsPath) {
+    throw new Error("rootfs disk mismatch: " + JSON.stringify(rootfsDisk));
   }
-  if (!config.vsock || typeof config.vsock.cid !== "number") {
-    throw new Error("expected a vsock device with a numeric cid");
+  if (workspaceDisk.id !== "workspace" || workspaceDisk.path !== expectedWorkspacePath) {
+    throw new Error("workspace disk mismatch: " + JSON.stringify(workspaceDisk));
   }
   for (const disk of disks) {
     if (disk.path && disk.path.endsWith("api.socket")) {
       throw new Error("API socket path is exposed as a guest disk");
     }
   }
-' "$vm_info" || fail_security "vm.info device-topology assertion failed: $vm_info"
+
+  const net = config.net || [];
+  if (net.length !== 1) {
+    throw new Error("expected exactly 1 net device, got " + net.length);
+  }
+  if (net[0].id !== "net0" || net[0].tap !== expectedTap) {
+    throw new Error("net device mismatch: expected id=net0 tap=" + expectedTap + ", got " + JSON.stringify(net[0]));
+  }
+
+  if (!config.vsock || config.vsock.cid !== 3 || config.vsock.socket !== expectedVsockSocket) {
+    throw new Error("vsock device mismatch: expected cid=3 socket=" + expectedVsockSocket + ", got " + JSON.stringify(config.vsock));
+  }
+' "$vm_info" "$expected_tap" "$expected_rootfs_path" "$expected_workspace_path" "$expected_vsock_socket" \
+  || fail_security "vm.info device-topology assertion failed: $vm_info"
+
+# Cross-check the expected TAP interface actually exists on the host (not
+# just referenced in the VMM's own self-reported config).
+sudo ip link show "$expected_tap" >/dev/null 2>&1 \
+  || fail_security "expected TAP interface $expected_tap not found on host"
 
 kill -TERM "$sec_pid"
 set +e

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -66,6 +66,20 @@ COMMON=(
   --cloud-hypervisor-kernel-sha256 "$(digest vmlinux.bin)"
   --cloud-hypervisor-rootfs-sha256 "$(digest rootfs.ext4)"
   --cloud-hypervisor-supervisor-sha256 "$(digest awf-supervisor)"
+  # Single vCPU: GitHub-hosted Ubuntu runners run under nested
+  # virtualization (Cloud Hypervisor itself logs "Running under nested
+  # virtualisation. Hypervisor string: Microsoft Hv" there). Live validation
+  # showed the guest kernel's boot stalling for 90+ real seconds right after
+  # "kvm-guest: setup PV IPIs" — the point where a >1-vCPU guest starts
+  # bringing up its secondary (AP) CPUs via inter-processor interrupts.
+  # Local APIC / IPI virtualization for a *nested* (L2) guest is not
+  # hardware-accelerated the way it is for an L1 guest on this class of
+  # infrastructure, so AP bring-up traps all the way up to the L0 host and
+  # back for every step — a well-known, order-of-magnitude nested-KVM SMP
+  # penalty, not a Cloud Hypervisor or AWF defect. A single-vCPU guest never
+  # reaches that code path at all. See docs/cloud-hypervisor-foundation.md
+  # Part 15 for the full analysis.
+  --cloud-hypervisor-vcpus 1
   --allow-domains example.com
   --skip-pull
   --diagnostic-logs

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -362,9 +362,15 @@ sudo find /run/awf-cloud-hypervisor -mindepth 2 -maxdepth 2 -type d 2>/dev/null 
   echo "keep mode did not preserve the run directory" >&2
   exit 1
 }
-test -f "$keep_audit/cloud-hypervisor/network-plan.json"
-test -f "$keep_audit/cloud-hypervisor/cloud-hypervisor.log"
-find "$keep_audit/cloud-hypervisor" -type f -size +1048576c -print -quit \
+sudo test -f "$keep_audit/cloud-hypervisor/network-plan.json" || {
+  echo "keep mode did not preserve network-plan.json" >&2
+  exit 1
+}
+sudo test -f "$keep_audit/cloud-hypervisor/cloud-hypervisor.log" || {
+  echo "keep mode did not preserve cloud-hypervisor.log" >&2
+  exit 1
+}
+sudo find "$keep_audit/cloud-hypervisor" -type f -size +1048576c -print -quit \
   | grep -q . && {
     echo "Cloud Hypervisor diagnostic artifact exceeded the 1 MiB bound" >&2
     exit 1

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -159,7 +159,15 @@ run_case() {
     fi
     return 1
   fi
+  # awf-resolved-config.json's own agentCommand field always contains
+  # this case's shell command verbatim; for api-proxy-reflect that
+  # command intentionally references the sentinel string itself (the
+  # pattern it greps for, to assert the sentinel's absence from `env`).
+  # That is expected, self-referential test source text, not a leak of
+  # the sentinel value into somewhere it shouldn't be -- guest stdout,
+  # proxy logs, and every other diagnostic file are still fully scanned.
   if grep -R --binary-files=without-match -F "$SECRET_SENTINEL" \
+    --exclude='awf-resolved-config.json' \
     "$RUN_ROOT/$name/stdout.log" \
     "$audit" \
     "$proxy_logs" >/dev/null 2>&1; then

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -464,9 +464,27 @@ cap_eff=$(sudo awk '/^CapEff:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null ||
 no_new_privs=$(sudo awk '/^NoNewPrivs:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")
 [ "$no_new_privs" = "1" ] || fail_security "no_new_privs is not set (got ${no_new_privs:-unknown})"
 
-# Seccomp filter active (Cloud Hypervisor's own --seccomp true; mode 2 = filter).
-seccomp_mode=$(sudo awk '/^Seccomp:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")
-[ "$seccomp_mode" = "2" ] || fail_security "seccomp filter is not active (mode=${seccomp_mode:-unknown})"
+# Seccomp filter active (Cloud Hypervisor's own --seccomp true; mode 2 =
+# filter). Cloud Hypervisor spawns its actual VM-execution work on a
+# dedicated "vmm" thread (vmm::start_vmm_thread in its own main.rs), and
+# Linux applies a seccomp-bpf filter per-thread by default -- unlike
+# capabilities/no_new_privs (process-wide, so the main thread's own
+# /proc/<pid>/status correctly reflects them), a filter installed only on
+# that worker thread would never show up as active on the main/initial
+# thread's own status file. Checking every thread under this PID (task/*)
+# and accepting the assertion if *any* thread shows mode 2 is what
+# actually verifies this VM's execution has an active filter, regardless
+# of which specific thread Cloud Hypervisor happened to install it on.
+seccomp_mode=""
+for task_status in "/proc/$vmm_pid"/task/*/status; do
+  mode=$(sudo awk '/^Seccomp:/{print $2}' "$task_status" 2>/dev/null || echo "")
+  if [ "$mode" = "2" ]; then
+    seccomp_mode="2"
+    break
+  fi
+  [ -z "$seccomp_mode" ] && seccomp_mode="$mode"
+done
+[ "$seccomp_mode" = "2" ] || fail_security "seccomp filter is not active on any thread (last observed mode=${seccomp_mode:-unknown})"
 
 # Per-run cgroup membership and non-trivial, bounded limits.
 sudo test -f "$cgroup_path/cgroup.procs" || fail_security "cgroup.procs missing at $cgroup_path"

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -162,10 +162,36 @@ run_case() {
 
 assert_no_residue
 
+# Best-effort, bounded packet capture across the first live case only (never
+# a persistent/always-on capture): the live-KVM connectivity investigation
+# has confirmed ARP round-trips and per-rule nftables accept counters for
+# the guest's outbound SYN, but has not yet directly observed the actual
+# frames in flight on the shared bridge. `-i any` (all interfaces, since the
+# per-run bridge/veth names are only known once the CLI creates them) keeps
+# this decisive without needing to thread bridge naming into this script.
+# Failure to start tcpdump (not installed, insufficient privilege) must
+# never fail the suite -- this is diagnostics, not a behavioral assertion.
+tcpdump_pid=
+tcpdump_out="$RUN_ROOT/allowed-https/audit/tcpdump.pcap"
+mkdir -p "$(dirname "$tcpdump_out")"
+if command -v tcpdump >/dev/null 2>&1; then
+  sudo tcpdump -i any -w "$tcpdump_out" \
+    'port 3128 or arp or icmp' >/dev/null 2>&1 &
+  tcpdump_pid=$!
+  sleep 1
+fi
+
 boot_start_ns=$(date +%s%N)
 run_case allowed-https 0 \
   'wget -qO- https://example.com | grep -q "Example Domain"'
 boot_end_ns=$(date +%s%N)
+
+if [ -n "$tcpdump_pid" ]; then
+  sudo kill "$tcpdump_pid" >/dev/null 2>&1 || true
+  wait "$tcpdump_pid" 2>/dev/null || true
+  sudo chmod 0644 "$tcpdump_out" 2>/dev/null || true
+fi
+
 boot_ms=$(( (boot_end_ns - boot_start_ns) / 1000000 ))
 echo "Cloud Hypervisor boot+readiness+run+cleanup baseline: ${boot_ms}ms"
 if [ "$boot_ms" -gt "$BOOT_READINESS_CEILING_MS" ]; then

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -540,14 +540,25 @@ node -e '
 
   // Reject any unexpected top-level device-bearing config field (e.g. a
   // virtio-fs, pmem, vdpa, or VFIO device this preview never configures) —
-  // not just count the devices we do expect.
+  // not just count the devices we do expect. pvpanic/iommu/debug_console
+  // are always present in Cloud Hypervisor v53.0 own vm.info response
+  // as disabled feature toggles, not devices this preview ever attaches --
+  // they add no actual attack surface and are allowed here so this check
+  // still targets genuinely unexpected *devices*, not benign metadata.
   const allowedKeys = new Set([
     "cpus", "memory", "payload", "disks", "net", "rng", "serial", "console",
     "vsock", "watchdog", "landlock_enable", "landlock_rules",
+    "pvpanic", "iommu", "debug_console",
   ]);
   for (const key of Object.keys(config)) {
     if (!allowedKeys.has(key)) {
       throw new Error("unexpected device-bearing vm.info config field: " + key);
+    }
+    if ((key === "pvpanic" || key === "iommu") && config[key] !== false) {
+      throw new Error(key + " is unexpectedly enabled in vm.info: " + JSON.stringify(config[key]));
+    }
+    if (key === "debug_console" && config[key] && config[key].mode !== "Off") {
+      throw new Error("debug_console is unexpectedly enabled in vm.info: " + JSON.stringify(config[key]));
     }
   }
 

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Live GitHub-hosted Ubuntu x86_64 KVM smoke/security suite for the Cloud
+# Hypervisor preview backend.
+#
+# This reproduces the same 13-case behavioral/security contract as
+# scripts/ci/firecracker-live-smoke.sh (allowed/blocked domains, direct
+# egress, arbitrary TCP, DNS, metadata IP, mandatory API-proxy reflect with
+# secret-sentinel absence, workspace copy-back incl. symlinks/permissions,
+# exit-code propagation, timeout, SIGTERM cancellation, partial-start
+# rollback, keep/preserve diagnostics), then adds Cloud Hypervisor-specific
+# live checks that have no Firecracker/jailer equivalent:
+#
+#   - device-assumptions: confirms the guest-visible eth0/{/dev/vda,/dev/vdb}
+#     layout documented in docs/cloud-hypervisor-foundation.md Part 6 holds.
+#   - security-assertions: while a run is live, inspects the host-visible
+#     Cloud Hypervisor process and its own vm.info response to confirm the
+#     launcher's jailer-replacement boundary (netns join, non-root identity,
+#     empty capability set, no_new_privs, active seccomp filter, per-run
+#     cgroup membership/limits, landlock_enable reflected in vm.create, and
+#     an exactly-minimal disk/net/vsock device set with no path to the
+#     host-only API socket) — see src/cloud-hypervisor/launcher.ts.
+#
+# NOTE on shared namespace/interface naming: src/microvm/network.ts is
+# VMM-neutral and used unmodified by both the Firecracker and Cloud
+# Hypervisor backends (see docs/cloud-hypervisor-foundation.md Part 2), so
+# the network namespace (`awffc-*`) and veth/TAP (`fch*`/`fcn*`/`fct*`)
+# naming below is intentionally identical to Firecracker's, not a defect.
+# The cgroup path (`awf-cloud-hypervisor/<runId>`) and process name
+# (`cloud-hypervisor`) residue checks below ARE Cloud Hypervisor-specific.
+
+ARTIFACT_DIR=${1:?usage: cloud-hypervisor-live-smoke.sh ARTIFACT_DIR}
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+RUN_ROOT=${RUNNER_TEMP:-/tmp}/awf-cloud-hypervisor-live
+SECRET_SENTINEL=awf-cloud-hypervisor-real-secret-do-not-expose
+CGROUP_ROOT=/sys/fs/cgroup/awf-cloud-hypervisor
+# Generous, non-flaky ceilings for regression detection on shared
+# GitHub-hosted runners (see task Part 4: "measured but non-flaky").
+BOOT_READINESS_CEILING_MS=90000
+CLEANUP_CEILING_MS=20000
+
+ARTIFACT_DIR=$(cd "$ARTIFACT_DIR" && pwd)
+rm -rf "$RUN_ROOT"
+mkdir -p "$RUN_ROOT"
+
+digest() {
+  awk -v file="$1" '$2 == file { print $1; exit }' "$ARTIFACT_DIR/SHA256SUMS"
+}
+
+COMMON=(
+  --container-runtime cloud-hypervisor
+  --cloud-hypervisor-preview
+  --cloud-hypervisor-binary "$ARTIFACT_DIR/cloud-hypervisor"
+  --cloud-hypervisor-kernel "$ARTIFACT_DIR/vmlinux.bin"
+  --cloud-hypervisor-rootfs "$ARTIFACT_DIR/rootfs.ext4"
+  --cloud-hypervisor-supervisor "$ARTIFACT_DIR/awf-supervisor"
+  --cloud-hypervisor-binary-sha256 "$(digest cloud-hypervisor)"
+  --cloud-hypervisor-kernel-sha256 "$(digest vmlinux.bin)"
+  --cloud-hypervisor-rootfs-sha256 "$(digest rootfs.ext4)"
+  --cloud-hypervisor-supervisor-sha256 "$(digest awf-supervisor)"
+  --allow-domains example.com
+  --skip-pull
+  --diagnostic-logs
+)
+
+assert_no_residue() {
+  if sudo ip netns list | grep -q '^awffc-'; then
+    sudo ip netns list >&2
+    echo "Cloud Hypervisor network namespace residue detected" >&2
+    return 1
+  fi
+  if sudo ip -o link show | grep -Eq ' (fch|fcn|fct)[0-9a-f]{12}[:@]'; then
+    sudo ip -o link show >&2
+    echo "Cloud Hypervisor veth/TAP residue detected" >&2
+    return 1
+  fi
+  if [ -d "$CGROUP_ROOT" ] && [ -n "$(sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then
+    sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 >&2
+    echo "Cloud Hypervisor cgroup residue detected" >&2
+    return 1
+  fi
+  if pgrep -f 'cloud-hypervisor --api-socket' >/dev/null 2>&1; then
+    pgrep -af 'cloud-hypervisor --api-socket' >&2
+    echo "Cloud Hypervisor process residue detected" >&2
+    return 1
+  fi
+  if sudo find /tmp -maxdepth 4 -type d -name 'cloud-hypervisor-run' 2>/dev/null \
+    | xargs -r -I{} sudo find {} -mindepth 1 -maxdepth 3 -print 2>/dev/null \
+    | grep -q .; then
+    echo "Cloud Hypervisor run-directory residue detected" >&2
+    return 1
+  fi
+}
+
+run_case() {
+  local name=$1
+  local expected=$2
+  local command=$3
+  shift 3
+  local work="$RUN_ROOT/$name/work"
+  local workspace="$RUN_ROOT/$name/workspace"
+  local audit="$RUN_ROOT/$name/audit"
+  local proxy_logs="$RUN_ROOT/$name/proxy-logs"
+  mkdir -p "$work" "$workspace" "$audit" "$proxy_logs"
+  printf 'host-input\n' >"$workspace/input.txt"
+
+  set +e
+  (
+    export GITHUB_WORKSPACE="$workspace"
+    export OPENAI_API_KEY="$SECRET_SENTINEL"
+    sudo -E node "$ROOT/dist/cli.js" \
+      "${COMMON[@]}" \
+      --work-dir "$work" \
+      --audit-dir "$audit" \
+      --proxy-logs-dir "$proxy_logs" \
+      "$@" \
+      -- "$command"
+  ) >"$RUN_ROOT/$name/stdout.log" 2>"$RUN_ROOT/$name/stderr.log"
+  local status=$?
+  set -e
+
+  if [ "$status" -ne "$expected" ]; then
+    echo "case $name: expected exit $expected, got $status" >&2
+    tail -200 "$RUN_ROOT/$name/stderr.log" >&2
+    return 1
+  fi
+  if grep -R --binary-files=without-match -F "$SECRET_SENTINEL" \
+    "$RUN_ROOT/$name/stdout.log" \
+    "$audit" \
+    "$proxy_logs" >/dev/null 2>&1; then
+    echo "case $name: secret sentinel leaked into guest-visible or diagnostic output" >&2
+    return 1
+  fi
+  assert_no_residue
+}
+
+assert_no_residue
+
+boot_start_ns=$(date +%s%N)
+run_case allowed-https 0 \
+  'wget -qO- https://example.com | grep -q "Example Domain"'
+boot_end_ns=$(date +%s%N)
+boot_ms=$(( (boot_end_ns - boot_start_ns) / 1000000 ))
+echo "Cloud Hypervisor boot+readiness+run+cleanup baseline: ${boot_ms}ms"
+if [ "$boot_ms" -gt "$BOOT_READINESS_CEILING_MS" ]; then
+  echo "boot-readiness: exceeded ${BOOT_READINESS_CEILING_MS}ms ceiling (took ${boot_ms}ms)" >&2
+  exit 1
+fi
+
+run_case blocked-domain 0 \
+  '! wget -qO- https://github.com'
+run_case direct-egress 0 \
+  'unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ! wget -qO- https://example.com'
+run_case arbitrary-tcp 0 \
+  '! nc -z -w 3 1.1.1.1 443'
+run_case dns-denial 0 \
+  '! nslookup example.com 8.8.8.8'
+run_case metadata-denial 0 \
+  'unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ! wget -T 3 -qO- http://169.254.169.254/latest/meta-data/'
+run_case api-proxy-reflect 0 \
+  'wget -qO /tmp/reflect http://172.30.0.30:10000/reflect && grep -q "providers" /tmp/reflect && ! env | grep -F "awf-cloud-hypervisor-real-secret-do-not-expose"'
+
+run_case workspace-copyback 0 \
+  'printf changed > .hidden && mkdir -p bin && printf "#!/bin/sh\necho ok\n" > bin/run && chmod 755 bin/run && ln -s bin/run run-link'
+test "$(cat "$RUN_ROOT/workspace-copyback/workspace/.hidden")" = changed
+test -x "$RUN_ROOT/workspace-copyback/workspace/bin/run"
+test "$(readlink "$RUN_ROOT/workspace-copyback/workspace/run-link")" = bin/run
+
+run_case exit-code 37 'exit 37'
+run_case timeout-124 124 'sleep 90' --agent-timeout 1
+
+# Cloud Hypervisor-specific guest device-topology assumptions (Part 6 of
+# docs/cloud-hypervisor-foundation.md): PCI-attached rootfs/workspace disks
+# surface as /dev/vda and /dev/vdb, and the single virtio-net device is
+# deterministically named eth0.
+run_case device-assumptions 0 \
+  'test -b /dev/vda && test -b /dev/vdb && ip link show eth0 | grep -q eth0'
+
+corrupt="$RUN_ROOT/corrupt-rootfs.ext4"
+printf 'not-an-ext4-image\n' >"$corrupt"
+corrupt_digest=$(sha256sum "$corrupt" | awk '{print $1}')
+run_case partial-start-cleanup 1 'true' \
+  --cloud-hypervisor-rootfs "$corrupt" \
+  --cloud-hypervisor-rootfs-sha256 "$corrupt_digest" \
+  --cloud-hypervisor-api-timeout-ms 3000
+
+cancel_work="$RUN_ROOT/cancellation/work"
+cancel_workspace="$RUN_ROOT/cancellation/workspace"
+cancel_audit="$RUN_ROOT/cancellation/audit"
+mkdir -p "$cancel_work" "$cancel_workspace" "$cancel_audit"
+(
+  export GITHUB_WORKSPACE="$cancel_workspace"
+  export OPENAI_API_KEY="$SECRET_SENTINEL"
+  exec sudo -E node "$ROOT/dist/cli.js" \
+    "${COMMON[@]}" \
+    --work-dir "$cancel_work" \
+    --audit-dir "$cancel_audit" \
+    -- 'sleep 300'
+) >"$RUN_ROOT/cancellation/stdout.log" 2>"$RUN_ROOT/cancellation/stderr.log" &
+cancel_pid=$!
+for _ in $(seq 1 60); do
+  sudo ip netns list | grep -q '^awffc-' && break
+  sleep 1
+done
+cleanup_start_ns=$(date +%s%N)
+kill -TERM "$cancel_pid"
+set +e
+wait "$cancel_pid"
+cancel_status=$?
+set -e
+[ "$cancel_status" -eq 143 ] || {
+  echo "cancellation: expected exit 143, got $cancel_status" >&2
+  exit 1
+}
+assert_no_residue
+cleanup_end_ns=$(date +%s%N)
+cleanup_ms=$(( (cleanup_end_ns - cleanup_start_ns) / 1000000 ))
+echo "Cloud Hypervisor SIGTERM-to-clean-residue duration: ${cleanup_ms}ms"
+if [ "$cleanup_ms" -gt "$CLEANUP_CEILING_MS" ]; then
+  echo "cancellation: cleanup exceeded ${CLEANUP_CEILING_MS}ms ceiling (took ${cleanup_ms}ms)" >&2
+  exit 1
+fi
+
+keep_work="$RUN_ROOT/keep/work"
+keep_workspace="$RUN_ROOT/keep/workspace"
+keep_audit="$RUN_ROOT/keep/audit"
+mkdir -p "$keep_work" "$keep_workspace" "$keep_audit"
+(
+  export GITHUB_WORKSPACE="$keep_workspace"
+  export OPENAI_API_KEY="$SECRET_SENTINEL"
+  sudo -E node "$ROOT/dist/cli.js" \
+    "${COMMON[@]}" \
+    --keep-containers \
+    --work-dir "$keep_work" \
+    --audit-dir "$keep_audit" \
+    -- 'true'
+) >"$RUN_ROOT/keep/stdout.log" 2>"$RUN_ROOT/keep/stderr.log"
+sudo ip netns list | grep -q '^awffc-' || {
+  echo "keep mode did not preserve the run network namespace" >&2
+  exit 1
+}
+test -d "$keep_work/cloud-hypervisor-run"
+test -f "$keep_audit/cloud-hypervisor/network-plan.json"
+test -f "$keep_audit/cloud-hypervisor/cloud-hypervisor.log"
+find "$keep_audit/cloud-hypervisor" -type f -size +1048576c -print -quit \
+  | grep -q . && {
+    echo "Cloud Hypervisor diagnostic artifact exceeded the 1 MiB bound" >&2
+    exit 1
+  }
+
+while read -r namespace _; do
+  case "$namespace" in
+    awffc-*) sudo ip netns delete "$namespace" ;;
+  esac
+done < <(sudo ip netns list)
+sudo docker compose -f "$keep_work/docker-compose.yml" down --volumes --remove-orphans
+assert_no_residue
+
+# --- Cloud Hypervisor-specific live security assertions -------------------
+#
+# Reproduces the launcher's jailer-replacement boundary live, while a run is
+# in flight: netns-join + non-root privilege drop + empty capability set +
+# no_new_privs + active seccomp filter + per-run cgroup membership/limits +
+# landlock_enable reflected in vm.create + an exactly-minimal disk/net/vsock
+# device set (see src/cloud-hypervisor/launcher.ts and manager.ts).
+sec_work="$RUN_ROOT/security/work"
+sec_workspace="$RUN_ROOT/security/workspace"
+sec_audit="$RUN_ROOT/security/audit"
+mkdir -p "$sec_work" "$sec_workspace" "$sec_audit"
+(
+  export GITHUB_WORKSPACE="$sec_workspace"
+  export OPENAI_API_KEY="$SECRET_SENTINEL"
+  exec sudo -E node "$ROOT/dist/cli.js" \
+    "${COMMON[@]}" \
+    --work-dir "$sec_work" \
+    --audit-dir "$sec_audit" \
+    -- 'sleep 25'
+) >"$RUN_ROOT/security/stdout.log" 2>"$RUN_ROOT/security/stderr.log" &
+sec_pid=$!
+
+api_socket=""
+for _ in $(seq 1 60); do
+  api_socket=$(sudo find "$sec_work/cloud-hypervisor-run" -name api.socket 2>/dev/null | head -1)
+  [ -n "$api_socket" ] && break
+  sleep 1
+done
+if [ -z "$api_socket" ]; then
+  echo "security-assertions: Cloud Hypervisor API socket never appeared" >&2
+  kill -TERM "$sec_pid" 2>/dev/null || true
+  wait "$sec_pid" 2>/dev/null || true
+  exit 1
+fi
+run_directory=$(dirname "$api_socket")
+run_id=$(basename "$run_directory")
+# Cgroup root matches whichever hierarchy preflight detected (GitHub-hosted
+# Ubuntu runners use cgroup v2 exclusively per docs/cloud-hypervisor-foundation.md
+# Part 6, but this is discovered rather than assumed for robustness).
+if sudo test -d "$CGROUP_ROOT/$run_id"; then
+  cgroup_path="$CGROUP_ROOT/$run_id"
+elif sudo test -d "/sys/fs/cgroup/memory/awf-cloud-hypervisor/$run_id"; then
+  cgroup_path="/sys/fs/cgroup/memory/awf-cloud-hypervisor/$run_id"
+else
+  cgroup_path="$CGROUP_ROOT/$run_id"
+fi
+
+fail_security() {
+  echo "security-assertions: $*" >&2
+  kill -TERM "$sec_pid" 2>/dev/null || true
+  wait "$sec_pid" 2>/dev/null || true
+  exit 1
+}
+
+vmm_pid=""
+for _ in $(seq 1 30); do
+  vmm_pid=$(sudo cat "$cgroup_path/cgroup.procs" 2>/dev/null | head -1)
+  [ -n "$vmm_pid" ] && break
+  sleep 1
+done
+[ -n "$vmm_pid" ] || fail_security "no Cloud Hypervisor PID found in $cgroup_path/cgroup.procs"
+
+# Non-root process identity.
+proc_uid=$(sudo stat -c %u "/proc/$vmm_pid" 2>/dev/null || echo "")
+[ -n "$proc_uid" ] || fail_security "could not stat /proc/$vmm_pid"
+[ "$proc_uid" != "0" ] || fail_security "Cloud Hypervisor process is running as root"
+
+# Empty effective capability set (setpriv --inh-caps=-all --bounding-set=-all).
+cap_eff=$(sudo awk '/^CapEff:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")
+[ "$cap_eff" = "0000000000000000" ] \
+  || fail_security "process retains effective capabilities: ${cap_eff:-unknown}"
+
+# no_new_privs set (setpriv --no-new-privs).
+no_new_privs=$(sudo awk '/^NoNewPrivs:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")
+[ "$no_new_privs" = "1" ] || fail_security "no_new_privs is not set (got ${no_new_privs:-unknown})"
+
+# Seccomp filter active (Cloud Hypervisor's own --seccomp true; mode 2 = filter).
+seccomp_mode=$(sudo awk '/^Seccomp:/{print $2}' "/proc/$vmm_pid/status" 2>/dev/null || echo "")
+[ "$seccomp_mode" = "2" ] || fail_security "seccomp filter is not active (mode=${seccomp_mode:-unknown})"
+
+# Per-run cgroup membership and non-trivial, bounded limits.
+sudo test -f "$cgroup_path/cgroup.procs" || fail_security "cgroup.procs missing at $cgroup_path"
+if sudo test -f "$cgroup_path/memory.max"; then
+  memory_max=$(sudo cat "$cgroup_path/memory.max")
+  case "$memory_max" in
+    ''|*[!0-9]*) fail_security "memory.max is not a bounded numeric value: $memory_max" ;;
+  esac
+  memory_current=$(sudo cat "$cgroup_path/memory.current" 2>/dev/null || echo 0)
+  case "$memory_current" in
+    ''|*[!0-9]*) fail_security "memory.current is not numeric: $memory_current" ;;
+  esac
+  [ "$memory_current" -gt 0 ] || fail_security "memory.current reports zero usage; cgroup accounting looks inactive"
+  [ "$memory_current" -le "$memory_max" ] || fail_security "memory.current ($memory_current) exceeds memory.max ($memory_max)"
+elif sudo test -f "$cgroup_path/memory.limit_in_bytes"; then
+  memory_max=$(sudo cat "$cgroup_path/memory.limit_in_bytes")
+  case "$memory_max" in
+    ''|*[!0-9]*) fail_security "memory.limit_in_bytes is not a bounded numeric value: $memory_max" ;;
+  esac
+else
+  fail_security "no memory limit file found under $cgroup_path (neither cgroup v2 nor v1)"
+fi
+
+# vm.info reflects landlock_enable and an exactly-minimal, expected device
+# topology (rootfs+workspace disks, single net device, vsock) — proving the
+# host-only API socket is never exposed to the guest as any device.
+vm_info=$(sudo curl --silent --show-error --max-time 5 --unix-socket "$api_socket" \
+  http://localhost/api/v1/vm.info) || fail_security "vm.info request failed"
+node -e '
+  const info = JSON.parse(process.argv[1]);
+  const config = info.config || {};
+  if (config.landlock_enable !== true) {
+    throw new Error("landlock_enable is not true in vm.info: " + JSON.stringify(config.landlock_enable));
+  }
+  const disks = config.disks || [];
+  if (disks.length !== 2) {
+    throw new Error("expected exactly 2 disks (rootfs, workspace), got " + disks.length);
+  }
+  const net = config.net || [];
+  if (net.length !== 1) {
+    throw new Error("expected exactly 1 net device, got " + net.length);
+  }
+  if (!config.vsock || typeof config.vsock.cid !== "number") {
+    throw new Error("expected a vsock device with a numeric cid");
+  }
+  for (const disk of disks) {
+    if (disk.path && disk.path.endsWith("api.socket")) {
+      throw new Error("API socket path is exposed as a guest disk");
+    }
+  }
+' "$vm_info" || fail_security "vm.info device-topology assertion failed: $vm_info"
+
+kill -TERM "$sec_pid"
+set +e
+wait "$sec_pid"
+sec_status=$?
+set -e
+[ "$sec_status" -eq 143 ] || {
+  echo "security-assertions: expected exit 143 after cancellation, got $sec_status" >&2
+  exit 1
+}
+assert_no_residue
+
+echo "Cloud Hypervisor live smoke/security suite passed."

--- a/scripts/ci/firecracker-live-smoke.sh
+++ b/scripts/ci/firecracker-live-smoke.sh
@@ -77,7 +77,15 @@ run_case() {
     tail -200 "$RUN_ROOT/$name/stderr.log" >&2
     return 1
   fi
+  # awf-resolved-config.json's own agentCommand field always contains
+  # this case's shell command verbatim; for api-proxy-reflect that
+  # command intentionally references the sentinel string itself (the
+  # pattern it greps for, to assert the sentinel's absence from `env`).
+  # That is expected, self-referential test source text, not a leak of
+  # the sentinel value into somewhere it shouldn't be -- guest stdout,
+  # proxy logs, and every other diagnostic file are still fully scanned.
   if grep -R --binary-files=without-match -F "$SECRET_SENTINEL" \
+    --exclude='awf-resolved-config.json' \
     "$RUN_ROOT/$name/stdout.log" \
     "$audit" \
     "$proxy_logs" >/dev/null 2>&1; then

--- a/scripts/ci/firecracker-live-smoke.sh
+++ b/scripts/ci/firecracker-live-smoke.sh
@@ -188,11 +188,23 @@ sudo ip netns list | grep -q '^awffc-' || {
   echo "keep mode did not preserve the run network namespace" >&2
   exit 1
 }
-test -d "$keep_work/firecracker-jailer"
-test -f "$keep_audit/firecracker/network-plan.json"
-test -f "$keep_audit/firecracker/firecracker.log"
-test -f "$keep_audit/firecracker/firecracker.metrics.jsonl"
-find "$keep_audit/firecracker" -type f -size +1048576c -print -quit \
+sudo test -d "$keep_work/firecracker-jailer" || {
+  echo "keep mode did not preserve the firecracker-jailer work directory" >&2
+  exit 1
+}
+sudo test -f "$keep_audit/firecracker/network-plan.json" || {
+  echo "keep mode did not preserve network-plan.json" >&2
+  exit 1
+}
+sudo test -f "$keep_audit/firecracker/firecracker.log" || {
+  echo "keep mode did not preserve firecracker.log" >&2
+  exit 1
+}
+sudo test -f "$keep_audit/firecracker/firecracker.metrics.jsonl" || {
+  echo "keep mode did not preserve firecracker.metrics.jsonl" >&2
+  exit 1
+}
+sudo find "$keep_audit/firecracker" -type f -size +1048576c -print -quit \
   | grep -q . && {
     echo "Firecracker diagnostic artifact exceeded the 1 MiB bound" >&2
     exit 1

--- a/scripts/ci/firecracker-live-smoke.sh
+++ b/scripts/ci/firecracker-live-smoke.sh
@@ -162,6 +162,7 @@ keep_work="$RUN_ROOT/keep/work"
 keep_workspace="$RUN_ROOT/keep/workspace"
 keep_audit="$RUN_ROOT/keep/audit"
 mkdir -p "$keep_work" "$keep_workspace" "$keep_audit"
+set +e
 (
   export GITHUB_WORKSPACE="$keep_workspace"
   export OPENAI_API_KEY="$SECRET_SENTINEL"
@@ -172,6 +173,17 @@ mkdir -p "$keep_work" "$keep_workspace" "$keep_audit"
     --audit-dir "$keep_audit" \
     -- 'true'
 ) >"$RUN_ROOT/keep/stdout.log" 2>"$RUN_ROOT/keep/stderr.log"
+keep_status=$?
+set -e
+if [ "$keep_status" -ne 0 ]; then
+  # See the identical fix in cloud-hypervisor-live-smoke.sh: unlike
+  # run_case, this invocation is not wrapped by a helper that tails its
+  # own log on failure, so under `set -e` a non-zero exit here previously
+  # aborted the whole suite silently.
+  echo "keep-containers invocation: expected exit 0, got $keep_status" >&2
+  tail -200 "$RUN_ROOT/keep/stderr.log" >&2
+  exit 1
+fi
 sudo ip netns list | grep -q '^awffc-' || {
   echo "keep mode did not preserve the run network namespace" >&2
   exit 1

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import * as yaml from 'js-yaml';
+
+const workflowPath = path.resolve(__dirname, '../../.github/workflows/test-cloud-hypervisor.yml');
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+  uses?: string;
+  if?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  name?: string;
+  needs?: string | string[];
+  if?: string;
+  'runs-on'?: string;
+  'timeout-minutes'?: number;
+  steps?: WorkflowStep[];
+}
+
+interface WorkflowDoc {
+  on: Record<string, unknown>;
+  permissions: Record<string, string>;
+  concurrency: { group: string; 'cancel-in-progress': boolean };
+  jobs: Record<string, WorkflowJob>;
+}
+
+function loadWorkflow(): WorkflowDoc {
+  return yaml.load(fs.readFileSync(workflowPath, 'utf-8')) as WorkflowDoc;
+}
+
+describe('Cloud Hypervisor CI workflow', () => {
+  it('parses as valid YAML with the expected jobs', () => {
+    const doc = loadWorkflow();
+    expect(Object.keys(doc.jobs)).toEqual(['build-test-artifacts', 'live-kvm']);
+  });
+
+  it('grants only the minimal permissions the workflow needs', () => {
+    const doc = loadWorkflow();
+    expect(doc.permissions).toEqual({
+      contents: 'read',
+      'id-token': 'write',
+      attestations: 'write',
+    });
+  });
+
+  it('uses a non-cancelling concurrency group scoped to the ref', () => {
+    const doc = loadWorkflow();
+    expect(doc.concurrency.group).toBe('cloud-hypervisor-preview-${{ github.ref }}');
+    expect(doc.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('triggers only on workflow_dispatch and pull_request, scoped to relevant paths', () => {
+    const doc = loadWorkflow();
+    expect(Object.keys(doc.on).sort()).toEqual(['pull_request', 'workflow_dispatch']);
+    const pullRequest = doc.on.pull_request as { types: string[]; paths: string[] };
+    expect(pullRequest.types).toEqual(['opened', 'synchronize', 'reopened', 'labeled']);
+    expect(pullRequest.paths).toEqual(
+      expect.arrayContaining([
+        'guest/cloud-hypervisor/**',
+        'src/cloud-hypervisor/**',
+        'scripts/ci/cloud-hypervisor-*.sh',
+      ]),
+    );
+    const workflowDispatch = doc.on.workflow_dispatch as {
+      inputs: { run_live_kvm: { type: string; default: boolean } };
+    };
+    expect(workflowDispatch.inputs.run_live_kvm.type).toBe('boolean');
+    expect(workflowDispatch.inputs.run_live_kvm.default).toBe(true);
+  });
+
+  it('gates the live-kvm job on manual dispatch or an explicit label, never push/schedule', () => {
+    const doc = loadWorkflow();
+    const liveKvm = doc.jobs['live-kvm'];
+    expect(liveKvm.if).toContain('cloud-hypervisor-kvm');
+    expect(liveKvm.if).toContain("github.event_name == 'workflow_dispatch'");
+    expect(liveKvm.needs).toBe('build-test-artifacts');
+  });
+
+  it('builds and verifies pinned guest artifacts before attesting provenance', () => {
+    const doc = loadWorkflow();
+    const build = doc.jobs['build-test-artifacts'];
+    const runSteps = (build.steps ?? []).map((step) => step.run).filter(Boolean) as string[];
+    expect(runSteps.some((run) => run.includes('./guest/cloud-hypervisor/build-test-artifacts.sh'))).toBe(true);
+    expect(runSteps.some((run) => run.includes('./guest/cloud-hypervisor/verify-test-artifacts.sh'))).toBe(true);
+    const usesSteps = (build.steps ?? []).map((step) => step.uses).filter(Boolean) as string[];
+    expect(usesSteps.some((uses) => uses.startsWith('actions/attest-build-provenance@'))).toBe(true);
+    expect(usesSteps.some((uses) => uses.startsWith('actions/upload-artifact@'))).toBe(true);
+  });
+
+  it('verifies digests before running the live suite and cleans up unconditionally', () => {
+    const doc = loadWorkflow();
+    const live = doc.jobs['live-kvm'];
+    const steps = live.steps ?? [];
+    const preflightIndex = steps.findIndex((step) =>
+      (step.run ?? '').includes('cloud-hypervisor-host-preflight.sh'));
+    const smokeIndex = steps.findIndex((step) =>
+      (step.run ?? '').includes('cloud-hypervisor-live-smoke.sh'));
+    expect(preflightIndex).toBeGreaterThan(-1);
+    expect(smokeIndex).toBeGreaterThan(preflightIndex);
+
+    const cleanupStep = steps.find((step) => step.name === 'Enforce final residue cleanup');
+    expect(cleanupStep?.if).toBe('always()');
+    expect(cleanupStep?.run).toContain('awffc-');
+    expect(cleanupStep?.run).toContain('awf-cloud-hypervisor');
+
+    const diagnosticsStep = steps.find((step) => step.name === 'Collect redacted diagnostics');
+    expect(diagnosticsStep?.if).toBe('always()');
+    expect(diagnosticsStep?.run).toContain('awf-cloud-hypervisor-real-secret-do-not-expose');
+
+    const uploadStep = steps.find((step) => step.name === 'Upload actionable diagnostics');
+    expect(uploadStep?.if).toBe('always()');
+  });
+
+  it('does not run on push or schedule triggers', () => {
+    const source = fs.readFileSync(workflowPath, 'utf-8');
+    expect(source).not.toMatch(/^\s*push:/m);
+    expect(source).not.toMatch(/^\s*schedule:/m);
+  });
+
+  it('passes actionlint-equivalent shell syntax checks for every run: block', () => {
+    const doc = loadWorkflow();
+    for (const job of Object.values(doc.jobs)) {
+      for (const step of job.steps ?? []) {
+        if (!step.run) continue;
+        expect(() =>
+          execFileSync('bash', ['-n'], { input: step.run }),
+        ).not.toThrow();
+      }
+    }
+  });
+});

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -92,6 +92,34 @@ describe('Cloud Hypervisor CI workflow', () => {
     expect(usesSteps.some((uses) => uses.startsWith('actions/upload-artifact@'))).toBe(true);
   });
 
+  it('restores executable permissions lost by the artifact upload/download round-trip before preflight', () => {
+    // Regression test: actions/upload-artifact + actions/download-artifact do
+    // not reliably preserve the executable bit on binary files, even though
+    // guest/cloud-hypervisor/build-test-artifacts.sh chmods the binary to
+    // 0755 before archiving and verify-test-artifacts.sh confirms it is
+    // executable in the same job, pre-upload. Discovered via a live
+    // workflow_dispatch run: "Permission denied" executing the downloaded
+    // cloud-hypervisor binary despite a correct, digest-verified artifact.
+    const doc = loadWorkflow();
+    const live = doc.jobs['live-kvm'];
+    const steps = live.steps ?? [];
+    const downloadIndex = steps.findIndex((step) =>
+      (step.uses ?? '').startsWith('actions/download-artifact@'));
+    const restoreIndex = steps.findIndex((step) =>
+      step.name === 'Restore artifact executable permissions');
+    const preflightIndex = steps.findIndex((step) =>
+      (step.run ?? '').includes('cloud-hypervisor-host-preflight.sh'));
+
+    expect(downloadIndex).toBeGreaterThan(-1);
+    expect(restoreIndex).toBeGreaterThan(downloadIndex);
+    expect(preflightIndex).toBeGreaterThan(restoreIndex);
+
+    const restoreStep = steps[restoreIndex];
+    expect(restoreStep.run).toContain('chmod 0755');
+    expect(restoreStep.run).toContain('cloud-hypervisor-test-x86_64/cloud-hypervisor');
+    expect(restoreStep.run).toContain('cloud-hypervisor-test-x86_64/awf-supervisor');
+  });
+
   it('verifies digests before running the live suite and cleans up unconditionally', () => {
     const doc = loadWorkflow();
     const live = doc.jobs['live-kvm'];

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -295,19 +295,25 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(manager.stop).toHaveBeenCalledTimes(1);
   });
 
-  it('collects diagnostics before stopping on a startup failure, when --diagnostic-logs is set', async () => {
+  it('passes a beforeCleanup diagnostics hook to stop() on a startup failure, when --diagnostic-logs is set', async () => {
     // Regression test: manager.stop() deletes the private run directory
-    // (including the guest serial console log), so collectDiagnostics()
-    // must run BEFORE stop() on a startup failure, or there is nothing
-    // left for it to find. Discovered via live-KVM validation: a guest
-    // boot failure produced completely empty diagnostics artifacts.
+    // (including the guest serial console log) as its final step, but
+    // Cloud Hypervisor also does not flush buffered guest serial console
+    // output until its process actually exits. So collectDiagnostics()
+    // must run as a hook *inside* stop() — after process termination is
+    // confirmed (flushing buffers) but before the run directory is
+    // removed — rather than either before or after stop() entirely.
+    // Discovered via live-KVM validation: a guest boot failure produced
+    // completely empty diagnostics artifacts when collected too early.
     const { manager, deps } = harness();
     const order: string[] = [];
     manager.collectDiagnostics.mockImplementation(async () => {
       order.push('collect-diagnostics');
     });
-    manager.stop.mockImplementation(async () => {
-      order.push('stop');
+    manager.stop.mockImplementation(async (options?: { beforeCleanup?: () => Promise<void> }) => {
+      order.push('stop-process-terminated');
+      await options?.beforeCleanup?.();
+      order.push('stop-directory-removed');
     });
     manager.startInstance.mockRejectedValue(new Error('guest disconnected before readiness'));
     const backend = new CloudHypervisorRuntimeBackend(
@@ -318,10 +324,14 @@ describe('Cloud Hypervisor runtime backend', () => {
     await expect(backend.start('/tmp/awf', ['github.com']))
       .rejects.toThrow('guest disconnected before readiness');
     expect(manager.collectDiagnostics).toHaveBeenCalledTimes(1);
-    expect(order).toEqual(['collect-diagnostics', 'stop']);
+    expect(manager.stop).toHaveBeenCalledTimes(1);
+    expect(manager.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ beforeCleanup: expect.any(Function) }),
+    );
+    expect(order).toEqual(['stop-process-terminated', 'collect-diagnostics', 'stop-directory-removed']);
   });
 
-  it('does not collect diagnostics on a startup failure when --diagnostic-logs is unset', async () => {
+  it('does not pass a diagnostics hook to stop() on a startup failure when --diagnostic-logs is unset', async () => {
     const { manager, deps } = harness();
     manager.startInstance.mockRejectedValue(new Error('guest disconnected before readiness'));
     const backend = new CloudHypervisorRuntimeBackend(
@@ -333,11 +343,17 @@ describe('Cloud Hypervisor runtime backend', () => {
       .rejects.toThrow('guest disconnected before readiness');
     expect(manager.collectDiagnostics).not.toHaveBeenCalled();
     expect(manager.stop).toHaveBeenCalledTimes(1);
+    expect(manager.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ beforeCleanup: undefined }),
+    );
   });
 
   it('surfaces the original startup error even if pre-cleanup diagnostics collection itself fails', async () => {
     const { manager, deps } = harness();
     manager.collectDiagnostics.mockRejectedValue(new Error('diagnostics write failed'));
+    manager.stop.mockImplementation(async (options?: { beforeCleanup?: () => Promise<void> }) => {
+      await options?.beforeCleanup?.();
+    });
     manager.startInstance.mockRejectedValue(new Error('guest disconnected before readiness'));
     const backend = new CloudHypervisorRuntimeBackend(
       config({ diagnosticLogs: true } as Partial<WrapperConfig>),

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -422,6 +422,37 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(script).toMatch(/nc -v -z .* && \(unset .*HTTP_PROXY.*; wget /);
   });
 
+  it('uses generous nc/wget timeouts and an overall probe budget tolerant of nested-KVM scheduling delays', async () => {
+    // Regression test: live-KVM validation confirmed (via captured host
+    // network diagnostics) that the tap/nftables/vnet_hdr path was fully
+    // correct -- Squid's response packets reached the host-side veth --
+    // yet the probe still timed out, because the guest's own vCPU was
+    // scheduled so rarely under nested virtualization on GitHub-hosted
+    // runners that a short-lived `nc -z -w 5` couldn't get enough real
+    // CPU time to complete its connect() within that 5-second budget.
+    // Raised both the per-command timeouts and the overall exec budget
+    // to match the same generous, nested-KVM-tolerant convention used for
+    // guest boot readiness (see CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS).
+    const { manager, deps } = harness();
+    manager.execute.mockReset().mockResolvedValueOnce({
+      requestId: 'probe', exitCode: 0, signal: null, timedOut: false,
+    }).mockResolvedValueOnce({
+      requestId: 'agent', exitCode: 0, signal: null, timedOut: false,
+    });
+    const backend = new CloudHypervisorRuntimeBackend(
+      config({ enableApiProxy: true } as Partial<WrapperConfig>),
+      deps,
+    );
+
+    await backend.start('/tmp/awf', ['github.com']);
+
+    const probeCall = manager.execute.mock.calls[0][0];
+    const script = probeCall.argv[2] as string;
+    expect(script).toContain('nc -v -z -w 60');
+    expect(script).toContain('wget -q -T 20');
+    expect(probeCall.timeoutMs).toBe(90_000);
+  });
+
   it('passes a beforeCleanup diagnostics hook to stop() on a startup failure, when --diagnostic-logs is set', async () => {
     // Regression test: manager.stop() deletes the private run directory
     // (including the guest serial console log) as its final step, but

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -295,6 +295,23 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(manager.stop).toHaveBeenCalledTimes(1);
   });
 
+  it('includes captured guest stdout/stderr in the readiness probe failure message', async () => {
+    // Regression test: a bare exit code alone doesn't say which leg of the
+    // compound nc-then-wget probe command failed or why. Capture (bounded)
+    // stdout/stderr from the probe execution and surface it in the thrown
+    // error for faster live-KVM triage.
+    const { manager, deps } = harness();
+    manager.execute.mockReset().mockImplementationOnce(async (request) => {
+      request.stderr?.write('wget: can\'t connect to remote host: Connection refused\n');
+      return { requestId: 'probe', exitCode: 1, signal: null, timedOut: false };
+    });
+    const backend = new CloudHypervisorRuntimeBackend(config(), deps);
+
+    await expect(backend.start('/tmp/awf', ['github.com'])).rejects.toThrow(
+      /connectivity probe failed with exit code 1 \(stderr: wget: can't connect to remote host: Connection refused\)/,
+    );
+  });
+
   it('probes guest connectivity with nc/wget instead of curl, which the BusyBox guest rootfs lacks', async () => {
     // Regression test: the guest rootfs is a minimal BusyBox userland (see
     // guest/cloud-hypervisor/build-test-artifacts.sh) with no `curl`

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -664,6 +664,21 @@ describe('Cloud Hypervisor runtime backend', () => {
     )).toThrow(/Refusing to pass a real provider credential/);
   });
 
+  it('sets lowercase http_proxy so BusyBox wget honors the proxy for https:// too', () => {
+    // Regression coverage: a live-KVM connectivity investigation found
+    // BusyBox wget reads only the lowercase "http_proxy" env var for
+    // every protocol it supports, including https -- there is no
+    // https_proxy check anywhere in its proxy-detection logic. Without
+    // this (the shared container-runtime environment intentionally
+    // omits it, for curl/Ubuntu-specific reasons that don't apply to
+    // this guest's BusyBox wget), wget silently falls back to a direct,
+    // unproxied connection attempt, which fails outright since guest DNS
+    // is unconditionally blocked by network policy.
+    const environment = buildCloudHypervisorGuestEnvironment(config(), infrastructure());
+
+    expect(environment.http_proxy).toBe('http://172.30.0.10:3128');
+  });
+
   it('rejects unsupported strict-security and topology combinations', () => {
     expect(() => assertCloudHypervisorPreSecurityCompatibility(
       config({ enableDind: true }),

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -295,6 +295,58 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(manager.stop).toHaveBeenCalledTimes(1);
   });
 
+  it('marks itself stopped after a successful internal cleanup on startup failure, so a later stop() call is a no-op', async () => {
+    // Regression test: main-action.ts's cleanup handler unconditionally
+    // calls backend.stop() again after any startup failure. Without
+    // marking `stopped` after the internal cleanup here already
+    // succeeded, that second call re-invoked manager.stop() a second
+    // time -- harmless on its own (network/cgroup are already cleared),
+    // but wasteful and a source of confusion when diagnosing failures.
+    const { manager, deps } = harness();
+    manager.execute.mockReset().mockResolvedValue({
+      requestId: 'probe', exitCode: 41, signal: null, timedOut: false,
+    });
+    const backend = new CloudHypervisorRuntimeBackend(config(), deps);
+
+    await expect(backend.start('/tmp/awf', ['github.com']))
+      .rejects.toThrow(/connectivity probe failed/);
+    expect(manager.stop).toHaveBeenCalledTimes(1);
+
+    await backend.stop();
+    expect(manager.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('collects diagnostics at most once even if called again after teardown, avoiding a clobbered snapshot', async () => {
+    // Regression test: main-action.ts's cleanup handler unconditionally
+    // calls backend.collectDiagnostics() during shutdown, regardless of
+    // whether start()'s own failure path already collected diagnostics
+    // via the beforeCleanup hook (before stop() tore down the
+    // network/cgroup/run directory). A second, post-teardown call would
+    // overwrite that earlier, more useful snapshot with an
+    // empty/unavailable one -- discovered via live-KVM validation
+    // (network-diagnostics.txt regressed to "network namespace not set
+    // up" after a redundant second collectDiagnostics() call).
+    const { manager, deps } = harness();
+    manager.execute.mockReset().mockResolvedValue({
+      requestId: 'probe', exitCode: 41, signal: null, timedOut: false,
+    });
+    manager.stop.mockImplementation(async (options?: { beforeCleanup?: () => Promise<void> }) => {
+      await options?.beforeCleanup?.();
+    });
+    const backend = new CloudHypervisorRuntimeBackend(
+      config({ diagnosticLogs: true } as Partial<WrapperConfig>),
+      deps,
+    );
+
+    await expect(backend.start('/tmp/awf', ['github.com']))
+      .rejects.toThrow(/connectivity probe failed/);
+    expect(manager.collectDiagnostics).toHaveBeenCalledTimes(1);
+
+    // Simulates main-action.ts's cleanup handler calling this again.
+    await backend.collectDiagnostics();
+    expect(manager.collectDiagnostics).toHaveBeenCalledTimes(1);
+  });
+
   it('includes captured guest stdout/stderr in the readiness probe failure message', async () => {
     // Regression test: a bare exit code alone doesn't say which leg of the
     // compound nc-then-wget probe command failed or why. Capture (bounded)

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -295,6 +295,39 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(manager.stop).toHaveBeenCalledTimes(1);
   });
 
+  it('probes guest connectivity with nc/wget instead of curl, which the BusyBox guest rootfs lacks', async () => {
+    // Regression test: the guest rootfs is a minimal BusyBox userland (see
+    // guest/cloud-hypervisor/build-test-artifacts.sh) with no `curl`
+    // binary. The original probe shelled out to `curl`, which exits 127
+    // ("command not found") on this rootfs — discovered via live-KVM
+    // validation, where every guest boot up through vsock readiness
+    // succeeded but probeGuestConnectivity() then failed with exit 127.
+    const { manager, deps } = harness();
+    manager.execute.mockReset().mockResolvedValueOnce({
+      requestId: 'probe', exitCode: 0, signal: null, timedOut: false,
+    }).mockResolvedValueOnce({
+      requestId: 'agent', exitCode: 0, signal: null, timedOut: false,
+    });
+    const backend = new CloudHypervisorRuntimeBackend(
+      config({ enableApiProxy: true } as Partial<WrapperConfig>),
+      deps,
+    );
+
+    await backend.start('/tmp/awf', ['github.com']);
+
+    const probeCall = manager.execute.mock.calls[0][0];
+    expect(probeCall.argv[0]).toBe('/bin/sh');
+    expect(probeCall.argv[1]).toBe('-c');
+    const script = probeCall.argv[2] as string;
+    expect(script).not.toContain('curl');
+    expect(script).toContain('nc -z');
+    expect(script).toContain('wget');
+    // The API proxy request must bypass the guest's HTTP(S)_PROXY env vars
+    // (it targets the sidecar directly, not through Squid) and must only
+    // run if the Squid reachability check already succeeded.
+    expect(script).toMatch(/nc -z .* && \(unset .*HTTP_PROXY.*; wget /);
+  });
+
   it('passes a beforeCleanup diagnostics hook to stop() on a startup failure, when --diagnostic-logs is set', async () => {
     // Regression test: manager.stop() deletes the private run directory
     // (including the guest serial console log) as its final step, but

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -312,6 +312,31 @@ describe('Cloud Hypervisor runtime backend', () => {
     );
   });
 
+  it('includes captured guest network state (ip addr/route) in the readiness probe failure message', async () => {
+    // Regression test: a probe failure with empty stdout/stderr (BusyBox
+    // nc/wget are often silent on connection failure) still needs enough
+    // context to diagnose live-KVM guest networking issues. A best-effort
+    // follow-up `ip addr show; ip route show` call is issued only after
+    // the main probe fails, and its output is folded into the error.
+    const { manager, deps } = harness();
+    manager.execute.mockReset()
+      .mockImplementationOnce(async () => ({
+        requestId: 'probe', exitCode: 1, signal: null, timedOut: false,
+      }))
+      .mockImplementationOnce(async (request) => {
+        request.stdout?.write('1: lo: <LOOPBACK,UP>\n---\ndefault via 100.115.75.109 dev eth0\n');
+        return { requestId: 'netdiag', exitCode: 0, signal: null, timedOut: false };
+      });
+    const backend = new CloudHypervisorRuntimeBackend(config(), deps);
+
+    await expect(backend.start('/tmp/awf', ['github.com'])).rejects.toThrow(
+      /guest network state: 1: lo: <LOOPBACK,UP>/,
+    );
+    expect(manager.execute).toHaveBeenCalledTimes(2);
+    const netDiagCall = manager.execute.mock.calls[1][0];
+    expect(netDiagCall.argv).toEqual(['/bin/sh', '-c', 'ip addr show; echo ---; ip route show']);
+  });
+
   it('probes guest connectivity with nc/wget instead of curl, which the BusyBox guest rootfs lacks', async () => {
     // Regression test: the guest rootfs is a minimal BusyBox userland (see
     // guest/cloud-hypervisor/build-test-artifacts.sh) with no `curl`
@@ -337,12 +362,12 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(probeCall.argv[1]).toBe('-c');
     const script = probeCall.argv[2] as string;
     expect(script).not.toContain('curl');
-    expect(script).toContain('nc -z');
+    expect(script).toContain('nc -v -z');
     expect(script).toContain('wget');
     // The API proxy request must bypass the guest's HTTP(S)_PROXY env vars
     // (it targets the sidecar directly, not through Squid) and must only
     // run if the Squid reachability check already succeeded.
-    expect(script).toMatch(/nc -z .* && \(unset .*HTTP_PROXY.*; wget /);
+    expect(script).toMatch(/nc -v -z .* && \(unset .*HTTP_PROXY.*; wget /);
   });
 
   it('passes a beforeCleanup diagnostics hook to stop() on a startup failure, when --diagnostic-logs is set', async () => {

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -295,6 +295,60 @@ describe('Cloud Hypervisor runtime backend', () => {
     expect(manager.stop).toHaveBeenCalledTimes(1);
   });
 
+  it('collects diagnostics before stopping on a startup failure, when --diagnostic-logs is set', async () => {
+    // Regression test: manager.stop() deletes the private run directory
+    // (including the guest serial console log), so collectDiagnostics()
+    // must run BEFORE stop() on a startup failure, or there is nothing
+    // left for it to find. Discovered via live-KVM validation: a guest
+    // boot failure produced completely empty diagnostics artifacts.
+    const { manager, deps } = harness();
+    const order: string[] = [];
+    manager.collectDiagnostics.mockImplementation(async () => {
+      order.push('collect-diagnostics');
+    });
+    manager.stop.mockImplementation(async () => {
+      order.push('stop');
+    });
+    manager.startInstance.mockRejectedValue(new Error('guest disconnected before readiness'));
+    const backend = new CloudHypervisorRuntimeBackend(
+      config({ diagnosticLogs: true } as Partial<WrapperConfig>),
+      deps,
+    );
+
+    await expect(backend.start('/tmp/awf', ['github.com']))
+      .rejects.toThrow('guest disconnected before readiness');
+    expect(manager.collectDiagnostics).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['collect-diagnostics', 'stop']);
+  });
+
+  it('does not collect diagnostics on a startup failure when --diagnostic-logs is unset', async () => {
+    const { manager, deps } = harness();
+    manager.startInstance.mockRejectedValue(new Error('guest disconnected before readiness'));
+    const backend = new CloudHypervisorRuntimeBackend(
+      config({ diagnosticLogs: false } as Partial<WrapperConfig>),
+      deps,
+    );
+
+    await expect(backend.start('/tmp/awf', ['github.com']))
+      .rejects.toThrow('guest disconnected before readiness');
+    expect(manager.collectDiagnostics).not.toHaveBeenCalled();
+    expect(manager.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the original startup error even if pre-cleanup diagnostics collection itself fails', async () => {
+    const { manager, deps } = harness();
+    manager.collectDiagnostics.mockRejectedValue(new Error('diagnostics write failed'));
+    manager.startInstance.mockRejectedValue(new Error('guest disconnected before readiness'));
+    const backend = new CloudHypervisorRuntimeBackend(
+      config({ diagnosticLogs: true } as Partial<WrapperConfig>),
+      deps,
+    );
+
+    await expect(backend.start('/tmp/awf', ['github.com']))
+      .rejects.toThrow('guest disconnected before readiness');
+    expect(manager.stop).toHaveBeenCalledTimes(1);
+  });
+
   it('fails closed when manager readiness or startup cleanup is unavailable', async () => {
     const missingIp = harness();
     Reflect.set(missingIp.manager, 'guestIp', undefined);

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -386,7 +386,7 @@ describe('Cloud Hypervisor runtime backend', () => {
     );
     expect(manager.execute).toHaveBeenCalledTimes(2);
     const netDiagCall = manager.execute.mock.calls[1][0];
-    expect(netDiagCall.argv).toEqual(['/bin/sh', '-c', 'ip addr show; echo ---; ip route show']);
+    expect(netDiagCall.argv).toEqual(['/bin/sh', '-c', 'ip addr show; echo ---; ip route show; echo ---; ip neigh show']);
   });
 
   it('probes guest connectivity with nc/wget instead of curl, which the BusyBox guest rootfs lacks', async () => {

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -395,12 +395,23 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
     if (!identity) {
       throw new Error('Cloud Hypervisor guest identity is not ready');
     }
-    const squidProbe =
-      `curl --silent --show-error --max-time 5 --output /dev/null ` +
-      `http://${SQUID_IP}:3128/`;
+    // The guest rootfs is a minimal BusyBox userland (see
+    // guest/cloud-hypervisor/build-test-artifacts.sh); it has no `curl`
+    // binary, only BusyBox's `nc`/`wget` applets. `nc -z` verifies Squid's
+    // TCP listener is up without depending on HTTP status-code semantics
+    // (a raw, non-proxy-style request to Squid's own port returns a 4xx
+    // error page by design, which BusyBox wget would treat as a script
+    // failure by default, unlike curl without `--fail`). The API proxy
+    // check does expect a real 2xx from its `/reflect` endpoint, so wget
+    // is used there directly (matching the smoke test's own
+    // api-proxy-reflect case), with the proxy env vars unset so the
+    // request reaches the sidecar directly rather than being routed
+    // through Squid. Discovered via live-KVM validation: curl exits 127
+    // ("command not found") on this rootfs.
+    const squidProbe = `nc -z -w 5 ${SQUID_IP} 3128`;
     const apiProxyProbe = this.config.enableApiProxy
-      ? ` && curl --fail --silent --show-error --max-time 5 --noproxy '*' ` +
-        `--output /dev/null http://${API_PROXY_IP}:10000/reflect`
+      ? ` && (unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ` +
+        `wget -q -T 5 -O /dev/null http://${API_PROXY_IP}:10000/reflect)`
       : '';
     const result = await manager.execute({
       requestId: `probe-${process.pid}-${Date.now()}`,

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -402,14 +402,16 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
     // TCP listener is up without depending on HTTP status-code semantics
     // (a raw, non-proxy-style request to Squid's own port returns a 4xx
     // error page by design, which BusyBox wget would treat as a script
-    // failure by default, unlike curl without `--fail`). The API proxy
-    // check does expect a real 2xx from its `/reflect` endpoint, so wget
-    // is used there directly (matching the smoke test's own
-    // api-proxy-reflect case), with the proxy env vars unset so the
-    // request reaches the sidecar directly rather than being routed
-    // through Squid. Discovered via live-KVM validation: curl exits 127
-    // ("command not found") on this rootfs.
-    const squidProbe = `nc -z -w 5 ${SQUID_IP} 3128`;
+    // failure by default, unlike curl without `--fail`). `-v` makes
+    // BusyBox nc print an "open"/error line instead of staying silent, so
+    // a failure has *something* to report. The API proxy check does
+    // expect a real 2xx from its `/reflect` endpoint, so wget is used
+    // there directly (matching the smoke test's own api-proxy-reflect
+    // case), with the proxy env vars unset so the request reaches the
+    // sidecar directly rather than being routed through Squid. Discovered
+    // via live-KVM validation: curl exits 127 ("command not found") on
+    // this rootfs.
+    const squidProbe = `nc -v -z -w 5 ${SQUID_IP} 3128`;
     const apiProxyProbe = this.config.enableApiProxy
       ? ` && (unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ` +
         `wget -q -T 5 -O /dev/null http://${API_PROXY_IP}:10000/reflect)`
@@ -433,7 +435,12 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
     if (result.exitCode !== 0) {
       const stdout = stdoutCollector.toString().trim();
       const stderr = stderrCollector.toString().trim();
-      const detail = [stdout && `stdout: ${stdout}`, stderr && `stderr: ${stderr}`]
+      const netState = await this.captureGuestNetworkStateForDiagnostics();
+      const detail = [
+        stdout && `stdout: ${stdout}`,
+        stderr && `stderr: ${stderr}`,
+        netState && `guest network state: ${netState}`,
+      ]
         .filter((part): part is string => Boolean(part))
         .join('; ');
       throw new Error(
@@ -444,6 +451,37 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
     this.dependencies.logger.info(
       '[cloud-hypervisor] Guest supervisor, Squid, and API proxy connectivity verified',
     );
+  }
+
+  /**
+   * Best-effort diagnostic-only helper: on a connectivity probe failure,
+   * capture the guest's own view of its network configuration (interface
+   * addresses and routing table) so a live-KVM failure log shows *why* the
+   * guest couldn't reach Squid/API proxy (e.g. missing IP, missing
+   * default route) rather than only a bare exit code. Never throws --
+   * failures here are folded into an empty string rather than masking the
+   * original probe failure.
+   */
+  private async captureGuestNetworkStateForDiagnostics(): Promise<string> {
+    const manager = this.manager;
+    const environment = this.environment;
+    const identity = this.identity;
+    if (!manager || !environment || !identity) return '';
+    try {
+      const stdoutCollector = createBoundedOutputCollector();
+      await manager.execute({
+        requestId: `probe-netdiag-${process.pid}-${Date.now()}`,
+        argv: ['/bin/sh', '-c', 'ip addr show; echo ---; ip route show'],
+        env: environment,
+        cwd: CLOUD_HYPERVISOR_GUEST_WORKSPACE,
+        ...identity,
+        timeoutMs: CLOUD_HYPERVISOR_PROBE_TIMEOUT_MS,
+        stdout: stdoutCollector.stream,
+      });
+      return stdoutCollector.toString().trim();
+    } catch {
+      return '';
+    }
   }
 }
 

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -505,7 +505,17 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
       const stdoutCollector = createBoundedOutputCollector();
       await manager.execute({
         requestId: `probe-netdiag-${process.pid}-${Date.now()}`,
-        argv: ['/bin/sh', '-c', 'ip addr show; echo ---; ip route show'],
+        // `ip addr show` includes each interface's MAC (compared against
+        // the plan's configured guest MAC and the nftables anti-spoof
+        // rule during triage); note this deliberately omits `-d`
+        // (detailed) since the guest's minimal BusyBox `ip` applet does
+        // not reliably support it (unlike the real iproute2 used
+        // host-side in network.ts's captureDiagnosticsInNamespace).
+        // `ip neigh show` confirms the guest actually resolved the
+        // gateway's MAC via ARP (a failure here would mean the guest
+        // never got a reply to its own ARP request, independent of
+        // anything TCP/Squid-related).
+        argv: ['/bin/sh', '-c', 'ip addr show; echo ---; ip route show; echo ---; ip neigh show'],
         env: environment,
         cwd: CLOUD_HYPERVISOR_GUEST_WORKSPACE,
         ...identity,

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -53,7 +53,7 @@ interface CloudHypervisorManagerAdapter {
   cancel(reason?: string, requestId?: string): Promise<void>;
   writeStdin(data: Buffer, requestId?: string): Promise<void>;
   endStdin(requestId?: string): Promise<void>;
-  stop(options?: { preserve?: boolean }): Promise<void>;
+  stop(options?: { preserve?: boolean; beforeCleanup?: () => Promise<void> }): Promise<void>;
   collectDiagnostics(directory: string): Promise<void>;
 }
 
@@ -217,22 +217,30 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
         `[cloud-hypervisor] stage=${stage} status=failed: ${formatError(error)}`,
       );
       // Collect diagnostics (guest serial console, Cloud Hypervisor log,
-      // network plan, counters) before stop() deletes the private run
-      // directory below. Without this, a startup failure leaves nothing
-      // for the outer, --diagnostic-logs-gated collectDiagnostics() call
-      // (invoked later, from the CLI's cleanup path) to find — it would
-      // silently no-op on now-ENOENT paths.
-      if (this.config.diagnosticLogs && this.manager) {
-        try {
-          await this.collectDiagnostics();
-        } catch (diagnosticsError) {
-          this.dependencies.logger.warn(
-            `[cloud-hypervisor] failed to collect pre-cleanup diagnostics: ${formatError(diagnosticsError)}`,
-          );
-        }
-      }
+      // network plan, counters) once the Cloud Hypervisor process is
+      // confirmed terminated but before stop() deletes the private run
+      // directory. Collecting any earlier (before the process actually
+      // exits) can observe a still-empty guest serial console log, since
+      // Cloud Hypervisor does not guarantee flushing buffered console
+      // output to disk until the process exits. Without this hook at all,
+      // a startup failure would leave nothing for the outer,
+      // --diagnostic-logs-gated collectDiagnostics() call (invoked later,
+      // from the CLI's cleanup path) to find — it would silently no-op on
+      // now-ENOENT paths.
+      const collectPreCleanupDiagnostics =
+        this.config.diagnosticLogs && this.manager
+          ? async () => {
+              try {
+                await this.collectDiagnostics();
+              } catch (diagnosticsError) {
+                this.dependencies.logger.warn(
+                  `[cloud-hypervisor] failed to collect pre-cleanup diagnostics: ${formatError(diagnosticsError)}`,
+                );
+              }
+            }
+          : undefined;
       try {
-        await this.manager?.stop();
+        await this.manager?.stop({ beforeCleanup: collectPreCleanupDiagnostics });
       } catch (cleanupError) {
         const combined = new Error(
           `Cloud Hypervisor startup failed: ${formatError(error)}; ` +

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -216,6 +216,21 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
       this.dependencies.logger.warn(
         `[cloud-hypervisor] stage=${stage} status=failed: ${formatError(error)}`,
       );
+      // Collect diagnostics (guest serial console, Cloud Hypervisor log,
+      // network plan, counters) before stop() deletes the private run
+      // directory below. Without this, a startup failure leaves nothing
+      // for the outer, --diagnostic-logs-gated collectDiagnostics() call
+      // (invoked later, from the CLI's cleanup path) to find — it would
+      // silently no-op on now-ENOENT paths.
+      if (this.config.diagnosticLogs && this.manager) {
+        try {
+          await this.collectDiagnostics();
+        } catch (diagnosticsError) {
+          this.dependencies.logger.warn(
+            `[cloud-hypervisor] failed to collect pre-cleanup diagnostics: ${formatError(diagnosticsError)}`,
+          );
+        }
+      }
       try {
         await this.manager?.stop();
       } catch (cleanupError) {

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -22,6 +22,7 @@ import { getRealUserHome, getSafeHostGid, getSafeHostUid } from './host-identity
 import { logger } from './logger';
 import { buildAgentEnvironment } from './services/agent-service';
 import { buildAgentCredentialEnv } from './services/api-proxy-credential-env';
+import { SQUID_PORT } from './constants';
 import type { CloudHypervisorOptions, WrapperConfig } from './types';
 import {
   assertCloudHypervisorRuntimeCompatibility,
@@ -555,6 +556,21 @@ export function buildCloudHypervisorGuestEnvironment(
     SQUID_PROXY_HOST: infrastructure.squidIp,
     HOSTNAME: 'awf-cloud-hypervisor',
     AWF_RUNTIME: 'cloud-hypervisor',
+    // The shared container-runtime environment intentionally omits
+    // lowercase http_proxy (curl on Ubuntu 22.04 ignores uppercase
+    // HTTP_PROXY for plain HTTP, so HTTP falls through to iptables DNAT
+    // -> Squid instead of an explicit proxy connection, which is what
+    // keeps a blocked domain's Squid 403 page mapped to a real failure
+    // exit code there). The BusyBox guest's wget has different,
+    // guest-specific proxy-detection behavior: it reads only the
+    // lowercase "http_proxy" env var for *every* protocol including
+    // https (there is no https_proxy check in BusyBox's wget at all).
+    // Every wget-based https:// case in this guest's own smoke coverage
+    // either already relies on an explicit proxy connection or
+    // explicitly unsets all proxy vars first, so this is safe here even
+    // though it would not be for the container runtime's curl-based
+    // HTTP assertions.
+    http_proxy: `http://${infrastructure.squidIp}:${SQUID_PORT}`,
   });
   assertNoProviderSecrets(config, environment);
   return environment;

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -134,6 +134,7 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
   private stopping: Promise<void> | undefined;
   private identity: { uid: number; gid: number } | undefined;
   private preflightResult: CloudHypervisorPreflightResult | undefined;
+  private diagnosticsCollected = false;
 
   constructor(
     private readonly config: WrapperConfig,
@@ -242,6 +243,14 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
           : undefined;
       try {
         await this.manager?.stop({ beforeCleanup: collectPreCleanupDiagnostics });
+        // Mark the backend stopped so the CLI's own cleanup path (which
+        // unconditionally calls backend.stop() again after any startup
+        // failure) doesn't invoke a second, redundant manager.stop() --
+        // by this point network/cgroup/run-directory teardown has already
+        // completed. On a *failed* cleanup here, deliberately leave
+        // `stopped` false so that outer cleanup call gets a genuine retry
+        // attempt rather than silently no-op-ing on a botched teardown.
+        this.stopped = true;
       } catch (cleanupError) {
         const combined = new Error(
           `Cloud Hypervisor startup failed: ${formatError(error)}; ` +
@@ -329,11 +338,23 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
   };
 
   async collectDiagnostics(): Promise<void> {
-    if (!this.manager) return;
+    // Idempotent: main-action.ts's cleanup handler unconditionally calls
+    // this once during shutdown, but start()'s own failure path (above)
+    // already collects diagnostics *before* stop() tears down the
+    // network/cgroup/run directory (so buffered guest console output is
+    // captured, and the live network state is inspectable before the
+    // namespace is deleted). Without this guard, that second, redundant
+    // call would run *after* teardown and clobber the earlier, more
+    // useful snapshot with an empty/unavailable one (e.g.
+    // network-diagnostics.txt regressing to "network namespace not set
+    // up" once cleanup() has already cleared it) -- discovered via
+    // live-KVM validation.
+    if (this.diagnosticsCollected || !this.manager) return;
     const directory = this.config.auditDir
       ? `${this.config.auditDir}/cloud-hypervisor`
       : `${this.config.workDir}/diagnostics/cloud-hypervisor`;
     await this.manager.collectDiagnostics(directory);
+    this.diagnosticsCollected = true;
   }
 
   async stop(): Promise<void> {

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -34,7 +34,20 @@ export {
 
 const CLOUD_HYPERVISOR_GUEST_WORKSPACE = '/workspace';
 const CLOUD_HYPERVISOR_GUEST_HOME = `${CLOUD_HYPERVISOR_GUEST_WORKSPACE}/.awf-home`;
-const CLOUD_HYPERVISOR_PROBE_TIMEOUT_MS = 15_000;
+/**
+ * Generous, not a tight few-second timeout. Live-KVM validation on
+ * GitHub-hosted runners showed the guest's own vCPU getting scheduled so
+ * rarely under nested virtualization (see the CLOUD_HYPERVISOR_GUEST_READY_
+ * MAX_WAIT_MS comment in cloud-hypervisor/manager.ts for the same
+ * phenomenon during boot) that even a fully-correct network path (tap,
+ * nftables, vnet_hdr all confirmed working via live diagnostics — response
+ * packets reaching the host-side veth) could still leave a short-lived
+ * guest command like `nc -z -w 5` unable to get enough real CPU time to
+ * finish its own connect() before that 5-second budget elapsed. A short
+ * probe timeout would abort a guest that is merely slow to be scheduled,
+ * not one with a broken network path.
+ */
+const CLOUD_HYPERVISOR_PROBE_TIMEOUT_MS = 90_000;
 const CLOUD_HYPERVISOR_CANCEL_GRACE_MS = 3_000;
 const CLOUD_HYPERVISOR_MAX_TIMEOUT_MS = 86_400_000;
 
@@ -432,10 +445,10 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
     // sidecar directly rather than being routed through Squid. Discovered
     // via live-KVM validation: curl exits 127 ("command not found") on
     // this rootfs.
-    const squidProbe = `nc -v -z -w 5 ${SQUID_IP} 3128`;
+    const squidProbe = `nc -v -z -w 60 ${SQUID_IP} 3128`;
     const apiProxyProbe = this.config.enableApiProxy
       ? ` && (unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ` +
-        `wget -q -T 5 -O /dev/null http://${API_PROXY_IP}:10000/reflect)`
+        `wget -q -T 20 -O /dev/null http://${API_PROXY_IP}:10000/reflect)`
       : '';
     // Capture (bounded) stdout/stderr so a probe failure can report which
     // leg failed and why, rather than only a bare exit code -- useful for

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -1,4 +1,5 @@
-import type { Readable, Writable } from 'stream';
+import type { Readable } from 'stream';
+import { Writable } from 'stream';
 import type { WorkflowDependencies } from './cli-workflow';
 import type { ExternalAgentRuntimeBackend } from './external-runtime-backend';
 import {
@@ -413,6 +414,12 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
       ? ` && (unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ` +
         `wget -q -T 5 -O /dev/null http://${API_PROXY_IP}:10000/reflect)`
       : '';
+    // Capture (bounded) stdout/stderr so a probe failure can report which
+    // leg failed and why, rather than only a bare exit code -- useful for
+    // diagnosing this compound nc-then-wget command without a full guest
+    // command execution's live output stream.
+    const stdoutCollector = createBoundedOutputCollector();
+    const stderrCollector = createBoundedOutputCollector();
     const result = await manager.execute({
       requestId: `probe-${process.pid}-${Date.now()}`,
       argv: ['/bin/sh', '-c', `set -eu; ${squidProbe}${apiProxyProbe}`],
@@ -420,10 +427,18 @@ export class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBacken
       cwd: CLOUD_HYPERVISOR_GUEST_WORKSPACE,
       ...identity,
       timeoutMs: CLOUD_HYPERVISOR_PROBE_TIMEOUT_MS,
+      stdout: stdoutCollector.stream,
+      stderr: stderrCollector.stream,
     });
     if (result.exitCode !== 0) {
+      const stdout = stdoutCollector.toString().trim();
+      const stderr = stderrCollector.toString().trim();
+      const detail = [stdout && `stdout: ${stdout}`, stderr && `stderr: ${stderr}`]
+        .filter((part): part is string => Boolean(part))
+        .join('; ');
       throw new Error(
-        `Cloud Hypervisor guest connectivity probe failed with exit code ${result.exitCode}`,
+        `Cloud Hypervisor guest connectivity probe failed with exit code ${result.exitCode}` +
+          (detail ? ` (${detail})` : ''),
       );
     }
     this.dependencies.logger.info(
@@ -488,6 +503,35 @@ function assertNoProviderSecrets(
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * A bounded, in-memory Writable for capturing a guest command's stdout or
+ * stderr without printing it live (unlike the real agent command, whose
+ * output streams directly to the user). Used to enrich probeGuestConnectivity()
+ * failure messages with what the guest actually printed, discarding
+ * anything past the byte cap so a runaway/looping command can't grow
+ * memory unbounded.
+ */
+function createBoundedOutputCollector(maxBytes = 4096): {
+  readonly stream: Writable;
+  toString(): string;
+} {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const stream = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      if (total < maxBytes) {
+        chunks.push(chunk);
+        total += chunk.length;
+      }
+      callback();
+    },
+  });
+  return {
+    stream,
+    toString: () => Buffer.concat(chunks).subarray(0, maxBytes).toString('utf8'),
+  };
 }
 
 export function createCloudHypervisorRuntimeBackend(

--- a/src/cloud-hypervisor/api-client.ts
+++ b/src/cloud-hypervisor/api-client.ts
@@ -53,6 +53,9 @@ export interface CloudHypervisorNetConfig {
   mac: string;
   num_queues?: number;
   queue_size?: number;
+  offload_tso?: boolean;
+  offload_ufo?: boolean;
+  offload_csum?: boolean;
 }
 
 export interface CloudHypervisorRngConfig {

--- a/src/cloud-hypervisor/launcher.test.ts
+++ b/src/cloud-hypervisor/launcher.test.ts
@@ -61,7 +61,7 @@ describe('buildCloudHypervisorLaunchCommand', () => {
 });
 
 describe('computeCloudHypervisorLandlockRules', () => {
-  it('restricts the VMM to exactly the staged paths plus required device nodes', () => {
+  it('restricts the VMM to exactly the staged paths plus required device nodes and TAP sysfs entry', () => {
     const rules = computeCloudHypervisorLandlockRules({
       kernelPath: '/run/awf/kernel',
       rootfsPath: '/run/awf/rootfs.ext4',
@@ -69,6 +69,7 @@ describe('computeCloudHypervisorLandlockRules', () => {
       runDirectory: '/run/awf/run',
       apiSocketPath: '/run/awf/run/api.socket',
       vsockSocketPath: '/run/awf/run/vsock.socket',
+      tapName: 'fctabc123',
     });
 
     expect(rules).toEqual([
@@ -77,6 +78,7 @@ describe('computeCloudHypervisorLandlockRules', () => {
       { path: '/run/awf/run', access: 'rw' },
       { path: '/dev/kvm', access: 'rw' },
       { path: '/dev/net/tun', access: 'rw' },
+      { path: '/sys/class/net/fctabc123', access: 'r' },
       { path: '/run/awf/workspace.ext4', access: 'rw' },
     ]);
   });
@@ -88,9 +90,28 @@ describe('computeCloudHypervisorLandlockRules', () => {
       runDirectory: '/run/awf/run',
       apiSocketPath: '/run/awf/run/api.socket',
       vsockSocketPath: '/run/awf/run/vsock.socket',
+      tapName: 'fctabc123',
     });
 
     expect(rules.some((rule) => rule.path.includes('workspace'))).toBe(false);
+  });
+
+  it('grants read access to the TAP sysfs directory so tun_flags is readable under Landlock', () => {
+    // Regression test: /sys/class/net/<tap>/tun_flags is a world-readable
+    // (0444) kernel sysfs attribute with no capability requirement of its
+    // own, but Landlock still blocks the read if the path isn't in the
+    // allowlist — observed live as vm.boot failing with "Failed to read
+    // the TAP flags from sysfs: Permission denied".
+    const rules = computeCloudHypervisorLandlockRules({
+      kernelPath: '/run/awf/kernel',
+      rootfsPath: '/run/awf/rootfs.ext4',
+      runDirectory: '/run/awf/run',
+      apiSocketPath: '/run/awf/run/api.socket',
+      vsockSocketPath: '/run/awf/run/vsock.socket',
+      tapName: 'fctabc123',
+    });
+
+    expect(rules).toContainEqual({ path: '/sys/class/net/fctabc123', access: 'r' });
   });
 });
 

--- a/src/cloud-hypervisor/launcher.test.ts
+++ b/src/cloud-hypervisor/launcher.test.ts
@@ -16,7 +16,7 @@ describe('buildCloudHypervisorLaunchCommand', () => {
     logFilePath: '/run/awf/cloud-hypervisor.log',
   };
 
-  it('joins the namespace, drops privileges but retains the kvm group, then execs Cloud Hypervisor with no shell', () => {
+  it('joins the namespace, drops privileges but retains the kvm group and CAP_NET_ADMIN, then execs Cloud Hypervisor with no shell', () => {
     const result = buildCloudHypervisorLaunchCommand(baseOptions);
     expect(result.command).toBe('/usr/sbin/ip');
     expect(result.args).toEqual([
@@ -26,8 +26,9 @@ describe('buildCloudHypervisorLaunchCommand', () => {
       '--regid=1000',
       '--groups=978',
       '--no-new-privs',
-      '--inh-caps=-all',
-      '--bounding-set=-all',
+      '--inh-caps=-all,+net_admin',
+      '--bounding-set=-all,+net_admin',
+      '--ambient-caps=+net_admin',
       '--',
       '/opt/cloud-hypervisor',
       '--api-socket', 'path=/run/awf/api.socket',

--- a/src/cloud-hypervisor/launcher.test.ts
+++ b/src/cloud-hypervisor/launcher.test.ts
@@ -190,7 +190,9 @@ describe('CloudHypervisorCgroup', () => {
     );
     expect(deps.writeFile).toHaveBeenCalledWith(
       '/sys/fs/cgroup/awf-cloud-hypervisor/run-1/cpu.max',
-      '200000 100000',
+      // (2 vCPUs * 100000us/period) + 100000us fixed VMM-thread headroom
+      // (I/O, virtio device emulation, API) -- see CGROUP_CPU_HEADROOM_QUOTA_US.
+      '300000 100000',
     );
     expect(deps.writeFile).toHaveBeenCalledWith(
       '/sys/fs/cgroup/awf-cloud-hypervisor/run-1/pids.max',

--- a/src/cloud-hypervisor/launcher.test.ts
+++ b/src/cloud-hypervisor/launcher.test.ts
@@ -120,11 +120,13 @@ describe('CloudHypervisorCgroup', () => {
     mkdir: jest.Mock;
     writeFile: jest.Mock;
     rmdir: jest.Mock;
+    sleep: jest.Mock;
   } {
     return {
       mkdir: jest.fn().mockResolvedValue(undefined),
       writeFile: jest.fn().mockResolvedValue(undefined),
       rmdir: jest.fn().mockResolvedValue(undefined),
+      sleep: jest.fn().mockResolvedValue(undefined),
     };
   }
 
@@ -216,5 +218,70 @@ describe('CloudHypervisorCgroup', () => {
     await cgroup.cleanup();
     expect(deps.rmdir).toHaveBeenCalledWith('/sys/fs/cgroup/awf-cloud-hypervisor/run-1');
     expect(deps.rmdir).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries cleanup on EBUSY (cgroup v2 teardown race) until it succeeds', async () => {
+    // Regression test: live-KVM validation observed "Cloud Hypervisor
+    // cgroup residue remains after cleanup" after a guest-connectivity
+    // failure led to immediate teardown. cgroup v2 can reject rmdir()
+    // with EBUSY for a brief window after a process exits (memory
+    // controller charge-migration teardown lags process-exit slightly),
+    // even though stop() only calls cleanup() once process termination is
+    // already confirmed. Retry briefly instead of leaving residue.
+    const deps = dependencies();
+    const ebusy = Object.assign(new Error('rmdir failed'), { code: 'EBUSY' });
+    deps.rmdir
+      .mockRejectedValueOnce(ebusy)
+      .mockRejectedValueOnce(ebusy)
+      .mockResolvedValueOnce(undefined);
+    const cgroup = new CloudHypervisorCgroup(
+      '/sys/fs/cgroup/awf-cloud-hypervisor/run-1',
+      { memoryMib: 512, vcpuCount: 2 },
+      deps,
+    );
+    await cgroup.setup();
+
+    await cgroup.cleanup();
+
+    expect(deps.rmdir).toHaveBeenCalledTimes(3);
+    expect(deps.sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up and surfaces the error once EBUSY persists past the retry budget', async () => {
+    const deps = dependencies();
+    const ebusy = Object.assign(new Error('rmdir failed'), { code: 'EBUSY' });
+    let now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    deps.rmdir.mockImplementation(async () => {
+      now += 2_000; // simulate elapsed time exceeding the retry budget
+      throw ebusy;
+    });
+    const cgroup = new CloudHypervisorCgroup(
+      '/sys/fs/cgroup/awf-cloud-hypervisor/run-1',
+      { memoryMib: 512, vcpuCount: 2 },
+      deps,
+    );
+    await cgroup.setup();
+
+    try {
+      await expect(cgroup.cleanup()).rejects.toThrow('rmdir failed');
+    } finally {
+      (Date.now as jest.Mock).mockRestore();
+    }
+  });
+
+  it('does not retry and immediately surfaces non-EBUSY cleanup errors', async () => {
+    const deps = dependencies();
+    deps.rmdir.mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }));
+    const cgroup = new CloudHypervisorCgroup(
+      '/sys/fs/cgroup/awf-cloud-hypervisor/run-1',
+      { memoryMib: 512, vcpuCount: 2 },
+      deps,
+    );
+    await cgroup.setup();
+
+    await expect(cgroup.cleanup()).rejects.toThrow('permission denied');
+    expect(deps.rmdir).toHaveBeenCalledTimes(1);
+    expect(deps.sleep).not.toHaveBeenCalled();
   });
 });

--- a/src/cloud-hypervisor/launcher.ts
+++ b/src/cloud-hypervisor/launcher.ts
@@ -60,6 +60,10 @@ export interface CloudHypervisorLaunchPaths {
   readonly runDirectory: string;
   readonly apiSocketPath: string;
   readonly vsockSocketPath: string;
+  /** Host TAP interface name (e.g. `fct<token>`), for the
+   * `/sys/class/net/<tapName>` Landlock rule — see
+   * {@link computeCloudHypervisorLandlockRules}. */
+  readonly tapName: string;
 }
 
 export interface CloudHypervisorLaunchIdentity {
@@ -159,9 +163,16 @@ export function buildCloudHypervisorLaunchCommand(options: {
  * own process needs after `vm.create`: read access to the kernel image,
  * read-write access to the rootfs and (if present) workspace disk images,
  * read-write access to the private run directory (for the API and vsock
- * UNIX domain sockets it creates there), and read-write access to the
- * device nodes it must reopen for virtio-net TAP attachment and KVM
- * ioctls. Any path not listed here becomes inaccessible to the Cloud
+ * UNIX domain sockets it creates there), read-write access to the device
+ * nodes it must reopen for virtio-net TAP attachment and KVM ioctls, and
+ * read access to the TAP's own sysfs device directory. Cloud Hypervisor's
+ * virtio-net setup reads `/sys/class/net/<tapName>/tun_flags` (a
+ * world-readable, `0444` file with no capability requirement of its own)
+ * to detect multi-queue support; without a Landlock rule for it, that read
+ * fails with the kernel LSM's own EACCES — observed live as `vm.boot`
+ * failing with "Failed to read the TAP flags from sysfs: Permission
+ * denied" even though ordinary Unix file permissions would have allowed
+ * the read. Any path not listed here becomes inaccessible to the Cloud
  * Hypervisor process the instant Landlock is enabled, even to a
  * hypothetical guest-escape.
  */
@@ -174,6 +185,7 @@ export function computeCloudHypervisorLandlockRules(
     { path: paths.runDirectory, access: 'rw' },
     { path: '/dev/kvm', access: 'rw' },
     { path: '/dev/net/tun', access: 'rw' },
+    { path: `/sys/class/net/${paths.tapName}`, access: 'r' },
   ];
   if (paths.workspacePath) {
     rules.push({ path: paths.workspacePath, access: 'rw' });

--- a/src/cloud-hypervisor/launcher.ts
+++ b/src/cloud-hypervisor/launcher.ts
@@ -79,11 +79,11 @@ export interface CloudHypervisorLaunchToolPaths {
 
 /**
  * Builds the argv AWF spawns to launch Cloud Hypervisor: join the prepared
- * network namespace, drop to the non-root operator identity with an empty
- * capability bounding set, then exec the pinned Cloud Hypervisor binary
- * with only its API socket configured (the VM itself is created and booted
- * afterwards over that socket, mirroring Firecracker's `--api-sock`-only
- * jailer invocation).
+ * network namespace, drop to the non-root operator identity retaining
+ * exactly two things it needs to configure its own virtio-net TAP device,
+ * then exec the pinned Cloud Hypervisor binary with only its API socket
+ * configured (the VM itself is created and booted afterwards over that
+ * socket, mirroring Firecracker's `--api-sock`-only jailer invocation).
  *
  * The launched process retains exactly one supplementary group: the group
  * that owns `/dev/kvm` (resolved by preflight). A blanket `--clear-groups`
@@ -92,6 +92,18 @@ export interface CloudHypervisorLaunchToolPaths {
  * (see docs/cloud-hypervisor-foundation.md), that would make every real
  * launch fail with EACCES opening `/dev/kvm` even though preflight (which
  * runs as root) passed.
+ *
+ * It also retains exactly one capability: `CAP_NET_ADMIN`, via the
+ * bounding, inheritable, and ambient sets together (ambient capabilities
+ * are what let a specific capability survive `execve()` of a plain,
+ * non-file-capability-aware binary like `cloud-hypervisor` across a uid
+ * change, even under `--no-new-privs`). Cloud Hypervisor's virtio-net
+ * backend needs it to finish configuring the already-created,
+ * already-owned TAP device (observed live: `vm.boot` otherwise fails with
+ * "Failed to read the TAP flags from sysfs: Permission denied", even
+ * though the TAP device node itself is owned by the target uid/gid). This
+ * is a deliberate, minimal, single-capability exception to an otherwise
+ * fully empty capability set — not a broad grant.
  */
 export function buildCloudHypervisorLaunchCommand(options: {
   readonly tools: CloudHypervisorLaunchToolPaths;
@@ -127,8 +139,11 @@ export function buildCloudHypervisorLaunchCommand(options: {
       // also drop kvm access).
       `--groups=${options.kvmGid}`,
       '--no-new-privs',
-      '--inh-caps=-all',
-      '--bounding-set=-all',
+      // CAP_NET_ADMIN is the sole exception to an otherwise fully empty
+      // capability set — see the function doc comment above for why.
+      '--inh-caps=-all,+net_admin',
+      '--bounding-set=-all,+net_admin',
+      '--ambient-caps=+net_admin',
       '--',
       options.cloudHypervisorBinary,
       '--api-socket', `path=${options.apiSocketPath}`,

--- a/src/cloud-hypervisor/launcher.ts
+++ b/src/cloud-hypervisor/launcher.ts
@@ -200,6 +200,22 @@ export interface CloudHypervisorResourceLimits {
 
 /** Fixed VMM/guest-overhead headroom added on top of configured guest memory. */
 const CGROUP_MEMORY_HEADROOM_MIB = 256;
+/**
+ * Fixed CPU headroom (in the same units as `CGROUP_V2_PERIOD_US`) added on
+ * top of the per-vCPU quota. Cloud Hypervisor's own I/O, virtio device
+ * emulation (including the tap fd read/write loop for the guest's
+ * network device), and API threads all run in this *same* cgroup as the
+ * vCPU thread(s) and compete for the *same* CPU quota -- a quota sized
+ * for "1 CPU per vCPU" alone left no dedicated room for that VMM-side
+ * work. Live-KVM validation on GitHub-hosted runners (nested KVM, so
+ * vCPU exits are unusually expensive) showed guest network I/O
+ * essentially stalled (a handful of packets relayed regardless of how
+ * long the test waited) even after ruling out tap/vnet_hdr negotiation,
+ * conntrack/offload, and Docker bridge-isolation causes -- consistent
+ * with the VMM's own non-vCPU threads being starved of their share of an
+ * already-tight, vCPU-only-sized quota.
+ */
+const CGROUP_CPU_HEADROOM_QUOTA_US = 100_000;
 /** Bounds the number of Cloud Hypervisor host threads/tasks (defense in depth; it is a single process). */
 const CGROUP_MAX_PIDS = 256;
 const CGROUP_V2_PERIOD_US = 100_000;
@@ -270,7 +286,7 @@ export class CloudHypervisorCgroup {
     this.created = true;
 
     const memoryMaxBytes = (this.limits.memoryMib + CGROUP_MEMORY_HEADROOM_MIB) * 1024 * 1024;
-    const cpuQuotaUs = this.limits.vcpuCount * CGROUP_V2_PERIOD_US;
+    const cpuQuotaUs = this.limits.vcpuCount * CGROUP_V2_PERIOD_US + CGROUP_CPU_HEADROOM_QUOTA_US;
     await this.dependencies.writeFile(path.join(this.cgroupPath, 'memory.max'), String(memoryMaxBytes));
     await this.dependencies.writeFile(
       path.join(this.cgroupPath, 'cpu.max'),

--- a/src/cloud-hypervisor/launcher.ts
+++ b/src/cloud-hypervisor/launcher.ts
@@ -204,6 +204,19 @@ const CGROUP_MEMORY_HEADROOM_MIB = 256;
 const CGROUP_MAX_PIDS = 256;
 const CGROUP_V2_PERIOD_US = 100_000;
 const CGROUP_V2_CONTROLLERS = '+cpu +memory +pids';
+/**
+ * cgroup v2 rejects `rmdir()` on a non-empty cgroup (`EBUSY`) not only
+ * while a process is still a live member, but also for a short window
+ * after that process has fully exited: charge migration/accounting
+ * teardown for the memory controller can lag process-exit by a handful of
+ * milliseconds under load. `stop()` only calls `cleanup()` once process
+ * termination is already confirmed, so any EBUSY here is this teardown
+ * race, not a leaked process -- retry briefly instead of leaving residue.
+ * Observed live: "Cloud Hypervisor cgroup residue remains after cleanup"
+ * following a guest connectivity-probe failure and immediate teardown.
+ */
+const CGROUP_REMOVAL_RETRY_INTERVAL_MS = 100;
+const CGROUP_REMOVAL_MAX_WAIT_MS = 5_000;
 
 export interface CloudHypervisorCgroupDependencies {
   mkdir(directory: string): Promise<unknown>;
@@ -212,12 +225,14 @@ export interface CloudHypervisorCgroupDependencies {
    * controller/interface files are virtual and cannot be `unlink()`ed, so
    * this must be a plain `rmdir`, not a recursive tree removal. */
   rmdir(directory: string): Promise<void>;
+  sleep(milliseconds: number): Promise<void>;
 }
 
 const defaultCgroupDependencies: CloudHypervisorCgroupDependencies = {
   mkdir: (directory) => fs.mkdir(directory, { recursive: true, mode: 0o700 }),
   writeFile: (filePath, contents) => fs.writeFile(filePath, contents),
   rmdir: (directory) => fs.rmdir(directory),
+  sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
 };
 
 /**
@@ -273,8 +288,18 @@ export class CloudHypervisorCgroup {
 
   async cleanup(): Promise<void> {
     if (!this.created) return;
-    await this.dependencies.rmdir(this.cgroupPath);
-    this.created = false;
+    const deadline = Date.now() + CGROUP_REMOVAL_MAX_WAIT_MS;
+    for (;;) {
+      try {
+        await this.dependencies.rmdir(this.cgroupPath);
+        this.created = false;
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code !== 'EBUSY' || Date.now() >= deadline) throw error;
+        await this.dependencies.sleep(CGROUP_REMOVAL_RETRY_INTERVAL_MS);
+      }
+    }
   }
 
   private async enableControllers(directory: string): Promise<void> {

--- a/src/cloud-hypervisor/launcher.ts
+++ b/src/cloud-hypervisor/launcher.ts
@@ -296,7 +296,11 @@ export class CloudHypervisorCgroup {
         return;
       } catch (error) {
         const code = (error as NodeJS.ErrnoException | undefined)?.code;
-        if (code !== 'EBUSY' || Date.now() >= deadline) throw error;
+        // Retry both EBUSY and ENOTEMPTY: different kernel/cgroup-v2
+        // versions have been observed to report either errno for this
+        // same "a process only just exited, controller teardown hasn't
+        // fully settled yet" race.
+        if ((code !== 'EBUSY' && code !== 'ENOTEMPTY') || Date.now() >= deadline) throw error;
         await this.dependencies.sleep(CGROUP_REMOVAL_RETRY_INTERVAL_MS);
       }
     }

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -257,6 +257,7 @@ describe('CloudHypervisorManager', () => {
         infrastructureBridge: 'awfbr0',
         tapOwnerUid: 1000,
         tapOwnerGid: 1000,
+        tapVnetHdr: true,
       }),
       hostTools,
     );
@@ -786,6 +787,7 @@ describe('CloudHypervisorManager', () => {
       guestMac: '02:00:00:00:00:01',
       tapOwnerUid: 1000,
       tapOwnerGid: 1000,
+      tapVnetHdr: true,
       allowedEndpoints: [],
       networkInterface: { iface_id: 'eth0', host_dev_name: 'tap' },
     }, {

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -230,6 +230,22 @@ describe('CloudHypervisorManager', () => {
     }));
     expect(client.vmCreate).not.toHaveBeenCalledWith(expect.objectContaining({ vsock: expect.anything() }));
     expect(client.ping).toHaveBeenCalledTimes(1);
+    // Regression test: Cloud Hypervisor defaults all three offloads to
+    // enabled, but this network path is a fully-software bridge/veth/tap
+    // chain with no real NIC downstream to finish partially-offloaded
+    // frames. Live-KVM validation showed guest-to-Squid forward traffic
+    // being accepted by nftables (visible via its per-rule counters) but
+    // the return path never matching the established/related accept
+    // rule -- disabling all three offloads removes offload-related
+    // packet malformation as a possible cause, explicitly rather than
+    // relying on Cloud Hypervisor's own defaults.
+    expect(client.vmCreate).toHaveBeenCalledWith(expect.objectContaining({
+      net: [expect.objectContaining({
+        offload_tso: false,
+        offload_ufo: false,
+        offload_csum: false,
+      })],
+    }));
     expect(deps.createCgroup).toHaveBeenCalledWith(
       expect.stringContaining('awf-cloud-hypervisor/run-1'),
       { memoryMib: 512, vcpuCount: 2 },

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -431,6 +431,70 @@ describe('CloudHypervisorManager', () => {
     expect(order).toEqual(['extract']);
   });
 
+  it('retries the vsock connect on the guest-not-ready-yet boot race, with a fresh client each attempt', async () => {
+    // Regression test: Cloud Hypervisor's vsock-over-UDS multiplexer closes
+    // the host-facing connection immediately if the guest isn't yet
+    // listening on the target port, surfacing as "guest disconnected
+    // before readiness" even though vm.boot() itself succeeded — a real
+    // host/guest boot-timing race, not a fatal error. startInstance() must
+    // retry with a fresh client (MicrovmVsockClient cannot reconnect a
+    // socket that already closed) until the guest is ready.
+    const readyFrame = {
+      version: 1,
+      type: 'ready' as const,
+      requestId: 'control',
+      capabilities: { stdin: true, tty: false, resize: false },
+    };
+    const failingClient = {
+      connect: jest.fn().mockRejectedValue(new Error('guest disconnected before readiness')),
+      destroy: jest.fn(),
+    };
+    const succeedingClient = {
+      connect: jest.fn().mockResolvedValue(readyFrame),
+      execute: jest.fn().mockResolvedValue({
+        requestId: 'command', exitCode: 0, signal: null, timedOut: false,
+      }),
+      shutdown: jest.fn().mockResolvedValue(undefined),
+      destroy: jest.fn(),
+    };
+    const createVsockClient = jest.fn()
+      .mockReturnValueOnce(failingClient)
+      .mockReturnValueOnce(failingClient)
+      .mockReturnValueOnce(succeedingClient);
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(processMock()),
+      createWorkspaceImage: jest.fn().mockReturnValue({
+        prepare: jest.fn().mockResolvedValue({
+          rootfsImagePath: '/tmp/rootfs.ext4',
+          workspaceImagePath: '/tmp/workspace.ext4',
+        }),
+        extractAfterStop: jest.fn().mockResolvedValue(undefined),
+        cleanup: jest.fn().mockResolvedValue(undefined),
+      }),
+      createVsockClient,
+    });
+    const manager = new CloudHypervisorManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'retry-guest',
+      networkConfig(),
+      {
+        workspacePath: '/workspace',
+        homePath: '/home/runner',
+        supervisorBinaryPath: '/opt/awf-supervisor',
+        supervisorSha256: 'a'.repeat(64),
+      },
+    );
+
+    await manager.start();
+    await manager.startInstance();
+
+    expect(createVsockClient).toHaveBeenCalledTimes(3);
+    expect(failingClient.destroy).toHaveBeenCalledTimes(2);
+    expect(succeedingClient.connect).toHaveBeenCalledTimes(1);
+  });
+
   it('delegates guest cancellation, stdin, and resize only after readiness', async () => {
     const cold = new CloudHypervisorManager(
       config(),

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -495,6 +495,69 @@ describe('CloudHypervisorManager', () => {
     expect(succeedingClient.connect).toHaveBeenCalledTimes(1);
   });
 
+  it('tolerates guest boot taking well beyond the old 20-second budget under slow (nested-virtualization) conditions', async () => {
+    // Regression test: live-KVM validation on GitHub-hosted runners showed
+    // guest boot legitimately taking far longer than 20 seconds of real
+    // wall-clock time under nested virtualization (severe vCPU scheduling
+    // contention advanced the guest's own boot-log clock far slower than
+    // host wall-clock time). The vsock connect-retry budget was increased
+    // from 20s to 90s so a merely-slow (not hung/crashed) guest isn't
+    // aborted early. Simulate ~21s of wall-clock time elapsing per failed
+    // connect attempt and assert the retry loop survives several such
+    // cycles — which the old 20s budget could not have tolerated even
+    // once — before finally giving up once the 90s budget is exhausted.
+    const startedAtMs = 1_000_000;
+    let elapsedMs = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => startedAtMs + elapsedMs);
+    const failingClient = {
+      connect: jest.fn().mockImplementation(() => {
+        elapsedMs += 21_000;
+        return Promise.reject(new Error('guest disconnected before readiness'));
+      }),
+      destroy: jest.fn(),
+    };
+    const createVsockClient = jest.fn().mockReturnValue(failingClient);
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(processMock()),
+      createWorkspaceImage: jest.fn().mockReturnValue({
+        prepare: jest.fn().mockResolvedValue({
+          rootfsImagePath: '/tmp/rootfs.ext4',
+          workspaceImagePath: '/tmp/workspace.ext4',
+        }),
+        extractAfterStop: jest.fn().mockResolvedValue(undefined),
+        cleanup: jest.fn().mockResolvedValue(undefined),
+      }),
+      createVsockClient,
+    });
+    const manager = new CloudHypervisorManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'retry-guest-slow-boot',
+      networkConfig(),
+      {
+        workspacePath: '/workspace',
+        homePath: '/home/runner',
+        supervisorBinaryPath: '/opt/awf-supervisor',
+        supervisorSha256: 'a'.repeat(64),
+      },
+    );
+
+    try {
+      await manager.start();
+      await expect(manager.startInstance()).rejects.toThrow(
+        'guest disconnected before readiness',
+      );
+
+      // A 20s budget would have given up after a single ~21s attempt; the
+      // 90s budget must retry at least four times (~84s simulated) before
+      // exhausting.
+      expect(createVsockClient.mock.calls.length).toBeGreaterThanOrEqual(4);
+    } finally {
+      (Date.now as jest.Mock).mockRestore();
+    }
+  });
+
   it('delegates guest cancellation, stdin, and resize only after readiness', async () => {
     const cold = new CloudHypervisorManager(
       config(),

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -609,6 +609,100 @@ describe('CloudHypervisorManager', () => {
     expect(cgroup.cleanup).toHaveBeenCalledTimes(1);
   });
 
+  it('invokes a beforeCleanup hook after process termination but before run-directory removal', async () => {
+    // Regression test: Cloud Hypervisor does not flush buffered guest
+    // serial console output until its process actually exits, so
+    // diagnostics collection must happen after process termination is
+    // confirmed but before stop() removes the run directory those
+    // diagnostic files live in. Discovered via live-KVM validation: a
+    // guest boot failure produced a completely empty serial console log
+    // when diagnostics were collected any earlier (e.g. before
+    // vmm.shutdown()/process termination).
+    const child = processMock();
+    const workspace = {
+      prepare: jest.fn().mockResolvedValue({
+        workspaceImagePath: '/tmp/prepared-workspace.ext4',
+        rootfsImagePath: '/tmp/prepared-rootfs.ext4',
+        imageBytes: 1024,
+        originalManifest: new Map(),
+      }),
+      extractAfterStop: jest.fn().mockResolvedValue(undefined),
+      cleanup: jest.fn().mockResolvedValue(undefined),
+    } as unknown as MicrovmWorkspaceImage;
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(child),
+      createWorkspaceImage: jest.fn().mockReturnValue(workspace),
+    });
+    const manager = new CloudHypervisorManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'keep',
+      networkConfig(),
+      {
+        workspacePath: '/workspace',
+        homePath: '/home/runner',
+        supervisorBinaryPath: '/opt/awf-supervisor',
+        supervisorSha256: 'a'.repeat(64),
+      },
+    );
+    await manager.start();
+
+    const beforeCleanup = jest.fn(async () => {});
+
+    await manager.stop({ beforeCleanup });
+
+    expect(beforeCleanup).toHaveBeenCalledTimes(1);
+    expect(deps.rm).toHaveBeenCalledTimes(1);
+    // beforeCleanup must run strictly before the run-directory removal
+    // call (deps.rm), i.e. after process termination is confirmed but
+    // before diagnostic files are deleted.
+    const rmCallOrder = (deps.rm as jest.Mock).mock.invocationCallOrder[0];
+    expect(beforeCleanup.mock.invocationCallOrder[0]).toBeLessThan(rmCallOrder);
+  });
+
+  it('propagates a beforeCleanup hook failure alongside other stop() errors', async () => {
+    const child = processMock();
+    const workspace = {
+      prepare: jest.fn().mockResolvedValue({
+        workspaceImagePath: '/tmp/prepared-workspace.ext4',
+        rootfsImagePath: '/tmp/prepared-rootfs.ext4',
+        imageBytes: 1024,
+        originalManifest: new Map(),
+      }),
+      extractAfterStop: jest.fn().mockResolvedValue(undefined),
+      cleanup: jest.fn().mockResolvedValue(undefined),
+    } as unknown as MicrovmWorkspaceImage;
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(child),
+      createWorkspaceImage: jest.fn().mockReturnValue(workspace),
+    });
+    const manager = new CloudHypervisorManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'keep',
+      networkConfig(),
+      {
+        workspacePath: '/workspace',
+        homePath: '/home/runner',
+        supervisorBinaryPath: '/opt/awf-supervisor',
+        supervisorSha256: 'a'.repeat(64),
+      },
+    );
+    await manager.start();
+
+    await expect(
+      manager.stop({
+        beforeCleanup: async () => {
+          throw new Error('diagnostics write failed');
+        },
+      }),
+    ).rejects.toThrow(/diagnostics write failed/);
+    // Run-directory removal must still proceed even if beforeCleanup fails.
+    expect(deps.rm).toHaveBeenCalledTimes(1);
+  });
+
   it('builds explicit supervisor boot cmdline with PCI-required root/interface naming', () => {
     const args = buildSupervisorBootArgs({
       runId: 'run',

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -1008,4 +1008,77 @@ describe('CloudHypervisorManager', () => {
       { mode: 0o600 },
     );
   });
+
+  it('captures live network diagnostics (nft ruleset + interface counters) when the network lifecycle supports it', async () => {
+    // Regression test: a live-KVM connectivity failure investigation found
+    // that a bare probe exit code, and even the static network-plan.json,
+    // weren't enough to determine whether packets were being dropped by
+    // an nftables forward-chain rule or never reaching the tap at all.
+    // collectDiagnostics() must capture this live state (via the
+    // network lifecycle's optional captureDiagnostics()) while the
+    // namespace still exists.
+    const child = processMock();
+    const captureDiagnostics = jest.fn()
+      .mockResolvedValue('--- nft list ruleset ---\n(fake ruleset)\n');
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(child),
+      createNetwork: jest.fn((plan) => ({
+        ...networkLifecycle(plan),
+        captureDiagnostics,
+      })),
+    });
+    const manager = new CloudHypervisorManager(
+      config(), '/tmp/awf', deps, 'net-diagnostics', networkConfig(),
+    );
+
+    await manager.start();
+    await manager.collectDiagnostics('/tmp/diagnostics');
+
+    expect(captureDiagnostics).toHaveBeenCalledTimes(1);
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/network-diagnostics.txt',
+      '--- nft list ruleset ---\n(fake ruleset)\n\n',
+      { mode: 0o600 },
+    );
+  });
+
+  it('reports network diagnostics as unavailable when the lifecycle does not support capture, without throwing', async () => {
+    const child = processMock();
+    const deps = dependencies({ launch: jest.fn().mockReturnValue(child) });
+    const manager = new CloudHypervisorManager(
+      config(), '/tmp/awf', deps, 'net-diagnostics-unset', networkConfig(),
+    );
+
+    await manager.start();
+    await expect(manager.collectDiagnostics('/tmp/diagnostics')).resolves.toBeUndefined();
+
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/network-diagnostics.txt',
+      expect.stringContaining('network namespace not set up'),
+      { mode: 0o600 },
+    );
+  });
+
+  it('falls back to a capture-failed message rather than throwing when captureDiagnostics itself rejects', async () => {
+    const child = processMock();
+    const deps = dependencies({
+      launch: jest.fn().mockReturnValue(child),
+      createNetwork: jest.fn((plan) => ({
+        ...networkLifecycle(plan),
+        captureDiagnostics: jest.fn().mockRejectedValue(new Error('ip netns exec failed')),
+      })),
+    });
+    const manager = new CloudHypervisorManager(
+      config(), '/tmp/awf', deps, 'net-diagnostics-fail', networkConfig(),
+    );
+
+    await manager.start();
+    await expect(manager.collectDiagnostics('/tmp/diagnostics')).resolves.toBeUndefined();
+
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/network-diagnostics.txt',
+      expect.stringContaining('capture failed: ip netns exec failed'),
+      { mode: 0o600 },
+    );
+  });
 });

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -1011,6 +1011,53 @@ describe('CloudHypervisorManager', () => {
     );
   });
 
+  it('snapshots vm.info/vm.counters before any shutdown attempt, so collectDiagnostics() via beforeCleanup still has real data', async () => {
+    // Regression test: vm.info/vm.counters require the Cloud Hypervisor
+    // API socket to still be responsive. collectDiagnostics() usually
+    // runs via stop()'s beforeCleanup hook -- deliberately placed *after*
+    // process termination is confirmed (see that hook's own comment) so
+    // buffered serial console output has been flushed. But by that point
+    // the API socket is already closed (the process was just asked to
+    // exit), so a live vmCounters()/vmInfo() call there would always
+    // fail. stop() must snapshot both *before* it calls vmmShutdown(),
+    // and collectDiagnostics() must prefer that snapshot over a live call
+    // that can no longer succeed.
+    const child = processMock();
+    const deps = dependencies({ launch: jest.fn().mockReturnValue(child) });
+    const manager = new CloudHypervisorManager(
+      config(), '/tmp/awf', deps, 'vm-info-snapshot', networkConfig(),
+    );
+    const client = await manager.start();
+    await manager.startInstance();
+
+    let diagnosticsRanWithLiveClient = false;
+    await manager.stop({
+      beforeCleanup: async () => {
+        // Simulate collectDiagnostics() running here, as it does via the
+        // real beforeCleanup wiring in cloud-hypervisor-runtime-backend.ts.
+        await manager.collectDiagnostics('/tmp/diagnostics');
+        diagnosticsRanWithLiveClient = true;
+      },
+    });
+
+    expect(diagnosticsRanWithLiveClient).toBe(true);
+    // vmCounters/vmInfo were called exactly once each: during stop()'s
+    // pre-shutdown snapshot, not again (uselessly) from inside
+    // collectDiagnostics() after the client reference is already cleared.
+    expect(client.vmCounters).toHaveBeenCalledTimes(1);
+    expect(client.vmInfo).toHaveBeenCalledTimes(1);
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/counters.json',
+      expect.stringContaining('rx_bytes'),
+      { mode: 0o600 },
+    );
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/tmp/diagnostics/vm-info.json',
+      expect.not.stringMatching(/^null$/m),
+      { mode: 0o600 },
+    );
+  });
+
   it('captures live network diagnostics (nft ruleset + interface counters) when the network lifecycle supports it', async () => {
     // Regression test: a live-KVM connectivity failure investigation found
     // that a bare probe exit code, and even the static network-plan.json,

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -739,6 +739,26 @@ export class CloudHypervisorManager {
       `${JSON.stringify(this.networkPlan ?? null, null, 2)}\n`,
       { mode: 0o600 },
     );
+    // Best-effort, read-only host-side network diagnostics (live nftables
+    // ruleset + interface counters), captured only while the namespace
+    // still exists (this method runs via stop()'s beforeCleanup hook,
+    // before network.cleanup() tears the namespace down). Helps diagnose
+    // a guest connectivity failure (dropped by a forward-chain rule vs.
+    // never reaching the tap at all) without guessing from the guest
+    // side alone.
+    let networkDiagnostics = '(network namespace not set up)';
+    if (this.network?.captureDiagnostics) {
+      try {
+        networkDiagnostics = await this.network.captureDiagnostics();
+      } catch (error) {
+        networkDiagnostics = `(capture failed: ${formatError(error)})`;
+      }
+    }
+    await this.dependencies.writeFile(
+      path.join(directory, 'network-diagnostics.txt'),
+      `${networkDiagnostics}\n`,
+      { mode: 0o600 },
+    );
     await this.dependencies.writeFile(
       path.join(directory, 'counters.json'),
       `${JSON.stringify(counters, null, 2)}\n`,

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -520,7 +520,7 @@ export class CloudHypervisorManager {
     return this.guestClient.resize(columns, rows, requestId);
   }
 
-  async stop(options: { preserve?: boolean } = {}): Promise<void> {
+  async stop(options: { preserve?: boolean; beforeCleanup?: () => Promise<void> } = {}): Promise<void> {
     const errors: unknown[] = [];
     const instanceWasStarted = this.instanceStarted;
     let guestShutdownAcknowledged = false;
@@ -598,6 +598,22 @@ export class CloudHypervisorManager {
     }
     this.process = undefined;
     this.client = undefined;
+
+    // Run any caller-supplied diagnostics collection now: the Cloud
+    // Hypervisor process is confirmed terminated (so any buffered guest
+    // serial console / log output has been flushed by process exit), but
+    // the run directory containing those files has not been removed yet
+    // (that happens below). Collecting diagnostics any earlier (e.g.
+    // before vmm.shutdown()/process termination above) can observe a
+    // still-empty serial console log, since Cloud Hypervisor does not
+    // guarantee flushing it before the process actually exits.
+    if (options.beforeCleanup) {
+      try {
+        await options.beforeCleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
 
     if (this.workspace && instanceWasStarted) {
       try {

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -464,6 +464,20 @@ export class CloudHypervisorManager {
         id: 'net0',
         tap: networkPlan.networkInterface.host_dev_name,
         mac: networkPlan.networkInterface.guest_mac ?? '',
+        // Cloud Hypervisor defaults all three offloads to enabled. This
+        // entire network path is a fully-software bridge/veth/tap chain
+        // with no real NIC downstream to finish partially-offloaded
+        // (unchecksummed / not-yet-segmented) frames; live-KVM validation
+        // showed guest-to-Squid traffic being forwarded (visible in nft
+        // counters) but the return path never matching the
+        // established/related accept rule, with zero visibility into
+        // whether nftables' conntrack was marking replies as invalid.
+        // Disable all three explicitly rather than rely on Cloud
+        // Hypervisor's own defaults, removing offload-related packet
+        // malformation as a possible cause.
+        offload_tso: false,
+        offload_ufo: false,
+        offload_csum: false,
       }],
       rng: { src: '/dev/urandom' },
       serial: { mode: 'File' as const, file: this.paths.serialLogPath },

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -305,6 +305,21 @@ export class CloudHypervisorManager {
         ...this.networkConfig,
         tapOwnerUid: identity.uid,
         tapOwnerGid: identity.gid,
+        // Cloud Hypervisor's own tap handling (Tap::open_named() in
+        // net_util/src/tap.rs) always re-opens the tap with
+        // IFF_VNET_HDR requested; the tap must be *created* with that
+        // feature available or the host and Cloud Hypervisor disagree
+        // on frame layout for the host-to-guest direction, and guest
+        // connectivity checks silently time out even though the
+        // guest's own outbound traffic (and the host-side veth/nft
+        // layer) works normally. Discovered via live-KVM validation:
+        // tap RX=10 packets (guest-to-host, unaffected) vs. TX=1 packet
+        // (host-to-guest, effectively stalled) despite response
+        // packets already having arrived on the host-side veth.
+        // Firecracker's own tap handling does not request
+        // IFF_VNET_HDR, so this is opted in here only, not changed for
+        // the shared default.
+        tapVnetHdr: true,
       });
       this.networkPlan = networkPlan;
       this.network = this.dependencies.createNetwork(networkPlan, artifacts.tools);

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -389,6 +389,7 @@ export class CloudHypervisorManager {
       runDirectory: this.paths.runDirectory,
       apiSocketPath: this.paths.apiSocketPath,
       vsockSocketPath: this.paths.vsockSocketPath,
+      tapName: networkPlan.tapName,
     });
     return {
       cpus: {

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -47,6 +47,19 @@ const CLOUD_HYPERVISOR_CAPTURE_LIMIT_BYTES = 1024 * 1024;
 export const CLOUD_HYPERVISOR_GUEST_VSOCK_PORT = 52;
 const CLOUD_HYPERVISOR_GUEST_SHUTDOWN_GRACE_MS = 5_000;
 /**
+ * Cloud Hypervisor's vsock-over-UDS multiplexer closes the host-facing
+ * connection immediately (rather than blocking/retrying) if the guest
+ * isn't yet listening on the target vsock port when a `CONNECT <port>`
+ * handshake arrives — observed live as `startInstance()` failing with
+ * "guest disconnected before readiness" even on a successful `vm.boot()`.
+ * This is a real host/guest boot-timing race (kernel decompression +
+ * supervisor startup take a variable, host-load-dependent amount of time),
+ * not a fatal error, so the connect is retried with a fresh client and a
+ * short backoff until the guest is actually ready or this budget elapses.
+ */
+const CLOUD_HYPERVISOR_GUEST_READY_RETRY_INTERVAL_MS = 250;
+const CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS = 20_000;
+/**
  * Private run-directory root, deliberately **outside** `workDir`.
  *
  * `workDir` is created root-owned mode 0700 (it holds `docker-compose.yml`
@@ -433,13 +446,41 @@ export class CloudHypervisorManager {
     await this.client.vmBoot();
     this.instanceStarted = true;
     if (this.guestConfig) {
-      this.guestClient = this.dependencies.createVsockClient(
-        this.paths.vsockSocketPath,
+      this.guestClient = await this.connectGuestWithRetry(
         this.guestConfig.vsockPort ?? CLOUD_HYPERVISOR_GUEST_VSOCK_PORT,
+      );
+    }
+  }
+
+  /**
+   * Connects to the guest supervisor over vsock, retrying on the
+   * "guest disconnected before readiness" boot-timing race documented on
+   * {@link CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS} above. Each attempt
+   * uses a fresh client (MicrovmVsockClient does not support reconnecting
+   * a socket that already closed).
+   */
+  private async connectGuestWithRetry(port: number): Promise<MicrovmVsockClient> {
+    const deadline = Date.now() + CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS;
+    let lastError: unknown;
+    do {
+      const client = this.dependencies.createVsockClient(
+        this.paths.vsockSocketPath,
+        port,
         this.config.apiTimeoutMs,
       );
-      await this.guestClient.connect();
-    }
+      try {
+        await client.connect();
+        return client;
+      } catch (error) {
+        lastError = error;
+        client.destroy();
+        if (Date.now() >= deadline) break;
+        await this.dependencies.sleep(CLOUD_HYPERVISOR_GUEST_READY_RETRY_INTERVAL_MS);
+      }
+    } while (Date.now() < deadline);
+    throw lastError instanceof Error
+      ? lastError
+      : new Error('Cloud Hypervisor guest vsock connection failed');
   }
 
   async execute(

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -25,7 +25,11 @@ import {
   MicrovmWorkspaceImage,
   type MicrovmWorkspaceImageConfig,
 } from '../microvm/workspace';
-import { CloudHypervisorApiClient } from './api-client';
+import {
+  CloudHypervisorApiClient,
+  type CloudHypervisorVmCounters,
+  type CloudHypervisorVmInfo,
+} from './api-client';
 import {
   CLOUD_HYPERVISOR_GUEST_CID,
   CloudHypervisorCgroup,
@@ -268,6 +272,11 @@ export class CloudHypervisorManager {
   private cgroup: CloudHypervisorCgroup | undefined;
   private networkPlan: MicrovmNetworkPlan | undefined;
   private instanceStarted = false;
+  // Snapshotted in stop(), before any shutdown attempt, since the API
+  // socket becomes unresponsive once the process is asked to exit --
+  // see the comment at the top of stop() for why this ordering matters.
+  private lastVmInfo: CloudHypervisorVmInfo | undefined;
+  private lastVmCounters: CloudHypervisorVmCounters | undefined;
   private readonly stdoutCapture = new BoundedOutputCapture(CLOUD_HYPERVISOR_CAPTURE_LIMIT_BYTES);
   private readonly stderrCapture = new BoundedOutputCapture(CLOUD_HYPERVISOR_CAPTURE_LIMIT_BYTES);
 
@@ -550,6 +559,27 @@ export class CloudHypervisorManager {
   async stop(options: { preserve?: boolean; beforeCleanup?: () => Promise<void> } = {}): Promise<void> {
     const errors: unknown[] = [];
     const instanceWasStarted = this.instanceStarted;
+    // vm.info/vm.counters require the Cloud Hypervisor API socket to
+    // still be responsive, which is only true *before* vmm.shutdown()/
+    // process termination below -- the opposite ordering constraint from
+    // serial console capture (which needs the process already exited to
+    // guarantee flushed output; see the beforeCleanup comment further
+    // down). Snapshot both here, before any shutdown attempt, so
+    // collectDiagnostics() (invoked later, via beforeCleanup, after the
+    // process has already exited) has a real, non-null snapshot to write
+    // instead of failing silently against an already-closed socket.
+    if (this.client && instanceWasStarted) {
+      try {
+        this.lastVmInfo = await this.client.vmInfo();
+      } catch {
+        this.lastVmInfo = undefined;
+      }
+      try {
+        this.lastVmCounters = await this.client.vmCounters();
+      } catch {
+        this.lastVmCounters = undefined;
+      }
+    }
     let guestShutdownAcknowledged = false;
     if (this.guestClient) {
       try {
@@ -727,12 +757,28 @@ export class CloudHypervisorManager {
 
   async collectDiagnostics(directory: string): Promise<void> {
     await this.dependencies.mkdir(directory, { recursive: true, mode: 0o700 });
-    let counters: unknown = null;
-    if (this.client && this.instanceStarted) {
+    // Prefer the snapshot stop() takes *before* any shutdown attempt (see
+    // the comment at the top of stop()): by the time collectDiagnostics()
+    // runs via the beforeCleanup hook, the API socket is already
+    // unresponsive (process already asked to exit), so a live call here
+    // would just fail. Fall back to a live call only when this method is
+    // invoked directly, outside of stop() (e.g. --diagnostic-logs without
+    // a failure, or this method's own unit tests), where the client may
+    // still be genuinely reachable.
+    let counters: unknown = this.lastVmCounters ?? null;
+    if (counters === null && this.client && this.instanceStarted) {
       try {
         counters = await this.client.vmCounters();
       } catch {
         counters = null;
+      }
+    }
+    let vmInfo: unknown = this.lastVmInfo ?? null;
+    if (vmInfo === null && this.client && this.instanceStarted) {
+      try {
+        vmInfo = await this.client.vmInfo();
+      } catch {
+        vmInfo = null;
       }
     }
     const writeBounded = async (fileName: string, contents: Buffer): Promise<void> => {
@@ -777,6 +823,11 @@ export class CloudHypervisorManager {
     await this.dependencies.writeFile(
       path.join(directory, 'counters.json'),
       `${JSON.stringify(counters, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+    await this.dependencies.writeFile(
+      path.join(directory, 'vm-info.json'),
+      `${JSON.stringify(vmInfo, null, 2)}\n`,
       { mode: 0o600 },
     );
     await this.dependencies.writeFile(

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -56,9 +56,21 @@ const CLOUD_HYPERVISOR_GUEST_SHUTDOWN_GRACE_MS = 5_000;
  * supervisor startup take a variable, host-load-dependent amount of time),
  * not a fatal error, so the connect is retried with a fresh client and a
  * short backoff until the guest is actually ready or this budget elapses.
+ *
+ * The budget is deliberately generous (not a tight few-second timeout):
+ * live validation on GitHub-hosted Ubuntu runners showed the guest kernel's
+ * own internal clock advancing far slower than host wall-clock time during
+ * early PCI/virtio device enumeration (e.g. ~9-20s of host wall-clock time
+ * elapsing while the guest's own boot log timestamps were still under 1s)
+ * — consistent with the extra scheduling overhead of nested virtualization
+ * on these runners (Cloud Hypervisor itself logs running under a
+ * "Microsoft Hv" nested hypervisor there). A short budget here would abort
+ * a guest that is simply slow to be scheduled, not actually hung or
+ * crashed. This matches the smoke test's own boot-readiness ceiling
+ * (`BOOT_READINESS_CEILING_MS` in cloud-hypervisor-live-smoke.sh).
  */
 const CLOUD_HYPERVISOR_GUEST_READY_RETRY_INTERVAL_MS = 250;
-const CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS = 20_000;
+const CLOUD_HYPERVISOR_GUEST_READY_MAX_WAIT_MS = 90_000;
 /**
  * Private run-directory root, deliberately **outside** `workDir`.
  *

--- a/src/firecracker-runtime-backend.test.ts
+++ b/src/firecracker-runtime-backend.test.ts
@@ -412,6 +412,16 @@ describe('Firecracker runtime backend', () => {
     )).toThrow(/Refusing to pass a real provider credential/);
   });
 
+  it('sets lowercase http_proxy so BusyBox wget honors the proxy for https:// too', () => {
+    // See the identical regression test in
+    // cloud-hypervisor-runtime-backend.test.ts: BusyBox wget (shared by
+    // both microVM guests) reads only lowercase "http_proxy" for every
+    // protocol including https, with no https_proxy check at all.
+    const environment = buildFirecrackerGuestEnvironment(config(), infrastructure());
+
+    expect(environment.http_proxy).toBe('http://172.30.0.10:3128');
+  });
+
   it('rejects unsupported strict-security and topology combinations', () => {
     expect(() => assertFirecrackerPreSecurityCompatibility(
       config({ enableDind: true }),

--- a/src/firecracker-runtime-backend.ts
+++ b/src/firecracker-runtime-backend.ts
@@ -21,6 +21,7 @@ import { getRealUserHome, getSafeHostGid, getSafeHostUid } from './host-identity
 import { logger } from './logger';
 import { buildAgentEnvironment } from './services/agent-service';
 import { buildAgentCredentialEnv } from './services/api-proxy-credential-env';
+import { SQUID_PORT } from './constants';
 import type { FirecrackerOptions, WrapperConfig } from './types';
 import {
   assertFirecrackerRuntimeCompatibility,
@@ -424,6 +425,12 @@ export function buildFirecrackerGuestEnvironment(
     SQUID_PROXY_HOST: infrastructure.squidIp,
     HOSTNAME: 'awf-firecracker',
     AWF_RUNTIME: 'firecracker',
+    // See buildCloudHypervisorGuestEnvironment's comment: the shared
+    // container-runtime environment intentionally omits lowercase
+    // http_proxy, but BusyBox's wget in this guest reads only lowercase
+    // "http_proxy" for every protocol including https (no https_proxy
+    // check at all), so it needs its own guest-specific override here.
+    http_proxy: `http://${infrastructure.squidIp}:${SQUID_PORT}`,
   });
   assertNoProviderSecrets(config, environment);
   return environment;

--- a/src/firecracker/manager.test.ts
+++ b/src/firecracker/manager.test.ts
@@ -239,6 +239,7 @@ describe('FirecrackerManager', () => {
         infrastructureBridge: 'awfbr0',
         tapOwnerUid: 1000,
         tapOwnerGid: 1000,
+        tapVnetHdr: false,
       }),
       hostTools,
     );
@@ -561,6 +562,7 @@ describe('FirecrackerManager', () => {
         guestMac: '02:00:00:00:00:01',
         tapOwnerUid: 1000,
         tapOwnerGid: 1000,
+        tapVnetHdr: false,
         allowedEndpoints: [],
         networkInterface: { iface_id: 'eth0', host_dev_name: 'tap' },
       }, {

--- a/src/microvm/infrastructure.test.ts
+++ b/src/microvm/infrastructure.test.ts
@@ -120,6 +120,29 @@ describe('microVM infrastructure discovery', () => {
     expect(deps.inspectLink).toHaveBeenCalledWith(`br-${'a'.repeat(12)}`, undefined);
   });
 
+  it('tolerates a Docker Engine that omits Gateway for an internal network, defaulting to the documented constant', async () => {
+    // Regression test: some Docker Engine builds (observed on GitHub-hosted
+    // Ubuntu runners) do not report an IPAM `Gateway` for `internal: true`
+    // networks when the compose config never requests one explicitly (the
+    // network-isolation topology never does — see
+    // sandbox-network-policy.json's `topology` section comment). This must
+    // not be treated as a topology mismatch.
+    const deps = dependencies(networkInspection({
+      IPAM: { Config: [{ Subnet: '172.30.0.0/24' }] },
+    }));
+    const resolved = await resolveMicrovmInfrastructure(true, deps);
+    expect(resolved.gateway).toBe('172.30.0.1');
+  });
+
+  it('still rejects a Docker-reported Gateway that does not match the expected value', async () => {
+    await expect(resolveMicrovmInfrastructure(
+      true,
+      dependencies(networkInspection({
+        IPAM: { Config: [{ Subnet: '172.30.0.0/24', Gateway: '172.30.0.99' }] },
+      })),
+    )).rejects.toThrow(/must have exactly 172\.30\.0\.0\/24/);
+  });
+
   it('rejects ambiguous, non-internal, or address-shifted topology', async () => {
     await expect(resolveMicrovmInfrastructure(
       true,

--- a/src/microvm/infrastructure.ts
+++ b/src/microvm/infrastructure.ts
@@ -148,11 +148,23 @@ async function inspectInfrastructure(
   }
 
   const ipv4Configs = (network.IPAM?.Config ?? []).filter((entry) => entry.Subnet?.includes('.'));
-  if (
-    ipv4Configs.length !== 1 ||
-    ipv4Configs[0].Subnet !== NETWORK_SUBNET ||
-    ipv4Configs[0].Gateway !== HOST_GATEWAY
-  ) {
+  if (ipv4Configs.length !== 1 || ipv4Configs[0].Subnet !== NETWORK_SUBNET) {
+    throw new Error(
+      `Docker network "${NETWORK_NAME}" must have exactly ${NETWORK_SUBNET} ` +
+      `with gateway ${HOST_GATEWAY}`,
+    );
+  }
+  // Docker's IPAM driver does not always report a `Gateway` for `internal:
+  // true` networks when the compose config never requests one explicitly
+  // (this backend's topology mode never does — the internal network is
+  // never routed to from the host, so a gateway address is not meaningful;
+  // see sandbox-network-policy.json's `topology` section comment). Observed
+  // to differ by Docker Engine version/build even for an identical compose
+  // config. When Docker *does* report a Gateway, it must still match the
+  // expected value exactly — this only tolerates its legitimate absence,
+  // not a substituted one.
+  const observedGateway = ipv4Configs[0].Gateway;
+  if (observedGateway !== undefined && observedGateway !== HOST_GATEWAY) {
     throw new Error(
       `Docker network "${NETWORK_NAME}" must have exactly ${NETWORK_SUBNET} ` +
       `with gateway ${HOST_GATEWAY}`,
@@ -183,7 +195,7 @@ async function inspectInfrastructure(
     networkId: network.Id,
     bridgeName,
     subnet: NETWORK_SUBNET,
-    gateway: HOST_GATEWAY,
+    gateway: observedGateway ?? HOST_GATEWAY,
     squidIp,
     ...(apiProxyIp ? { apiProxyIp } : {}),
   };

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -139,18 +139,21 @@ describe('microVM nftables policy', () => {
 
     expect(ruleset).toContain(`table inet ${plan.nftTableName}`);
     expect(ruleset.match(/policy drop;/g)).toHaveLength(3);
+    // `counter` on these rules is purely diagnostic (nft -a list ruleset
+    // then reports packet/byte hit counts per rule) and does not change
+    // any accept/drop decision — see generateMicrovmNftRuleset's comment.
     expect(ruleset).toContain(
-      `iifname "${plan.tapName}" ether saddr != ${plan.guestMac} drop`,
+      `iifname "${plan.tapName}" ether saddr != ${plan.guestMac} counter drop`,
     );
     expect(ruleset).toContain(
-      `iifname "${plan.tapName}" ip saddr != ${plan.guestIp} drop`,
+      `iifname "${plan.tapName}" ip saddr != ${plan.guestIp} counter drop`,
     );
-    expect(ruleset).toContain('ip daddr 169.254.0.0/16 drop');
-    expect(ruleset).toContain('ip daddr 224.0.0.0/4 drop');
-    expect(ruleset).toContain('ip daddr 172.30.0.1 drop');
-    expect(ruleset).toContain('udp dport 53 drop');
-    expect(ruleset).toContain('tcp dport 53 drop');
-    expect(ruleset).toContain('ct state established,related accept');
+    expect(ruleset).toContain('ip daddr 169.254.0.0/16 counter drop');
+    expect(ruleset).toContain('ip daddr 224.0.0.0/4 counter drop');
+    expect(ruleset).toContain('ip daddr 172.30.0.1 counter drop');
+    expect(ruleset).toContain('udp dport 53 counter drop');
+    expect(ruleset).toContain('tcp dport 53 counter drop');
+    expect(ruleset).toContain('ct state established,related counter accept');
     expect(ruleset).toContain('ip daddr 172.30.0.10 tcp dport 3128');
     for (let port = 10000; port <= 10004; port += 1) {
       expect(ruleset).toContain(`ip daddr 172.30.0.30 tcp dport ${port}`);
@@ -397,7 +400,7 @@ describe('microVM network lifecycle', () => {
     ))).toHaveLength(1);
   });
 
-  it('captureDiagnostics delegates to the namespace once setup completes, and is empty before/after', async () => {
+  it('captureDiagnostics delegates to the namespace and host bridge once setup completes, and is empty before/after', async () => {
     const plan = createPlan();
     const { commands } = commandHarness();
     const manager = new MicrovmNetworkManager(plan, commands);
@@ -407,9 +410,14 @@ describe('microVM network lifecycle', () => {
 
     await manager.setup();
     const captureSpy = jest.spyOn(commands, 'captureDiagnosticsInNamespace')
-      .mockResolvedValue('--- nft list ruleset ---\n(fake)\n');
-    expect(await manager.captureDiagnostics()).toBe('--- nft list ruleset ---\n(fake)\n');
+      .mockResolvedValue('--- nft -a list ruleset ---\n(fake)');
+    const bridgeSpy = jest.spyOn(commands, 'captureHostBridgeDiagnostics')
+      .mockResolvedValue('--- bridge fdb show br awfbr0 ---\n(fake fdb)');
+    expect(await manager.captureDiagnostics()).toBe(
+      '--- nft -a list ruleset ---\n(fake)\n--- bridge fdb show br awfbr0 ---\n(fake fdb)',
+    );
     expect(captureSpy).toHaveBeenCalledWith(plan.namespaceName);
+    expect(bridgeSpy).toHaveBeenCalledWith(plan.infrastructureBridge);
 
     await manager.cleanup();
     expect(await manager.captureDiagnostics()).toBe('');
@@ -512,14 +520,26 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
   // packets ever reached the tap/veth or were dropped by an nftables
   // forward-chain rule. This best-effort, read-only capture surfaces both
   // the live ruleset and interface counters for that triage.
-  it('combines nft list ruleset and ip -s link show output', async () => {
+  it('combines nft/link/route/neighbor/fdb diagnostics into one report', async () => {
     const commands = new LinuxNetworkCommands(
       jest.fn(async (_command, args) => {
         if (args.includes('nft')) {
           return { stdout: 'table inet awf_fc_abc123 { chain forward { ... } }' };
         }
-        if (args.includes('ip') && args.includes('link')) {
+        if (args.includes('-s') && args.includes('link')) {
           return { stdout: '2: eth0: <UP> ... RX: 0 bytes 0 packets' };
+        }
+        if (args.includes('-d') && args.includes('link')) {
+          return { stdout: '2: eth0: <UP> ... vnet_hdr' };
+        }
+        if (args.includes('route')) {
+          return { stdout: 'default via 100.64.0.1 dev tap0' };
+        }
+        if (args.includes('neigh')) {
+          return { stdout: '100.64.0.1 dev tap0 lladdr 02:00:00:00:00:01 REACHABLE' };
+        }
+        if (args.includes('bridge')) {
+          return { stdout: '02:00:00:00:00:01 dev tap0 master awfbr0' };
         }
         return { stdout: '' };
       }),
@@ -527,10 +547,18 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
 
     const result = await commands.captureDiagnosticsInNamespace('awffc-test');
 
-    expect(result).toContain('--- nft list ruleset ---');
+    expect(result).toContain('--- nft -a list ruleset (handles + hit counters) ---');
     expect(result).toContain('table inet awf_fc_abc123');
-    expect(result).toContain('--- ip -s link show ---');
+    expect(result).toContain('--- ip -s link show (packet/byte/error counters) ---');
     expect(result).toContain('RX: 0 bytes 0 packets');
+    expect(result).toContain('--- ip -d link show (detailed link info, incl. vnet_hdr/multiqueue flags) ---');
+    expect(result).toContain('vnet_hdr');
+    expect(result).toContain('--- ip route show ---');
+    expect(result).toContain('default via 100.64.0.1 dev tap0');
+    expect(result).toContain('--- ip neigh show (ARP/neighbor table) ---');
+    expect(result).toContain('REACHABLE');
+    expect(result).toContain('--- bridge fdb show (forwarding database) ---');
+    expect(result).toContain('master awfbr0');
   });
 
   it('never throws and reports unavailability when a command fails', async () => {

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -362,6 +362,24 @@ describe('microVM network lifecycle', () => {
       && call.args[2] === plan.namespaceName
     ))).toHaveLength(1);
   });
+
+  it('captureDiagnostics delegates to the namespace once setup completes, and is empty before/after', async () => {
+    const plan = createPlan();
+    const { commands } = commandHarness();
+    const manager = new MicrovmNetworkManager(plan, commands);
+
+    // Before setup(), there's no namespace to inspect.
+    expect(await manager.captureDiagnostics()).toBe('');
+
+    await manager.setup();
+    const captureSpy = jest.spyOn(commands, 'captureDiagnosticsInNamespace')
+      .mockResolvedValue('--- nft list ruleset ---\n(fake)\n');
+    expect(await manager.captureDiagnostics()).toBe('--- nft list ruleset ---\n(fake)\n');
+    expect(captureSpy).toHaveBeenCalledWith(plan.namespaceName);
+
+    await manager.cleanup();
+    expect(await manager.captureDiagnostics()).toBe('');
+  });
 });
 
 describe('LinuxNetworkCommands.nftInNamespace ruleset file handling', () => {
@@ -451,5 +469,45 @@ describe('LinuxNetworkCommands.nftInNamespace ruleset file handling', () => {
     await expect(
       commands.nftInNamespace('awffc-real-fs-test', ['-f', '-'], 'table inet awf { }'),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
+  // Regression coverage: a live-KVM connectivity failure investigation
+  // found bare exit codes insufficient to diagnose whether a guest's
+  // packets ever reached the tap/veth or were dropped by an nftables
+  // forward-chain rule. This best-effort, read-only capture surfaces both
+  // the live ruleset and interface counters for that triage.
+  it('combines nft list ruleset and ip -s link show output', async () => {
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (_command, args) => {
+        if (args.includes('nft')) {
+          return { stdout: 'table inet awf_fc_abc123 { chain forward { ... } }' };
+        }
+        if (args.includes('ip') && args.includes('link')) {
+          return { stdout: '2: eth0: <UP> ... RX: 0 bytes 0 packets' };
+        }
+        return { stdout: '' };
+      }),
+    );
+
+    const result = await commands.captureDiagnosticsInNamespace('awffc-test');
+
+    expect(result).toContain('--- nft list ruleset ---');
+    expect(result).toContain('table inet awf_fc_abc123');
+    expect(result).toContain('--- ip -s link show ---');
+    expect(result).toContain('RX: 0 bytes 0 packets');
+  });
+
+  it('never throws and reports unavailability when a command fails', async () => {
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async () => {
+        throw new Error('ip netns exec failed: No such file or directory');
+      }),
+    );
+
+    const result = await commands.captureDiagnosticsInNamespace('awffc-test');
+
+    expect(result).toContain('(empty or unavailable)');
   });
 });

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -658,6 +658,9 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
         if (args.includes('conntrack')) {
           return { stdout: 'tcp 6 100 ESTABLISHED src=100.64.0.2 dst=172.30.0.10' };
         }
+        if (args.some((a) => a.includes('rp_filter'))) {
+          return { stdout: '/proc/sys/net/ipv4/conf/tap0/rp_filter=1' };
+        }
         return { stdout: '' };
       }),
     );
@@ -678,6 +681,8 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
     expect(result).toContain('master awfbr0');
     expect(result).toContain('--- conntrack -L (connection tracking table state for this namespace) ---');
     expect(result).toContain('ESTABLISHED src=100.64.0.2');
+    expect(result).toContain('--- rp_filter (reverse-path filter mode) per interface in this namespace: 0=off 1=strict 2=loose ---');
+    expect(result).toContain('rp_filter=1');
   });
 
   it('never throws and reports unavailability when a command fails', async () => {

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -224,6 +224,40 @@ describe('microVM network lifecycle', () => {
     expect(probe.verify).toHaveBeenCalledWith(plan);
   });
 
+  it('creates the TAP with vnet_hdr only when the plan opts in (Cloud Hypervisor requires it; Firecracker does not)', async () => {
+    // Regression test: Cloud Hypervisor's own tap handling
+    // (Tap::open_named() in net_util/src/tap.rs) always re-opens the tap
+    // with IFF_VNET_HDR requested. If the tap wasn't *created* with that
+    // feature available, the host and Cloud Hypervisor disagree on frame
+    // layout for the host-to-guest direction: guest-to-host traffic (and
+    // the host-side veth/nft layer) keeps working, but host-to-guest
+    // traffic silently never reaches the guest -- observed live as a tap
+    // RX=10 packets / TX=1 packet asymmetry despite response packets
+    // already having arrived on the host-side veth. Firecracker's own tap
+    // handling does not request IFF_VNET_HDR, so this flag defaults to
+    // false (unchanged prior behavior) and is opted into explicitly.
+    const withVnetHdr = createPlan('run-vnet-hdr', { tapVnetHdr: true });
+    const { calls: vnetHdrCalls, commands: vnetHdrCommands } = commandHarness();
+    await new MicrovmNetworkManager(withVnetHdr, vnetHdrCommands).setup();
+    const vnetHdrTapCall = vnetHdrCalls.find((call) => call.args.includes('tuntap'));
+    expect(vnetHdrTapCall?.args).toEqual([
+      'netns', 'exec', withVnetHdr.namespaceName, 'ip',
+      'tuntap', 'add',
+      'dev', withVnetHdr.tapName,
+      'mode', 'tap',
+      'user', '1000',
+      'group', '1000',
+      'vnet_hdr',
+    ]);
+
+    const withoutVnetHdr = createPlan('run-no-vnet-hdr');
+    expect(withoutVnetHdr.tapVnetHdr).toBe(false);
+    const { calls: plainCalls, commands: plainCommands } = commandHarness();
+    await new MicrovmNetworkManager(withoutVnetHdr, plainCommands).setup();
+    const plainTapCall = plainCalls.find((call) => call.args.includes('tuntap'));
+    expect(plainTapCall?.args).not.toContain('vnet_hdr');
+  });
+
   it('rolls back every partial setup stage with run-specific cleanup', async () => {
     const plan = createPlan('rollback-all');
     const setupStageCount = 15;

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -206,7 +206,23 @@ describe('microVM network lifecycle', () => {
       'link', 'set', plan.hostVethName,
       'master', plan.infrastructureBridge,
     ]);
+    // Docker's own "same bridge" forwarding accept rule does not reliably
+    // match traffic from this manually-injected veth (see
+    // ensureBridgeForwardAcceptRule's doc comment), so a scoped
+    // DOCKER-USER rule is inserted for this exact bridge (after "link set
+    // hostVeth up", calls[4]): first checked (-C, absent in this mock so
+    // it "fails"/doesn't already exist), then inserted (-I).
     expect(calls[5].args).toEqual([
+      '-t', 'filter', '-C', 'DOCKER-USER',
+      '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-j', 'ACCEPT',
+    ]);
+    expect(calls[6].args).toEqual([
+      '-t', 'filter', '-I', 'DOCKER-USER', '1',
+      '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-j', 'ACCEPT',
+    ]);
+    expect(calls[7].args).toEqual([
       'netns', 'exec', plan.namespaceName, 'ip',
       'tuntap', 'add',
       'dev', plan.tapName,
@@ -214,17 +230,17 @@ describe('microVM network lifecycle', () => {
       'user', '1000',
       'group', '1000',
     ]);
-    expect(calls[11].args).toContain('net.ipv4.ip_forward=1');
-    expect(calls[12].args).toContain('net.ipv6.conf.all.disable_ipv6=1');
-    expect(calls[13].args).toContain('net.ipv6.conf.default.disable_ipv6=1');
+    expect(calls[13].args).toContain('net.ipv4.ip_forward=1');
+    expect(calls[14].args).toContain('net.ipv6.conf.all.disable_ipv6=1');
+    expect(calls[15].args).toContain('net.ipv6.conf.default.disable_ipv6=1');
     // The ruleset is written to a real temporary file and passed by path
     // (not piped via "-f -") — see LinuxNetworkCommands.nftInNamespace's
     // MicrovmNetworkRulesetFile doc comment for why.
-    expect(calls[14].command).toBe('ip');
-    expect(calls[14].args.slice(0, 4)).toEqual(['netns', 'exec', plan.namespaceName, 'nft']);
-    expect(calls[14].args[4]).toBe('-f');
-    expect(calls[14].args[5]).toMatch(/awf-nft-[0-9a-f]{16}\.nft$/);
-    expect(calls[14].options).toEqual({ reject: true });
+    expect(calls[16].command).toBe('ip');
+    expect(calls[16].args.slice(0, 4)).toEqual(['netns', 'exec', plan.namespaceName, 'nft']);
+    expect(calls[16].args[4]).toBe('-f');
+    expect(calls[16].args[5]).toMatch(/awf-nft-[0-9a-f]{16}\.nft$/);
+    expect(calls[16].options).toEqual({ reject: true });
     expect(probe.verify).toHaveBeenCalledWith(plan);
   });
 
@@ -422,6 +438,103 @@ describe('microVM network lifecycle', () => {
 
     await manager.cleanup();
     expect(await manager.captureDiagnostics()).toBe('');
+  });
+
+  it('inserts a scoped DOCKER-USER accept rule for the bridge during setup and removes it during cleanup', async () => {
+    // Regression test: live-KVM validation found traffic between our
+    // manually-injected veth and Docker-managed containers (Squid, the
+    // API proxy) on the same bridge was silently dropped by the host's
+    // FORWARD chain default-drop policy -- Docker's own generated "same
+    // bridge" accept rule in DOCKER-FORWARD never matched real traffic
+    // in this environment (confirmed via Squid's own access log showing
+    // zero incoming connection attempts, despite the microVM's own
+    // nftables table already accepting the traffic outbound). A scoped
+    // DOCKER-USER rule (both iif/oif = this exact bridge) fixes this
+    // without weakening any other bridge's isolation.
+    const plan = createPlan();
+    const { calls, commands } = commandHarness();
+    const manager = new MicrovmNetworkManager(plan, commands);
+
+    await manager.setup();
+    const insertCall = calls.find((call) => call.args.includes('-I'));
+    expect(insertCall?.args).toEqual([
+      '-t', 'filter', '-I', 'DOCKER-USER', '1',
+      '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-j', 'ACCEPT',
+    ]);
+
+    await manager.cleanup();
+    const deleteCall = calls.find((call) => call.args.includes('-D'));
+    expect(deleteCall?.args).toEqual([
+      '-t', 'filter', '-D', 'DOCKER-USER',
+      '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-j', 'ACCEPT',
+    ]);
+    // Removal must be tolerant of the rule already being gone (e.g. a
+    // partial-setup rollback before the rule was ever inserted).
+    expect(deleteCall?.options).toEqual({ reject: false });
+  });
+
+  it('skips inserting the DOCKER-USER accept rule when a check shows it already exists', async () => {
+    const plan = createPlan();
+    const executeCalls: string[][] = [];
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (_command, args) => {
+        executeCalls.push(args as string[]);
+        if (args.includes('-C')) return { exitCode: 0 };
+        return undefined;
+      }),
+    );
+
+    await new MicrovmNetworkManager(plan, commands).setup();
+
+    expect(executeCalls.some((args) => args.includes('-I'))).toBe(false);
+  });
+});
+
+describe('LinuxNetworkCommands.ensureBridgeForwardAcceptRule / removeBridgeForwardAcceptRule', () => {
+  it('inserts the rule only when the existence check does not already report it present', async () => {
+    const calls: { args: readonly string[] }[] = [];
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (_command, args) => {
+        calls.push({ args });
+        if (args.includes('-C')) return { exitCode: 1 };
+        return { exitCode: 0 };
+      }),
+    );
+
+    await commands.ensureBridgeForwardAcceptRule('awfbr0');
+
+    expect(calls).toEqual([
+      { args: ['-t', 'filter', '-C', 'DOCKER-USER', '-i', 'awfbr0', '-o', 'awfbr0', '-j', 'ACCEPT'] },
+      { args: ['-t', 'filter', '-I', 'DOCKER-USER', '1', '-i', 'awfbr0', '-o', 'awfbr0', '-j', 'ACCEPT'] },
+    ]);
+  });
+
+  it('does not insert the rule again when the existence check reports it already present', async () => {
+    const calls: { args: readonly string[] }[] = [];
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (_command, args) => {
+        calls.push({ args });
+        return { exitCode: 0 };
+      }),
+    );
+
+    await commands.ensureBridgeForwardAcceptRule('awfbr0');
+
+    expect(calls).toEqual([
+      { args: ['-t', 'filter', '-C', 'DOCKER-USER', '-i', 'awfbr0', '-o', 'awfbr0', '-j', 'ACCEPT'] },
+    ]);
+  });
+
+  it('removeBridgeForwardAcceptRule never throws even if the rule is already gone', async () => {
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async () => {
+        throw new Error('Bad rule (does a matching rule exist in that chain?)');
+      }),
+    );
+
+    await expect(commands.removeBridgeForwardAcceptRule('awfbr0')).resolves.toBeUndefined();
   });
 });
 

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -655,6 +655,9 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
         if (args.includes('bridge')) {
           return { stdout: '02:00:00:00:00:01 dev tap0 master awfbr0' };
         }
+        if (args.includes('conntrack')) {
+          return { stdout: 'tcp 6 100 ESTABLISHED src=100.64.0.2 dst=172.30.0.10' };
+        }
         return { stdout: '' };
       }),
     );
@@ -673,6 +676,8 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
     expect(result).toContain('REACHABLE');
     expect(result).toContain('--- bridge fdb show (forwarding database) ---');
     expect(result).toContain('master awfbr0');
+    expect(result).toContain('--- conntrack -L (connection tracking table state for this namespace) ---');
+    expect(result).toContain('ESTABLISHED src=100.64.0.2');
   });
 
   it('never throws and reports unavailability when a command fails', async () => {
@@ -707,6 +712,9 @@ describe('LinuxNetworkCommands.captureHostBridgeDiagnostics', () => {
         if (command === 'sysctl') {
           return { stdout: 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1' };
         }
+        if (command === 'ip' && args.includes('-s') && args.includes('link')) {
+          return { stdout: '5: vethX@if4: <UP> ... RX: 10 bytes 1 packets' };
+        }
         return { stdout: '' };
       }),
     );
@@ -721,6 +729,8 @@ describe('LinuxNetworkCommands.captureHostBridgeDiagnostics', () => {
     expect(result).toContain('-P FORWARD DROP');
     expect(result).toContain('--- sysctl net.bridge.bridge-nf-call-* ');
     expect(result).toContain('net.bridge.bridge-nf-call-iptables = 1');
+    expect(result).toContain('--- ip -s link show (host/default namespace: per-port RX/TX counters, incl. container veths) ---');
+    expect(result).toContain('RX: 10 bytes 1 packets');
   });
 
   it('never throws and reports unavailability when a command fails', async () => {

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -6,6 +6,7 @@ import {
   type MicrovmConnectivityProbe,
   type MicrovmNetworkCommandOptions,
   type MicrovmNetworkPlan,
+  type MicrovmNetworkRulesetFile,
 } from './network';
 
 interface CommandCall {
@@ -212,14 +213,14 @@ describe('microVM network lifecycle', () => {
     expect(calls[11].args).toContain('net.ipv4.ip_forward=1');
     expect(calls[12].args).toContain('net.ipv6.conf.all.disable_ipv6=1');
     expect(calls[13].args).toContain('net.ipv6.conf.default.disable_ipv6=1');
-    expect(calls[14]).toEqual({
-      command: 'ip',
-      args: ['netns', 'exec', plan.namespaceName, 'nft', '-f', '-'],
-      options: {
-        reject: true,
-        input: generateMicrovmNftRuleset(plan),
-      },
-    });
+    // The ruleset is written to a real temporary file and passed by path
+    // (not piped via "-f -") — see LinuxNetworkCommands.nftInNamespace's
+    // MicrovmNetworkRulesetFile doc comment for why.
+    expect(calls[14].command).toBe('ip');
+    expect(calls[14].args.slice(0, 4)).toEqual(['netns', 'exec', plan.namespaceName, 'nft']);
+    expect(calls[14].args[4]).toBe('-f');
+    expect(calls[14].args[5]).toMatch(/awf-nft-[0-9a-f]{16}\.nft$/);
+    expect(calls[14].options).toEqual({ reject: true });
     expect(probe.verify).toHaveBeenCalledWith(plan);
   });
 
@@ -360,5 +361,95 @@ describe('microVM network lifecycle', () => {
       && call.args[1] === 'delete'
       && call.args[2] === plan.namespaceName
     ))).toHaveLength(1);
+  });
+});
+
+describe('LinuxNetworkCommands.nftInNamespace ruleset file handling', () => {
+  // Regression coverage: nft -f - can fail with `Not a regular file:
+  // "/dev/stdin"` on nftables builds that open /dev/stdin directly rather
+  // than reading the already-piped fd 0 (observed on GitHub-hosted Ubuntu
+  // runners). The ruleset must be written to a real temp file and passed
+  // by path instead.
+  function rulesetFileHarness(): {
+    rulesetFile: jest.Mocked<MicrovmNetworkRulesetFile>;
+    calls: CommandCall[];
+    commands: LinuxNetworkCommands;
+  } {
+    const calls: CommandCall[] = [];
+    const rulesetFile: jest.Mocked<MicrovmNetworkRulesetFile> = {
+      write: jest.fn(async (contents: string) => `/tmp/awf-nft-fake.nft:${contents.length}`),
+      remove: jest.fn(async (_rulesetPath: string) => undefined),
+    };
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (command, args, options) => {
+        calls.push({ command, args, options });
+      }),
+      undefined,
+      rulesetFile,
+    );
+    return { rulesetFile, calls, commands };
+  }
+
+  it('writes the ruleset to a file and passes its path instead of "-f -"', async () => {
+    const { rulesetFile, calls, commands } = rulesetFileHarness();
+    await commands.nftInNamespace('awffc-test', ['-f', '-'], 'table inet awf {}');
+
+    expect(rulesetFile.write).toHaveBeenCalledWith('table inet awf {}');
+    expect(calls).toEqual([{
+      command: 'ip',
+      args: ['netns', 'exec', 'awffc-test', 'nft', '-f', '/tmp/awf-nft-fake.nft:17'],
+      options: { reject: true },
+    }]);
+  });
+
+  it('removes the temp file after a successful nft invocation', async () => {
+    const { rulesetFile, commands } = rulesetFileHarness();
+    await commands.nftInNamespace('awffc-test', ['-f', '-'], 'table inet awf {}');
+
+    expect(rulesetFile.remove).toHaveBeenCalledWith('/tmp/awf-nft-fake.nft:17');
+  });
+
+  it('still removes the temp file when the nft invocation fails', async () => {
+    const rulesetFile: jest.Mocked<MicrovmNetworkRulesetFile> = {
+      write: jest.fn(async (_contents: string) => '/tmp/awf-nft-fake.nft'),
+      remove: jest.fn(async (_rulesetPath: string) => undefined),
+    };
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async () => {
+        throw new Error('nft rejected the ruleset');
+      }),
+      undefined,
+      rulesetFile,
+    );
+
+    await expect(
+      commands.nftInNamespace('awffc-test', ['-f', '-'], 'table inet awf {}'),
+    ).rejects.toThrow('nft rejected the ruleset');
+    expect(rulesetFile.remove).toHaveBeenCalledWith('/tmp/awf-nft-fake.nft');
+  });
+
+  it('skips ruleset file handling entirely when no input is given', async () => {
+    const { rulesetFile, calls, commands } = rulesetFileHarness();
+    await commands.nftInNamespace('awffc-test', ['list', 'ruleset']);
+
+    expect(rulesetFile.write).not.toHaveBeenCalled();
+    expect(rulesetFile.remove).not.toHaveBeenCalled();
+    expect(calls).toEqual([{
+      command: 'ip',
+      args: ['netns', 'exec', 'awffc-test', 'nft', 'list', 'ruleset'],
+      options: { reject: true },
+    }]);
+  });
+
+  it('the default ruleset file performs a real fs write/remove round trip', async () => {
+    // Exercises the real (non-mocked) MicrovmNetworkRulesetFile end to end
+    // against the OS temp directory, catching issues a fully-mocked
+    // executor test would miss (e.g. permission or path-construction bugs).
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async () => undefined),
+    );
+    await expect(
+      commands.nftInNamespace('awffc-real-fs-test', ['-f', '-'], 'table inet awf { }'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -164,6 +164,25 @@ describe('microVM nftables policy', () => {
     expect(ruleset).not.toMatch(/ip daddr 0\.0\.0\.0\/0.*accept/);
   });
 
+  it('registers a prerouting nat hook so return traffic is un-SNAT-ed', () => {
+    // Regression coverage: a live-KVM connectivity investigation proved
+    // (via packet capture + per-rule hit counters) that without an
+    // explicit `prerouting` chain of type nat, nftables never applies
+    // conntrack's automatic reverse-SNAT translation to a reply packet
+    // (e.g. Squid's SYN-ACK) -- it keeps the SNAT'd destination address
+    // all the way to the forward chain, never matches the
+    // "ct state established,related" accept rule (which expects the
+    // guest's real IP), and is silently dropped by forward's own
+    // default policy with zero visible drop counters anywhere. The
+    // presence of this hook (not any specific rule inside it -- reverse
+    // translation is automatic once the hook exists) is what fixes it.
+    const plan = createPlan();
+    const ruleset = generateMicrovmNftRuleset(plan);
+
+    expect(ruleset).toContain('chain prerouting {');
+    expect(ruleset).toContain('type nat hook prerouting priority dstnat; policy accept;');
+  });
+
   it('emits SNAT only for the same exact allowed destination pairs', () => {
     const plan = createPlan('narrow-snat', { enableApiProxy: false });
     const ruleset = generateMicrovmNftRuleset(plan);

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -696,13 +696,16 @@ describe('LinuxNetworkCommands.captureHostBridgeDiagnostics', () => {
   // a way the microVM's own nftables counters would never reveal, so this
   // capture must also check the host-level ruleset (both nft and legacy
   // iptables, since Docker may configure either backend).
-  it('combines bridge fdb, host nftables ruleset, and legacy iptables rules', async () => {
+  it('combines bridge fdb, host nftables ruleset, legacy iptables rules, and bridge-netfilter sysctls', async () => {
     const commands = new LinuxNetworkCommands(
       jest.fn(async (command, args) => {
         if (command === 'bridge') return { stdout: 'aa:bb:cc:dd:ee:ff dev vethX master awfbr0' };
         if (command === 'nft') return { stdout: 'table ip docker { ... }' };
         if (command === 'iptables' && args.includes('-S')) {
           return { stdout: '-P FORWARD DROP\n-A DOCKER-USER -j RETURN' };
+        }
+        if (command === 'sysctl') {
+          return { stdout: 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1' };
         }
         return { stdout: '' };
       }),
@@ -716,6 +719,8 @@ describe('LinuxNetworkCommands.captureHostBridgeDiagnostics', () => {
     expect(result).toContain('table ip docker');
     expect(result).toContain('--- iptables -S (host/default namespace');
     expect(result).toContain('-P FORWARD DROP');
+    expect(result).toContain('--- sysctl net.bridge.bridge-nf-call-* ');
+    expect(result).toContain('net.bridge.bridge-nf-call-iptables = 1');
   });
 
   it('never throws and reports unavailability when a command fails', async () => {

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -574,3 +574,46 @@ describe('LinuxNetworkCommands.captureDiagnosticsInNamespace', () => {
     expect(result).toContain('(empty or unavailable)');
   });
 });
+
+describe('LinuxNetworkCommands.captureHostBridgeDiagnostics', () => {
+  // Regression coverage: Docker (and any other host-level firewall)
+  // manages its own iptables/nftables rules in the default (root) network
+  // namespace, entirely separate from the microVM's own table. Those
+  // rules could independently drop/alter traffic on the shared bridge in
+  // a way the microVM's own nftables counters would never reveal, so this
+  // capture must also check the host-level ruleset (both nft and legacy
+  // iptables, since Docker may configure either backend).
+  it('combines bridge fdb, host nftables ruleset, and legacy iptables rules', async () => {
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (command, args) => {
+        if (command === 'bridge') return { stdout: 'aa:bb:cc:dd:ee:ff dev vethX master awfbr0' };
+        if (command === 'nft') return { stdout: 'table ip docker { ... }' };
+        if (command === 'iptables' && args.includes('-S')) {
+          return { stdout: '-P FORWARD DROP\n-A DOCKER-USER -j RETURN' };
+        }
+        return { stdout: '' };
+      }),
+    );
+
+    const result = await commands.captureHostBridgeDiagnostics('awfbr0');
+
+    expect(result).toContain('--- bridge fdb show br awfbr0 (host-side, outside any netns) ---');
+    expect(result).toContain('master awfbr0');
+    expect(result).toContain('--- nft -a list ruleset (host/default namespace');
+    expect(result).toContain('table ip docker');
+    expect(result).toContain('--- iptables -S (host/default namespace');
+    expect(result).toContain('-P FORWARD DROP');
+  });
+
+  it('never throws and reports unavailability when a command fails', async () => {
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async () => {
+        throw new Error('command not found');
+      }),
+    );
+
+    const result = await commands.captureHostBridgeDiagnostics('awfbr0');
+
+    expect(result).toContain('(empty or unavailable)');
+  });
+});

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -142,6 +142,7 @@ describe('microVM nftables policy', () => {
     // `counter` on these rules is purely diagnostic (nft -a list ruleset
     // then reports packet/byte hit counts per rule) and does not change
     // any accept/drop decision — see generateMicrovmNftRuleset's comment.
+    expect(ruleset).toContain('ct state invalid counter drop');
     expect(ruleset).toContain(
       `iifname "${plan.tapName}" ether saddr != ${plan.guestMac} counter drop`,
     );

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -183,6 +183,35 @@ describe('microVM nftables policy', () => {
     expect(ruleset).toContain('type nat hook prerouting priority dstnat; policy accept;');
   });
 
+  it('accepts return traffic on ip daddr + ct state alone, without an impossible ether daddr match', () => {
+    // Regression coverage: the return-leg accept rule previously also
+    // required `ether daddr <guest-mac>`. At the forward hook this
+    // reflects the *incoming* frame's own L2 destination as it arrived on
+    // the veth (this veth's own kernel-assigned MAC), never the guest's
+    // MAC -- the guest's MAC is only ever a real L2 identity on the
+    // *other* side of the tap device, a separate L2 segment entirely.
+    // That condition could therefore never match any real reply packet
+    // (proven live: Squid's SYN-ACK reaching this veth, yet matching
+    // neither this accept rule nor even the ct-state-invalid drop),
+    // silently discarding every response via the chain's own default
+    // policy. Removing it is what actually fixes the live guest<->Squid
+    // connection, on top of the prerouting nat hook above.
+    const plan = createPlan();
+    const ruleset = generateMicrovmNftRuleset(plan);
+    const returnLine = ruleset
+      .split('\n')
+      .find(
+        (line) =>
+          line.includes(`iifname "${plan.namespaceVethName}"`) &&
+          line.includes(`oifname "${plan.tapName}"`),
+      );
+
+    expect(returnLine).toBeDefined();
+    expect(returnLine).not.toContain('ether daddr');
+    expect(returnLine).toContain(`ip daddr ${plan.guestIp}`);
+    expect(returnLine).toContain('ct state established,related counter accept');
+  });
+
   it('emits SNAT only for the same exact allowed destination pairs', () => {
     const plan = createPlan('narrow-snat', { enableApiProxy: false });
     const ruleset = generateMicrovmNftRuleset(plan);

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -716,6 +716,24 @@ export function generateMicrovmNftRuleset(plan: MicrovmNetworkPlan): string {
       'ct state established,related counter accept',
     ...allowRules,
     '  }',
+    // A `prerouting` chain of type nat is required for the *return* leg
+    // of the postrouting SNAT below to ever work: nftables only
+    // activates nf_nat's automatic conntrack-based reverse translation
+    // (undoing the SNAT for reply packets, e.g. Squid's SYN-ACK) for a
+    // given (family, hook) pair once *some* chain registers a hook
+    // there -- unlike legacy iptables, which always has both built-in.
+    // Without this chain, a reply packet keeps its SNAT'd destination
+    // address (the veth's own IP) all the way to the forward chain,
+    // never matches the "ct state established,related" accept rule
+    // above (which expects the guest's *real* IP), and is silently
+    // dropped by this chain's own default policy -- with no visible
+    // drop counter anywhere, since it never matched an explicit rule.
+    // No explicit rules are needed here: conntrack's own NAT state
+    // (recorded when postrouting first SNATs the outbound packet) does
+    // the reverse translation automatically once this hook exists.
+    '  chain prerouting {',
+    '    type nat hook prerouting priority dstnat; policy accept;',
+    '  }',
     '  chain postrouting {',
     '    type nat hook postrouting priority srcnat; policy accept;',
     ...snatRules,

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -217,12 +217,14 @@ export class LinuxNetworkCommands {
   }
 
   /**
-   * Best-effort, read-only diagnostic dump of the live nftables ruleset and
-   * per-interface packet/byte counters inside the given namespace. Used to
+   * Best-effort, read-only diagnostic dump of the live nftables ruleset,
+   * per-interface packet/byte counters, routes/neighbors, and the TAP/veth
+   * bridge-forwarding database inside the given namespace. Used to
    * diagnose a connectivity failure (e.g. is the forward-chain rule
-   * actually installed as expected, are packets reaching the tap/veth at
-   * all) without guessing from the guest side alone. Never throws --
-   * folds any command failure into an empty string for that command.
+   * actually installed and matching packets, are packets reaching the
+   * tap/veth at all, does ARP/neighbor resolution look right) without
+   * guessing from the guest side alone. Never throws -- folds any command
+   * failure into an empty string for that command.
    */
   async captureDiagnosticsInNamespace(namespaceName: string): Promise<string> {
     const run = async (tool: string, args: readonly string[]): Promise<string> => {
@@ -234,15 +236,54 @@ export class LinuxNetworkCommands {
       const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
       return typeof stdout === 'string' ? stdout : '';
     };
-    const [nftRuleset, linkStats] = await Promise.all([
-      run(this.tools.nft, ['list', 'ruleset']),
+    const [nftRuleset, linkStats, linkDetail, routes, neighbors, fdb] = await Promise.all([
+      // -a includes rule handles so a specific rule can be identified/
+      // referenced; the counters attached in generateMicrovmNftRuleset
+      // make hit counts visible per rule (not just per interface).
+      run(this.tools.nft, ['-a', 'list', 'ruleset']),
       run(this.tools.ip, ['-s', 'link', 'show']),
+      run(this.tools.ip, ['-d', 'link', 'show']),
+      run(this.tools.ip, ['route', 'show']),
+      run(this.tools.ip, ['neigh', 'show']),
+      // 'bridge' (iproute2) is not user-configurable like ip/nft/sysctl
+      // above -- it is only used here, best-effort, for diagnostics.
+      run('bridge', ['fdb', 'show']),
     ]);
     return [
-      '--- nft list ruleset ---',
+      '--- nft -a list ruleset (handles + hit counters) ---',
       nftRuleset.trim() || '(empty or unavailable)',
-      '--- ip -s link show ---',
+      '--- ip -s link show (packet/byte/error counters) ---',
       linkStats.trim() || '(empty or unavailable)',
+      '--- ip -d link show (detailed link info, incl. vnet_hdr/multiqueue flags) ---',
+      linkDetail.trim() || '(empty or unavailable)',
+      '--- ip route show ---',
+      routes.trim() || '(empty or unavailable)',
+      '--- ip neigh show (ARP/neighbor table) ---',
+      neighbors.trim() || '(empty or unavailable)',
+      '--- bridge fdb show (forwarding database) ---',
+      fdb.trim() || '(empty or unavailable)',
+    ].join('\n');
+  }
+
+  /**
+   * Best-effort, read-only diagnostic dump of the host-side (outside any
+   * netns) bridge forwarding database for the infrastructure bridge that
+   * Squid/API-proxy containers are attached to. MAC learning for
+   * guest<->container traffic happens on this bridge, not inside the
+   * microVM's own namespace, so this is a separate capture point. Never
+   * throws -- folds any command failure into an empty string.
+   */
+  async captureHostBridgeDiagnostics(bridgeName: string): Promise<string> {
+    const result = await this.execute(
+      'bridge',
+      ['fdb', 'show', 'br', bridgeName],
+      { reject: false },
+    ).catch(() => undefined);
+    const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
+    const fdb = typeof stdout === 'string' ? stdout.trim() : '';
+    return [
+      `--- bridge fdb show br ${bridgeName} (host-side, outside any netns) ---`,
+      fdb || '(empty or unavailable)',
     ].join('\n');
   }
 }
@@ -361,7 +402,11 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
 
   async captureDiagnostics(): Promise<string> {
     if (!this.setupComplete) return '';
-    return this.commands.captureDiagnosticsInNamespace(this.plan.namespaceName);
+    const [namespaceDiagnostics, hostBridgeDiagnostics] = await Promise.all([
+      this.commands.captureDiagnosticsInNamespace(this.plan.namespaceName),
+      this.commands.captureHostBridgeDiagnostics(this.plan.infrastructureBridge),
+    ]);
+    return [namespaceDiagnostics, hostBridgeDiagnostics].join('\n');
   }
 
   async cleanup(): Promise<void> {
@@ -474,7 +519,7 @@ export function generateMicrovmNftRuleset(plan: MicrovmNetworkPlan): string {
     `    iifname "${plan.tapName}" oifname "${plan.namespaceVethName}" ` +
       `ether saddr ${plan.guestMac} ip saddr ${plan.guestIp} ` +
       `ip daddr ${endpoint.ip} tcp dport ${endpoint.port} ` +
-      'ct state new,established accept',
+      'ct state new,established counter accept',
   ]);
   const snatRules = plan.allowedEndpoints.map((endpoint) =>
     `    iifname "${plan.tapName}" oifname "${plan.namespaceVethName}" ` +
@@ -497,17 +542,23 @@ export function generateMicrovmNftRuleset(plan: MicrovmNetworkPlan): string {
     '  chain forward {',
     '    type filter hook forward priority filter; policy drop;',
     '    ct state invalid drop',
-    `    iifname "${plan.tapName}" ether saddr != ${plan.guestMac} drop`,
-    `    iifname "${plan.tapName}" ip saddr != ${plan.guestIp} drop`,
-    `    iifname "${plan.tapName}" ip daddr ${BLOCKED_LINK_LOCAL_CIDR} drop`,
-    `    iifname "${plan.tapName}" ip daddr ${BLOCKED_MULTICAST_CIDR} drop`,
-    `    iifname "${plan.tapName}" ip daddr ${plan.hostGatewayIp} drop`,
-    `    iifname "${plan.tapName}" ip daddr ${plan.infrastructureIp} drop`,
-    `    iifname "${plan.tapName}" udp dport 53 drop`,
-    `    iifname "${plan.tapName}" tcp dport 53 drop`,
+    // `counter` on the anti-spoof/reverse-path rules below is purely
+    // diagnostic (nftables does not track packet/byte hits on a rule
+    // unless it includes an explicit `counter` object); it does not
+    // change any accept/drop decision. This makes `nft -a list ruleset`
+    // (captured in diagnostics) show exactly which rule is or isn't
+    // matching guest<->host traffic without guessing.
+    `    iifname "${plan.tapName}" ether saddr != ${plan.guestMac} counter drop`,
+    `    iifname "${plan.tapName}" ip saddr != ${plan.guestIp} counter drop`,
+    `    iifname "${plan.tapName}" ip daddr ${BLOCKED_LINK_LOCAL_CIDR} counter drop`,
+    `    iifname "${plan.tapName}" ip daddr ${BLOCKED_MULTICAST_CIDR} counter drop`,
+    `    iifname "${plan.tapName}" ip daddr ${plan.hostGatewayIp} counter drop`,
+    `    iifname "${plan.tapName}" ip daddr ${plan.infrastructureIp} counter drop`,
+    `    iifname "${plan.tapName}" udp dport 53 counter drop`,
+    `    iifname "${plan.tapName}" tcp dport 53 counter drop`,
     `    iifname "${plan.namespaceVethName}" oifname "${plan.tapName}" ` +
       `ether daddr ${plan.guestMac} ip daddr ${plan.guestIp} ` +
-      'ct state established,related accept',
+      'ct state established,related counter accept',
     ...allowRules,
     '  }',
     '  chain postrouting {',

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -334,7 +334,7 @@ export class LinuxNetworkCommands {
       const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
       return typeof stdout === 'string' ? stdout.trim() : '';
     };
-    const [fdb, hostNftRuleset, hostIptablesRules, bridgeNfSysctls] = await Promise.all([
+    const [fdb, hostNftRuleset, hostIptablesRules, bridgeNfSysctls, bridgeLinkState] = await Promise.all([
       run('bridge', ['fdb', 'show', 'br', bridgeName]),
       // Docker (and any other host-level firewall) manages its own
       // iptables/nftables rules in the *default* (root) network
@@ -361,6 +361,15 @@ export class LinuxNetworkCommands {
         'net.bridge.bridge-nf-call-ip6tables',
         'net.bridge.bridge-nf-call-arptables',
       ]),
+      // Bridge-netfilter is confirmed inactive (empty sysctl output),
+      // meaning bridged traffic is being switched purely at L2: STP port
+      // state (forwarding/learning/blocking) can independently and
+      // silently drop traffic through a bridge port regardless of any
+      // netfilter/nftables/iptables rule -- a newly-created port that
+      // hasn't yet finished STP's listening->learning->forwarding
+      // transition would exhibit exactly this symptom (an otherwise
+      // correctly wired-up port through which nothing gets forwarded).
+      run('bridge', ['link', 'show']),
     ]);
     return [
       `--- bridge fdb show br ${bridgeName} (host-side, outside any netns) ---`,
@@ -371,6 +380,8 @@ export class LinuxNetworkCommands {
       hostIptablesRules || '(empty or unavailable)',
       '--- sysctl net.bridge.bridge-nf-call-* (is bridged traffic even seen by netfilter?) ---',
       bridgeNfSysctls || '(empty, unavailable, or the bridge kernel module is not loaded)',
+      '--- bridge link show (STP port state: forwarding/learning/blocking) ---',
+      bridgeLinkState || '(empty or unavailable)',
     ].join('\n');
   }
 }

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -291,7 +291,7 @@ export class LinuxNetworkCommands {
       const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
       return typeof stdout === 'string' ? stdout : '';
     };
-    const [nftRuleset, linkStats, linkDetail, routes, neighbors, fdb, conntrack] = await Promise.all([
+    const [nftRuleset, linkStats, linkDetail, routes, neighbors, fdb, conntrack, rpFilter] = await Promise.all([
       // -a includes rule handles so a specific rule can be identified/
       // referenced; the counters attached in generateMicrovmNftRuleset
       // make hit counts visible per rule (not just per interface).
@@ -312,6 +312,20 @@ export class LinuxNetworkCommands {
       // packet arriving as an unrelated/untracked packet that the
       // default-drop policy then silently discards).
       run('conntrack', ['-L']),
+      // Squid's own reply (SYN-ACK) has been directly observed via packet
+      // capture reaching this namespace's host-side veth peer, yet it
+      // never appears in *any* forward-chain counter above (not even the
+      // ct-state-invalid drop) -- meaning it never reaches nftables
+      // evaluation at all. Linux's reverse-path filtering (rp_filter) can
+      // silently drop a packet before any netfilter hook ever sees it if
+      // strict mode considers the route asymmetric; this is evaluated
+      // per-interface (plus the "all"/"default" umbrella, whichever is
+      // stricter) so every interface actually present in this namespace
+      // must be enumerated at runtime rather than named statically.
+      run('sh', [
+        '-c',
+        'for f in /proc/sys/net/ipv4/conf/*/rp_filter; do printf "%s=%s\\n" "$f" "$(cat "$f" 2>/dev/null)"; done',
+      ]),
     ]);
     return [
       '--- nft -a list ruleset (handles + hit counters) ---',
@@ -328,6 +342,8 @@ export class LinuxNetworkCommands {
       fdb.trim() || '(empty or unavailable)',
       '--- conntrack -L (connection tracking table state for this namespace) ---',
       conntrack.trim() || '(empty, unavailable, or conntrack tool not installed)',
+      '--- rp_filter (reverse-path filter mode) per interface in this namespace: 0=off 1=strict 2=loose ---',
+      rpFilter.trim() || '(empty or unavailable)',
     ].join('\n');
   }
 

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -59,6 +59,23 @@ export interface MicrovmNetworkPlanOptions {
   readonly tapOwnerUid: number;
   readonly tapOwnerGid: number;
   readonly controlPeer?: MicrovmControlPeer;
+  /**
+   * Create the TAP device with the `vnet_hdr` feature (a `struct
+   * virtio_net_hdr` prefix on every frame read from/written to the tap
+   * fd). Cloud Hypervisor's own tap handling (`Tap::open_named()` in
+   * `net_util/src/tap.rs`) always re-opens the tap with `IFF_VNET_HDR`
+   * requested; if the tap wasn't *created* with that feature available,
+   * the host kernel and Cloud Hypervisor disagree on frame layout for
+   * one direction, and host-to-guest traffic silently fails to reach the
+   * guest even though guest-to-host traffic (and the host-side veth/nft
+   * layer) keeps working normally -- exactly the asymmetric RX-works/
+   * TX-stalls pattern observed live (tap RX=10 packets, TX=1 packet,
+   * despite 23 response packets already having arrived on the veth).
+   * Firecracker's own tap handling does not request `IFF_VNET_HDR`, so
+   * this defaults to `false` (this shared code's prior, Firecracker-only
+   * behavior) and Cloud Hypervisor opts in explicitly.
+   */
+  readonly tapVnetHdr?: boolean;
 }
 
 export interface MicrovmNetworkPlan {
@@ -80,6 +97,7 @@ export interface MicrovmNetworkPlan {
   readonly guestMac: string;
   readonly tapOwnerUid: number;
   readonly tapOwnerGid: number;
+  readonly tapVnetHdr: boolean;
   readonly allowedEndpoints: readonly MicrovmAllowedEndpoint[];
   readonly networkInterface: MicrovmTapInterface;
 }
@@ -284,6 +302,7 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
         'mode', 'tap',
         'user', String(this.plan.tapOwnerUid),
         'group', String(this.plan.tapOwnerGid),
+        ...(this.plan.tapVnetHdr ? ['vnet_hdr'] : []),
       ]);
       await this.commands.ipInNamespace(this.plan.namespaceName, [
         'addr', 'add',
@@ -437,6 +456,7 @@ export function createMicrovmNetworkPlan(
     guestMac,
     tapOwnerUid: options.tapOwnerUid,
     tapOwnerGid: options.tapOwnerGid,
+    tapVnetHdr: options.tapVnetHdr ?? false,
     allowedEndpoints,
     networkInterface: {
       iface_id: 'eth0',

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -291,7 +291,7 @@ export class LinuxNetworkCommands {
       const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
       return typeof stdout === 'string' ? stdout : '';
     };
-    const [nftRuleset, linkStats, linkDetail, routes, neighbors, fdb] = await Promise.all([
+    const [nftRuleset, linkStats, linkDetail, routes, neighbors, fdb, conntrack] = await Promise.all([
       // -a includes rule handles so a specific rule can be identified/
       // referenced; the counters attached in generateMicrovmNftRuleset
       // make hit counts visible per rule (not just per interface).
@@ -303,6 +303,15 @@ export class LinuxNetworkCommands {
       // 'bridge' (iproute2) is not user-configurable like ip/nft/sysctl
       // above -- it is only used here, best-effort, for diagnostics.
       run('bridge', ['fdb', 'show']),
+      // The forward chain's own accept rules key off `ct state`
+      // (established/related/new). If the *outbound* leg of a flow is
+      // accepted (new) but the *return* leg never matches the
+      // established/related accept rule, the conntrack table itself is
+      // the only place that can show whether the kernel ever recognized
+      // the two directions as the same tracked flow (vs. the return
+      // packet arriving as an unrelated/untracked packet that the
+      // default-drop policy then silently discards).
+      run('conntrack', ['-L']),
     ]);
     return [
       '--- nft -a list ruleset (handles + hit counters) ---',
@@ -317,6 +326,8 @@ export class LinuxNetworkCommands {
       neighbors.trim() || '(empty or unavailable)',
       '--- bridge fdb show (forwarding database) ---',
       fdb.trim() || '(empty or unavailable)',
+      '--- conntrack -L (connection tracking table state for this namespace) ---',
+      conntrack.trim() || '(empty, unavailable, or conntrack tool not installed)',
     ].join('\n');
   }
 
@@ -334,8 +345,9 @@ export class LinuxNetworkCommands {
       const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
       return typeof stdout === 'string' ? stdout.trim() : '';
     };
-    const [fdb, hostNftRuleset, hostIptablesRules, bridgeNfSysctls, bridgeLinkState] = await Promise.all([
-      run('bridge', ['fdb', 'show', 'br', bridgeName]),
+    const [fdb, hostNftRuleset, hostIptablesRules, bridgeNfSysctls, bridgeLinkState, hostLinkStats] =
+      await Promise.all([
+        run('bridge', ['fdb', 'show', 'br', bridgeName]),
       // Docker (and any other host-level firewall) manages its own
       // iptables/nftables rules in the *default* (root) network
       // namespace -- the same namespace this bridge and the container
@@ -370,6 +382,17 @@ export class LinuxNetworkCommands {
       // transition would exhibit exactly this symptom (an otherwise
       // correctly wired-up port through which nothing gets forwarded).
       run('bridge', ['link', 'show']),
+      // The microVM-side (in-namespace) `ip -s link show` capture only
+      // shows this bridge port's *peer* (the veth end inside our own
+      // namespace). Whether the *container* side (e.g. Squid's veth,
+      // which is not attached to our namespace) ever actually received
+      // an RX frame is a completely separate, host-root-namespace-only
+      // fact: if the bridge/container veth's RX counter never
+      // increments across a request while our own TX counter does, the
+      // frame left our port but was never delivered onto the
+      // container's port -- narrowing the failure to something the
+      // bridge itself is doing (or not doing) between those two ports.
+      run(this.tools.ip, ['-s', 'link', 'show']),
     ]);
     return [
       `--- bridge fdb show br ${bridgeName} (host-side, outside any netns) ---`,
@@ -382,6 +405,8 @@ export class LinuxNetworkCommands {
       bridgeNfSysctls || '(empty, unavailable, or the bridge kernel module is not loaded)',
       '--- bridge link show (STP port state: forwarding/learning/blocking) ---',
       bridgeLinkState || '(empty or unavailable)',
+      '--- ip -s link show (host/default namespace: per-port RX/TX counters, incl. container veths) ---',
+      hostLinkStats || '(empty or unavailable)',
     ].join('\n');
   }
 }

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -274,16 +274,33 @@ export class LinuxNetworkCommands {
    * throws -- folds any command failure into an empty string.
    */
   async captureHostBridgeDiagnostics(bridgeName: string): Promise<string> {
-    const result = await this.execute(
-      'bridge',
-      ['fdb', 'show', 'br', bridgeName],
-      { reject: false },
-    ).catch(() => undefined);
-    const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
-    const fdb = typeof stdout === 'string' ? stdout.trim() : '';
+    const run = async (tool: string, args: readonly string[]): Promise<string> => {
+      const result = await this.execute(tool, args, { reject: false }).catch(() => undefined);
+      const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
+      return typeof stdout === 'string' ? stdout.trim() : '';
+    };
+    const [fdb, hostNftRuleset, hostIptablesRules] = await Promise.all([
+      run('bridge', ['fdb', 'show', 'br', bridgeName]),
+      // Docker (and any other host-level firewall) manages its own
+      // iptables/nftables rules in the *default* (root) network
+      // namespace -- the same namespace this bridge and the container
+      // side of the microVM's veth pair live in. Those rules are
+      // completely separate from (and evaluated in addition to) the
+      // microVM's own table captured in captureDiagnosticsInNamespace,
+      // and could independently drop/alter traffic on this bridge that
+      // our own table's counters would never show as blocked. Docker may
+      // configure either the modern nftables backend or legacy
+      // iptables/xtables depending on the host, so both are captured.
+      run(this.tools.nft, ['-a', 'list', 'ruleset']),
+      run('iptables', ['-S']),
+    ]);
     return [
       `--- bridge fdb show br ${bridgeName} (host-side, outside any netns) ---`,
       fdb || '(empty or unavailable)',
+      '--- nft -a list ruleset (host/default namespace, e.g. Docker-managed nftables rules) ---',
+      hostNftRuleset || '(empty or unavailable)',
+      '--- iptables -S (host/default namespace, e.g. Docker-managed legacy iptables rules) ---',
+      hostIptablesRules || '(empty or unavailable)',
     ].join('\n');
   }
 }

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -711,8 +711,21 @@ export function generateMicrovmNftRuleset(plan: MicrovmNetworkPlan): string {
     `    iifname "${plan.tapName}" ip daddr ${plan.infrastructureIp} counter drop`,
     `    iifname "${plan.tapName}" udp dport 53 counter drop`,
     `    iifname "${plan.tapName}" tcp dport 53 counter drop`,
+    // The return-leg accept rule below intentionally has no `ether daddr`
+    // condition (an earlier version incorrectly required
+    // `ether daddr <guest-mac>` here): at the forward hook, `ether daddr`
+    // reflects the *incoming* frame's own L2 destination as it arrived on
+    // iifname (this veth), which is this veth's own MAC address (assigned
+    // by the kernel/bridge), never the guest's MAC -- the guest's MAC is
+    // only ever a real L2 identity on the *other* side of the tap device,
+    // a completely separate L2 segment. That condition could therefore
+    // never match any real reply packet, silently discarding every
+    // response (e.g. Squid's SYN-ACK) via this chain's own default-drop
+    // policy with no visible counter anywhere. `ip daddr` (the guest's
+    // real, post-un-SNAT IP) plus `ct state established,related` is both
+    // necessary and sufficient to identify legitimate return traffic.
     `    iifname "${plan.namespaceVethName}" oifname "${plan.tapName}" ` +
-      `ether daddr ${plan.guestMac} ip daddr ${plan.guestIp} ` +
+      `ip daddr ${plan.guestIp} ` +
       'ct state established,related counter accept',
     ...allowRules,
     '  }',

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -103,9 +103,7 @@ const defaultCommandExecutor: MicrovmNetworkCommandExecutor = async (
   command,
   args,
   options,
-) => {
-  await execa(command, [...args], options);
-};
+) => execa(command, [...args], options);
 
 export interface MicrovmNetworkRulesetFile {
   write(contents: string): Promise<string>;
@@ -199,12 +197,49 @@ export class LinuxNetworkCommands {
       await this.rulesetFile.remove(rulesetPath);
     }
   }
+
+  /**
+   * Best-effort, read-only diagnostic dump of the live nftables ruleset and
+   * per-interface packet/byte counters inside the given namespace. Used to
+   * diagnose a connectivity failure (e.g. is the forward-chain rule
+   * actually installed as expected, are packets reaching the tap/veth at
+   * all) without guessing from the guest side alone. Never throws --
+   * folds any command failure into an empty string for that command.
+   */
+  async captureDiagnosticsInNamespace(namespaceName: string): Promise<string> {
+    const run = async (tool: string, args: readonly string[]): Promise<string> => {
+      const result = await this.execute(
+        this.tools.ip,
+        ['netns', 'exec', namespaceName, tool, ...args],
+        { reject: false },
+      ).catch(() => undefined);
+      const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
+      return typeof stdout === 'string' ? stdout : '';
+    };
+    const [nftRuleset, linkStats] = await Promise.all([
+      run(this.tools.nft, ['list', 'ruleset']),
+      run(this.tools.ip, ['-s', 'link', 'show']),
+    ]);
+    return [
+      '--- nft list ruleset ---',
+      nftRuleset.trim() || '(empty or unavailable)',
+      '--- ip -s link show ---',
+      linkStats.trim() || '(empty or unavailable)',
+    ].join('\n');
+  }
 }
 
 export interface MicrovmNetworkLifecycle {
   readonly plan: MicrovmNetworkPlan;
   setup(): Promise<MicrovmNetworkPlan>;
   cleanup(): Promise<void>;
+  /**
+   * Optional, best-effort, read-only diagnostic dump (live nftables
+   * ruleset + interface counters) for troubleshooting a connectivity
+   * failure while the namespace still exists (i.e. called before
+   * `cleanup()`). Not required by every implementer/mock.
+   */
+  captureDiagnostics?(): Promise<string>;
 }
 
 /**
@@ -303,6 +338,11 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
       }
       throw error;
     }
+  }
+
+  async captureDiagnostics(): Promise<string> {
+    if (!this.setupComplete) return '';
+    return this.commands.captureDiagnosticsInNamespace(this.plan.namespaceName);
   }
 
   async cleanup(): Promise<void> {

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -541,7 +541,7 @@ export function generateMicrovmNftRuleset(plan: MicrovmNetworkPlan): string {
     '  }',
     '  chain forward {',
     '    type filter hook forward priority filter; policy drop;',
-    '    ct state invalid drop',
+    '    ct state invalid counter drop',
     // `counter` on the anti-spoof/reverse-path rules below is purely
     // diagnostic (nftables does not track packet/byte hits on a rule
     // unless it includes an explicit `counter` object); it does not

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -217,6 +217,61 @@ export class LinuxNetworkCommands {
   }
 
   /**
+   * Ensures a scoped `ACCEPT` rule exists in Docker's `DOCKER-USER` chain
+   * (which Docker evaluates *before* its own per-network isolation rules)
+   * for intra-bridge forwarding on the given infrastructure bridge -- both
+   * the incoming and outgoing interface must be this exact bridge.
+   *
+   * Live-KVM validation found that traffic between our manually-injected
+   * (non-Docker-managed) veth and Docker-managed containers (Squid, the
+   * API proxy) on the same bridge was silently dropped by the host's
+   * `FORWARD` chain default-drop policy: Docker's own generated
+   * "same bridge" accept rule in `DOCKER-FORWARD` never matched real
+   * traffic in this environment (confirmed via Squid's own access log
+   * showing zero incoming connection attempts, despite the microVM's own
+   * nftables table already accepting the traffic outbound). Genuine
+   * Docker-to-Docker container traffic on the same bridge is unaffected
+   * (Docker likely grants those containers rules of their own that our
+   * externally-injected veth never receives).
+   *
+   * Scoped to exactly this per-run bridge (Docker Compose assigns a
+   * unique bridge name per invocation) with both interfaces required to
+   * match, so this does not weaken isolation for any other bridge/network
+   * on the host, and does not bypass the microVM's own in-namespace
+   * nftables allowlist (which still restricts what the guest can send in
+   * the first place).
+   */
+  async ensureBridgeForwardAcceptRule(bridgeName: string): Promise<void> {
+    const checkResult = await this.execute(
+      'iptables',
+      ['-t', 'filter', '-C', 'DOCKER-USER', '-i', bridgeName, '-o', bridgeName, '-j', 'ACCEPT'],
+      { reject: false },
+    );
+    const exitCode = (checkResult as { exitCode?: number } | undefined)?.exitCode;
+    if (exitCode === 0) return;
+    await this.execute(
+      'iptables',
+      ['-t', 'filter', '-I', 'DOCKER-USER', '1', '-i', bridgeName, '-o', bridgeName, '-j', 'ACCEPT'],
+      { reject: true },
+    );
+  }
+
+  /** Removes the rule `ensureBridgeForwardAcceptRule` installs, if present. Tolerant of it already being gone or the underlying command failing outright. */
+  async removeBridgeForwardAcceptRule(bridgeName: string): Promise<void> {
+    try {
+      await this.execute(
+        'iptables',
+        ['-t', 'filter', '-D', 'DOCKER-USER', '-i', bridgeName, '-o', bridgeName, '-j', 'ACCEPT'],
+        { reject: false },
+      );
+    } catch {
+      // Best-effort cleanup: an already-removed rule, or the iptables
+      // binary itself being unavailable, must not fail the caller's own
+      // cleanup sequence.
+    }
+  }
+
+  /**
    * Best-effort, read-only diagnostic dump of the live nftables ruleset,
    * per-interface packet/byte counters, routes/neighbors, and the TAP/veth
    * bridge-forwarding database inside the given namespace. Used to
@@ -325,6 +380,7 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
   private setupComplete = false;
   private namespaceCreated = false;
   private hostVethCreated = false;
+  private dockerUserRuleInserted = false;
 
   constructor(
     readonly plan: MicrovmNetworkPlan,
@@ -353,6 +409,15 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
         'master', this.plan.infrastructureBridge,
       ]);
       await this.commands.ip(['link', 'set', this.plan.hostVethName, 'up']);
+      // See LinuxNetworkCommands.ensureBridgeForwardAcceptRule's own doc
+      // comment: Docker's own "same bridge" forwarding accept rule does
+      // not reliably match traffic from this manually-injected veth in
+      // this environment, silently dropping it via the FORWARD chain's
+      // default-drop policy. Must happen before any guest traffic can
+      // possibly flow (i.e. before the tap/guest side is even brought
+      // up below).
+      await this.commands.ensureBridgeForwardAcceptRule(this.plan.infrastructureBridge);
+      this.dockerUserRuleInserted = true;
 
       await this.commands.ipInNamespace(this.plan.namespaceName, [
         'tuntap', 'add',
@@ -436,6 +501,12 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
       }
     };
 
+    if (this.dockerUserRuleInserted) {
+      await attempt(async () => {
+        await this.commands.removeBridgeForwardAcceptRule(this.plan.infrastructureBridge);
+        this.dockerUserRuleInserted = false;
+      });
+    }
     if (this.hostVethCreated) {
       await attempt(async () => {
         await this.commands.ip(['link', 'delete', this.plan.hostVethName]);

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -334,7 +334,7 @@ export class LinuxNetworkCommands {
       const stdout = (result as { stdout?: unknown } | undefined)?.stdout;
       return typeof stdout === 'string' ? stdout.trim() : '';
     };
-    const [fdb, hostNftRuleset, hostIptablesRules] = await Promise.all([
+    const [fdb, hostNftRuleset, hostIptablesRules, bridgeNfSysctls] = await Promise.all([
       run('bridge', ['fdb', 'show', 'br', bridgeName]),
       // Docker (and any other host-level firewall) manages its own
       // iptables/nftables rules in the *default* (root) network
@@ -348,6 +348,19 @@ export class LinuxNetworkCommands {
       // iptables/xtables depending on the host, so both are captured.
       run(this.tools.nft, ['-a', 'list', 'ruleset']),
       run('iptables', ['-S']),
+      // If bridge-netfilter isn't wired up (kernel module not loaded, or
+      // its sysctls disabled), bridged traffic never traverses the
+      // iptables/nftables FORWARD hook at all -- it is forwarded purely
+      // at L2 -- which would make every rule/counter captured above
+      // (both ours and Docker's) irrelevant to what is actually
+      // happening to this bridge's traffic, and would explain a
+      // correctly-installed, correctly-targeted accept rule never
+      // matching any packets.
+      run('sysctl', [
+        'net.bridge.bridge-nf-call-iptables',
+        'net.bridge.bridge-nf-call-ip6tables',
+        'net.bridge.bridge-nf-call-arptables',
+      ]),
     ]);
     return [
       `--- bridge fdb show br ${bridgeName} (host-side, outside any netns) ---`,
@@ -356,6 +369,8 @@ export class LinuxNetworkCommands {
       hostNftRuleset || '(empty or unavailable)',
       '--- iptables -S (host/default namespace, e.g. Docker-managed legacy iptables rules) ---',
       hostIptablesRules || '(empty or unavailable)',
+      '--- sysctl net.bridge.bridge-nf-call-* (is bridged traffic even seen by netfilter?) ---',
+      bridgeNfSysctls || '(empty, unavailable, or the bridge kernel module is not loaded)',
     ].join('\n');
   }
 }

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -1,4 +1,7 @@
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import execa from 'execa';
 import {
   AGENT_IP,
@@ -104,6 +107,33 @@ const defaultCommandExecutor: MicrovmNetworkCommandExecutor = async (
   await execa(command, [...args], options);
 };
 
+export interface MicrovmNetworkRulesetFile {
+  write(contents: string): Promise<string>;
+  remove(rulesetPath: string): Promise<void>;
+}
+
+/**
+ * Writes an nftables ruleset to a real, private temporary file instead of
+ * piping it to `nft -f -` over stdin.
+ *
+ * Some nftables/libnftables builds internally `open("/dev/stdin")` when
+ * given `-f -` rather than reading the already-open fd 0, which fails with
+ * `Not a regular file: "/dev/stdin"` when stdin is a genuine pipe (as
+ * `execa`'s `input` option provides) rather than a terminal or redirected
+ * regular file — observed on GitHub-hosted Ubuntu runners. A real temp
+ * file sidesteps this entirely and is at least as safe: still argv-only
+ * (no shell), mode 0600, and removed immediately after the `nft` call
+ * regardless of success or failure.
+ */
+const defaultRulesetFile: MicrovmNetworkRulesetFile = {
+  write: async (contents) => {
+    const rulesetPath = path.join(os.tmpdir(), `awf-nft-${randomBytes(8).toString('hex')}.nft`);
+    await fs.writeFile(rulesetPath, contents, { mode: 0o600 });
+    return rulesetPath;
+  },
+  remove: (rulesetPath) => fs.rm(rulesetPath, { force: true }),
+};
+
 /**
  * Dependency-injected argv-only Linux networking operations.
  */
@@ -115,6 +145,7 @@ export class LinuxNetworkCommands {
       nft: 'nft',
       sysctl: 'sysctl',
     },
+    private readonly rulesetFile: MicrovmNetworkRulesetFile = defaultRulesetFile,
   ) {}
 
   ip(args: readonly string[], reject = true): Promise<unknown> {
@@ -141,17 +172,32 @@ export class LinuxNetworkCommands {
     );
   }
 
-  nftInNamespace(
+  async nftInNamespace(
     namespaceName: string,
     args: readonly string[],
     input?: string,
     reject = true,
   ): Promise<unknown> {
-    return this.execute(
-      this.tools.ip,
-      ['netns', 'exec', namespaceName, this.tools.nft, ...args],
-      { reject, ...(input === undefined ? {} : { input }) },
-    );
+    if (input === undefined) {
+      return this.execute(
+        this.tools.ip,
+        ['netns', 'exec', namespaceName, this.tools.nft, ...args],
+        { reject },
+      );
+    }
+    const rulesetPath = await this.rulesetFile.write(input);
+    try {
+      // Substitute the "read from stdin" placeholder ("-") with the real
+      // ruleset file path; any other args pass through unchanged.
+      const resolvedArgs = args.map((arg) => (arg === '-' ? rulesetPath : arg));
+      return await this.execute(
+        this.tools.ip,
+        ['netns', 'exec', namespaceName, this.tools.nft, ...resolvedArgs],
+        { reject },
+      );
+    } finally {
+      await this.rulesetFile.remove(rulesetPath);
+    }
   }
 }
 

--- a/src/microvm/workspace.test.ts
+++ b/src/microvm/workspace.test.ts
@@ -82,6 +82,18 @@ describe('microVM workspace images', () => {
     ]);
     expect(commands[1].args).toContain('rm /sbin/awf-supervisor');
     expect(commands[0].args).toEqual(expect.arrayContaining(['-b', '4096']));
+    // Regression coverage: a live-KVM investigation found the guest
+    // agent (running as a non-root uid/gid inside the microVM) getting
+    // EACCES writing directly into the workspace mount root, e.g.
+    // `printf x > .hidden`. mke2fs's -d option populates file/directory
+    // *contents* from the staging tree, but its own filesystem root
+    // inode defaults to the identity of whoever runs mke2fs (root, via
+    // sudo), not the staging directory's own ownership -- explicit
+    // -E root_owner=uid:gid is required to match the guest agent's
+    // actual identity.
+    expect(commands[0].args).toEqual(expect.arrayContaining([
+      '-E', `root_owner=${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`,
+    ]));
     await fs.rm(root, { recursive: true, force: true });
   });
 

--- a/src/microvm/workspace.ts
+++ b/src/microvm/workspace.ts
@@ -178,6 +178,20 @@ export class MicrovmWorkspaceImage {
       '-b', String(WORKSPACE_BLOCK_BYTES),
       '-N', String(inodeCount),
       '-d', imageRoot,
+      // mke2fs -d populates file/subdirectory contents (and their own
+      // metadata) from imageRoot, but the *filesystem's own root
+      // directory inode* is not one of those copied entries -- per
+      // mke2fs's own docs, its ownership defaults to whichever user
+      // actually runs mke2fs (root here, since this CLI is invoked via
+      // sudo), regardless of imageRoot's own mode/ownership. Left at
+      // that default (root:root, mode 0755), the non-root guest agent
+      // identity (config.uid/gid) can read but never write directly
+      // into the workspace mount root -- e.g. `printf x > .hidden`
+      // inside the guest's workspace fails with EACCES even though
+      // every file *inside* the image is correctly owned. Explicitly
+      // matching the guest agent's own identity here is what actually
+      // lets it write there.
+      '-E', `root_owner=${this.config.uid}:${this.config.gid}`,
       this.workspaceImagePath,
       String(imageBytes / WORKSPACE_BLOCK_BYTES),
     ]);


### PR DESCRIPTION
## Stack layer 4 of 5 (Cloud Hypervisor PR stack)

- Layer 1: VMM-neutral `src/microvm/` primitives — #7212
- Layer 2: Cloud Hypervisor v53.0 configuration/artifact foundation — #7222
- Layer 3: Runnable Cloud Hypervisor microVM backend — #7225 (merged)
- **Layer 4 (this PR)**: Live-KVM CI, parity/security smoke coverage, and documentation for the Cloud Hypervisor preview
- Layer 5 (follow-up, not started): removes Firecracker

### What this adds

- `.github/workflows/test-cloud-hypervisor.yml`: a deterministic no-KVM guest-artifact build/verification job, plus a gated GitHub-hosted Ubuntu live-KVM job (`cloud-hypervisor-kvm` label / `workflow_dispatch`).
- `scripts/ci/cloud-hypervisor-host-preflight.sh`: fail-closed host preflight (GitHub-hosted-only eligibility, `/dev/kvm`, Landlock LSM, `setpriv`, digest verification).
- `scripts/ci/cloud-hypervisor-live-smoke.sh`: reproduces Firecracker's 13-case behavioral/security contract (allowed/blocked domains, direct egress, arbitrary TCP, DNS, metadata IP, mandatory API-proxy reflect with secret-sentinel absence, workspace copy-back incl. symlinks/permissions, exit-code propagation, timeout, SIGTERM cancellation, partial-start rollback, keep/preserve diagnostics) plus two Cloud-Hypervisor-specific cases (device assumptions, security/jailer-replacement assertions).
- Unit tests for the workflow/scripts.
- `docs/cloud-hypervisor-foundation.md`, `docs/INTEGRATION-TESTS.md`, `docs/awf-config-spec.md` updates covering the CI design, GitHub-hosted-only limitation, no-jailer vs. netns+setpriv+cgroup+Landlock+seccomp boundary, and troubleshooting for issues found via live validation.

### Real production bugs found via live-KVM validation and fixed here, each with a regression test

- **`guest/firecracker-supervisor/runtime_linux.go`**: `mountWorkspace()` passed an empty fstype to `syscall.Mount()` (only valid for bind/remount), causing `ENODEV` and a guest kernel panic (`Attempted to kill init!`) on every boot. This binary is shared, unmodified, by Firecracker and Cloud Hypervisor — a genuine pre-existing defect affecting both backends. Added a `go test` CI step so this class of bug is caught without a live boot.
- Internal guest-readiness probe used `curl`, absent from the BusyBox guest rootfs (exit 127) — switched to `nc -z`/`wget`.
- Nested-virtualization SMP pathology: a >1-vCPU guest's AP bring-up via IPIs hits a severe nested-KVM APIC-virtualization penalty on GitHub-hosted runners, stalling boot 90+s — smoke test pins `--cloud-hypervisor-vcpus 1`; also raised the vsock guest-ready retry budget.
- cgroup v2 `rmdir()` EBUSY teardown race left cgroup residue after a partial-start failure — added a bounded retry.
- Diagnostics-collection ordering/buffering (serial console output wasn't flushed until after process termination), Docker IPAM gateway tolerance, `nft -f -` stdin failure, CAP_NET_ADMIN retention, Landlock TAP sysfs rule — all found and fixed via live validation.

### Status

Local validation (`tsc`, build, full Jest, `bash -n`/shellcheck, Go `go test`) is green. Live-KVM CI has made major progress through this iteration but is not yet green end-to-end; see the PR checks and linked session for the current blocker (a Cloud-Hypervisor-specific guest→Squid TCP connectivity issue under investigation). Layer 5 (Firecracker removal) should not begin until this job passes.
