### PR TITLE
feat: add Cloud Hypervisor filesystem write planner

### DIFF
--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -172,6 +172,22 @@ maps each guest path to the canonical host path beneath the deepest matching
 export, rejects `..`, missing paths, and symlink escapes, and classifies every
 export as unrestricted, read-only, fully writable, or selectively writable.
 
+Read-only enforcement is a host-side property. Each plan entry therefore carries
+two modes: `hostRootMode`, the mode the host backing tree root is staged with —
+the read-only bind that `virtiofsd.ts` already builds for read-only exports —
+and `guestMountMode`, the flags of the guest virtio-fs mount. A selectively
+writable export reports `hostRootMode: 'ro'` with `guestMountMode: 'rw'`:
+mounting a composite tree read-only in the guest would also block its writable
+nodes, because virtio-fs submounts are attached through `d_automount` and
+`finish_automount()` calls
+`do_add_mount(..., path->mnt->mnt_flags | MNT_SHRINKABLE)`, so an announced
+submount inherits `MNT_READONLY` from its parent mount. The host VFS, not the
+guest mount flag, denies writes outside the overlays.
+
+Overlay paths are absolute but canonical in different senses: `guestPath` is
+lexically normalized, while `hostPath` is realpath-canonical and verified not to
+escape the export source.
+
 The planner only removes write access: it never widens a read-only export and
 never introduces a host path that an existing read-write export does not
 already cover. It is pure policy planning and is not yet wired into runtime

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -164,6 +164,20 @@ Temporary microVM workspace data lives under:
 With `--keep-containers`, AWF preserves this directory, the network namespace,
 and runtime diagnostics for investigation.
 
+### Write-policy planning (inert)
+
+[`src/cloud-hypervisor/filesystem-write-policy.ts`](../src/cloud-hypervisor/filesystem-write-policy.ts)
+plans how a `filesystem.allowWrite` allowlist would narrow validated exports. It
+maps each guest path to the canonical host path beneath the deepest matching
+export, rejects `..`, missing paths, and symlink escapes, and classifies every
+export as unrestricted, read-only, fully writable, or selectively writable.
+
+The planner only removes write access: it never widens a read-only export and
+never introduces a host path that an existing read-write export does not
+already cover. It is pure policy planning and is not yet wired into runtime
+execution — `filesystem.allowWrite` is still rejected for the Cloud Hypervisor
+runtime by [`src/filesystem-policy.ts`](../src/filesystem-policy.ts).
+
 ## Limitations
 
 The preview rejects configurations that weaken or conflict with its boundary,

--- a/src/cloud-hypervisor/filesystem-write-policy.test.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.test.ts
@@ -76,6 +76,73 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
     expect(plan.exports[2].internal).toBe(true);
   });
 
+  describe('internal exports', () => {
+    let internalSource: string;
+    let withInternal: CloudHypervisorDirectoryExport[];
+
+    beforeEach(async () => {
+      internalSource = path.join(directory, 'internal');
+      await fs.mkdir(path.join(internalSource, 'cache'), { recursive: true });
+      withInternal = [
+        ...exports,
+        { tag: 'tmp-gh-aw', source: internalSource, target: '/tmp/gh-aw', mode: 'rw' },
+      ];
+    });
+
+    const plan = (allowWrite: string[]) =>
+      planCloudHypervisorFilesystemWrites(withInternal, allowWrite, {
+        internalTags: ['tmp-gh-aw'],
+      });
+
+    it('consumes an allowlist entry naming the internal export target exactly', () => {
+      const result = plan(['/tmp/gh-aw']);
+
+      expect(result.exports[2]).toEqual({
+        export: withInternal[2],
+        disposition: 'writable',
+        hostRootMode: 'rw',
+        guestMountMode: 'rw',
+        internal: true,
+        overlays: [],
+      });
+      expect(result.overlays).toEqual([]);
+      expect(result.exports[0].disposition).toBe('read-only');
+    });
+
+    it('consumes an existing nested path inside the internal export without an overlay', () => {
+      const result = plan(['/tmp/gh-aw/cache']);
+
+      expect(result.exports[2].disposition).toBe('writable');
+      expect(result.exports[2].overlays).toEqual([]);
+      expect(result.overlays).toEqual([]);
+    });
+
+    it('rejects a nested path that does not exist inside the internal export', () => {
+      expect(() => plan(['/tmp/gh-aw/missing'])).toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /tmp/gh-aw/missing',
+      );
+    });
+
+    it('rejects a strict ancestor of the internal export target', () => {
+      expect(() => plan(['/tmp'])).toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /tmp',
+      );
+    });
+
+    it('rejects a symlink that escapes the internal export source', async () => {
+      const outside = path.join(directory, 'internal-outside');
+      await fs.mkdir(outside);
+      await fs.symlink(outside, path.join(internalSource, 'escape'));
+
+      expect(() => plan(['/tmp/gh-aw/escape'])).toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /tmp/gh-aw/escape',
+      );
+    });
+  });
+
   it('keeps a whole export writable when its target is allowed', () => {
     const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace']);
 

--- a/src/cloud-hypervisor/filesystem-write-policy.test.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.test.ts
@@ -38,14 +38,16 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
       {
         export: exports[0],
         disposition: 'unrestricted',
-        effectiveMode: 'rw',
+        hostRootMode: 'rw',
+        guestMountMode: 'rw',
         internal: false,
         overlays: [],
       },
       {
         export: exports[1],
         disposition: 'unrestricted',
-        effectiveMode: 'ro',
+        hostRootMode: 'ro',
+        guestMountMode: 'ro',
         internal: false,
         overlays: [],
       },
@@ -64,11 +66,12 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
 
     expect(plan.restricted).toBe(true);
     expect(plan.overlays).toEqual([]);
-    expect(plan.exports.map((entry) => [entry.export.tag, entry.disposition, entry.effectiveMode]))
+    expect(plan.exports.map((entry) =>
+      [entry.export.tag, entry.disposition, entry.hostRootMode, entry.guestMountMode]))
       .toEqual([
-        ['workspace', 'read-only', 'ro'],
-        ['runner-tool-cache', 'read-only', 'ro'],
-        ['tmp-gh-aw', 'writable', 'rw'],
+        ['workspace', 'read-only', 'ro', 'ro'],
+        ['runner-tool-cache', 'read-only', 'ro', 'ro'],
+        ['tmp-gh-aw', 'writable', 'rw', 'rw'],
       ]);
     expect(plan.exports[2].internal).toBe(true);
   });
