### PR TITLE
Fix stale Cloud Hypervisor and enclave test assertions

### DIFF
--- a/src/cloud-hypervisor/config.test.ts
+++ b/src/cloud-hypervisor/config.test.ts
@@ -120,9 +120,9 @@ describe('Cloud Hypervisor configuration (foundation only)', () => {
       .toContain('config.cloudHypervisor.unsupported is not supported');
   });
 
-  it('rejects "cloud-hypervisor" as a --container-runtime value (not yet an available runtime)', () => {
+  it('accepts "cloud-hypervisor" as a container runtime', () => {
     expect(validateAwfFileConfig({
       container: { containerRuntime: 'cloud-hypervisor' },
-    }).some((error) => error.includes('container.containerRuntime'))).toBe(true);
+    })).toEqual([]);
   });
 });

--- a/src/enclave/preflight.test.ts
+++ b/src/enclave/preflight.test.ts
@@ -250,7 +250,7 @@ describe('validateEnclavesConfig', () => {
       enableApiProxy: true,
       copilotGithubToken: 'token',
     })).join('\n');
-    expect(errors).toMatch(/agent.maxOutputBytes must be at most 8192/);
+    expect(errors).toMatch(/maxOutputBytes must be at most 8192/);
     expect(errors).toMatch(/agent.maxTaskBytes must be at most 65536/);
   });
 


### PR DESCRIPTION
## Summary

- update the Cloud Hypervisor config test to reflect that `cloud-hypervisor` is now a supported runtime value
- align the enclave output-limit assertion with the normalized shared `maxOutputBytes` error path

## Testing

- `npm test -- --runInBand src/cloud-hypervisor/config.test.ts src/enclave/preflight.test.ts`
- `npm test -- --runInBand` (306 suites, 4,855 tests)