### PR TITLE
fix: complete gh-aw v0.87.0 upgrade

### DIFF
--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -58,9 +58,9 @@ jobs:
           persist-credentials: false
 
       - name: Install gh-aw
-        uses: github/gh-aw-actions/setup-cli@30aadb1626371455f145991c6385924babda2d04 # v0.86.3
+        uses: github/gh-aw-actions/setup-cli@b77e0d501fd2d2243d1f72722617e80d513f674e # v0.87.0
         with:
-          version: v0.86.3
+          version: v0.87.0
 
       - name: Compile + generate SBOMs (Syft)
         env:


### PR DESCRIPTION
## Summary

- update the supply-chain scan workflow's `setup-cli` action pin to the v0.87.0 SHA
- update its `gh-aw` version input from v0.86.3 to v0.87.0
- apply the review feedback left on #7411 after that PR was merged

Follow-up to #7411.

## Validation

- lint
- TypeScript build
- workflow diff check