### PR TITLE
Fix Cloud Hypervisor guest loopback networking

### DIFF
--- a/guest/microvm-supervisor/runtime_linux.go
+++ b/guest/microvm-supervisor/runtime_linux.go
@@ -271,6 +271,7 @@ func configureNetwork(config bootConfig) error {
 func networkSetupCommands(config bootConfig) [][]string {
 	return [][]string{
 		{"link", "set", "dev", "lo", "up"},
+		{"address", "replace", "127.0.0.1/8", "dev", "lo"},
 		{"link", "set", "dev", config.Interface, "up"},
 		{"address", "replace", config.GuestIP.String() + fmt.Sprintf("/%d", config.GuestPrefix), "dev", config.Interface},
 		{"route", "replace", "default", "via", config.Gateway.String(), "dev", config.Interface},

--- a/guest/microvm-supervisor/runtime_linux_test.go
+++ b/guest/microvm-supervisor/runtime_linux_test.go
@@ -70,6 +70,7 @@ func TestNetworkSetupCommandsBringUpLoopbackFirst(t *testing.T) {
 	got := networkSetupCommands(config)
 	want := [][]string{
 		{"link", "set", "dev", "lo", "up"},
+		{"address", "replace", "127.0.0.1/8", "dev", "lo"},
 		{"link", "set", "dev", "eth0", "up"},
 		{"address", "replace", "100.64.0.2/30", "dev", "eth0"},
 		{"route", "replace", "default", "via", "100.64.0.1", "dev", "eth0"},

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -255,6 +255,8 @@ fi
 
 run_case blocked-domain 0 \
   '! wget -qO- https://github.com'
+run_case loopback-tcp 0 \
+  'out=/tmp/loopback-tcp; nc -l -p 3002 >"$out" & listener=$!; trap "kill $listener 2>/dev/null || true" EXIT; sleep 1; printf loopback-ok | nc -w 3 127.0.0.1 3002; wait "$listener"; trap - EXIT; grep -q loopback-ok "$out"'
 run_case direct-egress 0 \
   'unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ! wget -qO- https://example.com'
 run_case arbitrary-tcp 0 \

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -256,7 +256,7 @@ fi
 run_case blocked-domain 0 \
   '! wget -qO- https://github.com'
 run_case loopback-tcp 0 \
-  'out=/tmp/loopback-tcp; nc -l -p 3002 >"$out" & listener=$!; trap "kill $listener 2>/dev/null || true" EXIT; sleep 1; printf loopback-ok | nc -w 3 127.0.0.1 3002; wait "$listener"; trap - EXIT; grep -q loopback-ok "$out"'
+  'out=/tmp/loopback-tcp; timeout 10 nc -l -p 3002 >"$out" & listener=$!; trap "kill $listener 2>/dev/null || true" EXIT; sleep 1; printf loopback-ok | nc -w 3 127.0.0.1 3002; wait "$listener"; trap - EXIT; grep -q loopback-ok "$out"'
 run_case direct-egress 0 \
   'unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy; ! wget -qO- https://example.com'
 run_case arbitrary-tcp 0 \


### PR DESCRIPTION
## Summary

- assign `127.0.0.1/8` to the Cloud Hypervisor guest loopback interface
- cover the supervisor network setup command
- add a live KVM smoke case that starts and reaches a TCP listener over loopback

The minimal guest uses `awf-supervisor` as init, so bringing `lo` up does not assign the standard IPv4 loopback address. This caused the Copilot SDK server to report that it was listening on port 3002 while its harness timed out connecting to `127.0.0.1:3002`.

Fixes github/gh-aw#54193