### PR TITLE
Fix enclave manager gateway test fixture

### DIFF
--- a/src/enclave/manager.test.ts
+++ b/src/enclave/manager.test.ts
@@ -35,6 +35,7 @@ function enclaveEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     AWF_ENCLAVE_MCP_CAPABILITY: 'a'.repeat(64),
     AWF_ENCLAVE_MCP_GATEWAY_IDENTITY: 'test-run-identity',
     AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT: 'http://127.0.0.1:8080/mcp/awf-enclave',
+    MCP_GATEWAY_API_KEY: 'g'.repeat(48),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- add the required `MCP_GATEWAY_API_KEY` to the enclave manager test environment
- keep manager preflight tests aligned with the gateway handoff contract

## Testing

- `npm test -- --runInBand`