### PR TITLE
fix: allow unprivileged Cloud Hypervisor preflight

### DIFF
--- a/src/cloud-hypervisor/preflight.test.ts
+++ b/src/cloud-hypervisor/preflight.test.ts
@@ -111,7 +111,6 @@ describe('Cloud Hypervisor preflight (foundation only)', () => {
 
   it('runs host policy and Docker probes through the default helper', async () => {
     const defaults = cloudHypervisorPreflightTestHelpers.defaultDependencies;
-    jest.spyOn(process, 'getuid').mockReturnValue(0);
     const access = jest.spyOn(fs, 'access').mockResolvedValue(undefined);
     await expect(defaults.assertHostPolicy()).resolves.toBe(2);
     expect(access).toHaveBeenCalledWith(
@@ -136,10 +135,11 @@ describe('Cloud Hypervisor preflight (foundation only)', () => {
     expect(statSpy).toHaveBeenCalledWith('/dev/kvm');
   });
 
-  it('reports host policy and Docker probe failures', async () => {
+  it('reports Docker probe failures without requiring root', async () => {
     const defaults = cloudHypervisorPreflightTestHelpers.defaultDependencies;
     jest.spyOn(process, 'getuid').mockReturnValue(1000);
-    await expect(defaults.assertHostPolicy()).rejects.toThrow(/requires root/);
+    jest.spyOn(fs, 'access').mockResolvedValue(undefined);
+    await expect(defaults.assertHostPolicy()).resolves.toBe(2);
 
     mockedExeca.mockResolvedValue({
       exitCode: 1,
@@ -152,7 +152,6 @@ describe('Cloud Hypervisor preflight (foundation only)', () => {
 
   it('rejects cgroup v1-only hosts explicitly instead of falling back', async () => {
     const defaults = cloudHypervisorPreflightTestHelpers.defaultDependencies;
-    jest.spyOn(process, 'getuid').mockReturnValue(0);
     jest.spyOn(fs, 'access').mockImplementation(async (target) => {
       if (target === '/sys/fs/cgroup/cgroup.controllers') {
         throw new Error('no cgroup v2');

--- a/src/cloud-hypervisor/preflight.ts
+++ b/src/cloud-hypervisor/preflight.ts
@@ -99,11 +99,6 @@ const defaultDependencies: CloudHypervisorPreflightDependencies = {
     throw new Error(`required trusted host tool "${tool}" was not found on PATH`);
   },
   assertHostPolicy: async () => {
-    if (process.getuid?.() !== 0) {
-      throw new Error(
-        'Cloud Hypervisor network setup requires root; invoke awf through sudo from a non-root account',
-      );
-    }
     try {
       await fs.access('/proc/sys/net/ipv4/ip_forward', constants.R_OK);
       await fs.access('/proc/sys/net/ipv6/conf/all/disable_ipv6', constants.R_OK);


### PR DESCRIPTION
## Summary

- remove the Cloud Hypervisor preflight hard UID-0 rejection
- continue validating kernel controls, cgroup v2, KVM access, trusted tools, and Docker infrastructure
- verify the host-policy probe succeeds for a non-root UID

## Motivation

AWF should not require its main process to run as root. Privileged host setup can be separated from AWF instead of enforcing `sudo awf` at preflight.

## Scope

This removes only the hard rejection. It does not grant non-root AWF the privileges needed by the current network/cgroup lifecycle; that setup must be delegated or prepared separately.

## Validation

- `npm test -- --runInBand src/cloud-hypervisor/preflight.test.ts`
- `npm run build`
- `npm run lint`