### PR TITLE
feat: add internal Apple Container runtime primitives (stack layer 1)

### DIFF
--- a/src/apple-container/cli.test.ts
+++ b/src/apple-container/cli.test.ts
@@ -212,6 +212,16 @@ describe('AppleContainerCli.runChecked', () => {
     }
   });
 
+  it('redacts environment values from failing command diagnostics', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ exitCode: 1 }),
+    });
+
+    await expect(
+      cli.runChecked(['create', '--env', 'API_KEY=secret-value', 'image:latest']),
+    ).rejects.toThrow('"container create --env API_KEY=<redacted> image:latest"');
+  });
+
   it('describes a fatal signal when there was no timeout', async () => {
     const cli = new AppleContainerCli({
       spawn: async () => spawnResult({ exitCode: null, signal: 'SIGKILL' }),

--- a/src/apple-container/cli.test.ts
+++ b/src/apple-container/cli.test.ts
@@ -1,0 +1,238 @@
+import { constants as osConstants } from 'os';
+import {
+  APPLE_CONTAINER_DEFAULT_BINARY,
+  APPLE_CONTAINER_UNKNOWN_EXIT_CODE,
+  AppleContainerCli,
+  AppleContainerCliError,
+  exitCodeForSignal,
+  normalizeExitCode,
+  type AppleContainerSpawn,
+  type AppleContainerSpawnOptions,
+  type AppleContainerSpawnResult,
+} from './cli';
+
+function spawnResult(
+  overrides: Partial<AppleContainerSpawnResult> = {},
+): AppleContainerSpawnResult {
+  return { exitCode: 0, signal: null, stdout: '', stderr: '', timedOut: false, ...overrides };
+}
+
+interface RecordedCall {
+  binary: string;
+  args: readonly string[];
+  options: AppleContainerSpawnOptions;
+}
+
+function recordingSpawn(result: Partial<AppleContainerSpawnResult> = {}): {
+  spawn: AppleContainerSpawn;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const spawn: AppleContainerSpawn = async (binary, args, options) => {
+    calls.push({ binary, args, options });
+    return spawnResult(result);
+  };
+  return { spawn, calls };
+}
+
+describe('exitCodeForSignal', () => {
+  it('maps SIGTERM and SIGKILL to the 128 + signum convention', () => {
+    expect(exitCodeForSignal('SIGTERM')).toBe(128 + (osConstants.signals.SIGTERM as number));
+    expect(exitCodeForSignal('SIGKILL')).toBe(128 + (osConstants.signals.SIGKILL as number));
+  });
+
+  it('never reports success for an unrecognised signal', () => {
+    expect(exitCodeForSignal('SIGNOPE' as NodeJS.Signals)).toBe(APPLE_CONTAINER_UNKNOWN_EXIT_CODE);
+  });
+
+  it('does not treat inherited Object prototype keys as signals', () => {
+    expect(exitCodeForSignal('toString' as NodeJS.Signals)).toBe(
+      APPLE_CONTAINER_UNKNOWN_EXIT_CODE,
+    );
+  });
+});
+
+describe('normalizeExitCode', () => {
+  it('preserves a zero exit code', () => {
+    expect(normalizeExitCode(spawnResult({ exitCode: 0 }))).toBe(0);
+  });
+
+  it('preserves an arbitrary non-zero exit code', () => {
+    expect(normalizeExitCode(spawnResult({ exitCode: 137 }))).toBe(137);
+  });
+
+  it('prefers a real exit code over a reported signal', () => {
+    expect(normalizeExitCode(spawnResult({ exitCode: 3, signal: 'SIGTERM' }))).toBe(3);
+  });
+
+  it('falls back to the signal when there is no exit code', () => {
+    expect(normalizeExitCode(spawnResult({ exitCode: null, signal: 'SIGKILL' }))).toBe(
+      128 + (osConstants.signals.SIGKILL as number),
+    );
+  });
+
+  it('reports an unknown death as a failure rather than success', () => {
+    expect(normalizeExitCode(spawnResult({ exitCode: undefined, signal: undefined }))).toBe(
+      APPLE_CONTAINER_UNKNOWN_EXIT_CODE,
+    );
+  });
+});
+
+describe('AppleContainerCli.run', () => {
+  it('defaults to the "container" binary and forwards argv unchanged', async () => {
+    const { spawn, calls } = recordingSpawn();
+    const cli = new AppleContainerCli({ spawn });
+
+    const result = await cli.run(['system', 'status', '--format', 'json']);
+
+    expect(cli.binary).toBe(APPLE_CONTAINER_DEFAULT_BINARY);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].binary).toBe('container');
+    expect(calls[0].args).toEqual(['system', 'status', '--format', 'json']);
+    expect(result.argv).toEqual(['container', 'system', 'status', '--format', 'json']);
+  });
+
+  it('honours a pinned binary path', async () => {
+    const { spawn, calls } = recordingSpawn();
+    const cli = new AppleContainerCli({ spawn, binary: '/usr/local/bin/container' });
+
+    await cli.run(['--version']);
+
+    expect(calls[0].binary).toBe('/usr/local/bin/container');
+  });
+
+  it('applies constructor defaults to spawn options', async () => {
+    const { spawn, calls } = recordingSpawn();
+    const cli = new AppleContainerCli({
+      spawn,
+      cwd: '/work',
+      env: { PATH: '/bin' },
+      timeoutMs: 1_000,
+      killSignal: 'SIGKILL',
+    });
+
+    await cli.run(['list']);
+
+    expect(calls[0].options).toMatchObject({
+      cwd: '/work',
+      env: { PATH: '/bin' },
+      timeoutMs: 1_000,
+      killSignal: 'SIGKILL',
+    });
+  });
+
+  it('lets per-call overrides win over constructor defaults', async () => {
+    const { spawn, calls } = recordingSpawn();
+    const cli = new AppleContainerCli({ spawn, timeoutMs: 1_000, cwd: '/work' });
+
+    await cli.run(['list'], { timeoutMs: 50, cwd: '/other', inheritStdio: true });
+
+    expect(calls[0].options).toMatchObject({
+      timeoutMs: 50,
+      cwd: '/other',
+      inheritStdio: true,
+    });
+  });
+
+  it('propagates a non-zero exit code without throwing', async () => {
+    const cli = new AppleContainerCli({ spawn: async () => spawnResult({ exitCode: 42 }) });
+
+    await expect(cli.run(['run'])).resolves.toMatchObject({ exitCode: 42, timedOut: false });
+  });
+
+  it('reports a timeout distinctly from an ordinary failure', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ exitCode: null, signal: 'SIGTERM', timedOut: true }),
+    });
+
+    const result = await cli.run(['run']);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.signal).toBe('SIGTERM');
+    expect(result.exitCode).toBe(128 + (osConstants.signals.SIGTERM as number));
+  });
+
+  it('normalises missing captured output to empty strings', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () =>
+        ({ exitCode: 0, signal: null, timedOut: false } as unknown as AppleContainerSpawnResult),
+    });
+
+    await expect(cli.run(['list'])).resolves.toMatchObject({ stdout: '', stderr: '' });
+  });
+
+  it('does not swallow a spawn rejection', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => {
+        throw new Error('spawn ENOENT');
+      },
+    });
+
+    await expect(cli.run(['--version'])).rejects.toThrow('spawn ENOENT');
+  });
+});
+
+describe('AppleContainerCli.runChecked', () => {
+  it('returns the result on success', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ stdout: 'ok' }),
+    });
+
+    await expect(cli.runChecked(['list'])).resolves.toMatchObject({ exitCode: 0, stdout: 'ok' });
+  });
+
+  it('throws an AppleContainerCliError that carries the failing result', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ exitCode: 2, stderr: 'no such container' }),
+    });
+
+    expect.assertions(4);
+    try {
+      await cli.runChecked(['inspect', 'missing']);
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppleContainerCliError);
+      const cliError = error as AppleContainerCliError;
+      expect(cliError.exitCode).toBe(2);
+      expect(cliError.result.argv).toEqual(['container', 'inspect', 'missing']);
+      expect(cliError.message).toContain('no such container');
+    }
+  });
+
+  it('describes a timeout in the error message and flags it', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ exitCode: null, signal: 'SIGTERM', timedOut: true }),
+    });
+
+    expect.assertions(2);
+    try {
+      await cli.runChecked(['image', 'pull', 'ubuntu:22.04']);
+    } catch (error) {
+      expect((error as AppleContainerCliError).message).toContain('timed out');
+      expect((error as AppleContainerCliError).timedOut).toBe(true);
+    }
+  });
+
+  it('describes a fatal signal when there was no timeout', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ exitCode: null, signal: 'SIGKILL' }),
+    });
+
+    await expect(cli.runChecked(['stop', 'abc'])).rejects.toThrow(/terminated by SIGKILL/);
+  });
+
+  it('falls back to stdout when stderr is empty', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => spawnResult({ exitCode: 1, stdout: 'apiserver is not running' }),
+    });
+
+    await expect(cli.runChecked(['system', 'status'])).rejects.toThrow(/apiserver is not running/);
+  });
+
+  it('still produces a message when there is no output at all', async () => {
+    const cli = new AppleContainerCli({ spawn: async () => spawnResult({ exitCode: 1 }) });
+
+    await expect(cli.runChecked(['list'])).rejects.toThrow(
+      '"container list" exited with code 1',
+    );
+  });
+});

