### PR TITLE
Remove bounded-query terminology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ The system is orchestrated by `src/cli.ts` and managed by `src/docker-manager.ts
 - **[docs/logging_quickref.md](docs/logging_quickref.md)** - Quick reference for log queries and monitoring
 - **[docs/releasing.md](docs/releasing.md)** - Release process and versioning instructions
 - **[docs/INTEGRATION-TESTS.md](docs/INTEGRATION-TESTS.md)** - Integration test coverage guide with gap analysis
-- **[docs/enclaves-architecture.md](docs/enclaves-architecture.md)** - Unified enclave architecture, MCP gateway handoff, migration, and coverage notes
+- **[docs/enclaves-architecture.md](docs/enclaves-architecture.md)** - Unified enclave architecture, MCP gateway handoff, and coverage notes
 - **[docs/cloud-hypervisor-foundation.md](docs/cloud-hypervisor-foundation.md)** - Cloud Hypervisor v53.0 microVM backend (preview): REST API client, secure launcher (network-namespace join + privilege drop + Landlock/seccomp in place of a jailer), manager/backend, GitHub-hosted Ubuntu x86_64 KVM runners only
 
 ## Development Workflow

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -1870,22 +1870,7 @@ Script and agent calls debit the same live per-repository balance and share one 
 
 `enclave_run_agent` necessarily sends repository-derived content to the configured model provider through the dedicated API proxy. The ledger bounds what the **calling agent** learns; it does not bound what the **provider** sees.
 
-### 14.5 Migration and removed surfaces
-
-The legacy private-repository surfaces are **removed, not deprecated**:
-
-| Removed surface | Replacement |
-| --- | --- |
-| `boundedQueries` | an `enclaves` entry keyed by `script` with its `repos` list |
-| `boundedAgents` | an `enclaves` entry keyed by `agent` with its `repos` list |
-| `bounded-query` wrapper / generated skill | `enclave_run_script` |
-| `bounded-agent` wrapper / generated skill | `enclave_run_agent` |
-| Separate legacy ledgers | One shared ledger inside `enclave-mcp-server` |
-| Direct legacy runtime handoffs | Compiler-launched `gh-aw-mcpg` handoff only |
-
-Configuration authors MUST remove the old keys instead of carrying a mixed legacy/unified document.
-
-### 14.6 Validation coverage
+### 14.5 Validation coverage
 
 Legacy bounded smoke and runtime-matrix workflow assets have been removed from the owned surface. Until a unified gh-aw enclave smoke workflow exists, local coverage remains unit-focused:
 
@@ -1897,7 +1882,7 @@ Legacy bounded smoke and runtime-matrix workflow assets have been removed from t
 - `src/enclave/mcp-server.test.ts`
 - `src/enclave/agent-mcp-server.test.ts`
 
-See [Unified Enclave Architecture and Migration](enclaves-architecture.md) for the operator-facing summary.
+See [Unified Enclave Architecture](enclaves-architecture.md) for the operator-facing summary.
 
 ## Normative References
 

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -1,8 +1,8 @@
-# Unified Enclave Architecture and Migration
+# Unified Enclave Architecture
 
 ## Status
 
-Layer 5 removes the legacy bounded-query and bounded-agent surfaces. AWF now documents one `enclaves` subsystem, one AWF-owned MCP server, and mcpg-only access through the compiler handoff contract.
+Layer 5 establishes one `enclaves` subsystem, one AWF-owned MCP server, and mcpg-only access through the compiler handoff contract.
 
 ## Architecture
 
@@ -132,21 +132,6 @@ Only the existing finite-schema result, shared ledger debit, and timing bucket
 can return to the primary agent. Shutdown drains admissions, removes labelled
 enclaves, stops the PAT-free proxy, preserves private audit, disconnects
 compiler-owned mcpg, and then removes private state.
-
-## Migration and removals
-
-The following legacy surfaces are **removed, not deprecated**:
-
-| Removed surface | Replacement |
-| --- | --- |
-| `boundedQueries` config | an `enclaves` entry keyed by `script` with its `repos` list |
-| `boundedAgents` config | an `enclaves` entry keyed by `agent` with its `repos` list |
-| `bounded-query` wrapper / generated skill | `enclave_run_script` MCP tool |
-| `bounded-agent` wrapper / generated skill | `enclave_run_agent` MCP tool |
-| Separate per-subsystem ledgers | One shared per-repository ledger inside `enclave-mcp-server` |
-| Direct legacy runtime surfaces | Compiler-launched `gh-aw-mcpg` handoff only |
-
-Mixed legacy + unified configuration is no longer a compatibility mode. Tooling should remove the old keys rather than carrying both.
 
 ## Coverage after legacy smoke removal
 

--- a/docs/sbx-integration.md
+++ b/docs/sbx-integration.md
@@ -100,7 +100,7 @@ network/lateral denial, PID/memory/CPU/disk/file-size enforcement, explicit
 guest mount targets, credential and cross-invocation isolation, canonical
 failure bytes, timing buckets, and interruption cleanup. See
 [AWF configuration spec §14](awf-config-spec.md#14-unified-enclaves) and
-[Unified Enclave Architecture and Migration](enclaves-architecture.md).
+[Unified Enclave Architecture](enclaves-architecture.md).
 
 ## Part 2 — How AWF uses `sbx`
 

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -160,14 +160,6 @@ describe('awf-config.schema.json', () => {
     expect(validate({ unknown: true })).toBe(false);
   });
 
-  it.each([
-    `bounded${'Queries'}`,
-    `bounded${'Agents'}`,
-  ])('rejects removed configuration key %s', (removedKey) => {
-    expect(validate({ [removedKey]: { enabled: true } })).toBe(false);
-    expect(validate.errors).not.toBeNull();
-  });
-
   it('rejects unknown network fields', () => {
     expect(validate({ network: { unknownField: true } })).toBe(false);
   });


### PR DESCRIPTION
## Summary

- remove legacy bounded-query migration references from enclave documentation
- rename the enclave architecture document and update inbound references
- remove the schema regression test that encoded removed legacy configuration names

## Validation

- `npm test -- --runInBand src/schema.test.ts`
- commit hooks: lint and TypeScript build