@@ -80,7 +83,8 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
     expect(plan.exports[0]).toEqual({
       export: exports[0],
       disposition: 'writable',
-      effectiveMode: 'rw',
+      hostRootMode: 'rw',
+      guestMountMode: 'rw',
       internal: false,
       overlays: [],
     });
@@ -92,7 +96,8 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
     const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace/nested/deep']);
 
     expect(plan.exports[0].disposition).toBe('selective');
-    expect(plan.exports[0].effectiveMode).toBe('ro');
+    expect(plan.exports[0].hostRootMode).toBe('ro');
+    expect(plan.exports[0].guestMountMode).toBe('rw');
     expect(plan.overlays).toEqual([
       {
         exportTag: 'workspace',
@@ -102,6 +107,25 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
         kind: 'directory',
       },
     ]);
+  });
+
+  it('keeps the guest mount read-write wherever a writable overlay exists', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace/nested/deep']);
+
+    // A guest-level MS_RDONLY would propagate to announced virtio-fs submounts
+    // (finish_automount passes the parent's mnt_flags), so read-only enforcement
+    // for a selective export must come from the host backing tree instead.
+    for (const entry of plan.exports) {
+      if (entry.overlays.length > 0) {
+        expect(entry.disposition).toBe('selective');
+        expect(entry.guestMountMode).toBe('rw');
+        expect(entry.hostRootMode).toBe('ro');
+      } else {
+        expect(entry.guestMountMode).toBe(entry.hostRootMode);
+      }
+      // A read-write host root is never published to a read-only guest mount.
+      expect(entry.hostRootMode === 'rw' && entry.guestMountMode === 'ro').toBe(false);
+    }
   });
 
   it('supports an existing file as an allowed path', () => {
@@ -195,7 +219,8 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
     expect(plan.exports[1]).toEqual({
       export: exports[1],
       disposition: 'read-only',
-      effectiveMode: 'ro',
+      hostRootMode: 'ro',
+      guestMountMode: 'ro',
       internal: false,
       overlays: [],
     });

--- a/src/cloud-hypervisor/filesystem-write-policy.test.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.test.ts
@@ -1,0 +1,271 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { CloudHypervisorDirectoryExport } from './exports';
+import { planCloudHypervisorFilesystemWrites } from './filesystem-write-policy';
+
+describe('Cloud Hypervisor filesystem write policy planner', () => {
+  let directory: string;
+  let workspaceSource: string;
+  let toolsSource: string;
+  let exports: CloudHypervisorDirectoryExport[];
+
+  beforeEach(async () => {
+    directory = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'ch-write-policy-')));
+    workspaceSource = path.join(directory, 'workspace');
+    toolsSource = path.join(directory, 'tools');
+    await fs.mkdir(path.join(workspaceSource, 'nested', 'deep'), { recursive: true });
+    await fs.mkdir(toolsSource, { recursive: true });
+    await fs.writeFile(path.join(workspaceSource, 'nested', 'file.txt'), 'data');
+    await fs.writeFile(path.join(toolsSource, 'tool.txt'), 'tool');
+    exports = [
+      { tag: 'workspace', source: workspaceSource, target: '/workspace', mode: 'rw' },
+      { tag: 'runner-tool-cache', source: toolsSource, target: '/tools', mode: 'ro' },
+    ];
+  });
+
+  afterEach(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+
+  it('preserves unrestricted per-export behavior when allowWrite is undefined', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, undefined);
+
+    expect(plan.restricted).toBe(false);
+    expect(plan.allowedPaths).toEqual([]);
+    expect(plan.overlays).toEqual([]);
+    expect(plan.exports).toEqual([
+      {
+        export: exports[0],
+        disposition: 'unrestricted',
+        effectiveMode: 'rw',
+        internal: false,
+        overlays: [],
+      },
+      {
+        export: exports[1],
+        disposition: 'unrestricted',
+        effectiveMode: 'ro',
+        internal: false,
+        overlays: [],
+      },
+    ]);
+  });
+
+  it('makes every writable non-internal export read-only for an empty allowlist', () => {
+    const withInternal = [
+      ...exports,
+      { tag: 'tmp-gh-aw', source: directory, target: '/tmp/gh-aw', mode: 'rw' as const },
+    ];
+
+    const plan = planCloudHypervisorFilesystemWrites(withInternal, [], {
+      internalTags: ['tmp-gh-aw'],
+    });
+
+    expect(plan.restricted).toBe(true);
+    expect(plan.overlays).toEqual([]);
+    expect(plan.exports.map((entry) => [entry.export.tag, entry.disposition, entry.effectiveMode]))
+      .toEqual([
+        ['workspace', 'read-only', 'ro'],
+        ['runner-tool-cache', 'read-only', 'ro'],
+        ['tmp-gh-aw', 'writable', 'rw'],
+      ]);
+    expect(plan.exports[2].internal).toBe(true);
+  });
+
+  it('keeps a whole export writable when its target is allowed', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace']);
+
+    expect(plan.allowedPaths).toEqual(['/workspace']);
+    expect(plan.exports[0]).toEqual({
+      export: exports[0],
+      disposition: 'writable',
+      effectiveMode: 'rw',
+      internal: false,
+      overlays: [],
+    });
+    expect(plan.exports[1].disposition).toBe('read-only');
+    expect(plan.overlays).toEqual([]);
+  });
+
+  it('narrows an export to a nested writable directory overlay', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace/nested/deep']);
+
+    expect(plan.exports[0].disposition).toBe('selective');
+    expect(plan.exports[0].effectiveMode).toBe('ro');
+    expect(plan.overlays).toEqual([
+      {
+        exportTag: 'workspace',
+        guestPath: '/workspace/nested/deep',
+        hostPath: path.join(workspaceSource, 'nested', 'deep'),
+        relativePath: 'nested/deep',
+        kind: 'directory',
+      },
+    ]);
+  });
+
+  it('supports an existing file as an allowed path', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace/nested/file.txt']);
+
+    expect(plan.overlays).toEqual([
+      {
+        exportTag: 'workspace',
+        guestPath: '/workspace/nested/file.txt',
+        hostPath: path.join(workspaceSource, 'nested', 'file.txt'),
+        relativePath: 'nested/file.txt',
+        kind: 'file',
+      },
+    ]);
+  });
+
+  it('translates guest paths to host source paths for non-identity targets', async () => {
+    const source = path.join(directory, 'exported');
+    await fs.mkdir(path.join(source, 'sub'), { recursive: true });
+    const plan = planCloudHypervisorFilesystemWrites(
+      [
+        { tag: 'workspace', source, target: '/workspace', mode: 'rw' },
+      ],
+      ['/workspace/sub'],
+    );
+
+    expect(plan.overlays).toEqual([
+      {
+        exportTag: 'workspace',
+        guestPath: '/workspace/sub',
+        hostPath: path.join(source, 'sub'),
+        relativePath: 'sub',
+        kind: 'directory',
+      },
+    ]);
+  });
+
+  it('normalizes duplicates and drops descendants covered by an ancestor', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, [
+      '/workspace/nested',
+      '/workspace/./nested/',
+      '/workspace/nested/deep',
+      '/workspace/nested/file.txt',
+    ]);
+
+    expect(plan.allowedPaths).toEqual(['/workspace/nested']);
+    expect(plan.overlays).toHaveLength(1);
+    expect(plan.overlays[0].guestPath).toBe('/workspace/nested');
+  });
+
+  it('rejects relative paths and paths containing ".."', () => {
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['workspace/nested']))
+      .toThrow("filesystem.allowWrite path must be absolute without '..': workspace/nested");
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/workspace/../etc']))
+      .toThrow("filesystem.allowWrite path must be absolute without '..': /workspace/../etc");
+  });
+
+  it('rejects a path that does not exist on the host', () => {
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/workspace/missing']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /workspace/missing',
+      );
+  });
+
+  it('rejects a symlink that escapes the export source', async () => {
+    const outside = path.join(directory, 'outside');
+    await fs.mkdir(outside);
+    await fs.symlink(outside, path.join(workspaceSource, 'escape'));
+
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/workspace/escape']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /workspace/escape',
+      );
+  });
+
+  it('never upgrades a read-only export', () => {
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/tools/tool.txt']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /tools/tool.txt',
+      );
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/tools']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /tools',
+      );
+
+    const plan = planCloudHypervisorFilesystemWrites(exports, ['/workspace/nested']);
+    expect(plan.exports[1]).toEqual({
+      export: exports[1],
+      disposition: 'read-only',
+      effectiveMode: 'ro',
+      internal: false,
+      overlays: [],
+    });
+  });
+
+  it('rejects a path outside every export target', () => {
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/elsewhere']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /elsewhere',
+      );
+  });
+
+  it('reports every unmatched path in one error', () => {
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/elsewhere', '/workspace/missing']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /elsewhere, /workspace/missing',
+      );
+  });
+
+  it('resolves overlapping exports to the deepest matching export', () => {
+    const nestedSource = path.join(workspaceSource, 'nested');
+    const overlapping: CloudHypervisorDirectoryExport[] = [
+      { tag: 'workspace', source: workspaceSource, target: '/workspace', mode: 'rw' },
+      { tag: 'nested', source: nestedSource, target: '/workspace/nested', mode: 'rw' },
+    ];
+
+    const plan = planCloudHypervisorFilesystemWrites(overlapping, ['/workspace/nested/deep']);
+
+    expect(plan.exports[0].disposition).toBe('read-only');
+    expect(plan.exports[1].disposition).toBe('selective');
+    expect(plan.overlays).toEqual([
+      {
+        exportTag: 'nested',
+        guestPath: '/workspace/nested/deep',
+        hostPath: path.join(nestedSource, 'deep'),
+        relativePath: 'deep',
+        kind: 'directory',
+      },
+    ]);
+  });
+
+  it('does not widen a deeper read-only export through a shallower writable one', () => {
+    const overlapping: CloudHypervisorDirectoryExport[] = [
+      { tag: 'workspace', source: workspaceSource, target: '/workspace', mode: 'rw' },
+      {
+        tag: 'nested',
+        source: path.join(workspaceSource, 'nested'),
+        target: '/workspace/nested',
+        mode: 'ro',
+      },
+    ];
+
+    expect(() => planCloudHypervisorFilesystemWrites(overlapping, ['/workspace/nested/deep']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /workspace/nested/deep',
+      );
+  });
+
+  it('collects multiple overlays for one export in allowlist order', () => {
+    const plan = planCloudHypervisorFilesystemWrites(exports, [
+      '/workspace/nested/deep',
+      '/workspace/nested/file.txt',
+    ]);
+
+    expect(plan.exports[0].disposition).toBe('selective');
+    expect(plan.exports[0].overlays.map((overlay) => overlay.guestPath))
+      .toEqual(['/workspace/nested/deep', '/workspace/nested/file.txt']);
+    expect(plan.overlays).toHaveLength(2);
+  });
+});

