### PR TITLE
fix: make Cloud Hypervisor writable overlays privately propagated

### DIFF
--- a/src/cloud-hypervisor/mount-tree.test.ts
+++ b/src/cloud-hypervisor/mount-tree.test.ts
@@ -64,7 +64,15 @@ function mountTable(options: { ineffectiveRemount?: boolean; shared?: boolean } 
       return;
     }
     if (args[0] === '--bind') {
-      table.set(args[2], { options: ['rw', 'relatime'], optionalFields: [] });
+      // A new bind mount joins the *source's* peer group, so binding from a
+      // shared host mount yields a shared mount even when the destination's
+      // parent is already private. Modelling that is what makes the overlay's
+      // explicit `--make-rprivate` observable here instead of only on a real
+      // kernel.
+      table.set(args[2], {
+        options: ['rw', 'relatime'],
+        optionalFields: options.shared === false ? [] : ['shared:23'],
+      });
       return;
     }
     if (args[0] === '--make-rprivate') {
@@ -275,6 +283,7 @@ describe('StagedHostMountTree', () => {
     await staged.stage();
     expect(fake.commands.slice(4)).toEqual([
       [tools.mount, '--bind', '/host/workspace/out', `${ROOT}/out`],
+      [tools.mount, '--make-rprivate', `${ROOT}/out`],
       [tools.mount, '-o', 'remount,bind,rw,nosuid,nodev', `${ROOT}/out`],
       [
         tools.mount,
@@ -282,6 +291,7 @@ describe('StagedHostMountTree', () => {
         '/host/workspace/deep/nested/state.json',
         `${ROOT}/deep/nested/state.json`,
       ],
+      [tools.mount, '--make-rprivate', `${ROOT}/deep/nested/state.json`],
       [
         tools.mount,
         '-o',
@@ -293,6 +303,26 @@ describe('StagedHostMountTree', () => {
     expect(fake.table.get(`${ROOT}/out`)?.options).toContain('nosuid');
     expect(fake.table.get(ROOT)?.options).toContain('ro');
     expect(fake.table.get(`${ROOT}/nested`)?.options).toContain('ro');
+  });
+
+  it('makes each writable overlay privately propagated so it cannot leak to the host', async () => {
+    // Regression: overlays were previously bound without being made private.
+    // A bind mount joins the source's peer group, so on any host where the
+    // workspace lives under a shared mount -- the default under systemd, and
+    // what GitHub-hosted runners provide -- every selective `allowWrite` run
+    // aborted with "Staged mount tree propagation would leak".
+    const fake = mountTable();
+    const staged = tree(
+      fake,
+      plan([
+        { source: '/host/workspace/out', destination: '/host/workspace/out', kind: 'directory' },
+      ]),
+    );
+    await expect(staged.stage()).resolves.toBeUndefined();
+    expect(fake.commands).toContainEqual([tools.mount, '--make-rprivate', `${ROOT}/out`]);
+    expect(fake.table.get(`${ROOT}/out`)?.optionalFields).toEqual([]);
+    expect(fake.table.get(`${ROOT}/out`)?.options).toContain('rw');
+    expect(fake.table.get(ROOT)?.options).toContain('ro');
   });
 
   it('unmounts children deepest-first and the staged root last', async () => {
@@ -315,7 +345,9 @@ describe('StagedHostMountTree', () => {
       ROOT,
     ]);
     await staged.unmount();
-    expect(fake.commands.slice(8)).toEqual([
+    // Sliced from the end so the assertion stays about unmount ordering rather
+    // than the exact number of staging commands that preceded it.
+    expect(fake.commands.slice(-3)).toEqual([
       [tools.umount, `${ROOT}/deep/nested/state.json`],
       [tools.umount, `${ROOT}/out`],
       [tools.umount, '-R', ROOT],

--- a/src/cloud-hypervisor/mount-tree.ts
+++ b/src/cloud-hypervisor/mount-tree.ts
@@ -266,6 +266,15 @@ export class StagedHostMountTree {
         overlay.stagedDestination,
       ]);
       this.pendingMounts.add(overlay.stagedDestination);
+      // A new bind mount joins the *source's* peer group, so an overlay bound
+      // from a shared host mount (the default for `/` under systemd, and what
+      // GitHub-hosted runners provide) arrives shared even though the staged
+      // root was already made private. Making the root private beforehand only
+      // covers mounts that existed at that point, so each overlay has to be
+      // made private in turn -- otherwise the writable overlay would propagate
+      // back into the host peer group and `assertPrivatePropagation()` would
+      // (correctly) refuse to stage the tree at all.
+      await dependencies.runTool(tools.mount, ['--make-rprivate', overlay.stagedDestination]);
       await dependencies.runTool(tools.mount, [
         '-o',
         WRITABLE_REMOUNT_OPTIONS,

--- a/src/cloud-hypervisor/virtiofsd.test.ts
+++ b/src/cloud-hypervisor/virtiofsd.test.ts
@@ -284,6 +284,7 @@ describe('VirtiofsdManager host mount-tree enforcement', () => {
       ['/usr/bin/mount', ['--make-rprivate', STAGED_ROOT]],
       ['/usr/bin/mount', ['-o', 'remount,bind,ro,nosuid,nodev', STAGED_ROOT]],
       ['/usr/bin/mount', ['--bind', '/host/workspace/out', `${STAGED_ROOT}/out`]],
+      ['/usr/bin/mount', ['--make-rprivate', `${STAGED_ROOT}/out`]],
       ['/usr/bin/mount', ['-o', 'remount,bind,rw,nosuid,nodev', `${STAGED_ROOT}/out`]],
     ]);
     expect(deps.mkdir).toHaveBeenCalledWith(STAGED_ROOT, { recursive: true, mode: 0o700 });


### PR DESCRIPTION
Fixes a defect in #7669 (merged as `664ffc1c`) that made selective `filesystem.allowWrite` fail on every real host. Found by the live-KVM job, which I triggered on #7669 via the `cloud-hypervisor-kvm` label.

## Symptom

The `allow-write` case aborts during VMM configuration, before the guest boots:

```
case allow-write: expected exit 0, got 1
[cloud-hypervisor] stage=vmm-configuration status=failed boot-attempt=1/3:
  Staged mount tree propagation would leak: /run/awf-cloud-hypervisor/virtiofsd/awf-16660-.../0-workspace/allowed has shared:1
    at assertPrivatePropagation (mount-tree.js:364)
    at StagedHostMountTree.assertOnlyOverlaysAreWritable (mount-tree.js:321)
    at StagedHostMountTree.stageWritableOverlays (mount-tree.js:203)
```

Run: https://github.com/github/gh-aw-firewall/actions/runs/32658105752

## Root cause

`stageReadonlyRoot()` applies `--make-rprivate` to the staged root, but that only covers mounts that exist *at that moment*. `stageWritableOverlays()` then creates **new** bind mounts — and a bind mount joins the **source's** peer group, not the destination parent's. Since the workspace lives under a shared mount on any systemd host (including GitHub-hosted runners), each overlay arrived `shared:N`, and `assertPrivatePropagation()` correctly refused to stage the tree.

The fail-closed check from #7661 was doing its job; the staging sequence was wrong. Reproduced on a real kernel:

```
root propagation: private
overlay propagation AFTER bind: shared
89 88 0:61 /ws/allowed /sim/root/allowed rw,relatime shared:4
```

## Fix

Make each overlay private immediately after binding it, before the writable remount. `--make-rprivate` is already required by `assertMountToolSupported()` (util-linux >= 2.23), so this adds no new tool requirement, and the overlay bind stays non-recursive.

## Why unit tests missed it

The fake mount table modelled `mount --bind` as producing an **already-private** mount, so the bug was invisible. This PR corrects the fake to model the kernel's real peer-group inheritance — which reproduces the exact production error (`has shared:23`) — and adds a named regression test.

Confirmed the test now actually catches it: removing the one-line fix fails 3 tests with the production error message; restoring it passes.

## Real-kernel verification

Simulated the exact staging sequence against a real kernel with a shared-mount workspace, covering all three dispositions:

| Case | Assertions | Behaviour |
|---|---|---|
| selective **directory** overlay | PASS | allowed write persists to host; sibling / truncate / rename / delete all denied |
| selective **file** overlay | PASS | file write persists to host; sibling create denied |
| fully read-only (zero overlays) | PASS | all writes denied |

Teardown (deepest-first, then `umount -R` root, matching `cleanupOrder()`) leaves **0 residual mounts** with the host tree intact.

## Validation

- `npx jest cloud-hypervisor` — 17 suites / **273 passed**
- Full `npx jest` — 319 suites / **5069 passed**
- `npm run type-check`, `npm run build` — clean
- `npx eslint src` — **0 errors**

## Live KVM: CONFIRMED PASSING

Triggered on this PR via the `cloud-hypervisor-kvm` label. The full 16-case suite passed on a real GitHub-hosted KVM runner:

```
Cloud Hypervisor live smoke/security suite passed.
```

Run: https://github.com/github/gh-aw-firewall/actions/runs/32659697061 (`Live Cloud Hypervisor KVM smoke/security` = success)

This covers the three `allowWrite` cases added in #7669 (`allow-write`, `allow-write-file`, `allow-write-none`) — the same `allow-write` case that failed before this fix — plus the namespace/cgroup/process residue checks.

Before this fix (on #7669's merged head): `case allow-write: expected exit 0, got 1`.