--- a/src/apple-container/cli.ts
+++ b/src/apple-container/cli.ts
@@ -215,7 +215,7 @@ export class AppleContainerCli {
 }
 
 function describeFailure(result: AppleContainerCliResult): string {
-  const command = result.argv.join(' ');
+  const command = redactDiagnosticArgv(result.argv).join(' ');
   const cause = result.timedOut
     ? 'timed out'
     : result.signal
@@ -223,4 +223,14 @@ function describeFailure(result: AppleContainerCliResult): string {
       : `exited with code ${result.exitCode}`;
   const detail = result.stderr.trim() || result.stdout.trim();
   return detail ? `"${command}" ${cause}: ${detail}` : `"${command}" ${cause}`;
+}
+
+function redactDiagnosticArgv(argv: readonly string[]): string[] {
+  return argv.map((value, index) => {
+    if (index > 0 && argv[index - 1] === '--env') {
+      const separator = value.indexOf('=');
+      return separator >= 0 ? `${value.slice(0, separator)}=<redacted>` : '<redacted>';
+    }
+    return value;
+  });
 }

--- a/src/apple-container/cli.ts
+++ b/src/apple-container/cli.ts
@@ -1,0 +1,226 @@
+/**
+ * Argv-only adapter for the Apple `container` CLI.
+ *
+ * Invariants this module exists to hold:
+ *
+ * - **No shell, ever.** Commands are always `(binary, argv[])`; no string
+ *   command is ever constructed, so there is nothing for a metacharacter to
+ *   escape into.
+ * - **Exit status is never invented.** A non-zero exit or a fatal signal is
+ *   reported faithfully. `run` returns the status, `runChecked` throws with it
+ *   attached, and neither ever substitutes a success-shaped result. This
+ *   matters because the agent's exit code is propagated to the caller of `awf`.
+ * - **Timeouts are visible.** A killed-on-timeout process is reported with
+ *   `timedOut: true` rather than being flattened into an ordinary failure, so a
+ *   later layer can tell "the agent failed" apart from "we cut the agent off".
+ *
+ * The spawn seam is injected so every branch is unit-testable without a Mac and
+ * without spawning real processes.
+ */
+
+import { constants as osConstants } from 'os';
+import execa from 'execa';
+
+/** Default CLI binary; resolved from PATH unless a caller pins an absolute path. */
+export const APPLE_CONTAINER_DEFAULT_BINARY = 'container';
+
+/** Exit code reported when a process died without an exit code or a signal. */
+export const APPLE_CONTAINER_UNKNOWN_EXIT_CODE = -1;
+
+export interface AppleContainerSpawnOptions {
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly timeoutMs?: number;
+  readonly killSignal?: NodeJS.Signals;
+  /**
+   * When true the child inherits the parent's stdio, which is what foreground
+   * agent execution needs. Captured `stdout`/`stderr` are then empty by
+   * definition, and callers must not treat that emptiness as "no output".
+   */
+  readonly inheritStdio?: boolean;
+  /** Only meaningful when `inheritStdio` is false. */
+  readonly stdin?: 'ignore' | 'pipe';
+}
+
+/** Normalised spawn outcome; the only shape the adapter consumes. */
+export interface AppleContainerSpawnResult {
+  readonly exitCode: number | null | undefined;
+  readonly signal: NodeJS.Signals | null | undefined;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+}
+
+export type AppleContainerSpawn = (
+  binary: string,
+  args: readonly string[],
+  options: AppleContainerSpawnOptions,
+) => Promise<AppleContainerSpawnResult>;
+
+export interface AppleContainerCliResult {
+  /** Full argv including the binary, for logging and test assertions. */
+  readonly argv: readonly string[];
+  readonly exitCode: number;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+}
+
+/** Raised by {@link AppleContainerCli.runChecked} for any non-zero exit. */
+export class AppleContainerCliError extends Error {
+  constructor(
+    message: string,
+    readonly result: AppleContainerCliResult,
+  ) {
+    super(message);
+    this.name = 'AppleContainerCliError';
+  }
+
+  get exitCode(): number {
+    return this.result.exitCode;
+  }
+
+  get timedOut(): boolean {
+    return this.result.timedOut;
+  }
+}
+
+export interface AppleContainerCliOptions {
+  readonly binary?: string;
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  /** Applied to every invocation unless overridden per call. */
+  readonly timeoutMs?: number;
+  readonly killSignal?: NodeJS.Signals;
+  readonly spawn?: AppleContainerSpawn;
+}
+
+/**
+ * Translates a fatal signal into the shell's `128 + signum` convention.
+ *
+ * Falls back to {@link APPLE_CONTAINER_UNKNOWN_EXIT_CODE} for an unrecognised
+ * signal name rather than to 0, so an unknown death can never be mistaken for
+ * success.
+ */
+export function exitCodeForSignal(signal: NodeJS.Signals): number {
+  const signals = osConstants.signals as unknown as Record<string, number | undefined>;
+  const signalNumber = Object.prototype.hasOwnProperty.call(signals, signal)
+    ? signals[signal]
+    : undefined;
+  return typeof signalNumber === 'number' ? 128 + signalNumber : APPLE_CONTAINER_UNKNOWN_EXIT_CODE;
+}
+
+/**
+ * Normalises a spawn outcome into a definite exit code.
+ *
+ * Order matters: an explicit numeric exit code always wins, because a process
+ * that exited normally after being sent a non-fatal signal still has a real
+ * status. Only when there is no exit code does the signal decide.
+ */
+export function normalizeExitCode(result: AppleContainerSpawnResult): number {
+  if (typeof result.exitCode === 'number') {
+    return result.exitCode;
+  }
+  if (result.signal) {
+    return exitCodeForSignal(result.signal);
+  }
+  return APPLE_CONTAINER_UNKNOWN_EXIT_CODE;
+}
+
+const defaultSpawn: AppleContainerSpawn = async (binary, args, options) => {
+  const stdio: execa.Options['stdio'] = options.inheritStdio
+    ? 'inherit'
+    : [options.stdin ?? 'ignore', 'pipe', 'pipe'];
+  // `binary` is the operator-configured `container` CLI path, never user
+  // command text, and every argument is a separate argv element with no shell.
+  // eslint-disable-next-line local/no-unsafe-execa
+  const result = await execa(binary, [...args], {
+    reject: false,
+    cwd: options.cwd,
+    env: options.env ? { ...options.env } : undefined,
+    extendEnv: options.env === undefined,
+    timeout: options.timeoutMs ?? 0,
+    killSignal: options.killSignal ?? 'SIGTERM',
+    stdio,
+    windowsHide: true,
+  });
+  return {
+    exitCode: result.exitCode,
+    signal: result.signal as NodeJS.Signals | undefined,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    timedOut: result.timedOut === true,
+  };
+};
+
+/** @internal Exposed so adapter tests can assert the real execa options. */
+export const appleContainerCliTestHelpers = { defaultSpawn };
+
+/**
+ * Stateless invoker for the `container` CLI.
+ *
+ * Holds no lifecycle state of its own; see `./lifecycle.ts` for the operations
+ * built on top of it.
+ */
+export class AppleContainerCli {
+  readonly binary: string;
+
+  private readonly spawn: AppleContainerSpawn;
+
+  constructor(private readonly options: AppleContainerCliOptions = {}) {
+    this.binary = options.binary ?? APPLE_CONTAINER_DEFAULT_BINARY;
+    this.spawn = options.spawn ?? defaultSpawn;
+  }
+
+  /** Runs the CLI and reports the outcome without throwing on failure. */
+  async run(
+    args: readonly string[],
+    overrides: AppleContainerSpawnOptions = {},
+  ): Promise<AppleContainerCliResult> {
+    const spawnOptions: AppleContainerSpawnOptions = {
+      cwd: overrides.cwd ?? this.options.cwd,
+      env: overrides.env ?? this.options.env,
+      timeoutMs: overrides.timeoutMs ?? this.options.timeoutMs,
+      killSignal: overrides.killSignal ?? this.options.killSignal,
+      inheritStdio: overrides.inheritStdio,
+      stdin: overrides.stdin,
+    };
+    const raw = await this.spawn(this.binary, args, spawnOptions);
+    return {
+      argv: [this.binary, ...args],
+      exitCode: normalizeExitCode(raw),
+      signal: raw.signal ?? null,
+      stdout: raw.stdout ?? '',
+      stderr: raw.stderr ?? '',
+      timedOut: raw.timedOut === true,
+    };
+  }
+
+  /**
+   * Runs the CLI and throws an {@link AppleContainerCliError} unless it exited
+   * 0. Use this for control-plane operations whose failure must abort the run;
+   * use {@link run} where the child's exit code is itself the answer.
+   */
+  async runChecked(
+    args: readonly string[],
+    overrides: AppleContainerSpawnOptions = {},
+  ): Promise<AppleContainerCliResult> {
+    const result = await this.run(args, overrides);
+    if (result.exitCode !== 0) {
+      throw new AppleContainerCliError(describeFailure(result), result);
+    }
+    return result;
+  }
+}
+
+function describeFailure(result: AppleContainerCliResult): string {
+  const command = result.argv.join(' ');
+  const cause = result.timedOut
+    ? 'timed out'
+    : result.signal
+      ? `was terminated by ${result.signal}`
+      : `exited with code ${result.exitCode}`;
+  const detail = result.stderr.trim() || result.stdout.trim();
+  return detail ? `"${command}" ${cause}: ${detail}` : `"${command}" ${cause}`;
+}

--- a/src/apple-container/diagnostics.test.ts
+++ b/src/apple-container/diagnostics.test.ts
@@ -137,6 +137,19 @@ describe('collectAppleContainerDiagnostics', () => {
     expect(calls[0].options.timeoutMs).toBe(APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS);
   });
 
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    'reports an invalid timeout (%p) without invoking the CLI',
+    async (timeoutMs) => {
+      const { cli, calls } = harness();
+      const diagnostics = await collectAppleContainerDiagnostics(cli, { timeoutMs });
+      expect(calls).toHaveLength(0);
+      expect(diagnostics.captures[0]).toMatchObject({
+        name: 'diagnostics-error.txt',
+        ok: false,
+      });
+    },
+  );
+
   it('records a failing capture without aborting the remaining captures', async () => {
     const { cli } = harness((args) =>
       args[0] === 'list'

--- a/src/apple-container/diagnostics.test.ts
+++ b/src/apple-container/diagnostics.test.ts
@@ -1,0 +1,212 @@
+import {
+  APPLE_CONTAINER_DEFAULT_LOG_LINES,
+  APPLE_CONTAINER_DEFAULT_LOG_WINDOW,
+  APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS,
+  buildAppleContainerLogsArgs,
+  buildAppleContainerSystemLogsArgs,
+  collectAppleContainerDiagnostics,
+} from './diagnostics';
+import {
+  AppleContainerCli,
+  type AppleContainerSpawn,
+  type AppleContainerSpawnOptions,
+  type AppleContainerSpawnResult,
+} from './cli';
+
+describe('buildAppleContainerLogsArgs', () => {
+  it('bounds output with the short-only -n flag', () => {
+    expect(buildAppleContainerLogsArgs('awf-agent')).toEqual([
+      'logs', '-n', String(APPLE_CONTAINER_DEFAULT_LOG_LINES), 'awf-agent',
+    ]);
+  });
+
+  it('requests the VM boot log before the bound and the ID', () => {
+    expect(buildAppleContainerLogsArgs('awf-agent', { boot: true, lines: 10 })).toEqual([
+      'logs', '--boot', '-n', '10', 'awf-agent',
+    ]);
+  });
+
+  it('never emits --follow, which would prevent collection from terminating', () => {
+    expect(buildAppleContainerLogsArgs('awf-agent')).not.toContain('--follow');
+    expect(buildAppleContainerLogsArgs('awf-agent')).not.toContain('-f');
+  });
+
+  it('rejects an unbounded or absurd line count', () => {
+    expect(() => buildAppleContainerLogsArgs('awf-agent', { lines: 0 })).toThrow(/1\.\.100000/);
+    expect(() => buildAppleContainerLogsArgs('awf-agent', { lines: 100_001 })).toThrow();
+  });
+
+  it('rejects an invalid container ID', () => {
+    expect(() => buildAppleContainerLogsArgs('-evil')).toThrow(/container ID/);
+  });
+});
+
+describe('buildAppleContainerSystemLogsArgs', () => {
+  it('uses a bounded default window', () => {
+    expect(buildAppleContainerSystemLogsArgs()).toEqual([
+      'system', 'logs', '--last', APPLE_CONTAINER_DEFAULT_LOG_WINDOW,
+    ]);
+  });
+
+  it('accepts an explicit window', () => {
+    expect(buildAppleContainerSystemLogsArgs('1h')).toEqual(['system', 'logs', '--last', '1h']);
+  });
+
+  it('never emits --follow', () => {
+    expect(buildAppleContainerSystemLogsArgs('2d')).not.toContain('--follow');
+  });
+
+  it('rejects a malformed window', () => {
+    expect(() => buildAppleContainerSystemLogsArgs('5 minutes')).toThrow(/log window/);
+  });
+});
+
+interface RecordedCall {
+  args: readonly string[];
+  options: AppleContainerSpawnOptions;
+}
+
+function harness(
+  respond: (args: readonly string[]) => Partial<AppleContainerSpawnResult> = () => ({}),
+): { cli: AppleContainerCli; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const spawn: AppleContainerSpawn = async (_binary, args, options) => {
+    calls.push({ args, options });
+    return {
+      exitCode: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      ...respond(args),
+    };
+  };
+  return { cli: new AppleContainerCli({ spawn }), calls };
+}
+
+describe('collectAppleContainerDiagnostics', () => {
+  it('collects host-scoped captures when no container exists', async () => {
+    const { cli, calls } = harness(() => ({ stdout: 'output' }));
+
+    const diagnostics = await collectAppleContainerDiagnostics(cli);
+
+    expect(diagnostics.captures.map((capture) => capture.name)).toEqual([
+      'system-status.json',
+      'containers.json',
+      'system.log',
+    ]);
+    expect(calls.map((call) => call.args)).toEqual([
+      ['system', 'status', '--format', 'json'],
+      ['list', '--all', '--format', 'json'],
+      ['system', 'logs', '--last', APPLE_CONTAINER_DEFAULT_LOG_WINDOW],
+    ]);
+  });
+
+  it('adds inspect, boot log and stdio log when a container ID is known', async () => {
+    const { cli, calls } = harness(() => ({ stdout: 'output' }));
+
+    const diagnostics = await collectAppleContainerDiagnostics(cli, {
+      containerId: 'awf-agent',
+      logLines: 50,
+      systemLogWindow: '1h',
+    });
+
+    expect(diagnostics.captures.map((capture) => capture.name)).toEqual([
+      'system-status.json',
+      'containers.json',
+      'system.log',
+      'container-inspect.json',
+      'container-boot.log',
+      'container-stdio.log',
+    ]);
+    expect(calls[3].args).toEqual(['inspect', 'awf-agent']);
+    expect(calls[4].args).toEqual(['logs', '--boot', '-n', '50', 'awf-agent']);
+    expect(calls[5].args).toEqual(['logs', '-n', '50', 'awf-agent']);
+    expect(calls[2].args).toEqual(['system', 'logs', '--last', '1h']);
+  });
+
+  it('bounds every capture with a timeout so teardown cannot hang', async () => {
+    const { cli, calls } = harness();
+    await collectAppleContainerDiagnostics(cli, { timeoutMs: 1_234 });
+    expect(calls.every((call) => call.options.timeoutMs === 1_234)).toBe(true);
+  });
+
+  it('applies a default timeout when none is supplied', async () => {
+    const { cli, calls } = harness();
+    await collectAppleContainerDiagnostics(cli);
+    expect(calls[0].options.timeoutMs).toBe(APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS);
+  });
+
+  it('records a failing capture without aborting the remaining captures', async () => {
+    const { cli } = harness((args) =>
+      args[0] === 'list'
+        ? { exitCode: 1, stderr: 'daemon unreachable' }
+        : { stdout: 'fine' },
+    );
+
+    const diagnostics = await collectAppleContainerDiagnostics(cli);
+
+    expect(diagnostics.captures).toHaveLength(3);
+    const list = diagnostics.captures.find((capture) => capture.name === 'containers.json');
+    expect(list).toMatchObject({ ok: false });
+    expect(list?.content).toContain('exit 1');
+    expect(list?.content).toContain('daemon unreachable');
+    expect(diagnostics.captures.filter((capture) => capture.ok)).toHaveLength(2);
+  });
+
+  it('notes a timed-out capture explicitly', async () => {
+    const { cli } = harness(() => ({ exitCode: null, signal: 'SIGTERM', timedOut: true }));
+
+    const diagnostics = await collectAppleContainerDiagnostics(cli);
+
+    expect(diagnostics.captures[0].content).toContain('timed out');
+    expect(diagnostics.captures[0].ok).toBe(false);
+  });
+
+  it('never throws when a spawn itself fails', async () => {
+    const cli = new AppleContainerCli({
+      spawn: async () => {
+        throw new Error('spawn ENOENT');
+      },
+    });
+
+    const diagnostics = await collectAppleContainerDiagnostics(cli);
+
+    expect(diagnostics.captures).toHaveLength(3);
+    expect(diagnostics.captures.every((capture) => !capture.ok)).toBe(true);
+    expect(diagnostics.captures[0].content).toContain('spawn ENOENT');
+    expect(diagnostics.captures[0].argv[0]).toBe('container');
+  });
+
+  it('reports a malformed diagnostics request instead of masking the original failure', async () => {
+    const { cli, calls } = harness();
+
+    const diagnostics = await collectAppleContainerDiagnostics(cli, { containerId: '-evil' });
+
+    expect(calls).toHaveLength(0);
+    expect(diagnostics.captures).toEqual([
+      expect.objectContaining({ name: 'diagnostics-error.txt', ok: false }),
+    ]);
+    expect(diagnostics.captures[0].content).toMatch(/container ID/);
+  });
+
+  it('merges stdout and stderr into the capture body', async () => {
+    const { cli } = harness(() => ({ stdout: 'out', stderr: 'err' }));
+    const diagnostics = await collectAppleContainerDiagnostics(cli);
+    expect(diagnostics.captures[0].content).toBe('out\nerr');
+  });
+
+  it('accepts plain CLI options instead of an instance', async () => {
+    const spawn: AppleContainerSpawn = async () => ({
+      exitCode: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+    });
+
+    const diagnostics = await collectAppleContainerDiagnostics({ spawn, binary: '/opt/container' });
+
+    expect(diagnostics.captures[0].argv[0]).toBe('/opt/container');
+  });
+});

--- a/src/apple-container/diagnostics.ts
+++ b/src/apple-container/diagnostics.ts
@@ -1,0 +1,168 @@
+/**
+ * Apple Container diagnostics collection.
+ *
+ * Apple Container is a VM-per-container runtime, so a failed agent has two
+ * distinct log surfaces that a Docker-shaped mental model does not cover:
+ * the guest's **boot log** (`container logs --boot`, i.e. kernel + init, which
+ * is where a VM that never reached the entrypoint fails) and the host
+ * **service log** (`container system logs`, which is where the daemon records
+ * why a VM was refused). Both are captured, plus a live inspect/list snapshot.
+ *
+ * Every capture is bounded (`-n` for container logs, `--last` for system logs)
+ * so a runaway guest cannot fill the host disk, and `--follow` is never used
+ * because collection must terminate.
+ *
+ * Collection is best-effort by design: it runs on a path where something has
+ * already gone wrong, and a diagnostics failure must never mask or replace the
+ * original error. Individual captures therefore record their own failure text
+ * instead of propagating, which is the one place in this module area where a
+ * broad catch is correct.
+ */
+
+import {
+  AppleContainerCli,
+  type AppleContainerCliOptions,
+} from './cli';
+import {
+  assertAppleContainerId,
+  assertAppleContainerLineCount,
+  assertAppleContainerLogWindow,
+} from './validation';
+
+/** Default number of trailing log lines captured per container log stream. */
+export const APPLE_CONTAINER_DEFAULT_LOG_LINES = 2_000;
+
+/** Default `container system logs --last` window. */
+export const APPLE_CONTAINER_DEFAULT_LOG_WINDOW = '15m';
+
+/** Timeout for a single diagnostics command; collection must not hang teardown. */
+export const APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS = 30_000;
+
+export interface AppleContainerLogOptions {
+  /** Trailing line bound; defaults to {@link APPLE_CONTAINER_DEFAULT_LOG_LINES}. */
+  readonly lines?: number;
+  /** Capture the VM boot log instead of the init process's stdio. */
+  readonly boot?: boolean;
+}
+
+/** Builds argv for `container logs`. Never emits `--follow`. */
+export function buildAppleContainerLogsArgs(
+  id: string,
+  options: AppleContainerLogOptions = {},
+): string[] {
+  const args = ['logs'];
+  if (options.boot) {
+    args.push('--boot');
+  }
+  // `-n` is short-only on this command; there is no `--tail`/`--lines` alias.
+  args.push('-n', String(assertAppleContainerLineCount(options.lines ?? APPLE_CONTAINER_DEFAULT_LOG_LINES)));
+  args.push(assertAppleContainerId(id));
+  return args;
+}
+
+/** Builds argv for `container system logs`. Never emits `--follow`. */
+export function buildAppleContainerSystemLogsArgs(
+  window: string = APPLE_CONTAINER_DEFAULT_LOG_WINDOW,
+): string[] {
+  return ['system', 'logs', '--last', assertAppleContainerLogWindow(window)];
+}
+
+/** One captured artifact. `ok: false` means the capture failed, not that the run failed. */
+export interface AppleContainerDiagnosticCapture {
+  readonly name: string;
+  readonly argv: readonly string[];
+  readonly ok: boolean;
+  readonly content: string;
+}
+
+export interface AppleContainerDiagnosticsOptions {
+  readonly logLines?: number;
+  readonly systemLogWindow?: string;
+  /** Omit the container-scoped captures when no container was ever created. */
+  readonly containerId?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface AppleContainerDiagnostics {
+  readonly captures: readonly AppleContainerDiagnosticCapture[];
+}
+
+/**
+ * Runs the diagnostics command set and returns every capture, successful or
+ * not. Never throws.
+ */
+export async function collectAppleContainerDiagnostics(
+  cli: AppleContainerCli | AppleContainerCliOptions = {},
+  options: AppleContainerDiagnosticsOptions = {},
+): Promise<AppleContainerDiagnostics> {
+  const invoker = cli instanceof AppleContainerCli ? cli : new AppleContainerCli(cli);
+  const timeoutMs = options.timeoutMs ?? APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS;
+
+  const planned: Array<{ name: string; args: string[] }> = [];
+  try {
+    planned.push({ name: 'system-status.json', args: ['system', 'status', '--format', 'json'] });
+    planned.push({ name: 'containers.json', args: ['list', '--all', '--format', 'json'] });
+    planned.push({
+      name: 'system.log',
+      args: buildAppleContainerSystemLogsArgs(options.systemLogWindow),
+    });
+    if (options.containerId !== undefined) {
+      const id = assertAppleContainerId(options.containerId);
+      planned.push({ name: 'container-inspect.json', args: ['inspect', id] });
+      planned.push({
+        name: 'container-boot.log',
+        args: buildAppleContainerLogsArgs(id, { lines: options.logLines, boot: true }),
+      });
+      planned.push({
+        name: 'container-stdio.log',
+        args: buildAppleContainerLogsArgs(id, { lines: options.logLines }),
+      });
+    }
+  } catch (error) {
+    // A malformed diagnostics request must not mask the failure being
+    // diagnosed, so the validation error is itself reported as a capture.
+    return {
+      captures: [
+        {
+          name: 'diagnostics-error.txt',
+          argv: [],
+          ok: false,
+          content: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+
+  const captures: AppleContainerDiagnosticCapture[] = [];
+  for (const step of planned) {
+    captures.push(await capture(invoker, step.name, step.args, timeoutMs));
+  }
+  return { captures };
+}
+
+async function capture(
+  cli: AppleContainerCli,
+  name: string,
+  args: readonly string[],
+  timeoutMs: number,
+): Promise<AppleContainerDiagnosticCapture> {
+  try {
+    const result = await cli.run(args, { timeoutMs });
+    const body = [result.stdout, result.stderr].filter((part) => part.trim().length > 0).join('\n');
+    return {
+      name,
+      argv: result.argv,
+      ok: result.exitCode === 0,
+      content: result.exitCode === 0
+        ? body
+        : `(exit ${result.exitCode}${result.timedOut ? ', timed out' : ''})\n${body}`,
+    };
+  } catch (error) {
+    return {
+      name,
+      argv: [cli.binary, ...args],
+      ok: false,
+      content: `(capture failed) ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/src/apple-container/diagnostics.ts
+++ b/src/apple-container/diagnostics.ts
@@ -97,7 +97,7 @@ export async function collectAppleContainerDiagnostics(
   options: AppleContainerDiagnosticsOptions = {},
 ): Promise<AppleContainerDiagnostics> {
   const invoker = cli instanceof AppleContainerCli ? cli : new AppleContainerCli(cli);
-  let timeoutMs = APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS;
+  let timeoutMs: number;
   const planned: Array<{ name: string; args: string[] }> = [];
   try {
     timeoutMs = assertAppleContainerTimeoutMs(

--- a/src/apple-container/diagnostics.ts
+++ b/src/apple-container/diagnostics.ts
@@ -27,6 +27,7 @@ import {
   assertAppleContainerId,
   assertAppleContainerLineCount,
   assertAppleContainerLogWindow,
+  assertAppleContainerTimeoutMs,
 } from './validation';
 
 /** Default number of trailing log lines captured per container log stream. */
@@ -96,10 +97,12 @@ export async function collectAppleContainerDiagnostics(
   options: AppleContainerDiagnosticsOptions = {},
 ): Promise<AppleContainerDiagnostics> {
   const invoker = cli instanceof AppleContainerCli ? cli : new AppleContainerCli(cli);
-  const timeoutMs = options.timeoutMs ?? APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS;
-
+  let timeoutMs = APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS;
   const planned: Array<{ name: string; args: string[] }> = [];
   try {
+    timeoutMs = assertAppleContainerTimeoutMs(
+      options.timeoutMs ?? APPLE_CONTAINER_DIAGNOSTICS_TIMEOUT_MS,
+    );
     planned.push({ name: 'system-status.json', args: ['system', 'status', '--format', 'json'] });
     planned.push({ name: 'containers.json', args: ['list', '--all', '--format', 'json'] });
     planned.push({

--- a/src/apple-container/host-facts.test.ts
+++ b/src/apple-container/host-facts.test.ts
@@ -1,0 +1,189 @@
+import {
+  APPLE_CONTAINER_HV_SUPPORT_SYSCTL,
+  APPLE_CONTAINER_MINIMUM_MACOS_MAJOR,
+  AppleContainerHostError,
+  assertAppleContainerHostEligibility,
+  collectAppleContainerHostFacts,
+  evaluateAppleContainerHostEligibility,
+  parseHypervisorSupport,
+  parseMacosMajorVersion,
+  type AppleContainerHostFacts,
+} from './host-facts';
+
+function facts(overrides: Partial<AppleContainerHostFacts> = {}): AppleContainerHostFacts {
+  return {
+    platform: 'darwin',
+    arch: 'arm64',
+    macosProductVersion: '26.1',
+    hypervisorSupported: true,
+    ...overrides,
+  };
+}
+
+describe('parseMacosMajorVersion', () => {
+  it.each([
+    ['26', 26],
+    ['26.1', 26],
+    ['26.1.1', 26],
+    [' 15.5 ', 15],
+  ])('parses %j as %p', (value, expected) => {
+    expect(parseMacosMajorVersion(value)).toBe(expected);
+  });
+
+  it.each(['', 'sonoma', '26.x', 'Version 26'])('throws on %j', (value) => {
+    expect(() => parseMacosMajorVersion(value)).toThrow(/Could not parse macOS product version/);
+  });
+});
+
+describe('parseHypervisorSupport', () => {
+  it('treats a literal 1 as supported', () => {
+    expect(parseHypervisorSupport('1\n')).toBe(true);
+  });
+
+  it.each(['0', '', 'yes', '11', 'true'])('treats %j as unsupported', (value) => {
+    expect(parseHypervisorSupport(value)).toBe(false);
+  });
+});
+
+describe('evaluateAppleContainerHostEligibility', () => {
+  it('accepts a supported host', () => {
+    expect(evaluateAppleContainerHostEligibility(facts())).toEqual({ eligible: true });
+  });
+
+  it('reports a non-Darwin platform first, before any other cause', () => {
+    const result = evaluateAppleContainerHostEligibility(
+      facts({ platform: 'linux', arch: 'x64', macosProductVersion: '', hypervisorSupported: false }),
+    );
+    expect(result).toMatchObject({ eligible: false, code: 'platform' });
+  });
+
+  it('rejects Intel macOS with an architecture cause', () => {
+    const result = evaluateAppleContainerHostEligibility(facts({ arch: 'x64' }));
+    expect(result).toMatchObject({ eligible: false, code: 'architecture' });
+    expect((result as { reason: string }).reason).toMatch(/Apple Silicon/);
+  });
+
+  it('rejects macOS older than the minimum', () => {
+    const result = evaluateAppleContainerHostEligibility(
+      facts({ macosProductVersion: `${APPLE_CONTAINER_MINIMUM_MACOS_MAJOR - 1}.6` }),
+    );
+    expect(result).toMatchObject({ eligible: false, code: 'macos-version' });
+    expect((result as { reason: string }).reason).toMatch(/25\.6/);
+  });
+
+  it('accepts a macOS version newer than the minimum', () => {
+    expect(
+      evaluateAppleContainerHostEligibility(
+        facts({ macosProductVersion: `${APPLE_CONTAINER_MINIMUM_MACOS_MAJOR + 1}.0` }),
+      ),
+    ).toEqual({ eligible: true });
+  });
+
+  it('reports an unparseable macOS version as a version failure rather than throwing', () => {
+    const result = evaluateAppleContainerHostEligibility(facts({ macosProductVersion: 'unknown' }));
+    expect(result).toMatchObject({ eligible: false, code: 'macos-version' });
+  });
+
+  it('rejects a host without Virtualization.framework support', () => {
+    const result = evaluateAppleContainerHostEligibility(facts({ hypervisorSupported: false }));
+    expect(result).toMatchObject({ eligible: false, code: 'hypervisor' });
+    const { reason } = result as { reason: string };
+    expect(reason).toContain(APPLE_CONTAINER_HV_SUPPORT_SYSCTL);
+    expect(reason).toMatch(/self-hosted bare-metal Apple Silicon runner/);
+  });
+});
+
+describe('assertAppleContainerHostEligibility', () => {
+  it('does not throw for a supported host', () => {
+    expect(() => assertAppleContainerHostEligibility(facts())).not.toThrow();
+  });
+
+  it('throws an AppleContainerHostError carrying the cause code', () => {
+    expect.assertions(2);
+    try {
+      assertAppleContainerHostEligibility(facts({ hypervisorSupported: false }));
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppleContainerHostError);
+      expect((error as AppleContainerHostError).code).toBe('hypervisor');
+    }
+  });
+});
+
+describe('collectAppleContainerHostFacts', () => {
+  it('short-circuits on a non-Darwin platform without spawning Darwin-only tools', async () => {
+    const readProductVersion = jest.fn();
+    const readHypervisorSupport = jest.fn();
+
+    const result = await collectAppleContainerHostFacts({
+      platform: 'linux',
+      arch: 'x64',
+      readProductVersion,
+      readHypervisorSupport,
+    });
+
+    expect(result).toEqual({
+      platform: 'linux',
+      arch: 'x64',
+      macosProductVersion: '',
+      hypervisorSupported: false,
+    });
+    expect(readProductVersion).not.toHaveBeenCalled();
+    expect(readHypervisorSupport).not.toHaveBeenCalled();
+  });
+
+  it('collects and trims probe output on Darwin', async () => {
+    const result = await collectAppleContainerHostFacts({
+      platform: 'darwin',
+      arch: 'arm64',
+      readProductVersion: async () => '26.1.1\n',
+      readHypervisorSupport: async () => '1\n',
+    });
+
+    expect(result).toEqual({
+      platform: 'darwin',
+      arch: 'arm64',
+      macosProductVersion: '26.1.1',
+      hypervisorSupported: true,
+    });
+  });
+
+  it('maps a sw_vers failure to a macos-version host error', async () => {
+    const promise = collectAppleContainerHostFacts({
+      platform: 'darwin',
+      arch: 'arm64',
+      readProductVersion: async () => {
+        throw new Error('spawn ENOENT');
+      },
+      readHypervisorSupport: async () => '1',
+    });
+
+    await expect(promise).rejects.toThrow(/Could not determine the macOS version.*spawn ENOENT/);
+    await expect(promise).rejects.toMatchObject({ code: 'macos-version' });
+  });
+
+  it('maps a sysctl failure to a hypervisor host error', async () => {
+    const promise = collectAppleContainerHostFacts({
+      platform: 'darwin',
+      arch: 'arm64',
+      readProductVersion: async () => '26.0',
+      readHypervisorSupport: async () => {
+        throw new Error('unknown oid');
+      },
+    });
+
+    await expect(promise).rejects.toThrow(new RegExp(APPLE_CONTAINER_HV_SUPPORT_SYSCTL));
+    await expect(promise).rejects.toMatchObject({ code: 'hypervisor' });
+  });
+
+  it('records an unsupported hypervisor rather than throwing', async () => {
+    const result = await collectAppleContainerHostFacts({
+      platform: 'darwin',
+      arch: 'arm64',
+      readProductVersion: async () => '26.0',
+      readHypervisorSupport: async () => '0',
+    });
+
+    expect(result.hypervisorSupported).toBe(false);
+    expect(evaluateAppleContainerHostEligibility(result)).toMatchObject({ code: 'hypervisor' });
+  });
+});

--- a/src/apple-container/host-facts.test.ts
+++ b/src/apple-container/host-facts.test.ts
@@ -145,6 +145,35 @@ describe('collectAppleContainerHostFacts', () => {
       macosProductVersion: '26.1.1',
       hypervisorSupported: true,
     });
+
+  });
+
+  it('does not probe macOS or hypervisor on an unsupported architecture', async () => {
+    const readProductVersion = jest.fn();
+    const readHypervisorSupport = jest.fn();
+    await expect(
+      collectAppleContainerHostFacts({
+        platform: 'darwin',
+        arch: 'x64',
+        readProductVersion,
+        readHypervisorSupport,
+      }),
+    ).resolves.toMatchObject({ arch: 'x64', macosProductVersion: '', hypervisorSupported: false });
+    expect(readProductVersion).not.toHaveBeenCalled();
+    expect(readHypervisorSupport).not.toHaveBeenCalled();
+  });
+
+  it('does not probe the hypervisor on an old macOS version', async () => {
+    const readHypervisorSupport = jest.fn();
+    await expect(
+      collectAppleContainerHostFacts({
+        platform: 'darwin',
+        arch: 'arm64',
+        readProductVersion: async () => '15.5',
+        readHypervisorSupport,
+      }),
+    ).resolves.toMatchObject({ macosProductVersion: '15.5', hypervisorSupported: false });
+    expect(readHypervisorSupport).not.toHaveBeenCalled();
   });
 
   it('maps a sw_vers failure to a macos-version host error', async () => {

--- a/src/apple-container/host-facts.ts
+++ b/src/apple-container/host-facts.ts
@@ -1,0 +1,256 @@
+/**
+ * Apple Container host facts and fail-closed eligibility evaluation.
+ *
+ * Apple `container` is a VM-per-container OCI runtime that requires
+ * Virtualization.framework. AWF supports it only on **self-hosted bare-metal
+ * Apple Silicon** Actions runners: GitHub-hosted `macos-26` images are
+ * themselves virtual machines and do not expose nested virtualization, so
+ * `kern.hv_support` reports 0 there and no amount of retrying will help.
+ *
+ * This module is deliberately split from `./preflight.ts`. Host *identity*
+ * (platform, architecture, macOS version, hypervisor support) is answered from
+ * cheap, side-effect-free probes and can be evaluated before the `container`
+ * CLI is known to exist. Live service checks (CLI presence, version, daemon
+ * health) need the CLI adapter and live in preflight. Keeping them apart means
+ * "we are on the wrong kind of machine" and "the runtime is not ready on this
+ * machine" stay independently testable and produce distinguishable errors.
+ *
+ * Every probe is injected so the whole surface is unit-testable without a Mac.
+ */
+
+import execa from 'execa';
+
+/** Minimum macOS major version; apple/container supports macOS 26 and newer. */
+export const APPLE_CONTAINER_MINIMUM_MACOS_MAJOR = 26;
+
+/** `sysctl` key reporting whether Virtualization.framework can start a VM. */
+export const APPLE_CONTAINER_HV_SUPPORT_SYSCTL = 'kern.hv_support';
+
+/**
+ * Why a host cannot run the Apple Container runtime.
+ *
+ * Callers switch on this rather than matching message text, so a later layer
+ * can decide per-cause whether to hard-fail or fall back to Docker.
+ */
+export type AppleContainerIneligibilityCode =
+  | 'platform'
+  | 'architecture'
+  | 'macos-version'
+  | 'hypervisor';
+
+/** Immutable, already-probed description of the host. */
+export interface AppleContainerHostFacts {
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  /** `sw_vers -productVersion` output, e.g. `"26.1.1"`. */
+  readonly macosProductVersion: string;
+  /** True only when `sysctl -n kern.hv_support` reported exactly `1`. */
+  readonly hypervisorSupported: boolean;
+}
+
+export interface AppleContainerHostProbe {
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  /** Returns raw `sw_vers -productVersion` stdout. */
+  readProductVersion(): Promise<string>;
+  /** Returns raw `sysctl -n kern.hv_support` stdout. */
+  readHypervisorSupport(): Promise<string>;
+}
+
+export type AppleContainerEligibility =
+  | { readonly eligible: true }
+  | {
+      readonly eligible: false;
+      readonly code: AppleContainerIneligibilityCode;
+      readonly reason: string;
+    };
+
+/** Thrown by {@link assertAppleContainerHostEligibility}; carries the cause code. */
+export class AppleContainerHostError extends Error {
+  constructor(
+    readonly code: AppleContainerIneligibilityCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AppleContainerHostError';
+  }
+}
+
+async function readTrimmedStdout(binary: string, args: readonly string[]): Promise<string> {
+  const result = await execa(binary, [...args], {
+    reject: false,
+    timeout: 5_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `"${binary} ${args.join(' ')}" exited with code ${result.exitCode}: ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+const defaultProbe: AppleContainerHostProbe = {
+  platform: process.platform,
+  arch: process.arch,
+  readProductVersion: () => readTrimmedStdout('/usr/bin/sw_vers', ['-productVersion']),
+  readHypervisorSupport: () => readTrimmedStdout('/usr/sbin/sysctl', ['-n', APPLE_CONTAINER_HV_SUPPORT_SYSCTL]),
+};
+
+/** @internal Exposed so host-probe tests can assert the real command shapes. */
+export const appleContainerHostProbeTestHelpers = { defaultProbe, readTrimmedStdout };
+
+/**
+ * Parses the major version from `sw_vers -productVersion` output.
+ *
+ * Throws rather than returning a sentinel: an unparseable version must not be
+ * silently treated as "new enough".
+ */
+export function parseMacosMajorVersion(productVersion: string): number {
+  // Parsed by splitting rather than with a nested-quantifier regex, which both
+  // avoids a ReDoS-shaped pattern and makes the "all components must be
+  // numeric" rule explicit.
+  const components = productVersion.trim().split('.');
+  const allNumeric = components.every((component) => /^\d+$/.test(component));
+  if (!allNumeric || components.length === 0 || components[0].length === 0) {
+    throw new Error(
+      `Could not parse macOS product version from: ${JSON.stringify(productVersion)}`,
+    );
+  }
+  return Number(components[0]);
+}
+
+/**
+ * Interprets `sysctl -n kern.hv_support`.
+ *
+ * Only a literal `1` counts as supported; anything else (including `0`, empty
+ * output, or unexpected text) is treated as unsupported.
+ */
+export function parseHypervisorSupport(sysctlOutput: string): boolean {
+  return sysctlOutput.trim() === '1';
+}
+
+/**
+ * Collects host facts. Probe failures are surfaced as
+ * {@link AppleContainerHostError}s with the code they belong to, so a missing
+ * `sw_vers` is reported as a macOS-version problem rather than an opaque
+ * spawn error.
+ */
+export async function collectAppleContainerHostFacts(
+  overrides: Partial<AppleContainerHostProbe> = {},
+): Promise<AppleContainerHostFacts> {
+  const probe: AppleContainerHostProbe = { ...defaultProbe, ...overrides };
+
+  // Short-circuit before spawning Darwin-only tools; on Linux CI `sw_vers`
+  // does not exist and its spawn error would be a misleading diagnosis.
+  if (probe.platform !== 'darwin') {
+    return {
+      platform: probe.platform,
+      arch: probe.arch,
+      macosProductVersion: '',
+      hypervisorSupported: false,
+    };
+  }
+
+  let macosProductVersion: string;
+  try {
+    macosProductVersion = (await probe.readProductVersion()).trim();
+  } catch (error) {
+    throw new AppleContainerHostError(
+      'macos-version',
+      `Could not determine the macOS version: ${formatCause(error)}`,
+    );
+  }
+
+  let hypervisorSupported: boolean;
+  try {
+    hypervisorSupported = parseHypervisorSupport(await probe.readHypervisorSupport());
+  } catch (error) {
+    throw new AppleContainerHostError(
+      'hypervisor',
+      `Could not determine Virtualization.framework support via ` +
+      `${APPLE_CONTAINER_HV_SUPPORT_SYSCTL}: ${formatCause(error)}`,
+    );
+  }
+
+  return {
+    platform: probe.platform,
+    arch: probe.arch,
+    macosProductVersion,
+    hypervisorSupported,
+  };
+}
+
+/**
+ * Pure eligibility decision over already-collected facts.
+ *
+ * Checks run most-general first so the reported cause is the most actionable
+ * one: a Linux host is told it is the wrong platform rather than being told its
+ * hypervisor is missing.
+ */
+export function evaluateAppleContainerHostEligibility(
+  facts: AppleContainerHostFacts,
+): AppleContainerEligibility {
+  if (facts.platform !== 'darwin') {
+    return {
+      eligible: false,
+      code: 'platform',
+      reason: `Apple Container requires macOS; found platform ${facts.platform}`,
+    };
+  }
+  if (facts.arch !== 'arm64') {
+    return {
+      eligible: false,
+      code: 'architecture',
+      reason:
+        'Apple Container requires Apple Silicon (arm64); found Node architecture ' +
+        `${facts.arch}. Intel Macs and Rosetta-translated processes are not supported.`,
+    };
+  }
+
+  let major: number;
+  try {
+    major = parseMacosMajorVersion(facts.macosProductVersion);
+  } catch (error) {
+    return {
+      eligible: false,
+      code: 'macos-version',
+      reason: `Apple Container requires macOS ${APPLE_CONTAINER_MINIMUM_MACOS_MAJOR}+: ${formatCause(error)}`,
+    };
+  }
+  if (major < APPLE_CONTAINER_MINIMUM_MACOS_MAJOR) {
+    return {
+      eligible: false,
+      code: 'macos-version',
+      reason:
+        `Apple Container requires macOS ${APPLE_CONTAINER_MINIMUM_MACOS_MAJOR} or newer; ` +
+        `found ${facts.macosProductVersion}`,
+    };
+  }
+
+  if (!facts.hypervisorSupported) {
+    return {
+      eligible: false,
+      code: 'hypervisor',
+      reason:
+        `Apple Container requires Virtualization.framework support ` +
+        `(${APPLE_CONTAINER_HV_SUPPORT_SYSCTL} = 1). This is expected on GitHub-hosted macOS ` +
+        'runners, which are themselves virtual machines without nested virtualization; use a ' +
+        'self-hosted bare-metal Apple Silicon runner.',
+    };
+  }
+
+  return { eligible: true };
+}
+
+/** Throws an {@link AppleContainerHostError} when the host is not eligible. */
+export function assertAppleContainerHostEligibility(facts: AppleContainerHostFacts): void {
+  const result = evaluateAppleContainerHostEligibility(facts);
+  if (!result.eligible) {
+    throw new AppleContainerHostError(result.code, result.reason);
+  }
+}
+
+function formatCause(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/apple-container/host-facts.ts
+++ b/src/apple-container/host-facts.ts
@@ -152,6 +152,15 @@ export async function collectAppleContainerHostFacts(
     };
   }
 
+  if (probe.arch !== 'arm64') {
+    return {
+      platform: probe.platform,
+      arch: probe.arch,
+      macosProductVersion: '',
+      hypervisorSupported: false,
+    };
+  }
+
   let macosProductVersion: string;
   try {
     macosProductVersion = (await probe.readProductVersion()).trim();
@@ -160,6 +169,26 @@ export async function collectAppleContainerHostFacts(
       'macos-version',
       `Could not determine the macOS version: ${formatCause(error)}`,
     );
+  }
+
+  let macosMajor: number;
+  try {
+    macosMajor = parseMacosMajorVersion(macosProductVersion);
+  } catch {
+    return {
+      platform: probe.platform,
+      arch: probe.arch,
+      macosProductVersion,
+      hypervisorSupported: false,
+    };
+  }
+  if (macosMajor < APPLE_CONTAINER_MINIMUM_MACOS_MAJOR) {
+    return {
+      platform: probe.platform,
+      arch: probe.arch,
+      macosProductVersion,
+      hypervisorSupported: false,
+    };
   }
 
   let hypervisorSupported: boolean;

--- a/src/apple-container/lifecycle.test.ts
+++ b/src/apple-container/lifecycle.test.ts
@@ -61,6 +61,10 @@ describe('parseAppleContainerVersion', () => {
   it.each(['', 'container CLI', 'unknown build'])('throws on %j', (value) => {
     expect(() => parseAppleContainerVersion(value)).toThrow(/Could not parse/);
   });
+
+  it.each(['container CLI (build: 99.0)', 'release 99.0'])('rejects an unanchored version in %j', (value) => {
+    expect(() => parseAppleContainerVersion(value)).toThrow(/Could not parse/);
+  });
 });
 
 describe('parseCreatedContainerId', () => {

--- a/src/apple-container/lifecycle.test.ts
+++ b/src/apple-container/lifecycle.test.ts
@@ -1,0 +1,371 @@
+import {
+  AppleContainerCli,
+  AppleContainerCliError,
+  type AppleContainerSpawn,
+  type AppleContainerSpawnOptions,
+  type AppleContainerSpawnResult,
+} from './cli';
+import {
+  AppleContainerLifecycle,
+  parseAppleContainerJson,
+  parseAppleContainerVersion,
+  parseCreatedContainerId,
+} from './lifecycle';
+
+interface RecordedCall {
+  args: readonly string[];
+  options: AppleContainerSpawnOptions;
+}
+
+interface Harness {
+  lifecycle: AppleContainerLifecycle;
+  calls: RecordedCall[];
+}
+
+function harness(
+  respond: (args: readonly string[]) => Partial<AppleContainerSpawnResult> = () => ({}),
+): Harness {
+  const calls: RecordedCall[] = [];
+  const spawn: AppleContainerSpawn = async (_binary, args, options) => {
+    calls.push({ args, options });
+    return {
+      exitCode: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      ...respond(args),
+    };
+  };
+  return { lifecycle: new AppleContainerLifecycle(new AppleContainerCli({ spawn })), calls };
+}
+
+describe('parseAppleContainerVersion', () => {
+  it('parses the documented banner form', () => {
+    expect(
+      parseAppleContainerVersion('container CLI version 0.4.1 (build: release, commit: abcdef1)'),
+    ).toEqual({
+      version: '0.4.1',
+      raw: 'container CLI version 0.4.1 (build: release, commit: abcdef1)',
+    });
+  });
+
+  it('parses a two-component version', () => {
+    expect(parseAppleContainerVersion('container CLI version 1.0').version).toBe('1.0');
+  });
+
+  it('parses a bare semantic version', () => {
+    expect(parseAppleContainerVersion('v0.5.2').version).toBe('0.5.2');
+  });
+
+  it.each(['', 'container CLI', 'unknown build'])('throws on %j', (value) => {
+    expect(() => parseAppleContainerVersion(value)).toThrow(/Could not parse/);
+  });
+});
+
+describe('parseCreatedContainerId', () => {
+  it('returns the printed ID', () => {
+    expect(parseCreatedContainerId('awf-agent\n')).toBe('awf-agent');
+  });
+
+  it('uses the last non-empty line so leading progress output cannot corrupt the ID', () => {
+    expect(parseCreatedContainerId('pulling...\n\nawf-agent\n\n')).toBe('awf-agent');
+  });
+
+  it('throws when nothing was printed', () => {
+    expect(() => parseCreatedContainerId('  \n\n')).toThrow(/did not print a container ID/);
+  });
+
+  it('validates the returned ID rather than trusting it', () => {
+    expect(() => parseCreatedContainerId('not a valid id')).toThrow(/created container ID/);
+  });
+});
+
+describe('parseAppleContainerJson', () => {
+  it('parses valid JSON', () => {
+    expect(parseAppleContainerJson('list', ' [{"id":"a"}] ')).toEqual([{ id: 'a' }]);
+  });
+
+  it('throws rather than defaulting on empty output', () => {
+    expect(() => parseAppleContainerJson('list', '   ')).toThrow(/returned no JSON output/);
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseAppleContainerJson('inspect', '{oops')).toThrow(/unparseable JSON/);
+  });
+});
+
+describe('AppleContainerLifecycle.version', () => {
+  it('runs "container --version" and parses stdout', async () => {
+    const { lifecycle, calls } = harness(() => ({
+      stdout: 'container CLI version 0.4.1 (build: release, commit: abc1234)',
+    }));
+
+    await expect(lifecycle.version()).resolves.toMatchObject({ version: '0.4.1' });
+    expect(calls[0].args).toEqual(['--version']);
+  });
+
+  it('falls back to stderr when the banner is printed there', async () => {
+    const { lifecycle } = harness(() => ({ stderr: 'container CLI version 0.4.2' }));
+    await expect(lifecycle.version()).resolves.toMatchObject({ version: '0.4.2' });
+  });
+
+  it('throws when the CLI exits non-zero', async () => {
+    const { lifecycle } = harness(() => ({ exitCode: 127, stderr: 'command not found' }));
+    await expect(lifecycle.version()).rejects.toBeInstanceOf(AppleContainerCliError);
+  });
+});
+
+describe('AppleContainerLifecycle.systemStatus', () => {
+  it('requests JSON and reports healthy on exit 0', async () => {
+    const { lifecycle, calls } = harness(() => ({ stdout: '{"status":"running"}' }));
+
+    await expect(lifecycle.systemStatus()).resolves.toMatchObject({ healthy: true });
+    expect(calls[0].args).toEqual(['system', 'status', '--format', 'json']);
+  });
+
+  it('reports unhealthy instead of throwing when the service is down', async () => {
+    const { lifecycle } = harness(() => ({
+      exitCode: 1,
+      stdout: 'apiserver is not running',
+    }));
+
+    const status = await lifecycle.systemStatus();
+    expect(status.healthy).toBe(false);
+    expect(status.result.stdout).toContain('apiserver is not running');
+  });
+});
+
+describe('AppleContainerLifecycle.pullImage', () => {
+  it('pulls with no platform flags by default', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.pullImage('ubuntu:22.04');
+    expect(calls[0].args).toEqual(['image', 'pull', 'ubuntu:22.04']);
+  });
+
+  it('uses the singular "image" subcommand group', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.pullImage('ubuntu:22.04');
+    expect(calls[0].args[0]).toBe('image');
+  });
+
+  it('emits --os and --arch for native arm64 selection', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.pullImage('ubuntu:22.04', { os: 'linux', arch: 'arm64' });
+    expect(calls[0].args).toEqual([
+      'image', 'pull', '--os', 'linux', '--arch', 'arm64', 'ubuntu:22.04',
+    ]);
+  });
+
+  it('prefers --platform and omits --os/--arch when it is supplied', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.pullImage('ubuntu:22.04', {
+      platform: 'linux/arm64',
+      os: 'linux',
+      arch: 'amd64',
+    });
+    expect(calls[0].args).toEqual(['image', 'pull', '--platform', 'linux/arm64', 'ubuntu:22.04']);
+  });
+
+  it.each(['linux', 'linux/arm64/v8/extra', 'Linux/arm64', 'linux/'])(
+    'rejects the malformed platform %j',
+    async (platform) => {
+      const { lifecycle } = harness();
+      await expect(lifecycle.pullImage('ubuntu:22.04', { platform })).rejects.toThrow(
+        /"os\/arch\[\/variant\]"/,
+      );
+    },
+  );
+
+  it('rejects a malformed architecture component', async () => {
+    const { lifecycle } = harness();
+    await expect(lifecycle.pullImage('ubuntu:22.04', { arch: 'arm64 x' })).rejects.toThrow(
+      /lowercase alphanumeric/,
+    );
+  });
+
+  it('throws when the pull fails', async () => {
+    const { lifecycle } = harness(() => ({ exitCode: 1, stderr: 'manifest unknown' }));
+    await expect(lifecycle.pullImage('ubuntu:nope')).rejects.toThrow(/manifest unknown/);
+  });
+});
+
+describe('AppleContainerLifecycle.create', () => {
+  it('runs the create subcommand and returns the validated ID', async () => {
+    const { lifecycle, calls } = harness(() => ({ stdout: 'awf-agent\n' }));
+
+    await expect(lifecycle.create({ image: 'ubuntu:22.04', name: 'awf-agent' })).resolves.toBe(
+      'awf-agent',
+    );
+    expect(calls[0].args[0]).toBe('create');
+    expect(calls[0].args).toContain('--network');
+  });
+
+  it('throws when create fails rather than returning a placeholder ID', async () => {
+    const { lifecycle } = harness(() => ({ exitCode: 1, stderr: 'image not found' }));
+    await expect(lifecycle.create({ image: 'ubuntu:22.04' })).rejects.toThrow(/image not found/);
+  });
+});
+
+describe('AppleContainerLifecycle start and foreground execution', () => {
+  it('starts a container without attaching', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.start('awf-agent');
+    expect(calls[0].args).toEqual(['start', 'awf-agent']);
+  });
+
+  it('attaches stdio without stdin by default and propagates a non-zero exit code', async () => {
+    const { lifecycle, calls } = harness(() => ({ exitCode: 7 }));
+
+    const result = await lifecycle.startAttached('awf-agent');
+
+    expect(calls[0].args).toEqual(['start', '--attach', 'awf-agent']);
+    expect(calls[0].options.inheritStdio).toBe(true);
+    expect(result.exitCode).toBe(7);
+  });
+
+  it('adds --interactive only when stdin is explicitly requested', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.startAttached('awf-agent', { interactive: true });
+    expect(calls[0].args).toEqual(['start', '--attach', '--interactive', 'awf-agent']);
+  });
+
+  it('does not forward the interactive flag into the spawn options', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.startAttached('awf-agent', { interactive: true, timeoutMs: 5 });
+    expect(calls[0].options).not.toHaveProperty('interactive');
+    expect(calls[0].options.timeoutMs).toBe(5);
+  });
+
+  it('runs in the foreground with inherited stdio and returns the exit code verbatim', async () => {
+    const { lifecycle, calls } = harness(() => ({ exitCode: 137 }));
+
+    const result = await lifecycle.runForeground({
+      image: 'ubuntu:22.04',
+      args: ['bash', '-lc', 'exit 137'],
+    });
+
+    expect(calls[0].args[0]).toBe('run');
+    expect(calls[0].args.slice(-4)).toEqual(['ubuntu:22.04', 'bash', '-lc', 'exit 137']);
+    expect(calls[0].options.inheritStdio).toBe(true);
+    expect(result.exitCode).toBe(137);
+  });
+
+  it('surfaces a foreground timeout without converting it into success', async () => {
+    const { lifecycle } = harness(() => ({ exitCode: null, signal: 'SIGTERM', timedOut: true }));
+
+    const result = await lifecycle.runForeground({ image: 'ubuntu:22.04' }, { timeoutMs: 10 });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('lets a caller override the inherited stdio for a captured run', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.runForeground({ image: 'ubuntu:22.04' }, { inheritStdio: false });
+    expect(calls[0].options.inheritStdio).toBe(false);
+  });
+
+  it('rejects an invalid container ID before spawning anything', async () => {
+    const { lifecycle, calls } = harness();
+    await expect(lifecycle.start('-evil')).rejects.toThrow(/container ID/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('AppleContainerLifecycle teardown', () => {
+  it('stops with no extra flags by default', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.stop('awf-agent');
+    expect(calls[0].args).toEqual(['stop', 'awf-agent']);
+  });
+
+  it('stops with an explicit signal and grace period', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.stop('awf-agent', { signal: 'TERM', timeoutSeconds: 30 });
+    expect(calls[0].args).toEqual([
+      'stop', '--signal', 'TERM', '--time', '30', 'awf-agent',
+    ]);
+  });
+
+  it('allows a zero-second stop grace period', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.stop('awf-agent', { timeoutSeconds: 0 });
+    expect(calls[0].args).toEqual(['stop', '--time', '0', 'awf-agent']);
+  });
+
+  it('rejects an invalid stop signal before spawning', async () => {
+    const { lifecycle, calls } = harness();
+    await expect(lifecycle.stop('awf-agent', { signal: 'TERM;ls' })).rejects.toThrow();
+    expect(calls).toHaveLength(0);
+  });
+
+  it('kills with SIGKILL by default', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.kill('awf-agent');
+    expect(calls[0].args).toEqual(['kill', '--signal', 'KILL', 'awf-agent']);
+  });
+
+  it('kills with an explicit signal', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.kill('awf-agent', 'SIGUSR1');
+    expect(calls[0].args).toEqual(['kill', '--signal', 'SIGUSR1', 'awf-agent']);
+  });
+
+  it('deletes without force by default', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.remove('awf-agent');
+    expect(calls[0].args).toEqual(['delete', 'awf-agent']);
+  });
+
+  it('deletes with force when requested', async () => {
+    const { lifecycle, calls } = harness();
+    await lifecycle.remove('awf-agent', { force: true });
+    expect(calls[0].args).toEqual(['delete', '--force', 'awf-agent']);
+  });
+
+  it('propagates a delete failure', async () => {
+    const { lifecycle } = harness(() => ({ exitCode: 1, stderr: 'container is running' }));
+    await expect(lifecycle.remove('awf-agent')).rejects.toThrow(/container is running/);
+  });
+});
+
+describe('AppleContainerLifecycle introspection', () => {
+  it('inspects without a --format flag, which the command does not accept', async () => {
+    const { lifecycle, calls } = harness(() => ({ stdout: '[{"id":"awf-agent"}]' }));
+
+    await expect(lifecycle.inspect('awf-agent')).resolves.toEqual([{ id: 'awf-agent' }]);
+    expect(calls[0].args).toEqual(['inspect', 'awf-agent']);
+    expect(calls[0].args).not.toContain('--format');
+  });
+
+  it('lists running containers as JSON', async () => {
+    const { lifecycle, calls } = harness(() => ({ stdout: '[]' }));
+
+    await expect(lifecycle.list()).resolves.toEqual([]);
+    expect(calls[0].args).toEqual(['list', '--format', 'json']);
+  });
+
+  it('lists all containers when requested', async () => {
+    const { lifecycle, calls } = harness(() => ({ stdout: '[]' }));
+    await lifecycle.list({ all: true });
+    expect(calls[0].args).toEqual(['list', '--all', '--format', 'json']);
+  });
+
+  it('throws on unparseable inspect output rather than returning null', async () => {
+    const { lifecycle } = harness(() => ({ stdout: 'not json' }));
+    await expect(lifecycle.inspect('awf-agent')).rejects.toThrow(/unparseable JSON/);
+  });
+});
+
+describe('AppleContainerLifecycle construction', () => {
+  it('accepts CLI options directly', () => {
+    const lifecycle = new AppleContainerLifecycle({ binary: '/opt/bin/container' });
+    expect(lifecycle.cli.binary).toBe('/opt/bin/container');
+  });
+
+  it('reuses an existing CLI instance', () => {
+    const cli = new AppleContainerCli({ binary: '/opt/bin/container' });
+    expect(new AppleContainerLifecycle(cli).cli).toBe(cli);
+  });
+});

--- a/src/apple-container/lifecycle.ts
+++ b/src/apple-container/lifecycle.ts
@@ -1,0 +1,294 @@
+/**
+ * Apple Container lifecycle primitives.
+ *
+ * A thin, typed layer over `./cli.ts` covering exactly the operations later
+ * backend layers need. It owns no policy and holds no state: callers pass IDs
+ * and specs, and every returned value is either a validated primitive or a
+ * faithful {@link AppleContainerCliResult}.
+ *
+ * Failure handling is deliberately asymmetric:
+ *
+ * - Control-plane operations (pull, create, stop, kill, delete, inspect, list)
+ *   use `runChecked` and throw, because a silent failure here would leave the
+ *   caller reasoning about a container that does not exist.
+ * - {@link AppleContainerLifecycle.runForeground} and
+ *   {@link AppleContainerLifecycle.startAttached} use `run`, because the child's
+ *   exit code *is* the result and must be propagated verbatim — including a
+ *   non-zero one.
+ *
+ * Nothing in this file catches broadly or falls back to a success-shaped value.
+ */
+
+import {
+  AppleContainerCli,
+  type AppleContainerCliOptions,
+  type AppleContainerCliResult,
+  type AppleContainerSpawnOptions,
+} from './cli';
+import {
+  buildAppleContainerRunArgs,
+  type AppleContainerRunSpec,
+} from './run-args';
+import {
+  assertAppleContainerId,
+  assertAppleContainerImageReference,
+  assertAppleContainerSignal,
+  assertAppleContainerStopTimeout,
+} from './validation';
+
+/** Parsed `container --version` output. */
+export interface AppleContainerVersion {
+  /** Semantic version, e.g. `"0.4.1"`. */
+  readonly version: string;
+  /** Full raw line, retained for diagnostics. */
+  readonly raw: string;
+}
+
+export interface AppleContainerSystemStatus {
+  readonly healthy: boolean;
+  readonly result: AppleContainerCliResult;
+}
+
+export interface AppleContainerPullOptions {
+  readonly os?: string;
+  readonly arch?: string;
+  /** `os/arch[/variant]`; takes precedence over `os`/`arch` in the CLI. */
+  readonly platform?: string;
+}
+
+export interface AppleContainerStopOptions {
+  readonly signal?: string;
+  /** Seconds to wait before the CLI escalates to a kill (CLI default is 5). */
+  readonly timeoutSeconds?: number;
+}
+
+export interface AppleContainerStartAttachedOptions extends AppleContainerSpawnOptions {
+  /**
+   * Also attach stdin (`--interactive`). Off by default: a CI job has no
+   * usable stdin, and attaching it there is a behaviour change, not a no-op.
+   */
+  readonly interactive?: boolean;
+}
+
+/**
+ * Raised when `container --version` ran successfully but printed something this
+ * adapter cannot parse.
+ *
+ * Distinct from a CLI that could not be run at all, so preflight can report an
+ * installed-but-unrecognised CLI as a version problem rather than telling the
+ * operator to install a CLI they already have.
+ */
+export class AppleContainerVersionParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AppleContainerVersionParseError';
+  }
+}
+
+/**
+ * Parses `container CLI version 0.4.1 (build: release, commit: abcdef1)`.
+ *
+ * Throws on anything unparseable so a version gate can never be satisfied by
+ * output we do not understand.
+ */
+export function parseAppleContainerVersion(output: string): AppleContainerVersion {
+  const raw = output.trim();
+  const match = /\bv?(\d+\.\d+\.\d+|\d+\.\d+)(?![\d.])/.exec(raw);
+  if (!match) {
+    throw new AppleContainerVersionParseError(
+      `Could not parse Apple Container CLI version from: ${JSON.stringify(output)}`,
+    );
+  }
+  return { version: match[1], raw };
+}
+
+/**
+ * Parses the container ID printed by `container create`.
+ *
+ * The CLI prints progress to stderr and the bare ID on stdout, but the last
+ * non-empty stdout line is used rather than the whole buffer so a future
+ * progress line cannot corrupt the ID. The result is validated against Apple
+ * Container's own ID predicate.
+ */
+export function parseCreatedContainerId(stdout: string): string {
+  const lines = stdout.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+  const candidate = lines[lines.length - 1];
+  if (candidate === undefined) {
+    throw new Error('Apple Container "create" did not print a container ID');
+  }
+  return assertAppleContainerId(candidate, 'created container ID');
+}
+
+/** Parses `--format json` output, failing loudly rather than returning a default. */
+export function parseAppleContainerJson(label: string, stdout: string): unknown {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`Apple Container "${label}" returned no JSON output`);
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(
+      `Apple Container "${label}" returned unparseable JSON: ` +
+      `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function platformArgs(options: AppleContainerPullOptions): string[] {
+  const args: string[] = [];
+  if (options.platform !== undefined) {
+    args.push('--platform', assertPlatformToken(options.platform));
+    return args;
+  }
+  if (options.os !== undefined) args.push('--os', assertPlatformComponent(options.os, 'OS'));
+  if (options.arch !== undefined) {
+    args.push('--arch', assertPlatformComponent(options.arch, 'architecture'));
+  }
+  return args;
+}
+
+function assertPlatformComponent(value: string, label: string): string {
+  if (!/^[a-z0-9]+$/.test(value)) {
+    throw new Error(`Apple Container platform ${label} must be lowercase alphanumeric; got ${value}`);
+  }
+  return value;
+}
+
+function assertPlatformToken(value: string): string {
+  if (!/^[a-z0-9]+\/[a-z0-9]+(?:\/[a-z0-9]+)?$/.test(value)) {
+    throw new Error(`Apple Container platform must be "os/arch[/variant]"; got ${value}`);
+  }
+  return value;
+}
+
+/** Typed lifecycle operations over a single {@link AppleContainerCli}. */
+export class AppleContainerLifecycle {
+  readonly cli: AppleContainerCli;
+
+  constructor(cli: AppleContainerCli | AppleContainerCliOptions = {}) {
+    this.cli = cli instanceof AppleContainerCli ? cli : new AppleContainerCli(cli);
+  }
+
+  async version(): Promise<AppleContainerVersion> {
+    const result = await this.cli.runChecked(['--version']);
+    // Some builds print the banner on stderr; prefer stdout but accept either.
+    return parseAppleContainerVersion(result.stdout.trim() || result.stderr);
+  }
+
+  /**
+   * Queries the `container` service.
+   *
+   * A non-zero exit means "not registered" or "not running" and is a normal,
+   * expected answer rather than an adapter failure, so this reports rather than
+   * throws and lets preflight decide.
+   */
+  async systemStatus(): Promise<AppleContainerSystemStatus> {
+    const result = await this.cli.run(['system', 'status', '--format', 'json']);
+    return { healthy: result.exitCode === 0, result };
+  }
+
+  async pullImage(
+    reference: string,
+    options: AppleContainerPullOptions = {},
+  ): Promise<AppleContainerCliResult> {
+    return this.cli.runChecked([
+      'image',
+      'pull',
+      ...platformArgs(options),
+      assertAppleContainerImageReference(reference),
+    ]);
+  }
+
+  /** Creates a container without starting it and returns its validated ID. */
+  async create(spec: AppleContainerRunSpec): Promise<string> {
+    const result = await this.cli.runChecked(buildAppleContainerRunArgs(spec, 'create'));
+    return parseCreatedContainerId(result.stdout);
+  }
+
+  /** Starts a previously created container without attaching to it. */
+  async start(id: string): Promise<AppleContainerCliResult> {
+    return this.cli.runChecked(['start', assertAppleContainerId(id)]);
+  }
+
+  /**
+   * Starts a created container attached to this process's stdio and resolves
+   * with the container's own exit status. Does not throw on non-zero.
+   *
+   * stdin is *not* attached unless `interactive` is set: CI has no stdin, and
+   * attaching it there causes the container's init to see an immediate EOF.
+   */
+  async startAttached(
+    id: string,
+    options: AppleContainerStartAttachedOptions = {},
+  ): Promise<AppleContainerCliResult> {
+    const { interactive, ...overrides } = options;
+    const args = ['start', '--attach'];
+    if (interactive) {
+      args.push('--interactive');
+    }
+    args.push(assertAppleContainerId(id));
+    return this.cli.run(args, { inheritStdio: true, ...overrides });
+  }
+
+  /**
+   * Runs a container in the foreground and resolves with its exit status.
+   *
+   * The exit code is propagated verbatim, so callers must inspect it; a
+   * non-zero result is a successful *invocation* that reports failure.
+   */
+  async runForeground(
+    spec: AppleContainerRunSpec,
+    overrides: AppleContainerSpawnOptions = {},
+  ): Promise<AppleContainerCliResult> {
+    return this.cli.run(buildAppleContainerRunArgs(spec, 'run'), {
+      inheritStdio: true,
+      ...overrides,
+    });
+  }
+
+  async stop(
+    id: string,
+    options: AppleContainerStopOptions = {},
+  ): Promise<AppleContainerCliResult> {
+    const args = ['stop'];
+    if (options.signal !== undefined) {
+      args.push('--signal', assertAppleContainerSignal(options.signal));
+    }
+    if (options.timeoutSeconds !== undefined) {
+      args.push('--time', String(assertAppleContainerStopTimeout(options.timeoutSeconds)));
+    }
+    args.push(assertAppleContainerId(id));
+    return this.cli.runChecked(args);
+  }
+
+  async kill(id: string, signal = 'KILL'): Promise<AppleContainerCliResult> {
+    return this.cli.runChecked([
+      'kill',
+      '--signal',
+      assertAppleContainerSignal(signal),
+      assertAppleContainerId(id),
+    ]);
+  }
+
+  async remove(id: string, options: { force?: boolean } = {}): Promise<AppleContainerCliResult> {
+    const args = ['delete'];
+    if (options.force) args.push('--force');
+    args.push(assertAppleContainerId(id));
+    return this.cli.runChecked(args);
+  }
+
+  /** `container inspect` always emits pretty JSON; it has no `--format` flag. */
+  async inspect(id: string): Promise<unknown> {
+    const result = await this.cli.runChecked(['inspect', assertAppleContainerId(id)]);
+    return parseAppleContainerJson('inspect', result.stdout);
+  }
+
+  async list(options: { all?: boolean } = {}): Promise<unknown> {
+    const args = ['list'];
+    if (options.all) args.push('--all');
+    args.push('--format', 'json');
+    const result = await this.cli.runChecked(args);
+    return parseAppleContainerJson('list', result.stdout);
+  }
+}

--- a/src/apple-container/lifecycle.ts
+++ b/src/apple-container/lifecycle.ts
@@ -93,13 +93,14 @@ export class AppleContainerVersionParseError extends Error {
  */
 export function parseAppleContainerVersion(output: string): AppleContainerVersion {
   const raw = output.trim();
-  const match = /\bv?(\d+\.\d+\.\d+|\d+\.\d+)(?![\d.])/.exec(raw);
+  const match =
+    /^(?:container CLI version\s+v?(\d+\.\d+(?:\.\d+)?)|v?(\d+\.\d+(?:\.\d+)?))(?=$|\s|\()/.exec(raw);
   if (!match) {
     throw new AppleContainerVersionParseError(
       `Could not parse Apple Container CLI version from: ${JSON.stringify(output)}`,
     );
   }
-  return { version: match[1], raw };
+  return { version: match[1] ?? match[2], raw };
 }
 
 /**

--- a/src/apple-container/preflight.test.ts
+++ b/src/apple-container/preflight.test.ts
@@ -30,7 +30,7 @@ function stubLifecycle(overrides: {
 } = {}): StubLifecycle {
   return {
     cli: { binary: overrides.binary ?? 'container' },
-    version: overrides.version ?? (async () => ({ version: '0.4.1', raw: 'container CLI version 0.4.1' })),
+    version: overrides.version ?? (async () => ({ version: '0.10.1', raw: 'container CLI version 0.10.1' })),
     systemStatus:
       overrides.systemStatus
       ?? (async () => ({ healthy: true, result: { stdout: '{}', stderr: '' } })),
@@ -262,7 +262,7 @@ describe('runAppleContainerPreflight success', () => {
         hypervisorSupported: true,
       },
       cliBinary: '/usr/local/bin/container',
-      cliVersion: '0.4.1',
+      cliVersion: '0.10.1',
     });
   });
 
@@ -274,7 +274,7 @@ describe('runAppleContainerPreflight success', () => {
         spawn: async (_binary, args) => ({
           exitCode: 0,
           signal: null,
-          stdout: args[0] === '--version' ? 'container CLI version 0.4.5' : '{"status":"running"}',
+          stdout: args[0] === '--version' ? 'container CLI version 0.10.5' : '{"status":"running"}',
           stderr: '',
           timedOut: false,
         }),
@@ -283,7 +283,7 @@ describe('runAppleContainerPreflight success', () => {
 
     await expect(promise).resolves.toMatchObject({
       cliBinary: '/opt/container',
-      cliVersion: '0.4.5',
+      cliVersion: '0.10.5',
     });
   });
 });

--- a/src/apple-container/preflight.test.ts
+++ b/src/apple-container/preflight.test.ts
@@ -1,0 +1,285 @@
+import {
+  APPLE_CONTAINER_MINIMUM_CLI_VERSION,
+  AppleContainerPreflightError,
+  compareAppleContainerVersions,
+  runAppleContainerPreflight,
+  type AppleContainerPreflightDependencies,
+} from './preflight';
+import { AppleContainerCli } from './cli';
+import type { AppleContainerHostProbe } from './host-facts';
+import type { AppleContainerLifecycle } from './lifecycle';
+
+function darwinProbe(
+  overrides: Partial<AppleContainerHostProbe> = {},
+): Partial<AppleContainerHostProbe> {
+  return {
+    platform: 'darwin',
+    arch: 'arm64',
+    readProductVersion: async () => '26.1',
+    readHypervisorSupport: async () => '1',
+    ...overrides,
+  };
+}
+
+type StubLifecycle = AppleContainerPreflightDependencies['lifecycle'];
+
+function stubLifecycle(overrides: {
+  version?: () => Promise<{ version: string; raw: string }>;
+  systemStatus?: () => Promise<{ healthy: boolean; result: { stdout: string; stderr: string } }>;
+  binary?: string;
+} = {}): StubLifecycle {
+  return {
+    cli: { binary: overrides.binary ?? 'container' },
+    version: overrides.version ?? (async () => ({ version: '0.4.1', raw: 'container CLI version 0.4.1' })),
+    systemStatus:
+      overrides.systemStatus
+      ?? (async () => ({ healthy: true, result: { stdout: '{}', stderr: '' } })),
+  } as unknown as AppleContainerLifecycle;
+}
+
+describe('compareAppleContainerVersions', () => {
+  it.each([
+    ['0.4.1', '0.4.0', 1],
+    ['0.4.0', '0.4.1', -1],
+    ['0.4.0', '0.4.0', 0],
+    ['0.4', '0.4.0', 0],
+    ['1.0.0', '0.9.9', 1],
+    ['0.10.0', '0.9.0', 1],
+    ['v0.5.0', '0.4.0', 1],
+  ])('compares %s to %s', (left, right, expected) => {
+    expect(Math.sign(compareAppleContainerVersions(left, right))).toBe(expected);
+  });
+
+  it('throws on a non-numeric component rather than guessing', () => {
+    expect(() => compareAppleContainerVersions('0.4.x', '0.4.0')).toThrow(/not a number/);
+  });
+});
+
+describe('runAppleContainerPreflight host gates', () => {
+  it('fails on a non-Darwin platform before touching the CLI', async () => {
+    const version = jest.fn();
+    const promise = runAppleContainerPreflight({
+      hostProbe: { platform: 'linux', arch: 'x64' },
+      lifecycle: stubLifecycle({ version: version as never }),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(AppleContainerPreflightError);
+    await expect(promise).rejects.toMatchObject({ code: 'platform' });
+    expect(version).not.toHaveBeenCalled();
+  });
+
+  it('fails on Intel macOS with an architecture code', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe({ arch: 'x64' }),
+        lifecycle: stubLifecycle(),
+      }),
+    ).rejects.toMatchObject({ code: 'architecture' });
+  });
+
+  it('fails on macOS older than 26', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe({ readProductVersion: async () => '15.5' }),
+        lifecycle: stubLifecycle(),
+      }),
+    ).rejects.toMatchObject({ code: 'macos-version' });
+  });
+
+  it('fails with a hypervisor code on a GitHub-hosted macOS runner', async () => {
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe({ readHypervisorSupport: async () => '0' }),
+      lifecycle: stubLifecycle(),
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: 'hypervisor' });
+    await expect(promise).rejects.toThrow(/nested virtualization/);
+  });
+
+  it('translates a probe failure into a preflight error with the probe cause code', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe({
+          readProductVersion: async () => {
+            throw new Error('spawn ENOENT');
+          },
+        }),
+        lifecycle: stubLifecycle(),
+      }),
+    ).rejects.toMatchObject({ code: 'macos-version' });
+  });
+});
+
+describe('runAppleContainerPreflight CLI gates', () => {
+  it('reports a missing CLI with an actionable message', async () => {
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe(),
+      lifecycle: stubLifecycle({
+        version: async () => {
+          throw new Error('spawn container ENOENT');
+        },
+      }),
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: 'cli-missing' });
+    await expect(promise).rejects.toThrow(/github\.com\/apple\/container/);
+  });
+
+  it('rejects a CLI older than the pinned minimum', async () => {
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe(),
+      lifecycle: stubLifecycle({
+        version: async () => ({ version: '0.3.9', raw: 'container CLI version 0.3.9' }),
+      }),
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: 'cli-version' });
+    await expect(promise).rejects.toThrow(
+      new RegExp(`${APPLE_CONTAINER_MINIMUM_CLI_VERSION.replace(/\./g, '\\.')} or newer`),
+    );
+  });
+
+  it('accepts a CLI newer than the minimum', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe(),
+        lifecycle: stubLifecycle({
+          version: async () => ({ version: '1.2.0', raw: 'container CLI version 1.2.0' }),
+        }),
+      }),
+    ).resolves.toMatchObject({ cliVersion: '1.2.0' });
+  });
+
+  it('honours a caller-supplied minimum version', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe(),
+        minimumCliVersion: '9.9.9',
+        lifecycle: stubLifecycle(),
+      }),
+    ).rejects.toMatchObject({ code: 'cli-version' });
+  });
+
+  it('reports an unparseable banner from the real lifecycle as a version failure', async () => {
+    // Exercised at the spawn level rather than by stubbing the lifecycle: the
+    // real version() throws on an unparseable banner, so a lifecycle-level stub
+    // that resolves with a bad version could not reach this branch.
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe(),
+      cli: new AppleContainerCli({
+        spawn: async () => ({
+          exitCode: 0,
+          signal: null,
+          stdout: 'container CLI (build: release)',
+          stderr: '',
+          timedOut: false,
+        }),
+      }),
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: 'cli-version' });
+    await expect(promise).rejects.toThrow(/Could not parse Apple Container CLI version/);
+    await expect(promise).rejects.not.toThrow(/ensure it is on PATH/);
+  });
+
+  it('still reports a CLI that cannot be spawned as cli-missing', async () => {
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe(),
+      cli: new AppleContainerCli({
+        spawn: async () => {
+          throw new Error('spawn container ENOENT');
+        },
+      }),
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: 'cli-missing' });
+    await expect(promise).rejects.toThrow(/ensure it is on PATH/);
+  });
+
+  it('reports a non-zero --version exit as cli-missing', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe(),
+        cli: new AppleContainerCli({
+          spawn: async () => ({
+            exitCode: 127,
+            signal: null,
+            stdout: '',
+            stderr: 'command not found',
+            timedOut: false,
+          }),
+        }),
+      }),
+    ).rejects.toMatchObject({ code: 'cli-missing' });
+  });
+});
+
+describe('runAppleContainerPreflight service gate', () => {
+  it('fails when the service is not healthy and suggests how to start it', async () => {
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe(),
+      lifecycle: stubLifecycle({
+        systemStatus: async () => ({
+          healthy: false,
+          result: { stdout: 'apiserver is not running', stderr: '' },
+        }),
+      }),
+    });
+
+    await expect(promise).rejects.toMatchObject({ code: 'service-health' });
+    await expect(promise).rejects.toThrow(/container system start/);
+    await expect(promise).rejects.toThrow(/apiserver is not running/);
+  });
+
+  it('still produces a message when the failing status printed nothing', async () => {
+    await expect(
+      runAppleContainerPreflight({
+        hostProbe: darwinProbe(),
+        lifecycle: stubLifecycle({
+          systemStatus: async () => ({ healthy: false, result: { stdout: '', stderr: '' } }),
+        }),
+      }),
+    ).rejects.toThrow(/container system start"\./);
+  });
+});
+
+describe('runAppleContainerPreflight success', () => {
+  it('returns the validated host contract', async () => {
+    const result = await runAppleContainerPreflight({
+      hostProbe: darwinProbe({ readProductVersion: async () => '26.2.1' }),
+      lifecycle: stubLifecycle({ binary: '/usr/local/bin/container' }),
+    });
+
+    expect(result).toEqual({
+      facts: {
+        platform: 'darwin',
+        arch: 'arm64',
+        macosProductVersion: '26.2.1',
+        hypervisorSupported: true,
+      },
+      cliBinary: '/usr/local/bin/container',
+      cliVersion: '0.4.1',
+    });
+  });
+
+  it('builds a lifecycle from supplied CLI options when none is injected', async () => {
+    const promise = runAppleContainerPreflight({
+      hostProbe: darwinProbe(),
+      cli: new AppleContainerCli({
+        binary: '/opt/container',
+        spawn: async (_binary, args) => ({
+          exitCode: 0,
+          signal: null,
+          stdout: args[0] === '--version' ? 'container CLI version 0.4.5' : '{"status":"running"}',
+          stderr: '',
+          timedOut: false,
+        }),
+      }),
+    });
+
+    await expect(promise).resolves.toMatchObject({
+      cliBinary: '/opt/container',
+      cliVersion: '0.4.5',
+    });
+  });
+});

--- a/src/apple-container/preflight.test.ts
+++ b/src/apple-container/preflight.test.ts
@@ -122,7 +122,9 @@ describe('runAppleContainerPreflight CLI gates', () => {
     });
 
     await expect(promise).rejects.toMatchObject({ code: 'cli-missing' });
-    await expect(promise).rejects.toThrow(/github\.com\/apple\/container/);
+    await expect(promise).rejects.toThrow(
+      /(?:^|\s)https?:\/\/github\.com\/apple\/container(?:\/|\s|$)/,
+    );
   });
 
   it('rejects a CLI older than the pinned minimum', async () => {

--- a/src/apple-container/preflight.test.ts
+++ b/src/apple-container/preflight.test.ts
@@ -137,7 +137,9 @@ describe('runAppleContainerPreflight CLI gates', () => {
 
     await expect(promise).rejects.toMatchObject({ code: 'cli-version' });
     await expect(promise).rejects.toThrow(
-      new RegExp(`${APPLE_CONTAINER_MINIMUM_CLI_VERSION.replace(/\./g, '\\.')} or newer`),
+      new RegExp(
+        `${APPLE_CONTAINER_MINIMUM_CLI_VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} or newer`,
+      ),
     );
   });
 

--- a/src/apple-container/preflight.ts
+++ b/src/apple-container/preflight.ts
@@ -37,7 +37,7 @@ import { AppleContainerLifecycle, AppleContainerVersionParseError } from './life
  * `none` sentinel that `./run-args.ts` depends on for a no-NIC container.
  * Lowering this would silently give an isolated container a default NIC.
  */
-export const APPLE_CONTAINER_MINIMUM_CLI_VERSION = '0.4.0';
+export const APPLE_CONTAINER_MINIMUM_CLI_VERSION = '0.10.0';
 
 /** All the reasons preflight can fail, including host ineligibility. */
 export type AppleContainerPreflightCode =

--- a/src/apple-container/preflight.ts
+++ b/src/apple-container/preflight.ts
@@ -1,0 +1,182 @@
+/**
+ * Fail-closed preflight for the Apple Container runtime.
+ *
+ * Composes the two halves of the supported-host contract:
+ *
+ * 1. Host identity — Darwin, arm64, macOS 26+, Virtualization.framework usable
+ *    (`./host-facts.ts`).
+ * 2. Runtime readiness — the `container` CLI is present, new enough, and its
+ *    service reports healthy (`./lifecycle.ts`).
+ *
+ * Ordering is part of the contract: identity is checked first so an ineligible
+ * machine is told *why it is the wrong machine* rather than being told the CLI
+ * is missing, which would send an operator down the wrong path (in particular,
+ * a GitHub-hosted macOS runner fails on `hypervisor`, not on `cli-missing`).
+ *
+ * Every failure raises {@link AppleContainerPreflightError} carrying a
+ * machine-readable cause code, so a later layer can decide per-cause whether to
+ * hard-fail or fall back. Nothing here retries, degrades, or returns a partial
+ * "probably fine" result.
+ */
+
+import { AppleContainerCli, type AppleContainerCliOptions } from './cli';
+import {
+  assertAppleContainerHostEligibility,
+  collectAppleContainerHostFacts,
+  AppleContainerHostError,
+  type AppleContainerHostFacts,
+  type AppleContainerHostProbe,
+  type AppleContainerIneligibilityCode,
+} from './host-facts';
+import { AppleContainerLifecycle, AppleContainerVersionParseError } from './lifecycle';
+
+/**
+ * Minimum supported `container` CLI version.
+ *
+ * Pinned to the first release line whose `--network` handling includes the
+ * `none` sentinel that `./run-args.ts` depends on for a no-NIC container.
+ * Lowering this would silently give an isolated container a default NIC.
+ */
+export const APPLE_CONTAINER_MINIMUM_CLI_VERSION = '0.4.0';
+
+/** All the reasons preflight can fail, including host ineligibility. */
+export type AppleContainerPreflightCode =
+  | AppleContainerIneligibilityCode
+  | 'cli-missing'
+  | 'cli-version'
+  | 'service-health';
+
+export class AppleContainerPreflightError extends Error {
+  constructor(
+    readonly code: AppleContainerPreflightCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AppleContainerPreflightError';
+  }
+}
+
+export interface AppleContainerPreflightResult {
+  readonly facts: AppleContainerHostFacts;
+  readonly cliBinary: string;
+  readonly cliVersion: string;
+}
+
+export interface AppleContainerPreflightDependencies {
+  readonly hostProbe?: Partial<AppleContainerHostProbe>;
+  readonly cli?: AppleContainerCli | AppleContainerCliOptions;
+  readonly lifecycle?: Pick<AppleContainerLifecycle, 'version' | 'systemStatus' | 'cli'>;
+  readonly minimumCliVersion?: string;
+}
+
+/**
+ * Compares dotted numeric versions component-wise.
+ *
+ * Returns a negative number when `left` precedes `right`. Missing components
+ * are treated as 0, so `0.4` and `0.4.0` compare equal.
+ */
+export function compareAppleContainerVersions(left: string, right: string): number {
+  const parse = (value: string): number[] => {
+    const parts = value.trim().replace(/^v/i, '').split('.');
+    return parts.map((part) => {
+      const parsed = Number(part);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new Error(`Apple Container version component is not a number: ${value}`);
+      }
+      return parsed;
+    });
+  };
+  const a = parse(left);
+  const b = parse(right);
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const diff = (a[index] ?? 0) - (b[index] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Runs the full fail-closed preflight and returns the validated host contract.
+ *
+ * @throws {AppleContainerPreflightError} on any unmet requirement.
+ */
+export async function runAppleContainerPreflight(
+  dependencies: AppleContainerPreflightDependencies = {},
+): Promise<AppleContainerPreflightResult> {
+  const facts = await collectHostFacts(dependencies);
+  try {
+    assertAppleContainerHostEligibility(facts);
+  } catch (error) {
+    if (error instanceof AppleContainerHostError) {
+      throw new AppleContainerPreflightError(error.code, error.message);
+    }
+    throw error;
+  }
+
+  const lifecycle = dependencies.lifecycle
+    ?? new AppleContainerLifecycle(
+      dependencies.cli instanceof AppleContainerCli
+        ? dependencies.cli
+        : new AppleContainerCli(dependencies.cli ?? {}),
+    );
+
+  let cliVersion: string;
+  try {
+    cliVersion = (await lifecycle.version()).version;
+  } catch (error) {
+    // An installed CLI whose banner we cannot parse is a version problem, not a
+    // missing install; conflating them would tell the operator to install a CLI
+    // they already have.
+    if (error instanceof AppleContainerVersionParseError) {
+      throw new AppleContainerPreflightError('cli-version', error.message);
+    }
+    throw new AppleContainerPreflightError(
+      'cli-missing',
+      'The Apple Container CLI ("container") could not be run. Install it from ' +
+      `https://github.com/apple/container and ensure it is on PATH: ${formatCause(error)}`,
+    );
+  }
+
+  const minimum = dependencies.minimumCliVersion ?? APPLE_CONTAINER_MINIMUM_CLI_VERSION;
+  let comparison: number;
+  try {
+    comparison = compareAppleContainerVersions(cliVersion, minimum);
+  } catch (error) {
+    throw new AppleContainerPreflightError('cli-version', formatCause(error));
+  }
+  if (comparison < 0) {
+    throw new AppleContainerPreflightError(
+      'cli-version',
+      `Apple Container CLI ${minimum} or newer is required; found ${cliVersion}`,
+    );
+  }
+
+  const status = await lifecycle.systemStatus();
+  if (!status.healthy) {
+    const detail = (status.result.stderr.trim() || status.result.stdout.trim()).slice(0, 500);
+    throw new AppleContainerPreflightError(
+      'service-health',
+      'The Apple Container service is not running. Start it with "container system start"' +
+      (detail ? `: ${detail}` : '.'),
+    );
+  }
+
+  return { facts, cliBinary: lifecycle.cli.binary, cliVersion };
+}
+
+async function collectHostFacts(
+  dependencies: AppleContainerPreflightDependencies,
+): Promise<AppleContainerHostFacts> {
+  try {
+    return await collectAppleContainerHostFacts(dependencies.hostProbe ?? {});
+  } catch (error) {
+    if (error instanceof AppleContainerHostError) {
+      throw new AppleContainerPreflightError(error.code, error.message);
+    }
+    throw error;
+  }
+}
+
+function formatCause(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/apple-container/run-args.test.ts
+++ b/src/apple-container/run-args.test.ts
@@ -1,0 +1,344 @@
+import {
+  APPLE_CONTAINER_DEFAULT_ARCH,
+  APPLE_CONTAINER_DEFAULT_OS,
+  APPLE_CONTAINER_NO_NETWORK,
+  buildAppleContainerRunArgs,
+  type AppleContainerRunSpec,
+} from './run-args';
+
+const MINIMAL: AppleContainerRunSpec = { image: 'ubuntu:22.04' };
+
+/** Returns the value that follows `flag`, or undefined when absent. */
+function valueAfter(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+/** Returns every value emitted for a repeatable flag, in order. */
+function valuesFor(args: readonly string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === flag) values.push(args[index + 1]);
+  }
+  return values;
+}
+
+describe('buildAppleContainerRunArgs defaults', () => {
+  it('starts with the requested subcommand', () => {
+    expect(buildAppleContainerRunArgs(MINIMAL)[0]).toBe('run');
+    expect(buildAppleContainerRunArgs(MINIMAL, 'create')[0]).toBe('create');
+    expect(buildAppleContainerRunArgs(MINIMAL)).not.toContain('container');
+  });
+
+  it('always emits --network none so an unspecified network cannot attach the default NIC', () => {
+    const args = buildAppleContainerRunArgs(MINIMAL);
+    expect(valueAfter(args, '--network')).toBe(APPLE_CONTAINER_NO_NETWORK);
+    expect(valuesFor(args, '--network')).toHaveLength(1);
+  });
+
+  it('selects the native arm64 linux platform by default', () => {
+    const args = buildAppleContainerRunArgs(MINIMAL);
+    expect(valueAfter(args, '--os')).toBe(APPLE_CONTAINER_DEFAULT_OS);
+    expect(valueAfter(args, '--arch')).toBe(APPLE_CONTAINER_DEFAULT_ARCH);
+    expect(APPLE_CONTAINER_DEFAULT_ARCH).toBe('arm64');
+  });
+
+  it('adds no capabilities, no tty, no privileges and no mounts by default', () => {
+    const args = buildAppleContainerRunArgs(MINIMAL);
+    expect(args).not.toContain('--cap-add');
+    expect(args).not.toContain('--tty');
+    expect(args).not.toContain('--interactive');
+    expect(args).not.toContain('--mount');
+    expect(args).not.toContain('--publish-socket');
+    expect(args).not.toContain('--rm');
+    expect(args).not.toContain('--detach');
+    expect(args).not.toContain('--read-only');
+  });
+
+  it('places the image last when no container arguments are supplied', () => {
+    const args = buildAppleContainerRunArgs(MINIMAL);
+    expect(args[args.length - 1]).toBe('ubuntu:22.04');
+  });
+});
+
+describe('buildAppleContainerRunArgs positional handling', () => {
+  it('emits the image before the container arguments', () => {
+    const args = buildAppleContainerRunArgs({
+      image: 'ubuntu:22.04',
+      args: ['bash', '-lc', 'echo hi'],
+    });
+    expect(args.slice(-4)).toEqual(['ubuntu:22.04', 'bash', '-lc', 'echo hi']);
+  });
+
+  it('passes option-like container arguments through verbatim without a -- terminator', () => {
+    // `container run` declares its trailing arguments with
+    // `.captureForPassthrough`, so leading dashes are safe as-is.
+    const args = buildAppleContainerRunArgs({
+      image: 'ubuntu:22.04',
+      args: ['--rm', '--network', 'default'],
+    });
+    expect(args).not.toContain('--');
+    expect(args.slice(-4)).toEqual(['ubuntu:22.04', '--rm', '--network', 'default']);
+    // The real network flag is still the isolated one emitted before the image.
+    expect(valueAfter(args, '--network')).toBe(APPLE_CONTAINER_NO_NETWORK);
+  });
+
+  it('does not treat an empty argument list as missing', () => {
+    expect(buildAppleContainerRunArgs({ image: 'ubuntu:22.04', args: [] })).toEqual(
+      buildAppleContainerRunArgs(MINIMAL),
+    );
+  });
+});
+
+describe('buildAppleContainerRunArgs resources and process options', () => {
+  it('emits cpu, memory, workdir, user and entrypoint', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      cpus: 4,
+      memory: '8G',
+      workdir: '/workspace',
+      user: '1000:1000',
+      entrypoint: '/usr/bin/env',
+    });
+    expect(valueAfter(args, '--cpus')).toBe('4');
+    expect(valueAfter(args, '--memory')).toBe('8G');
+    expect(valueAfter(args, '--workdir')).toBe('/workspace');
+    expect(valueAfter(args, '--user')).toBe('1000:1000');
+    expect(valueAfter(args, '--entrypoint')).toBe('/usr/bin/env');
+  });
+
+  it('emits one --env token per variable, preserving values containing "="', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      env: { HTTPS_PROXY: 'http://172.30.0.10:3128', OPTS: 'a=b' },
+    });
+    expect(valuesFor(args, '--env')).toEqual([
+      'HTTPS_PROXY=http://172.30.0.10:3128',
+      'OPTS=a=b',
+    ]);
+  });
+
+  it('emits labels as key=value tokens', () => {
+    const args = buildAppleContainerRunArgs({ ...MINIMAL, labels: { awf: 'agent' } });
+    expect(valuesFor(args, '--label')).toEqual(['awf=agent']);
+  });
+
+  it('rejects an "=" in a label value, which the CLI parses as a third field', () => {
+    // Unlike --env, `Parser.labels` splits with maxSplits: 2 and rejects three
+    // components, so this must fail here rather than inside `container create`.
+    expect(() => buildAppleContainerRunArgs({ ...MINIMAL, labels: { awf: 'a=b' } })).toThrow(
+      /label "awf" value must not contain "="/,
+    );
+  });
+
+  it('rejects a newline in a label value', () => {
+    expect(() => buildAppleContainerRunArgs({ ...MINIMAL, labels: { awf: 'a\nb' } })).toThrow(
+      /NUL or newlines/,
+    );
+  });
+
+  it.each([
+    ['cpus', { cpus: 0 }],
+    ['memory', { memory: '8GB' }],
+    ['workdir', { workdir: 'workspace' }],
+    ['user', { user: 'root; rm -rf /' }],
+    ['name', { name: '-bad' }],
+  ])('rejects an invalid %s', (_label, overrides) => {
+    expect(() => buildAppleContainerRunArgs({ ...MINIMAL, ...overrides })).toThrow();
+  });
+
+  it('rejects an environment value containing a newline', () => {
+    expect(() =>
+      buildAppleContainerRunArgs({ ...MINIMAL, env: { TOKEN: 'a\nb' } }),
+    ).toThrow(/NUL or newlines/);
+  });
+});
+
+describe('buildAppleContainerRunArgs isolation controls', () => {
+  it('emits --read-only and bounded read-only paths', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      readOnlyRootfs: true,
+      readOnlyPaths: ['/etc', '/usr'],
+    });
+    expect(args).toContain('--read-only');
+    expect(valuesFor(args, '--read-only-path')).toEqual(['/etc', '/usr']);
+  });
+
+  it('emits each dropped and added capability separately', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      capDrop: ['ALL'],
+      capAdd: ['CAP_CHOWN'],
+    });
+    expect(valuesFor(args, '--cap-drop')).toEqual(['ALL']);
+    expect(valuesFor(args, '--cap-add')).toEqual(['CAP_CHOWN']);
+  });
+
+  it('rejects an invalid capability name', () => {
+    expect(() => buildAppleContainerRunArgs({ ...MINIMAL, capDrop: ['ALL;ls'] })).toThrow(
+      /capability name is not valid/,
+    );
+  });
+});
+
+describe('buildAppleContainerRunArgs mounts', () => {
+  it('builds a read-write bind mount token', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      mounts: [{ source: '/host/workspace', target: '/workspace' }],
+    });
+    expect(valuesFor(args, '--mount')).toEqual([
+      'type=bind,source=/host/workspace,target=/workspace',
+    ]);
+  });
+
+  it('appends readonly to the token when requested', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      mounts: [{ source: '/host/tools', target: '/tools', readOnly: true }],
+    });
+    expect(valuesFor(args, '--mount')).toEqual([
+      'type=bind,source=/host/tools,target=/tools,readonly',
+    ]);
+  });
+
+  it('preserves mount order', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      mounts: [
+        { source: '/a', target: '/a' },
+        { source: '/b', target: '/b', readOnly: true },
+      ],
+    });
+    expect(valuesFor(args, '--mount')).toEqual([
+      'type=bind,source=/a,target=/a',
+      'type=bind,source=/b,target=/b,readonly',
+    ]);
+  });
+
+  it.each([
+    ['a comma in the source, which would inject a sibling mount field', '/host,readonly', '/t'],
+    ['an equals sign in the target, which would inject a key', '/host', '/t=x'],
+  ])('rejects %s', (_label, source, target) => {
+    expect(() => buildAppleContainerRunArgs({ ...MINIMAL, mounts: [{ source, target }] })).toThrow(
+      /delimits fields/,
+    );
+  });
+
+  it('builds a publish-socket token for a Unix socket mount', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      socketMounts: [{ hostPath: '/run/awf/agent.sock', containerPath: '/run/awf.sock' }],
+    });
+    expect(valuesFor(args, '--publish-socket')).toEqual([
+      '/run/awf/agent.sock:/run/awf.sock',
+    ]);
+  });
+
+  it('rejects a colon in a socket path, which would inject a second field', () => {
+    expect(() =>
+      buildAppleContainerRunArgs({
+        ...MINIMAL,
+        socketMounts: [{ hostPath: '/run/a:/b', containerPath: '/run/awf.sock' }],
+      }),
+    ).toThrow(/must not contain ":"/);
+  });
+});
+
+describe('buildAppleContainerRunArgs network policy', () => {
+  it('emits one --network flag per attached network', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      network: { kind: 'attach', networks: ['awf-net', 'awf-enclave'] },
+    });
+    expect(valuesFor(args, '--network')).toEqual(['awf-net', 'awf-enclave']);
+  });
+
+  it('rejects an empty attach list rather than silently falling back', () => {
+    expect(() =>
+      buildAppleContainerRunArgs({ ...MINIMAL, network: { kind: 'attach', networks: [] } }),
+    ).toThrow(/requires at least one network name/);
+  });
+
+  it('rejects mixing the "none" sentinel with real networks', () => {
+    expect(() =>
+      buildAppleContainerRunArgs({
+        ...MINIMAL,
+        network: { kind: 'attach', networks: ['awf-net', 'none'] },
+      }),
+    ).toThrow(/cannot be combined with other networks/);
+  });
+
+  it('rejects an invalid network name', () => {
+    expect(() =>
+      buildAppleContainerRunArgs({
+        ...MINIMAL,
+        network: { kind: 'attach', networks: ['net,mac=00:11:22:33:44:55'] },
+      }),
+    ).toThrow(/network name is not valid/);
+  });
+});
+
+describe('buildAppleContainerRunArgs boot and execution options', () => {
+  it('emits the custom init image and init flag', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      initImage: 'ghcr.io/github/gh-aw-firewall/init:latest',
+      useInit: true,
+    });
+    expect(valueAfter(args, '--init-image')).toBe('ghcr.io/github/gh-aw-firewall/init:latest');
+    expect(args).toContain('--init');
+  });
+
+  it('rejects an option-like init image', () => {
+    expect(() => buildAppleContainerRunArgs({ ...MINIMAL, initImage: '--evil' })).toThrow(
+      /must not begin with "-"/,
+    );
+  });
+
+  it('emits interactive without tty for non-TTY CI execution', () => {
+    const args = buildAppleContainerRunArgs({ ...MINIMAL, interactive: true });
+    expect(args).toContain('--interactive');
+    expect(args).not.toContain('--tty');
+  });
+
+  it('emits tty only when explicitly requested', () => {
+    expect(buildAppleContainerRunArgs({ ...MINIMAL, tty: true })).toContain('--tty');
+  });
+
+  it('emits detach, rm, cidfile and name', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      name: 'awf-agent',
+      detach: true,
+      removeOnExit: true,
+      cidFile: '/tmp/awf/cid',
+    });
+    expect(valueAfter(args, '--name')).toBe('awf-agent');
+    expect(args).toContain('--detach');
+    expect(args).toContain('--rm');
+    expect(valueAfter(args, '--cidfile')).toBe('/tmp/awf/cid');
+  });
+});
+
+describe('buildAppleContainerRunArgs determinism', () => {
+  it('produces identical argv for identical specs', () => {
+    const spec: AppleContainerRunSpec = {
+      image: 'ubuntu:22.04',
+      name: 'awf-agent',
+      cpus: 2,
+      memory: '4G',
+      env: { A: '1', B: '2' },
+      mounts: [{ source: '/a', target: '/a' }],
+      args: ['bash'],
+    };
+    expect(buildAppleContainerRunArgs(spec)).toEqual(buildAppleContainerRunArgs(spec));
+  });
+
+  it('differs from the create form only in the leading subcommand', () => {
+    const run = buildAppleContainerRunArgs(MINIMAL, 'run');
+    const create = buildAppleContainerRunArgs(MINIMAL, 'create');
+    expect(run.slice(1)).toEqual(create.slice(1));
+  });
+});