--- a/src/cloud-hypervisor/filesystem-write-policy.test.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.test.ts
@@ -226,6 +226,17 @@ describe('Cloud Hypervisor filesystem write policy planner', () => {
     });
   });
 
+  it('rejects an ancestor of an export target instead of widening the whole export', () => {
+    // `/` is above every export target, not an existing path reachable within
+    // one, so it must not be treated as a full-export match even though it is
+    // lexically "at or below" itself for every candidate target.
+    expect(() => planCloudHypervisorFilesystemWrites(exports, ['/']))
+      .toThrow(
+        'filesystem.allowWrite path is not an existing path within a writable ' +
+        'Cloud Hypervisor export: /',
+      );
+  });
+
   it('rejects a path outside every export target', () => {
     expect(() => planCloudHypervisorFilesystemWrites(exports, ['/elsewhere']))
       .toThrow(

--- a/src/cloud-hypervisor/filesystem-write-policy.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.ts
@@ -9,8 +9,8 @@ import type { CloudHypervisorDirectoryExport, CloudHypervisorExportMode } from '
  * - `unrestricted`: no policy was supplied, the declared export mode stands.
  * - `read-only`: the export is exposed read-only under the policy.
  * - `writable`: the whole export stays read-write.
- * - `selective`: the export itself is read-only, but the listed overlays below
- *   it must be re-exported read-write.
+ * - `selective`: the host backing tree is staged read-only outside the listed
+ *   overlays, which stay read-write.
  */
 export type CloudHypervisorExportWriteDisposition =
   | 'unrestricted'
@@ -19,16 +19,18 @@ export type CloudHypervisorExportWriteDisposition =
   | 'selective';
 
 /**
- * A canonical host/guest path pair that must stay writable inside an otherwise
- * read-only export. Both paths are absolute and fully resolved, so a later
- * integration can mount them directly without re-resolving symlinks.
+ * A host/guest path pair that must stay writable inside an otherwise read-only
+ * export. Both paths are absolute, but they are canonical in different senses:
+ * `guestPath` is only lexically normalized (the guest filesystem does not exist
+ * yet at planning time), while `hostPath` is realpath-canonical and verified not
+ * to escape the export source.
  */
 export interface CloudHypervisorWritableOverlay {
   /** Tag of the export this overlay is carved out of. */
   readonly exportTag: string;
-  /** Guest-visible absolute path that must be writable. */
+  /** Guest-visible absolute path that must be writable, lexically normalized. */
   readonly guestPath: string;
-  /** Canonical host path backing {@link guestPath}. */
+  /** Realpath-canonical host path backing {@link guestPath}. */
   readonly hostPath: string;
   /** Path of the overlay relative to the export target/source root. */
   readonly relativePath: string;
@@ -38,8 +40,25 @@ export interface CloudHypervisorWritableOverlay {
 export interface CloudHypervisorExportWritePlan {
   readonly export: CloudHypervisorDirectoryExport;
   readonly disposition: CloudHypervisorExportWriteDisposition;
-  /** Mode the export itself must be published with. */
-  readonly effectiveMode: CloudHypervisorExportMode;
+  /**
+   * Mode the host backing tree root must be staged with. `ro` means the host
+   * VFS — a read-only bind of the export source, as `virtiofsd.ts` already does
+   * for read-only exports — is what denies writes, independently of any guest
+   * mount flag.
+   */
+  readonly hostRootMode: CloudHypervisorExportMode;
+  /**
+   * Mode the guest virtio-fs mount must use.
+   *
+   * A `selective` export deliberately reports `rw` here while `hostRootMode` is
+   * `ro`. Mounting the composite tree read-only in the guest would also block
+   * the writable overlays: virtio-fs submounts are attached through
+   * `d_automount`, and `finish_automount()` calls
+   * `do_add_mount(..., path->mnt->mnt_flags | MNT_SHRINKABLE)`, so an announced
+   * submount inherits `MNT_READONLY` from its parent mount. Guest-side `ro` is
+   * therefore only correct when the whole export is read-only.
+   */
+  readonly guestMountMode: CloudHypervisorExportMode;
   /** True when the export is AWF-owned and stays writable under any policy. */
   readonly internal: boolean;
   /** Non-empty only when {@link disposition} is `selective`. */
@@ -91,7 +110,8 @@ export function planCloudHypervisorFilesystemWrites(
       exports: exports.map((entry) => ({
         export: entry,
         disposition: 'unrestricted',
-        effectiveMode: entry.mode,
+        hostRootMode: entry.mode,
+        guestMountMode: entry.mode,
         internal: internalTags.has(entry.tag),
         overlays: [],
       })),
@@ -107,20 +127,35 @@ export function planCloudHypervisorFilesystemWrites(
       return {
         export: entry,
         disposition: 'read-only',
-        effectiveMode: 'ro',
+        hostRootMode: 'ro',
+        guestMountMode: 'ro',
         internal,
         overlays: [],
       };
     }
     if (internal) {
-      return { export: entry, disposition: 'writable', effectiveMode: 'rw', internal, overlays: [] };
+      return {
+        export: entry,
+        disposition: 'writable',
+        hostRootMode: 'rw',
+        guestMountMode: 'rw',
+        internal,
+        overlays: [],
+      };
     }
 
     const overlays: CloudHypervisorWritableOverlay[] = [];
     for (const allowedPath of allowedPaths) {
       if (isPathAtOrBelow(entry.target, allowedPath)) {
         matched.add(allowedPath);
-        return { export: entry, disposition: 'writable', effectiveMode: 'rw', internal, overlays: [] };
+        return {
+          export: entry,
+          disposition: 'writable',
+          hostRootMode: 'rw',
+          guestMountMode: 'rw',
+          internal,
+          overlays: [],
+        };
       }
       if (!isDeepestWritableExport(exports, entry, allowedPath)) continue;
 
@@ -131,10 +166,14 @@ export function planCloudHypervisorFilesystemWrites(
       }
     }
 
+    // A selective export keeps a read-write guest mount so that writable
+    // overlays are not blocked by an inherited MNT_READONLY; the read-only host
+    // backing tree is what denies writes everywhere else.
     return {
       export: entry,
       disposition: overlays.length > 0 ? 'selective' : 'read-only',
-      effectiveMode: 'ro',
+      hostRootMode: 'ro',
+      guestMountMode: overlays.length > 0 ? 'rw' : 'ro',
       internal,
       overlays,
     };

--- a/src/cloud-hypervisor/filesystem-write-policy.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.ts
@@ -146,7 +146,11 @@ export function planCloudHypervisorFilesystemWrites(
 
     const overlays: CloudHypervisorWritableOverlay[] = [];
     for (const allowedPath of allowedPaths) {
-      if (isPathAtOrBelow(entry.target, allowedPath)) {
+      // Only an exact match against the export target keeps the whole export
+      // writable. A strict ancestor (e.g. `/` above `/workspace`) is not itself
+      // an existing path reachable within this export, so it must go through
+      // the same host-resolution as any other overlay candidate below.
+      if (allowedPath === entry.target) {
         matched.add(allowedPath);
         return {
           export: entry,

--- a/src/cloud-hypervisor/filesystem-write-policy.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.ts
@@ -1,0 +1,236 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { CloudHypervisorDirectoryExport, CloudHypervisorExportMode } from './exports';
+
+/**
+ * How a single Cloud Hypervisor directory export is affected by
+ * `filesystem.allowWrite`.
+ *
+ * - `unrestricted`: no policy was supplied, the declared export mode stands.
+ * - `read-only`: the export is exposed read-only under the policy.
+ * - `writable`: the whole export stays read-write.
+ * - `selective`: the export itself is read-only, but the listed overlays below
+ *   it must be re-exported read-write.
+ */
+export type CloudHypervisorExportWriteDisposition =
+  | 'unrestricted'
+  | 'read-only'
+  | 'writable'
+  | 'selective';
+
+/**
+ * A canonical host/guest path pair that must stay writable inside an otherwise
+ * read-only export. Both paths are absolute and fully resolved, so a later
+ * integration can mount them directly without re-resolving symlinks.
+ */
+export interface CloudHypervisorWritableOverlay {
+  /** Tag of the export this overlay is carved out of. */
+  readonly exportTag: string;
+  /** Guest-visible absolute path that must be writable. */
+  readonly guestPath: string;
+  /** Canonical host path backing {@link guestPath}. */
+  readonly hostPath: string;
+  /** Path of the overlay relative to the export target/source root. */
+  readonly relativePath: string;
+  readonly kind: 'directory' | 'file';
+}
+
+export interface CloudHypervisorExportWritePlan {
+  readonly export: CloudHypervisorDirectoryExport;
+  readonly disposition: CloudHypervisorExportWriteDisposition;
+  /** Mode the export itself must be published with. */
+  readonly effectiveMode: CloudHypervisorExportMode;
+  /** True when the export is AWF-owned and stays writable under any policy. */
+  readonly internal: boolean;
+  /** Non-empty only when {@link disposition} is `selective`. */
+  readonly overlays: readonly CloudHypervisorWritableOverlay[];
+}
+
+export interface CloudHypervisorFilesystemWritePlan {
+  /** False when `filesystem.allowWrite` was absent (`undefined`). */
+  readonly restricted: boolean;
+  /** Normalized allowlist with duplicates and covered descendants removed. */
+  readonly allowedPaths: readonly string[];
+  readonly exports: readonly CloudHypervisorExportWritePlan[];
+  /** Every overlay across all exports, in export order. */
+  readonly overlays: readonly CloudHypervisorWritableOverlay[];
+}
+
+export interface CloudHypervisorFilesystemWritePolicyOptions {
+  /**
+   * Tags of AWF-owned exports that must remain writable for the sandbox to
+   * operate. They are never narrowed, mirroring the always-writable Docker
+   * mounts.
+   */
+  readonly internalTags?: Iterable<string>;
+}
+
+/**
+ * Plans how `filesystem.allowWrite` narrows Cloud Hypervisor directory exports.
+ *
+ * The planner only ever removes write access: it never upgrades a read-only
+ * export and never exposes a host path that is not already reachable through an
+ * existing read-write export. `exports` is expected to already satisfy
+ * {@link validateCloudHypervisorExports}; overlapping targets are tolerated so
+ * that a future export layout resolves to the deepest matching export.
+ *
+ * This module is pure policy planning: it computes a plan and performs no
+ * mounting, launching, or other side effects.
+ */
+export function planCloudHypervisorFilesystemWrites(
+  exports: readonly CloudHypervisorDirectoryExport[],
+  allowWrite: string[] | undefined,
+  options: CloudHypervisorFilesystemWritePolicyOptions = {},
+): CloudHypervisorFilesystemWritePlan {
+  const internalTags = new Set(options.internalTags ?? []);
+
+  if (allowWrite === undefined) {
+    return {
+      restricted: false,
+      allowedPaths: [],
+      exports: exports.map((entry) => ({
+        export: entry,
+        disposition: 'unrestricted',
+        effectiveMode: entry.mode,
+        internal: internalTags.has(entry.tag),
+        overlays: [],
+      })),
+      overlays: [],
+    };
+  }
+
+  const allowedPaths = normalizeAllowedPaths(allowWrite);
+  const matched = new Set<string>();
+  const plans: CloudHypervisorExportWritePlan[] = exports.map((entry) => {
+    const internal = internalTags.has(entry.tag);
+    if (entry.mode !== 'rw') {
+      return {
+        export: entry,
+        disposition: 'read-only',
+        effectiveMode: 'ro',
+        internal,
+        overlays: [],
+      };
+    }
+    if (internal) {
+      return { export: entry, disposition: 'writable', effectiveMode: 'rw', internal, overlays: [] };
+    }
+
+    const overlays: CloudHypervisorWritableOverlay[] = [];
+    for (const allowedPath of allowedPaths) {
+      if (isPathAtOrBelow(entry.target, allowedPath)) {
+        matched.add(allowedPath);
+        return { export: entry, disposition: 'writable', effectiveMode: 'rw', internal, overlays: [] };
+      }
+      if (!isDeepestWritableExport(exports, entry, allowedPath)) continue;
+
+      const overlay = resolveWritableOverlay(entry, allowedPath);
+      if (overlay) {
+        matched.add(allowedPath);
+        overlays.push(overlay);
+      }
+    }
+
+    return {
+      export: entry,
+      disposition: overlays.length > 0 ? 'selective' : 'read-only',
+      effectiveMode: 'ro',
+      internal,
+      overlays,
+    };
+  });
+
+  const unmatched = allowedPaths.filter((allowedPath) => !matched.has(allowedPath));
+  if (unmatched.length > 0) {
+    throw new Error(
+      'filesystem.allowWrite path is not an existing path within a writable ' +
+      `Cloud Hypervisor export: ${unmatched.join(', ')}`,
+    );
+  }
+
+  return {
+    restricted: true,
+    allowedPaths,
+    exports: plans,
+    overlays: plans.flatMap((plan) => plan.overlays),
+  };
+}
+
+function normalizeAllowedPaths(allowWrite: readonly string[]): string[] {
+  for (const value of allowWrite) {
+    if (!path.posix.isAbsolute(value) || value.split('/').includes('..') || value.includes('\0')) {
+      throw new Error(`filesystem.allowWrite path must be absolute without '..': ${value}`);
+    }
+  }
+
+  const normalized = [...new Set(allowWrite.map(normalizeGuestPath))];
+  return normalized.filter((candidate) =>
+    !normalized.some((parent) => parent !== candidate && isPathAtOrBelow(candidate, parent))
+  );
+}
+
+/**
+ * Current export validation rejects overlapping targets, so at most one export
+ * matches today. The deepest-match rule keeps the planner correct if nested
+ * exports are ever introduced, and refuses to widen a nested read-only export.
+ */
+function isDeepestWritableExport(
+  exports: readonly CloudHypervisorDirectoryExport[],
+  entry: CloudHypervisorDirectoryExport,
+  allowedPath: string,
+): boolean {
+  const covering = exports.filter((candidate) => isPathAtOrBelow(allowedPath, candidate.target));
+  if (!covering.includes(entry)) return false;
+
+  const deepest = Math.max(...covering.map((candidate) => pathDepth(candidate.target)));
+  if (pathDepth(entry.target) !== deepest) return false;
+  return !covering.some(
+    (candidate) => pathDepth(candidate.target) === deepest && candidate.mode !== 'rw',
+  );
+}
+
+function resolveWritableOverlay(
+  entry: CloudHypervisorDirectoryExport,
+  allowedPath: string,
+): CloudHypervisorWritableOverlay | undefined {
+  const relativePath = path.posix.relative(entry.target, allowedPath);
+  if (relativePath === '') return undefined;
+
+  let realSourceRoot: string;
+  let realSource: string;
+  let stats: fs.Stats;
+  try {
+    realSourceRoot = fs.realpathSync(entry.source);
+    realSource = fs.realpathSync(path.join(entry.source, relativePath));
+    stats = fs.statSync(realSource);
+  } catch {
+    return undefined;
+  }
+
+  // Same invariant as the Docker policy: the allowlist may not escape the
+  // export source through a symlink anywhere below its root.
+  if (realSource !== path.resolve(realSourceRoot, relativePath)) return undefined;
+  if (!stats.isDirectory() && !stats.isFile()) return undefined;
+
+  return {
+    exportTag: entry.tag,
+    guestPath: allowedPath,
+    hostPath: realSource,
+    relativePath,
+    kind: stats.isDirectory() ? 'directory' : 'file',
+  };
+}
+
+function normalizeGuestPath(value: string): string {
+  const normalized = path.posix.normalize(value);
+  return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized;
+}
+
+function isPathAtOrBelow(candidate: string, parent: string): boolean {
+  const relative = path.posix.relative(parent, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.posix.isAbsolute(relative));
+}
+
+function pathDepth(value: string): number {
+  return value.split('/').filter(Boolean).length;
+}

--- a/src/cloud-hypervisor/filesystem-write-policy.ts
+++ b/src/cloud-hypervisor/filesystem-write-policy.ts
@@ -79,7 +79,9 @@ export interface CloudHypervisorFilesystemWritePolicyOptions {
   /**
    * Tags of AWF-owned exports that must remain writable for the sandbox to
    * operate. They are never narrowed, mirroring the always-writable Docker
-   * mounts.
+   * mounts. An allowlist entry that resolves inside such an export is still
+   * validated and consumed, so it is not reported as unmatched, but it produces
+   * no overlay because the whole export is already writable.
    */
   readonly internalTags?: Iterable<string>;
 }
@@ -133,7 +135,21 @@ export function planCloudHypervisorFilesystemWrites(
         overlays: [],
       };
     }
+    // An internal export stays fully writable, but it still consumes allowlist
+    // entries it covers so they are not misreported as unmatched. As above, only
+    // an exact target match is taken directly; a nested path goes through the
+    // same existence/realpath validation as a normal overlay. The resolved
+    // overlay is discarded because the whole export is already writable.
     if (internal) {
+      for (const allowedPath of allowedPaths) {
+        if (
+          allowedPath === entry.target ||
+          (isDeepestWritableExport(exports, entry, allowedPath) &&
+            resolveWritableOverlay(entry, allowedPath) !== undefined)
+        ) {
+          matched.add(allowedPath);
+        }
+      }
       return {
         export: entry,
         disposition: 'writable',


### PR DESCRIPTION
## Summary

Adds a pure, strongly typed **policy-planning foundation** for `filesystem.allowWrite` on the Cloud Hypervisor runtime. This PR is **inert**: nothing is wired into runtime execution, `src/cloud-hypervisor/virtiofsd.ts` is untouched, and `filesystem.allowWrite` is still rejected for the Cloud Hypervisor runtime by `src/filesystem-policy.ts`. **No behavior change.**

New module: `src/cloud-hypervisor/filesystem-write-policy.ts`

```ts
planCloudHypervisorFilesystemWrites(
  exports: readonly CloudHypervisorDirectoryExport[],
  allowWrite: string[] | undefined,
  options?: { internalTags?: Iterable<string> },
): CloudHypervisorFilesystemWritePlan
```

## Semantics

- `undefined` → `restricted: false`, every export keeps its declared mode (`disposition: 'unrestricted'`).
- `[]` → every writable non-internal export becomes read-only; AWF-owned exports named in `internalTags` stay writable (mirrors the always-writable Docker mounts).
- Each allowed path must be absolute, normalized, free of `..`, exist on the host, and resolve beneath an existing **read-write** export target.
- Narrowing only: a read-only export is never upgraded and no host path outside an existing rw export is ever exposed.
- Guest → host translation uses the export-target-relative path against the export source.
- Symlink escapes are rejected with the same realpath-equality invariant used by `src/services/agent-volumes/filesystem-write-policy.ts`.
- Existing files and directories are both supported (`kind: 'file' | 'directory'`).
- Duplicates are normalized (including trailing slashes) and descendants of an allowed ancestor are dropped.
- Only an **exact** match against an export target keeps the whole export writable. A strict ancestor (e.g. `/` above `/workspace`) is not itself a path reachable within the export, so it goes through the same host resolution as any other candidate and is rejected if it does not resolve.
- Entries covered by an **internal** (`internalTags`) read-write export are validated and consumed rather than reported as unmatched, but emit no overlay because the whole export is already writable. A nested internal path still passes the same existence / realpath-equality / file-or-directory checks, so `/tmp/gh-aw/missing` or a symlink escape under an internal export is still rejected.
- Overlapping exports resolve to the deepest matching export; a deeper read-only export is not widened through a shallower writable one. Current export validation forbids overlap, so this is forward-compatibility only.
- Errors match the existing `filesystem.allowWrite` wording: `filesystem.allowWrite path must be absolute without '..': …` and `filesystem.allowWrite path is not an existing path within a writable Cloud Hypervisor export: …` (all unmatched paths reported at once).

## Host root mode vs guest mount mode

Read-only enforcement for a selectively writable export is a **host-side** property, so each plan entry carries two modes rather than one:

| disposition | `hostRootMode` | `guestMountMode` |
| --- | --- | --- |
| `unrestricted` | declared export mode | declared export mode |
| `read-only` | `ro` | `ro` |
| `writable` | `rw` | `rw` |
| `selective` | `ro` | **`rw`** |

A `selective` export must not be mounted read-only in the guest. virtio-fs submounts are attached through `d_automount` → `fuse_dentry_automount()` → `fc_mount()` → `finish_automount()`, and `finish_automount()` calls:

```c
err = do_add_mount(mnt, mp, path, path->mnt->mnt_flags | MNT_SHRINKABLE);
```

(`fs/namespace.c`) — the announced submount inherits the **parent mount's** `mnt_flags`, including `MNT_READONLY`. (`fs_context_for_submount()` passes `sb_flags = 0`, so the submount superblock is not `SB_RDONLY`, but the inherited per-mount `MNT_READONLY` still denies writes.) A guest-level `MS_RDONLY` on a composite tree would therefore block writes to every writable node beneath it. The read-only host backing tree root — the same host-side read-only bind `virtiofsd.ts` already builds for `ro` exports — is what denies writes outside the overlays.

## Output shape

A later integration PR can distinguish the cases and get the paths directly:

- `CloudHypervisorExportWritePlan`: `disposition` (`unrestricted` | `read-only` | `writable` | `selective`), `hostRootMode`, `guestMountMode`, `internal`, `overlays`.
- `CloudHypervisorWritableOverlay`: `exportTag`, `guestPath`, `hostPath`, `relativePath`, `kind`. Both paths are absolute, but canonical in different senses — `guestPath` is only **lexically normalized** (the guest filesystem does not exist at planning time), while `hostPath` is **realpath-canonical** and verified not to escape the export source.
- `CloudHypervisorFilesystemWritePlan`: `restricted`, normalized `allowedPaths`, per-export `exports`, and a flattened `overlays` list.

## Tests

`src/cloud-hypervisor/filesystem-write-policy.test.ts` — 22 focused cases covering: undefined, empty list, internal tag exemption, full-export allowance, strict-ancestor rejection, nested directory, existing file, source/target translation, duplicate/descendant normalization, relative and `..` rejection, nonexistent path, symlink escape, read-only export (both target and nested path), unmatched path, multi-path error aggregation, deepest-export resolution, deeper-ro non-widening, multiple overlays per export, and the host-root/guest-mount mode invariant (an overlay-bearing export is always `hostRootMode: 'ro'` + `guestMountMode: 'rw'`, and a `rw` host root is never published to a `ro` guest mount).

An `internal exports` block covers the internal cases specifically: exact internal target, valid nested internal path (consumed, no overlay), missing nested internal path (rejected), strict ancestor of the internal target (rejected), and symlink escape under the internal export (rejected).

## Validation

- `npx jest src/cloud-hypervisor` → 13 suites, 172 tests passed
- `npm test` → 316 suites, 4989 tests passed
- `npm run build` (tsc) → clean
- `npx eslint` on the new files → 0 errors (only the pre-existing `security/detect-non-literal-fs-filename` warnings that the sibling Docker policy module also emits)

## Docs

`docs/cloud-hypervisor-foundation.md` gains a "Write-policy planning (inert)" subsection describing the planner, the host-VFS enforcement rationale for the two modes, and the path-canonicality distinction.