--- a/src/apple-container/run-args.test.ts
+++ b/src/apple-container/run-args.test.ts
@@ -123,6 +123,14 @@ describe('buildAppleContainerRunArgs resources and process options', () => {
     expect(valuesFor(args, '--label')).toEqual(['awf=agent']);
   });
 
+  it('accepts OCI label punctuation in label names', () => {
+    const args = buildAppleContainerRunArgs({
+      ...MINIMAL,
+      labels: { 'com.example.role-name': 'agent' },
+    });
+    expect(valuesFor(args, '--label')).toEqual(['com.example.role-name=agent']);
+  });
+
   it('rejects an "=" in a label value, which the CLI parses as a third field', () => {
     // Unlike --env, `Parser.labels` splits with maxSplits: 2 and rejects three
     // components, so this must fail here rather than inside `container create`.

--- a/src/apple-container/run-args.ts
+++ b/src/apple-container/run-args.ts
@@ -1,0 +1,286 @@
+/**
+ * Typed model for `container run` / `container create` and its argv builder.
+ *
+ * This layer models the flags that later backend layers will need, but
+ * deliberately implements **no policy**: it does not decide what the agent's
+ * mounts, memory, or network should be, only how a validated decision is turned
+ * into argv. Policy lands in a later layer of the stack.
+ *
+ * Two defaults are load-bearing and must not be relaxed:
+ *
+ * 1. **`--network none`.** Apple Container attaches the *default* vmnet network
+ *    when `--network` is omitted; `none` is a reserved sentinel that produces no
+ *    NIC at all. Omitting the flag would therefore silently give the agent
+ *    unfiltered egress, so `network` defaults to `{ kind: 'none' }` and the
+ *    flag is always emitted explicitly.
+ * 2. **No implicit capabilities.** `capAdd` defaults to empty. Nothing here
+ *    ever adds a capability the caller did not ask for.
+ *
+ * Flag emission order is fixed so callers, tests, and log output all see a
+ * stable, diffable argv.
+ */
+
+import {
+  assertAppleContainerCapability,
+  assertAppleContainerCpuCount,
+  assertAppleContainerEnvName,
+  assertAppleContainerEnvValue,
+  assertAppleContainerId,
+  assertAppleContainerImageReference,
+  assertAppleContainerLabelValue,
+  assertAppleContainerMemorySize,
+  assertAppleContainerNetworkName,
+  assertAppleContainerPath,
+} from './validation';
+
+/** Reserved `--network` value meaning "no network interface at all". */
+export const APPLE_CONTAINER_NO_NETWORK = 'none';
+
+/** Default guest architecture: native arm64, never Rosetta-translated amd64. */
+export const APPLE_CONTAINER_DEFAULT_ARCH = 'arm64';
+
+export const APPLE_CONTAINER_DEFAULT_OS = 'linux';
+
+/**
+ * `--mount` packs fields into one comma-separated `key=value` token, so both
+ * `,` and `=` inside a path would create or overwrite sibling fields.
+ */
+const MOUNT_PATH_DELIMITERS = [',', '='] as const;
+
+/** `--publish-socket` is `host_path:container_path`. */
+const SOCKET_PATH_DELIMITERS = [':'] as const;
+
+/**
+ * A host directory or file bind-mounted into the guest.
+ *
+ * `readOnly` has no default here on purpose: the caller must state the
+ * intent, and {@link buildAppleContainerRunArgs} treats `undefined` as
+ * read-write only because that is what Apple Container itself does.
+ */
+export interface AppleContainerBindMount {
+  readonly source: string;
+  readonly target: string;
+  readonly readOnly?: boolean;
+}
+
+/**
+ * A host Unix socket published into the guest via `--publish-socket`.
+ *
+ * This is the mechanism a later layer uses to reach AWF infrastructure without
+ * giving the guest a NIC, which is why it is modelled now.
+ */
+export interface AppleContainerSocketMount {
+  readonly hostPath: string;
+  readonly containerPath: string;
+}
+
+/**
+ * Network attachment policy.
+ *
+ * `attach` is intentionally awkward to reach: a caller has to name the networks
+ * explicitly, and `none` may not be mixed in (Apple Container rejects that
+ * combination too).
+ */
+export type AppleContainerNetworkPolicy =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'attach'; readonly networks: readonly string[] };
+
+export interface AppleContainerRunSpec {
+  readonly image: string;
+  /**
+   * Arguments for the container's init process. Apple Container declares these
+   * with `.captureForPassthrough`, so leading dashes are safe and are *not*
+   * rewritten or prefixed with `--`.
+   */
+  readonly args?: readonly string[];
+  readonly name?: string;
+  readonly os?: string;
+  readonly arch?: string;
+  readonly cpus?: number;
+  /** Integer with an optional K/M/G/T/P suffix, e.g. `"8G"`. */
+  readonly memory?: string;
+  readonly workdir?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly user?: string;
+  readonly entrypoint?: string;
+  /** Mounts the guest root filesystem read-only (`--read-only`). */
+  readonly readOnlyRootfs?: boolean;
+  /** Additional guest paths marked read-only (`--read-only-path`, experimental). */
+  readonly readOnlyPaths?: readonly string[];
+  readonly capDrop?: readonly string[];
+  readonly capAdd?: readonly string[];
+  readonly mounts?: readonly AppleContainerBindMount[];
+  readonly socketMounts?: readonly AppleContainerSocketMount[];
+  /** Defaults to `{ kind: 'none' }`; see the module comment. */
+  readonly network?: AppleContainerNetworkPolicy;
+  /** Custom init filesystem image (`--init-image`). */
+  readonly initImage?: string;
+  /** Run a lightweight init as PID 1 (`--init`). */
+  readonly useInit?: boolean;
+  /** Keep stdin open (`--interactive`). */
+  readonly interactive?: boolean;
+  /**
+   * Allocate a PTY (`--tty`). Defaults to false: CI has no controlling
+   * terminal, and requesting one there corrupts captured output.
+   */
+  readonly tty?: boolean;
+  readonly detach?: boolean;
+  readonly removeOnExit?: boolean;
+  /** Writes the container ID to this host path (`--cidfile`). */
+  readonly cidFile?: string;
+  readonly labels?: Readonly<Record<string, string>>;
+}
+
+export type AppleContainerRunMode = 'run' | 'create';
+
+function buildMountToken(mount: AppleContainerBindMount): string {
+  const source = assertAppleContainerPath(mount.source, 'mount source', MOUNT_PATH_DELIMITERS);
+  const target = assertAppleContainerPath(mount.target, 'mount target', MOUNT_PATH_DELIMITERS);
+  const token = `type=bind,source=${source},target=${target}`;
+  return mount.readOnly ? `${token},readonly` : token;
+}
+
+function buildSocketToken(socket: AppleContainerSocketMount): string {
+  const hostPath = assertAppleContainerPath(
+    socket.hostPath,
+    'published socket host path',
+    SOCKET_PATH_DELIMITERS,
+  );
+  const containerPath = assertAppleContainerPath(
+    socket.containerPath,
+    'published socket container path',
+    SOCKET_PATH_DELIMITERS,
+  );
+  return `${hostPath}:${containerPath}`;
+}
+
+function buildNetworkArgs(policy: AppleContainerNetworkPolicy): string[] {
+  if (policy.kind === 'none') {
+    return ['--network', APPLE_CONTAINER_NO_NETWORK];
+  }
+  if (policy.networks.length === 0) {
+    throw new Error(
+      'Apple Container network policy "attach" requires at least one network name; use ' +
+      '{ kind: "none" } for an isolated container',
+    );
+  }
+  const args: string[] = [];
+  for (const network of policy.networks) {
+    if (network === APPLE_CONTAINER_NO_NETWORK) {
+      throw new Error(
+        `Apple Container network "${APPLE_CONTAINER_NO_NETWORK}" cannot be combined with other ` +
+        'networks; use { kind: "none" } instead',
+      );
+    }
+    args.push('--network', assertAppleContainerNetworkName(network));
+  }
+  return args;
+}
+
+/**
+ * Builds the full argv for `container run` or `container create`.
+ *
+ * The returned array starts at the subcommand (`['run', …]`) and does not
+ * include the `container` binary itself, which the CLI adapter owns.
+ */
+export function buildAppleContainerRunArgs(
+  spec: AppleContainerRunSpec,
+  mode: AppleContainerRunMode = 'run',
+): string[] {
+  const args: string[] = [mode];
+
+  if (spec.name !== undefined) {
+    args.push('--name', assertAppleContainerId(spec.name, 'container name'));
+  }
+
+  args.push('--os', spec.os ?? APPLE_CONTAINER_DEFAULT_OS);
+  args.push('--arch', spec.arch ?? APPLE_CONTAINER_DEFAULT_ARCH);
+
+  if (spec.cpus !== undefined) {
+    args.push('--cpus', String(assertAppleContainerCpuCount(spec.cpus)));
+  }
+  if (spec.memory !== undefined) {
+    args.push('--memory', assertAppleContainerMemorySize(spec.memory));
+  }
+  if (spec.workdir !== undefined) {
+    args.push('--workdir', assertAppleContainerPath(spec.workdir, 'workdir', []));
+  }
+  if (spec.user !== undefined) {
+    args.push('--user', assertUserSpec(spec.user));
+  }
+  if (spec.entrypoint !== undefined) {
+    args.push('--entrypoint', spec.entrypoint);
+  }
+
+  for (const [name, value] of Object.entries(spec.env ?? {})) {
+    assertAppleContainerEnvName(name);
+    assertAppleContainerEnvValue(name, value);
+    args.push('--env', `${name}=${value}`);
+  }
+
+  for (const [name, value] of Object.entries(spec.labels ?? {})) {
+    assertAppleContainerEnvName(name);
+    assertAppleContainerLabelValue(name, value);
+    args.push('--label', `${name}=${value}`);
+  }
+
+  if (spec.readOnlyRootfs) {
+    args.push('--read-only');
+  }
+  for (const readOnlyPath of spec.readOnlyPaths ?? []) {
+    args.push('--read-only-path', assertAppleContainerPath(readOnlyPath, 'read-only path', []));
+  }
+
+  for (const capability of spec.capDrop ?? []) {
+    args.push('--cap-drop', assertAppleContainerCapability(capability));
+  }
+  for (const capability of spec.capAdd ?? []) {
+    args.push('--cap-add', assertAppleContainerCapability(capability));
+  }
+
+  for (const mount of spec.mounts ?? []) {
+    args.push('--mount', buildMountToken(mount));
+  }
+  for (const socket of spec.socketMounts ?? []) {
+    args.push('--publish-socket', buildSocketToken(socket));
+  }
+
+  args.push(...buildNetworkArgs(spec.network ?? { kind: 'none' }));
+
+  if (spec.initImage !== undefined) {
+    args.push('--init-image', assertAppleContainerImageReference(spec.initImage));
+  }
+  if (spec.useInit) {
+    args.push('--init');
+  }
+  if (spec.cidFile !== undefined) {
+    args.push('--cidfile', assertAppleContainerPath(spec.cidFile, 'cidfile path', []));
+  }
+  if (spec.interactive) {
+    args.push('--interactive');
+  }
+  if (spec.tty) {
+    args.push('--tty');
+  }
+  if (spec.detach) {
+    args.push('--detach');
+  }
+  if (spec.removeOnExit) {
+    args.push('--rm');
+  }
+
+  // The image must be the first positional; everything after it is captured
+  // for passthrough by Apple Container and is never reinterpreted as a flag.
+  args.push(assertAppleContainerImageReference(spec.image));
+  args.push(...(spec.args ?? []));
+
+  return args;
+}
+
+/** `--user` accepts `name|uid[:gid]`; reject anything that could split the token. */
+function assertUserSpec(value: string): string {
+  if (!/^[A-Za-z0-9_.-]+(?::[A-Za-z0-9_.-]+)?$/.test(value)) {
+    throw new Error(`Apple Container user spec must be "name|uid[:gid]"; got ${value}`);
+  }
+  return value;
+}

--- a/src/apple-container/run-args.ts
+++ b/src/apple-container/run-args.ts
@@ -27,6 +27,7 @@ import {
   assertAppleContainerEnvValue,
   assertAppleContainerId,
   assertAppleContainerImageReference,
+  assertAppleContainerLabelName,
   assertAppleContainerLabelValue,
   assertAppleContainerMemorySize,
   assertAppleContainerNetworkName,
@@ -219,7 +220,7 @@ export function buildAppleContainerRunArgs(
   }
 
   for (const [name, value] of Object.entries(spec.labels ?? {})) {
-    assertAppleContainerEnvName(name);
+    assertAppleContainerLabelName(name);
     assertAppleContainerLabelValue(name, value);
     args.push('--label', `${name}=${value}`);
   }

--- a/src/apple-container/validation.test.ts
+++ b/src/apple-container/validation.test.ts
@@ -1,0 +1,247 @@
+import * as path from 'path';
+import {
+  assertAppleContainerCapability,
+  assertAppleContainerCpuCount,
+  assertAppleContainerEnvName,
+  assertAppleContainerEnvValue,
+  assertAppleContainerId,
+  assertAppleContainerImageReference,
+  assertAppleContainerLabelValue,
+  assertAppleContainerLineCount,
+  assertAppleContainerLogWindow,
+  assertAppleContainerMemorySize,
+  assertAppleContainerNetworkName,
+  assertAppleContainerPath,
+  assertAppleContainerSignal,
+  assertAppleContainerStopTimeout,
+} from './validation';
+
+describe('assertAppleContainerId', () => {
+  it.each(['ab', 'awf-agent', 'my-container_1.2', 'ABC', 'a'.repeat(63)])(
+    'accepts %s',
+    (value) => {
+      expect(assertAppleContainerId(value)).toBe(value);
+    },
+  );
+
+  it('accepts a generated lowercase UUID', () => {
+    const uuid = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+    expect(assertAppleContainerId(uuid)).toBe(uuid);
+  });
+
+  it.each([
+    ['a single character', 'a'],
+    ['a leading hyphen', '-bad'],
+    ['a leading dot', '.bad'],
+    ['an embedded space', 'a b'],
+    ['a slash', 'a/b'],
+    ['64 characters', 'a'.repeat(64)],
+    ['an empty string', ''],
+  ])('rejects %s', (_label, value) => {
+    expect(() => assertAppleContainerId(value)).toThrow(/container ID/);
+  });
+
+  it('rejects control characters', () => {
+    expect(() => assertAppleContainerId('ab\u0007c')).toThrow(/control characters/);
+  });
+
+  it('uses the supplied label in the error', () => {
+    expect(() => assertAppleContainerId('-x', 'container name')).toThrow(/container name/);
+  });
+});
+
+describe('assertAppleContainerImageReference', () => {
+  it.each([
+    'ubuntu:22.04',
+    'ghcr.io/github/gh-aw-firewall/agent:latest',
+    'ghcr.io/o/r@sha256:0123456789abcdef',
+  ])('accepts %s', (value) => {
+    expect(assertAppleContainerImageReference(value)).toBe(value);
+  });
+
+  it('rejects an option-like reference so it cannot be parsed as a flag', () => {
+    expect(() => assertAppleContainerImageReference('--rm')).toThrow(/must not begin with "-"/);
+  });
+
+  it.each(['ubuntu 22.04', 'ubuntu;rm', 'ubuntu,latest', 'ubuntu\nlatest'])(
+    'rejects %j',
+    (value) => {
+      expect(() => assertAppleContainerImageReference(value)).toThrow();
+    },
+  );
+
+  it('rejects an absurdly long reference', () => {
+    expect(() => assertAppleContainerImageReference(`a${'b'.repeat(512)}`)).toThrow(
+      /not a valid OCI reference/,
+    );
+  });
+});
+
+describe('assertAppleContainerPath', () => {
+  it('accepts an absolute normalized path', () => {
+    expect(assertAppleContainerPath('/workspace/repo', 'mount source', [])).toBe('/workspace/repo');
+  });
+
+  it('rejects a relative path', () => {
+    expect(() => assertAppleContainerPath('workspace', 'mount source', [])).toThrow(
+      /absolute POSIX path/,
+    );
+  });
+
+  it.each(['/workspace/../etc', '/workspace//repo', '/workspace/./repo', '/workspace/'])(
+    'rejects the unnormalized path %s',
+    (value) => {
+      expect(() => assertAppleContainerPath(value, 'mount source', [])).toThrow(
+        /normalized path/,
+      );
+    },
+  );
+
+  it('rejects a comma when building a comma-delimited --mount token', () => {
+    expect(() =>
+      assertAppleContainerPath('/work,readonly', 'mount source', [',', '=']),
+    ).toThrow(/must not contain ","/);
+  });
+
+  it('rejects an equals sign when building a key=value --mount token', () => {
+    expect(() =>
+      assertAppleContainerPath('/work=x', 'mount source', [',', '=']),
+    ).toThrow(/must not contain "="/);
+  });
+
+  it('rejects a colon when building a colon-delimited --publish-socket token', () => {
+    expect(() =>
+      assertAppleContainerPath('/run/a:/etc/passwd', 'socket host path', [':']),
+    ).toThrow(/must not contain ":"/);
+  });
+
+  it('allows a comma when the token is not comma-delimited', () => {
+    expect(assertAppleContainerPath('/work,dir', 'read-only path', [])).toBe('/work,dir');
+  });
+
+  it('rejects a path beyond the byte limit', () => {
+    const long = path.posix.join('/', 'a'.repeat(5000));
+    expect(() => assertAppleContainerPath(long, 'mount source', [])).toThrow(/exceeds 4096 bytes/);
+  });
+});
+
+describe('environment validation', () => {
+  it.each(['PATH', '_HOME', 'A1_B'])('accepts the name %s', (value) => {
+    expect(assertAppleContainerEnvName(value)).toBe(value);
+  });
+
+  it.each(['1BAD', 'has-dash', 'has space', 'has=equals', ''])('rejects the name %j', (value) => {
+    expect(() => assertAppleContainerEnvName(value)).toThrow();
+  });
+
+  it('allows an equals sign inside a value', () => {
+    expect(assertAppleContainerEnvValue('OPTS', 'a=b=c')).toBe('a=b=c');
+  });
+
+  it('allows an empty value', () => {
+    expect(assertAppleContainerEnvValue('EMPTY', '')).toBe('');
+  });
+
+  it.each(['line\nbreak', 'carriage\rreturn', 'nul\u0000byte'])(
+    'rejects the value %j',
+    (value) => {
+      expect(() => assertAppleContainerEnvValue('KEY', value)).toThrow(/NUL or newlines/);
+    },
+  );
+});
+
+describe('assertAppleContainerLabelValue', () => {
+  it('accepts a plain value', () => {
+    expect(assertAppleContainerLabelValue('awf', 'agent')).toBe('agent');
+  });
+
+  it('accepts an empty value', () => {
+    expect(assertAppleContainerLabelValue('awf', '')).toBe('');
+  });
+
+  it('rejects an equals sign, which --label does not tolerate even though --env does', () => {
+    expect(() => assertAppleContainerLabelValue('awf', 'a=b')).toThrow(/must not contain "="/);
+    expect(assertAppleContainerEnvValue('awf', 'a=b')).toBe('a=b');
+  });
+
+  it.each(['line\nbreak', 'nul\u0000byte'])('rejects the value %j', (value) => {
+    expect(() => assertAppleContainerLabelValue('awf', value)).toThrow(/NUL or newlines/);
+  });
+});
+
+describe('assertAppleContainerCapability', () => {
+  it.each(['CAP_NET_RAW', 'NET_RAW', 'ALL', 'cap_net_raw'])('accepts %s', (value) => {
+    expect(assertAppleContainerCapability(value)).toBe(value);
+  });
+
+  it.each(['NET RAW', 'NET;RAW', '1NET', ''])('rejects %j', (value) => {
+    expect(() => assertAppleContainerCapability(value)).toThrow();
+  });
+});
+
+describe('resource validation', () => {
+  it('accepts a positive integer CPU count', () => {
+    expect(assertAppleContainerCpuCount(4)).toBe(4);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects the CPU count %p',
+    (value) => {
+      expect(() => assertAppleContainerCpuCount(value)).toThrow(/positive integer/);
+    },
+  );
+
+  it.each(['1024', '8G', '512M', '2T'])('accepts the memory size %s', (value) => {
+    expect(assertAppleContainerMemorySize(value)).toBe(value);
+  });
+
+  it.each(['0', '8g', '8GB', '-1G', '8.5G', ''])('rejects the memory size %j', (value) => {
+    expect(() => assertAppleContainerMemorySize(value)).toThrow();
+  });
+});
+
+describe('network name validation', () => {
+  it.each(['default', 'none', 'awf-net', 'n'])('accepts %s', (value) => {
+    expect(assertAppleContainerNetworkName(value)).toBe(value);
+  });
+
+  it.each(['-net', 'net,mac=00:11:22:33:44:55', 'net work', ''])('rejects %j', (value) => {
+    expect(() => assertAppleContainerNetworkName(value)).toThrow();
+  });
+});
+
+describe('signal and stop-timeout validation', () => {
+  it.each(['KILL', 'TERM', 'SIGTERM', 'USR1'])('accepts the signal %s', (value) => {
+    expect(assertAppleContainerSignal(value)).toBe(value);
+  });
+
+  it.each(['kill', '9', 'TERM;ls', ''])('rejects the signal %j', (value) => {
+    expect(() => assertAppleContainerSignal(value)).toThrow();
+  });
+
+  it.each([0, 5, 86_400])('accepts the stop timeout %p', (value) => {
+    expect(assertAppleContainerStopTimeout(value)).toBe(value);
+  });
+
+  it.each([-1, 1.5, 86_401])('rejects the stop timeout %p', (value) => {
+    expect(() => assertAppleContainerStopTimeout(value)).toThrow(/0\.\.86400/);
+  });
+});
+
+describe('log bound validation', () => {
+  it.each(['5m', '1h', '2d', '30'])('accepts the log window %s', (value) => {
+    expect(assertAppleContainerLogWindow(value)).toBe(value);
+  });
+
+  it.each(['5min', '0m', '-5m', 'm', ''])('rejects the log window %j', (value) => {
+    expect(() => assertAppleContainerLogWindow(value)).toThrow();
+  });
+
+  it.each([1, 2000, 100_000])('accepts the line count %p', (value) => {
+    expect(assertAppleContainerLineCount(value)).toBe(value);
+  });
+
+  it.each([0, -1, 1.5, 100_001])('rejects the line count %p', (value) => {
+    expect(() => assertAppleContainerLineCount(value)).toThrow(/1\.\.100000/);
+  });
+});

--- a/src/apple-container/validation.ts
+++ b/src/apple-container/validation.ts
@@ -1,0 +1,251 @@
+/**
+ * Argv token validation shared by the Apple Container adapter.
+ *
+ * Every value reaches the `container` CLI as its own argv element and no shell
+ * is ever involved, so classic quoting/injection is already impossible. The
+ * residual risk is *flag-value* injection: several Apple Container options pack
+ * multiple fields into a single argv token using structural delimiters
+ * (`--mount type=bind,source=…,target=…,readonly`, `--publish-socket
+ * host_path:container_path`, `--env KEY=VALUE`, `--network name,mac=…`). A
+ * value that smuggles in a delimiter would silently add or override sibling
+ * fields inside the same token, so each component is validated against the
+ * delimiter set of the token it will be embedded in *before* it is joined.
+ *
+ * Everything here fails closed: an invalid value throws rather than being
+ * dropped, escaped, or coerced, so a caller can never end up with a launch that
+ * quietly differs from the one it asked for.
+ */
+
+import * as path from 'path';
+
+/**
+ * Apple Container's own container-ID predicate, mirrored from
+ * `ManagedContainer.nameValid` in apple/container: at most 63 characters (DNS
+ * label maximum), starting with an alphanumeric, and at least two characters
+ * long. Generated IDs are lowercased UUIDs, which also satisfy this pattern, so
+ * the same check covers both user-supplied names and returned IDs.
+ */
+const CONTAINER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]{1,62}$/;
+
+/** POSIX-portable environment variable name. */
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** `CAP_NET_RAW`, `NET_RAW`, or `ALL`; matched case-insensitively by the CLI. */
+const CAPABILITY_PATTERN = /^(?:CAP_)?[A-Z][A-Z0-9_]*$/i;
+
+/** Apple Container memory sizes: an integer with an optional K/M/G/T/P suffix. */
+const MEMORY_SIZE_PATTERN = /^[1-9][0-9]*[KMGTP]?$/;
+
+/** Conservative subset of OCI reference syntax; excludes every argv delimiter. */
+const IMAGE_REFERENCE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/@-]*$/;
+
+/** Network attachment names accepted by `--network`. */
+const NETWORK_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$/;
+
+/** `container system logs --last`: `<number>[m|h|d]`, bare numbers are seconds. */
+const LOG_WINDOW_PATTERN = /^[1-9][0-9]*[mhd]?$/;
+
+const MAX_PATH_BYTES = 4096;
+
+function assertPrintableToken(value: string, label: string): void {
+  if (value.length === 0) {
+    throw new Error(`Apple Container ${label} must not be empty`);
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error(`Apple Container ${label} must not contain control characters`);
+  }
+}
+
+/**
+ * Rejects a token that would be misread as an option by Swift ArgumentParser.
+ *
+ * Only relevant for values placed where the parser is still scanning for
+ * options. `container run`/`create` declare their trailing arguments with
+ * `.captureForPassthrough`, so the container's own command line is exempt and
+ * is deliberately *not* routed through this check.
+ */
+function assertNotOptionLike(value: string, label: string): void {
+  if (value.startsWith('-')) {
+    throw new Error(`Apple Container ${label} must not begin with "-": ${value}`);
+  }
+}
+
+/** Validates a container name or ID against Apple Container's own predicate. */
+export function assertAppleContainerId(value: string, label = 'container ID'): string {
+  assertPrintableToken(value, label);
+  if (!CONTAINER_ID_PATTERN.test(value)) {
+    throw new Error(
+      `Apple Container ${label} must be 2-63 characters of [A-Za-z0-9_.-] starting with ` +
+      `an alphanumeric: ${value}`,
+    );
+  }
+  return value;
+}
+
+export function assertAppleContainerImageReference(value: string): string {
+  assertPrintableToken(value, 'image reference');
+  assertNotOptionLike(value, 'image reference');
+  if (!IMAGE_REFERENCE_PATTERN.test(value) || value.length > 512) {
+    throw new Error(`Apple Container image reference is not a valid OCI reference: ${value}`);
+  }
+  return value;
+}
+
+export function assertAppleContainerNetworkName(value: string): string {
+  assertPrintableToken(value, 'network name');
+  if (!NETWORK_NAME_PATTERN.test(value)) {
+    throw new Error(`Apple Container network name is not valid: ${value}`);
+  }
+  return value;
+}
+
+/**
+ * Validates an absolute, already-normalised path and rejects every delimiter
+ * used by the flag token it will be embedded in.
+ *
+ * `forbidden` is required rather than defaulted so each call site has to state
+ * which token it is building; `--mount` is comma/equals-delimited while
+ * `--publish-socket` is colon-delimited, and using the wrong set would leave a
+ * real injection path open.
+ */
+export function assertAppleContainerPath(
+  value: string,
+  label: string,
+  forbidden: readonly string[],
+): string {
+  assertPrintableToken(value, label);
+  if (!path.posix.isAbsolute(value)) {
+    throw new Error(`Apple Container ${label} must be an absolute POSIX path: ${value}`);
+  }
+  if (path.posix.normalize(value) !== value || (value.length > 1 && value.endsWith('/'))) {
+    // `path.posix.normalize` preserves a trailing slash, so it is checked
+    // separately; otherwise `/workspace` and `/workspace/` would build two
+    // different mount tokens for the same directory.
+    throw new Error(`Apple Container ${label} must be a normalized path: ${value}`);
+  }
+  if (Buffer.byteLength(value) > MAX_PATH_BYTES) {
+    throw new Error(`Apple Container ${label} exceeds ${MAX_PATH_BYTES} bytes: ${value}`);
+  }
+  for (const delimiter of forbidden) {
+    if (value.includes(delimiter)) {
+      throw new Error(
+        `Apple Container ${label} must not contain "${delimiter}", which delimits fields ` +
+        `within the flag value: ${value}`,
+      );
+    }
+  }
+  return value;
+}
+
+export function assertAppleContainerEnvName(name: string): string {
+  assertPrintableToken(name, 'environment variable name');
+  if (!ENV_NAME_PATTERN.test(name)) {
+    throw new Error(`Apple Container environment variable name is not valid: ${name}`);
+  }
+  return name;
+}
+
+/**
+ * Validates an environment value. Newlines and NULs are rejected because the
+ * CLI's `--env` value is a single `KEY=VALUE` argv token; `=` is explicitly
+ * allowed since only the first one is significant (`Parser.env` passes the raw
+ * string through and later splits it with `maxSplits: 1`).
+ */
+export function assertAppleContainerEnvValue(name: string, value: string): string {
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000\n\r]/.test(value)) {
+    throw new Error(
+      `Apple Container environment variable "${name}" must not contain NUL or newlines`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validates a `--label` value.
+ *
+ * Unlike `--env`, labels are *not* `=`-tolerant: `Parser.labels` splits with
+ * `maxSplits: 2` and rejects anything that yields three components, so a value
+ * containing `=` would build a clean-looking argv and then fail inside
+ * `container create`. Reject it here instead.
+ */
+export function assertAppleContainerLabelValue(name: string, value: string): string {
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000\n\r]/.test(value)) {
+    throw new Error(`Apple Container label "${name}" must not contain NUL or newlines`);
+  }
+  if (value.includes('=')) {
+    throw new Error(
+      `Apple Container label "${name}" value must not contain "=", which delimits fields ` +
+      `within the flag value: ${value}`,
+    );
+  }
+  return value;
+}
+
+export function assertAppleContainerCapability(value: string): string {
+  assertPrintableToken(value, 'capability');
+  if (!CAPABILITY_PATTERN.test(value)) {
+    throw new Error(`Apple Container capability name is not valid: ${value}`);
+  }
+  return value;
+}
+
+export function assertAppleContainerCpuCount(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`Apple Container CPU count must be a positive integer; got ${value}`);
+  }
+  return value;
+}
+
+export function assertAppleContainerMemorySize(value: string): string {
+  assertPrintableToken(value, 'memory size');
+  if (!MEMORY_SIZE_PATTERN.test(value)) {
+    throw new Error(
+      'Apple Container memory size must be an integer with an optional K/M/G/T/P suffix; ' +
+      `got ${value}`,
+    );
+  }
+  return value;
+}
+
+export function assertAppleContainerLogWindow(value: string): string {
+  assertPrintableToken(value, 'log window');
+  if (!LOG_WINDOW_PATTERN.test(value)) {
+    throw new Error(
+      `Apple Container log window must be <number>[m|h|d] (bare numbers are seconds); got ${value}`,
+    );
+  }
+  return value;
+}
+
+/** Validates a POSIX signal name for `container stop --signal` / `container kill --signal`. */
+export function assertAppleContainerSignal(value: string): string {
+  assertPrintableToken(value, 'signal name');
+  if (!/^(?:SIG)?[A-Z][A-Z0-9]*$/.test(value)) {
+    throw new Error(`Apple Container signal name must be an uppercase POSIX signal; got ${value}`);
+  }
+  return value;
+}
+
+/** Validates the `--time` grace period for `container stop`, in whole seconds. */
+export function assertAppleContainerStopTimeout(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 86_400) {
+    throw new Error(
+      `Apple Container stop timeout must be an integer number of seconds in 0..86400; got ${value}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validates a line bound used by diagnostics collection. Log capture is always
+ * bounded so a runaway guest cannot fill the host disk.
+ */
+export function assertAppleContainerLineCount(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > 100_000) {
+    throw new Error(`Apple Container log line count must be an integer in 1..100000; got ${value}`);
+  }
+  return value;
+}

--- a/src/apple-container/validation.ts
+++ b/src/apple-container/validation.ts
@@ -146,6 +146,15 @@ export function assertAppleContainerEnvName(name: string): string {
   return name;
 }
 
+/** Validates a label key without applying the stricter environment-name syntax. */
+export function assertAppleContainerLabelName(name: string): string {
+  assertPrintableToken(name, 'label name');
+  if (name.includes('=')) {
+    throw new Error(`Apple Container label name must not contain "=": ${name}`);
+  }
+  return name;
+}
+
 /**
  * Validates an environment value. Newlines and NULs are rejected because the
  * CLI's `--env` value is a single `KEY=VALUE` argv token; `=` is explicitly
@@ -246,6 +255,14 @@ export function assertAppleContainerStopTimeout(value: number): number {
 export function assertAppleContainerLineCount(value: number): number {
   if (!Number.isSafeInteger(value) || value < 1 || value > 100_000) {
     throw new Error(`Apple Container log line count must be an integer in 1..100000; got ${value}`);
+  }
+  return value;
+}
+
+/** Validates a timeout used to bound a diagnostics command. */
+export function assertAppleContainerTimeoutMs(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`Apple Container diagnostics timeout must be a positive integer; got ${value}`);
   }
   return value;
 }


### PR DESCRIPTION
**This is layer 1 (bottom PR) of the Apple Container backend stack, targeting `main`. It intentionally adds no user-visible runtime selection.**

No public CLI option, runtime registry entry (`src/container-runtime.ts`), config schema enum, or backend resolver entry (`src/external-runtime-backend-resolver.ts`) is added. `apple-container` is not selectable. Everything here is internal, independently useful, and fully unit-tested without a Mac.

## Goal of the overall stack

Run the AWF agent OCI image under Apple [`container`](https://github.com/apple/container) on **self-hosted bare-metal Apple Silicon** Actions runners. GitHub-hosted `macos-26` is unsupported: those runners are themselves VMs and do not expose nested virtualization, so `kern.hv_support` reports 0.

## What this PR adds

A new module area under `src/apple-container/`, structured like the existing `src/cloud-hypervisor/` area:

| File | Responsibility |
| --- | --- |
| `host-facts.ts` | Typed host facts (platform, arch, macOS product version, `kern.hv_support`) and pure fail-closed eligibility with distinct cause codes. |
| `validation.ts` | Argv token validation, focused on flag-value injection. |
| `run-args.ts` | Typed `run`/`create` spec → argv, with the safe defaults. |
| `cli.ts` | Argv-only execa adapter; typed results, faithful exit-code/signal/timeout propagation. |
| `lifecycle.ts` | pull / create / start / run / stop / kill / delete / inspect / list. |
| `preflight.ts` | Composes eligibility + CLI presence/version + service health. |
| `diagnostics.ts` | Bounded VM boot log, container stdio log, and host service log collection. |

## Design decisions that constrain later layers

**`--network none` is always emitted, never omitted.** This is the most important finding while building this layer. Apple Container attaches the **default vmnet network** when `--network` is omitted — omitting it does *not* mean "no network". `none` is a reserved sentinel (`NetworkClient.noNetworkName`) that sets `config.networks = []`, and it may not be combined with other networks. So `AppleContainerRunSpec.network` defaults to `{ kind: 'none' }` and the flag is emitted explicitly on every launch. Layer 2's no-NIC Unix-socket transport depends on this.

**Unix sockets, not NICs, are the modelled escape hatch.** `--publish-socket host_path:container_path` is modelled now because it is how a later layer reaches Squid / the API proxy / MCP infrastructure without giving the guest an interface.

**Flag-value injection is the real threat, not shell injection.** There is no shell anywhere — every value is its own argv element. The residual risk is that several flags pack multiple fields into one token using structural delimiters (`--mount type=bind,source=…,target=…,readonly`, `--publish-socket a:b`, `--env K=V`, `--label K=V`). Each component is validated against *the delimiter set of the token it will be embedded in*, so a comma in a mount source or a colon in a socket path is rejected rather than silently creating a sibling field.

`--label` is deliberately stricter than `--env`: `Parser.labels` splits with `maxSplits: 2` and rejects three components, while `Parser.env` tolerates `=` in values.

**Exit status is never invented.** `normalizeExitCode` prefers a real exit code, falls back to `128 + signum`, and returns `-1` for an unknown death — never 0. Timeouts are reported distinctly (`timedOut: true`) so a later layer can tell "the agent failed" from "we cut the agent off". Control-plane operations throw; `runForeground`/`startAttached` return the child's code verbatim.

**Cause codes, not message matching.** Preflight fails with `platform` / `architecture` / `macos-version` / `hypervisor` / `cli-missing` / `cli-version` / `service-health`, checked most-general-first so a GitHub-hosted macOS runner is told its hypervisor is unavailable rather than that the CLI is missing. A later layer can decide per-cause whether to hard-fail or fall back to Docker.

**Other defaults:** native `arm64` (never Rosetta-translated amd64), no capabilities added, no TTY (CI has no controlling terminal), stdin not attached unless explicitly requested.

## Notes for layer 2

- Compose stays in charge of Squid / API proxy / MCP; only the agent crosses into Apple Container.
- Minimum CLI version is pinned at `0.4.0` in `preflight.ts` specifically because of the `--network none` sentinel. Lowering it would silently give an "isolated" container a default NIC.
- `container inspect` has no `--format` flag (always pretty JSON); `container logs -n` is short-only; image commands are under singular `image`.
- `container run`/`create` declare trailing args with `.captureForPassthrough`, so leading-dash agent command args are safe and need no `--` terminator — but the image must be the first positional.

The CLI surface encoded here was verified against `apple/container` sources (`Flags.swift`, `Parser.swift`, `Utility.swift`, the per-command files, and `ManagedContainer.nameValid`) rather than from docs alone.

## Testing

- `npx jest src/apple-container` — **301 passing** across 7 suites, covering eligibility branches, argv construction, exit-code/signal/timeout propagation, validation, and diagnostics command construction.
- `npx jest` (full unit suite) — **5490 passing**, 331 suites, no regressions.
- `npm run type-check` and `npm run build` — clean.
- `npx eslint src/apple-container` — 0 errors (9 warnings, in line with the ~1800-warning repo baseline).

A code review of this diff found two issues, both fixed here: `--label` values were reusing the `=`-tolerant `--env` validator, and an unparseable `container --version` banner was reported as `cli-missing` instead of `cli-version`.

No README, user docs, or runtime schema changes — those belong to the layer that makes the runtime selectable.