### PR TITLE
feat: Apple Container secure capability transport (stack layer 2)

### DIFF
--- a/.github/workflows/test-apple-container.yml
+++ b/.github/workflows/test-apple-container.yml
@@ -1,0 +1,106 @@
+name: Apple Container Transport
+
+# Layer 2 of the Apple Container backend stack: the host-side capability relay
+# and the guest init shim. Neither is wired into a user-visible runtime yet, so
+# there is nothing to exercise end to end here — and there is no GitHub-hosted
+# macOS runner that could, because Apple Container needs
+# Virtualization.framework and hosted macOS reports `kern.hv_support=0`.
+#
+# What this workflow can prove without a live VM is exactly what the design
+# depends on: the guest binary compiles for Linux arm64, its relay and init
+# logic behave, and the compiled-in host/guest contract halves agree.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.github/workflows/test-apple-container.yml'
+      - 'guest/apple-container-init/**'
+      - 'src/apple-container/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apple-container-transport-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guest-init:
+    name: Guest init shim (Linux arm64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.0'
+          cache-dependency-path: guest/apple-container-init/go.mod
+
+      - name: Vet guest init shim
+        working-directory: guest/apple-container-init
+        run: go vet ./...
+
+      # The relay tests bind real loopback sockets and Unix sockets, so they
+      # catch forwarding, half-close, and teardown defects here rather than as
+      # an unreachable capability inside a real VM.
+      - name: Test guest init shim
+        working-directory: guest/apple-container-init
+        run: go test ./...
+
+      - name: Build guest init shim for Linux arm64
+        working-directory: guest/apple-container-init
+        run: ./build.sh
+
+      - name: Verify the build is deterministic
+        working-directory: guest/apple-container-init
+        run: |
+          first=$(cut -d' ' -f1 awf-apple-guest-init.sha256)
+          rm -f awf-apple-guest-init awf-apple-guest-init.sha256
+          ./build.sh
+          second=$(cut -d' ' -f1 awf-apple-guest-init.sha256)
+          if [ "$first" != "$second" ]; then
+            echo "guest init build is not deterministic: $first != $second" >&2
+            exit 1
+          fi
+          echo "deterministic digest: $first"
+
+      - name: Verify the binary is a static Linux arm64 executable
+        working-directory: guest/apple-container-init
+        run: |
+          file awf-apple-guest-init | tee /dev/stderr | \
+            grep -q 'ELF 64-bit LSB executable, ARM aarch64'
+          file awf-apple-guest-init | grep -q 'statically linked'
+
+  host-transport:
+    name: Host transport unit tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run type-check
+
+      - name: Lint the Apple Container module
+        run: npx eslint src/apple-container
+
+      # transport-contract-sync.test.ts parses guest/apple-container-init/
+      # contract.go, so a divergence between the host and guest halves of the
+      # contract fails here instead of inside a VM nobody can reproduce.
+      - name: Run Apple Container unit tests
+        run: npx jest src/apple-container --testTimeout=15000

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ __pycache__/
 # (built binary shares its directory's module name with no extension,
 # easy to accidentally leave behind after a local build/test cycle)
 /guest/microvm-supervisor/microvm-supervisor
+/guest/apple-container-init/apple-guest-init
+/guest/apple-container-init/awf-apple-guest-init
+/guest/apple-container-init/awf-apple-guest-init.sha256

--- a/docs/apple-container-transport.md
+++ b/docs/apple-container-transport.md
@@ -1,0 +1,142 @@
+# Apple Container capability transport (internal)
+
+> **Internal design note.** Nothing described here is reachable from the CLI,
+> the config schema, or the runtime resolver. This is layer 2 of the Apple
+> Container backend stack; the selectable runtime lands in a later layer. There
+> is intentionally no user-facing documentation yet.
+
+## Problem
+
+The Apple Container agent VM is launched with `--network none`. That is not a
+hardening flag that can be traded away — omitting `--network` attaches Apple's
+default vmnet network, so the flag is the *only* thing standing between the
+agent and unfiltered egress. Apple Container has no daemon-side forced-proxy
+setting, so an advisory `HTTP_PROXY` would confine nothing on its own. The
+confinement is structural: the guest has zero NICs, so direct IP egress, DNS,
+DoH, IPv6, raw sockets, the `169.254.169.254` metadata address, and every host
+network path simply do not exist inside the VM.
+
+A NIC-less guest still has to reach a handful of AWF services that keep running
+under Docker Compose. The only transport Apple Container offers such a guest is
+`--publish-socket host_path:container_path`, which exposes one host Unix socket
+at one guest path and works with no NIC attached. Most tooling — curl, npm, pip,
+the agent CLIs — speaks TCP to a proxy endpoint and cannot be pointed at a Unix
+socket, so both ends need a relay.
+
+## Shape
+
+```
+ host (macOS)                        │ VM boundary │            guest (Linux)
+                                     │             │
+ AWF sidecar (Docker)                │             │
+   127.0.0.1:3128  ◀── host relay ───┤             │
+                       squid.sock ───┼──publish────┼──▶ /run/awf/transport/v1/
+                                     │   socket    │        squid.sock
+                                     │             │            │
+                                     │             │      guest relay
+                                     │             │            │
+                                     │             │      127.0.0.1:3128 ──▶ agent
+```
+
+Host half: `src/apple-container/transport-*.ts`.
+Guest half: `guest/apple-container-init/` (a static Linux arm64 Go binary).
+
+## Security boundary
+
+| Property | How it is enforced |
+| --- | --- |
+| Only named AWF capabilities cross the boundary | `APPLE_CONTAINER_TRANSPORT_CAPABILITIES` is a closed, frozen list with no extension point. `getAppleContainerCapability` throws on anything else. |
+| No generic host network or Docker socket | The plan is the sole source of `--publish-socket` pairs. A caller-supplied socket mount is accepted only when it is byte-identical to a planned one, so `/var/run/docker.sock` — a direct escape to host root that every other guarantee here would survive — cannot be published. A bind mount that would shadow the transport directory is refused too. |
+| Relays cannot be repointed | Upstreams must be IP literals on loopback or a private range. Hostnames are rejected, so no DNS lookup happens and no DNS answer can move a capability. Link-local (including the metadata address), multicast, and public addresses are refused. |
+| Sockets are private to the run | A fresh `0700` directory per run, created with a non-recursive `mkdir` so collisions fail, verified for real-directory/ownership/mode/self-resolution after creation. Sockets are `chmod 0600` immediately after bind. |
+| No stale or planted socket is ever reused | Binding never unlinks. An occupied path is a hard failure. |
+| No `sun_path` truncation | Paths are rejected above 103 bytes, so the published path is always the bound path. |
+| Workload capabilities | `NET_ADMIN`, `NET_RAW`, `SYS_ADMIN`, `SYS_MODULE`, and `SYS_RAWIO` are dropped unconditionally; adding any of them, or `ALL`, is refused rather than silently overridden. |
+| Networking cannot be weakened | `applyAppleContainerTransportToRunSpec` rejects any run spec carrying a network and always emits `{ kind: 'none' }`. |
+| Credentials never enter the guest | API proxy capabilities are unauthenticated from the guest's point of view. The real key is injected by the host-side API proxy sidecar, exactly as in the Docker topology, and never appears in guest env, argv, files, or logs. The diagnostics summary contains only ids, ports, and counters. |
+| No silent fallback | Every failure throws. If the transport cannot be started and verified, agent execution must not begin. |
+
+## Relays
+
+Both relays are deliberately dumb byte pumps. Neither parses HTTP, handles
+`CONNECT`, or inspects headers — parsing workload-controlled bytes on either
+side of the VM boundary would be the most dangerous thing this layer could do.
+Both are bounded: a concurrent-connection cap, a dial timeout, an idle timeout,
+and a hard cap on buffered bytes (host side) or a fixed 32 KiB copy buffer
+(guest side). Half-close is preserved in both directions, which HTTP proxying
+requires.
+
+A capability whose socket was never published fails to dial, and the connection
+is closed with no data — the same fail-closed outcome as a disabled capability.
+
+## Contract versioning
+
+The host half (`transport-capabilities.ts`) and the guest half (`contract.go`)
+are both compiled in. Nothing is negotiated at boot, so no configuration crosses
+the VM boundary and there is nothing for a workload to influence. The contract
+version is embedded in the guest directory path (`/run/awf/transport/v1`), so a
+mismatched host and init image cannot half-work — the guest simply finds no
+sockets where it expects them.
+
+`src/apple-container/transport-contract-sync.test.ts` parses `contract.go` and
+fails the build if the two halves ever diverge.
+
+The contract is also pinned to a `container` CLI range
+(`assertAppleContainerTransportCliVersion`). `--publish-socket` and
+`--init-image` are the load-bearing features, and a major release could move the
+init image layout, which would break the guest handoff silently.
+
+## Guest boot handoff
+
+The AWF init image is built from the pinned Apple init image with Apple's
+original binary relocated to `/sbin/vminitd.apple` and the AWF shim installed at
+`/sbin/vminitd`.
+
+1. containerization executes `/sbin/vminitd` (the shim).
+2. The shim re-execs itself with `--awf-relay` as a child, handing it a pipe on
+   fd 3.
+3. The child binds every allowlisted `127.0.0.1` port and writes
+   `awf-relay-ready` to fd 3. Binding is all-or-nothing.
+4. The shim reads exactly that token, then `syscall.Exec`s
+   `/sbin/vminitd.apple`.
+
+The handoff is an exec, not a supervision tree, so Apple's real `vminitd` keeps
+PID 1 and its reaping, signal, and lifecycle semantics are exactly what Apple
+shipped. The relay child is inherited and reaped by it like any other process.
+
+Every port is bound before the exec, and therefore before the workload starts,
+which removes any race between relay startup and workload startup. Ports for
+capabilities the host did not publish are bound too; their dials fail closed.
+
+Every failure path exits non-zero without exec'ing the real init: a guest that
+cannot serve its capabilities never reaches the workload, so there is no window
+in which an agent runs with partial egress mediation.
+
+## Startup and teardown
+
+`startAppleContainerTransport` is ordered and fails closed at every step: plan →
+upstream health probe → private directory → bind → end-to-end verification of
+every capability through its own socket. Any failure rolls everything back —
+relays stopped, sockets unlinked, directory removed — and the *original* error
+propagates.
+
+Each relay is registered for rollback *before* it is started, because `start()`
+binds the listener and only then verifies its mode and ownership; registering
+afterwards would strand a live, still-accepting relay if that tail failed.
+Cleanup removes only the sockets that actually reached `listen()`, so a
+`start()` that aborted on a pre-existing path never unlinks a file this run did
+not create.
+
+`stop()` is deterministic and idempotent, and concurrent calls share one
+shutdown. Only sockets this run created are unlinked and the directory is
+removed non-recursively. With `preserveDiagnostics` the directory and a small
+JSON summary survive for triage, but every socket is still unlinked first:
+diagnostics never leave an active access path.
+
+## What layer 3 still owns
+
+- Runtime registry, resolver, CLI flag, and config schema entry.
+- Building and publishing the pinned init image, and choosing its reference.
+- Deciding the capability set from `WrapperConfig` (which sidecars are enabled).
+- Mapping `AWF_APPLE_TRANSPORT_*_URL` onto provider-specific variables.
+- Workspace mounts, uid/gid, and the rest of agent launch policy.

--- a/guest/apple-container-init/build.sh
+++ b/guest/apple-container-init/build.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Builds the AWF Apple Container guest init shim.
+#
+# The output is a static, native arm64 Linux binary — Apple Container guests are
+# arm64 and Rosetta translation is never used. The build is deterministic
+# (`-trimpath`, no VCS stamping, no cgo) so the same source always produces the
+# same bytes and the recorded digest is meaningful.
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GO_VERSION=go1.25.0
+VERSION=${VERSION:-dev}
+OUTPUT=${OUTPUT:-"$ROOT/awf-apple-guest-init"}
+
+actual=$(go env GOVERSION)
+if [ "$actual" != "$GO_VERSION" ]; then
+  echo "required Go toolchain: $GO_VERSION (found $actual)" >&2
+  exit 1
+fi
+
+GOARCH=${GOARCH:-arm64}
+if [ "$GOARCH" != "arm64" ]; then
+  echo "Apple Container guests are arm64 only; refusing GOARCH=$GOARCH" >&2
+  exit 1
+fi
+
+cd "$ROOT"
+CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" \
+  go build -trimpath -buildvcs=false -ldflags="-s -w -X main.version=$VERSION" -o "$OUTPUT" .
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$OUTPUT" > "$OUTPUT.sha256"
+else
+  shasum -a 256 "$OUTPUT" > "$OUTPUT.sha256"
+fi

--- a/guest/apple-container-init/contract.go
+++ b/guest/apple-container-init/contract.go
@@ -1,0 +1,69 @@
+package main
+
+// Host/guest transport contract, contract version 1.
+//
+// This file is the guest half of the contract whose host half lives in
+// src/apple-container/transport-capabilities.ts. Both halves are compiled in,
+// so no configuration crosses the VM boundary at boot and there is nothing for
+// a workload to influence. src/apple-container/transport-contract-sync.test.ts
+// parses this file and fails the build if the two halves ever diverge.
+
+// ContractVersion is embedded in GuestDirectory so a host and a guest init
+// image that disagree cannot silently half-work.
+const ContractVersion = 1
+
+// GuestDirectory holds every socket published with --publish-socket. /run is a
+// tmpfs in the guest, so this stays writable under a read-only rootfs.
+const GuestDirectory = "/run/awf/transport/v1"
+
+// InitEntrypoint is where Apple's containerization runtime executes the init
+// binary from inside the init image. The AWF init image installs this shim
+// there and relocates Apple's original binary to RealInitPath.
+const InitEntrypoint = "/sbin/vminitd"
+
+// RealInitPath is Apple's unmodified vminitd, relocated at image build time.
+// The shim execs it after the relay is confirmed listening, so Apple's init
+// keeps PID 1 and its reaping and lifecycle semantics are untouched.
+const RealInitPath = "/sbin/vminitd.apple"
+
+// RelayFlag selects relay mode when the shim re-executes itself.
+const RelayFlag = "--awf-relay"
+
+// ReadyFD is the inherited pipe (child fd 3) the relay writes ReadyToken to
+// once every loopback listener is bound. The shim refuses to exec the real init
+// until it reads that token, so a workload can never start before its
+// capability endpoints exist.
+const ReadyFD = 3
+
+// ReadyToken is the exact line the relay writes to ReadyFD.
+const ReadyToken = "awf-relay-ready"
+
+// Capability is one allowlisted host service reachable from the guest.
+type Capability struct {
+	ID         string
+	SocketName string
+	GuestPort  int
+}
+
+// Capabilities is the complete allowlist. There is no dynamic extension point:
+// a socket published at any other guest path is simply never served, and a
+// loopback port not listed here is never bound.
+//
+// Every port is bound unconditionally at boot. Binding a port whose host socket
+// was not published is deliberate and safe: the dial fails and the connection is
+// closed with no data, which is the same fail-closed outcome as a disabled
+// capability, and it removes any race between the relay and workload startup.
+var Capabilities = []Capability{
+	{ID: "squid", SocketName: "squid.sock", GuestPort: 3128},
+	{ID: "api-proxy-openai", SocketName: "api-proxy-openai.sock", GuestPort: 10000},
+	{ID: "api-proxy-anthropic", SocketName: "api-proxy-anthropic.sock", GuestPort: 10001},
+	{ID: "api-proxy-copilot", SocketName: "api-proxy-copilot.sock", GuestPort: 10002},
+	{ID: "api-proxy-gemini", SocketName: "api-proxy-gemini.sock", GuestPort: 10003},
+	{ID: "cli-proxy", SocketName: "cli-proxy.sock", GuestPort: 11000},
+	{ID: "mcp-gateway", SocketName: "mcp-gateway.sock", GuestPort: 8080},
+}
+
+// SocketPath is the guest path a capability's socket is published at.
+func (c Capability) SocketPath() string {
+	return GuestDirectory + "/" + c.SocketName
+}

--- a/guest/apple-container-init/go.mod
+++ b/guest/apple-container-init/go.mod
@@ -1,0 +1,5 @@
+module github.com/github/gh-aw-firewall/apple-guest-init
+
+go 1.24.0
+
+toolchain go1.25.0

--- a/guest/apple-container-init/main.go
+++ b/guest/apple-container-init/main.go
@@ -1,0 +1,197 @@
+// awf-apple-guest-init is the AWF init shim for Apple Container guests that run
+// with `--network none`.
+//
+// The guest has zero network interfaces, so the only way it can reach an AWF
+// service is through a Unix socket published with `--publish-socket`. Most
+// tooling — curl, npm, pip, the agent CLIs — speaks TCP to a proxy endpoint and
+// cannot be pointed at a Unix socket, so something inside the VM has to bridge
+// the two. That is this binary.
+//
+// Boot sequence:
+//
+//	containerization exec /sbin/vminitd   (this shim)
+//	  -> re-exec self with --awf-relay as a child
+//	  -> child binds every allowlisted 127.0.0.1 port, writes "awf-relay-ready"
+//	     on fd 3
+//	  -> shim reads the token, then syscall.Exec()s /sbin/vminitd.apple
+//	  -> Apple's real vminitd becomes PID 1 with its own argv and environment
+//	     and takes over the boot unchanged
+//
+// The handoff is an exec, not a supervision tree, so Apple's init keeps PID 1
+// and its reaping, signal, and lifecycle semantics are exactly what Apple
+// shipped. The shim contributes nothing at runtime beyond the background relay.
+//
+// Every failure path exits non-zero without exec'ing the real init. That is the
+// fail-closed guarantee the host side depends on: a guest that cannot serve its
+// capabilities never reaches the workload at all, so there is no window in
+// which an agent runs with partial or missing egress mediation.
+package main
+
+import (
+	"bufio"
+	"errors"
+
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var version = "dev"
+
+// relayReadyTimeout bounds how long the shim waits for the relay to bind. It is
+// generous relative to seven loopback binds but still finite, so a wedged relay
+// fails the boot instead of hanging it.
+const relayReadyTimeout = 20 * time.Second
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == RelayFlag {
+		if err := runRelay(); err != nil {
+			fmt.Fprintln(os.Stderr, "awf-apple-guest-init relay:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if len(args) == 1 && (args[0] == "--version" || args[0] == "-version") {
+		fmt.Println(version)
+		return
+	}
+
+	if err := runInit(); err != nil {
+		fmt.Fprintln(os.Stderr, "awf-apple-guest-init:", err)
+		os.Exit(1)
+	}
+}
+
+// runRelay binds every allowlisted loopback port, reports readiness, and serves
+// until it is signalled.
+func runRelay() error {
+	relays, err := bindRelays(Capabilities)
+	if err != nil {
+		return err
+	}
+	for _, r := range relays {
+		go r.serve()
+	}
+	if err := signalReady(readyPipe()); err != nil {
+		for _, r := range relays {
+			r.close()
+		}
+		return err
+	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+	<-signals
+	for _, r := range relays {
+		r.close()
+	}
+	return nil
+}
+
+// runInit starts the relay, waits for it, and hands off to Apple's real init.
+// It only returns on error; on success the process image is replaced.
+func runInit() error {
+	realInit, err := resolveRealInit(RealInitPath)
+	if err != nil {
+		return err
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not resolve own executable: %w", err)
+	}
+
+	readReady, writeReady, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("could not create readiness pipe: %w", err)
+	}
+
+	child := exec.Command(self, RelayFlag)
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	child.ExtraFiles = []*os.File{writeReady} // becomes fd 3 in the child
+	if err := child.Start(); err != nil {
+		writeReady.Close()
+		readReady.Close()
+		return fmt.Errorf("could not start capability relay: %w", err)
+	}
+	// The parent must drop its copy of the write end, otherwise a relay that
+	// dies without writing would leave the read below blocking forever.
+	writeReady.Close()
+
+	if err := awaitReady(readReady, relayReadyTimeout); err != nil {
+		readReady.Close()
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+		return err
+	}
+	readReady.Close()
+
+	// syscall.Exec replaces this process, so the relay child is inherited by
+	// Apple's vminitd as PID 1 and is reaped by it like any other process.
+	if err := syscall.Exec(realInit, os.Args, os.Environ()); err != nil {
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+		return fmt.Errorf("could not exec %s: %w", realInit, err)
+	}
+	return nil
+}
+
+// awaitReady reads exactly the readiness token, or fails.
+func awaitReady(pipe *os.File, timeout time.Duration) error {
+	type result struct {
+		line string
+		err  error
+	}
+	results := make(chan result, 1)
+	go func() {
+		reader := bufio.NewReaderSize(pipe, 64)
+		// A bounded read: the token is a fixed short string and anything longer
+		// or different is rejected rather than scanned.
+		line, err := reader.ReadString('\n')
+		results <- result{line: line, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return fmt.Errorf("capability relay did not report ready within %s", timeout)
+	case got := <-results:
+		if got.err != nil {
+			return fmt.Errorf("capability relay exited before reporting ready: %w", got.err)
+		}
+		if strings.TrimRight(got.line, "\n") != ReadyToken {
+			return errors.New("capability relay sent an unexpected readiness token")
+		}
+		return nil
+	}
+}
+
+// resolveRealInit verifies Apple's relocated init binary before the shim
+// commits to exec'ing it.
+func resolveRealInit(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("Apple init binary %s is missing; the AWF init image must relocate it there: %w", path, err)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return "", fmt.Errorf("Apple init binary %s is a symlink; refusing to exec a substituted path", path)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("Apple init binary %s is not a regular file", path)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("Apple init binary %s is not executable", path)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return "", fmt.Errorf("Apple init binary %s is group/world writable", path)
+	}
+	return path, nil
+}

--- a/guest/apple-container-init/relay.go
+++ b/guest/apple-container-init/relay.go
@@ -1,0 +1,194 @@
+package main
+
+// Guest-side relay: loopback TCP in, published Unix socket out.
+//
+// This is the mirror image of the host relay in
+// src/apple-container/transport-relay.ts and is just as deliberately dumb. It
+// performs no protocol parsing of any kind — no HTTP framing, no CONNECT
+// handling, no header inspection — because the bytes it moves are produced by
+// the workload, which is the least trusted thing in the system. It is a byte
+// pump with fixed bounds:
+//
+//   - listeners are bound to 127.0.0.1 only, so nothing outside the VM can
+//     reach them (there is nothing outside the VM to reach them with: the guest
+//     has no NIC);
+//   - a per-capability concurrent connection cap, enforced by dropping excess
+//     connections rather than queueing them;
+//   - a dial timeout on the Unix socket;
+//   - an idle timeout refreshed on every successful read or write;
+//   - a fixed 32 KiB copy buffer per direction, so memory is bounded by
+//     connections x buffers and nothing accumulates.
+//
+// A capability whose socket was not published simply fails to dial and the
+// connection is closed with no data written. There is no retry and no fallback.
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	maxConnectionsPerCapability = 64
+	dialTimeout                 = 5 * time.Second
+	idleTimeout                 = 300 * time.Second
+	copyBufferBytes             = 32 * 1024
+)
+
+// halfCloser is implemented by both *net.TCPConn and *net.UnixConn. Preserving
+// half-close in both directions is required for HTTP: a client that shuts down
+// its write side after sending a request must still receive the full response.
+type halfCloser interface {
+	net.Conn
+	CloseWrite() error
+}
+
+type relay struct {
+	capability Capability
+	// socketPath is resolved once at bind time from the compiled-in contract.
+	// It is a field rather than a call so tests can point a relay at a
+	// temporary socket without weakening the production path, which always
+	// uses Capability.SocketPath().
+	socketPath string
+	listener   net.Listener
+	active     atomic.Int32
+	wg         sync.WaitGroup
+}
+
+// bindRelays binds every allowlisted loopback port.
+//
+// It is all-or-nothing: a single bind failure closes the listeners already
+// bound and returns an error, so the shim never execs the real init with a
+// partial capability set.
+func bindRelays(capabilities []Capability) ([]*relay, error) {
+	relays := make([]*relay, 0, len(capabilities))
+	for _, capability := range capabilities {
+		listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(capability.GuestPort)))
+		if err != nil {
+			for _, bound := range relays {
+				_ = bound.listener.Close()
+			}
+			return nil, errors.New("bind 127.0.0.1:" + strconv.Itoa(capability.GuestPort) + ": " + err.Error())
+		}
+		relays = append(relays, &relay{
+			capability: capability,
+			socketPath: capability.SocketPath(),
+			listener:   listener,
+		})
+	}
+	return relays, nil
+}
+
+// serve accepts until the listener is closed.
+func (r *relay) serve() {
+	for {
+		conn, err := r.listener.Accept()
+		if err != nil {
+			return
+		}
+		// Reserve the slot with a single atomic increment and give it back on
+		// overflow, so concurrent accepts can never exceed the cap.
+		if r.active.Add(1) > maxConnectionsPerCapability {
+			r.active.Add(-1)
+			_ = conn.Close()
+			continue
+		}
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			defer r.active.Add(-1)
+			r.handle(conn)
+		}()
+	}
+}
+
+func (r *relay) close() {
+	_ = r.listener.Close()
+	r.wg.Wait()
+}
+
+func (r *relay) handle(conn net.Conn) {
+	defer conn.Close()
+
+	upstream, err := net.DialTimeout("unix", r.socketPath, dialTimeout)
+	if err != nil {
+		// Fail closed: the workload sees an immediately closed connection, never
+		// a fallback path.
+		return
+	}
+	defer upstream.Close()
+
+	guest, guestOK := conn.(halfCloser)
+	host, hostOK := upstream.(halfCloser)
+	if !guestOK || !hostOK {
+		return
+	}
+	forward(guest, host)
+}
+
+// forward copies both directions and returns once both have finished.
+func forward(guest, host halfCloser) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		copyBounded(host, guest)
+		_ = host.CloseWrite()
+	}()
+	go func() {
+		defer wg.Done()
+		copyBounded(guest, host)
+		_ = guest.CloseWrite()
+	}()
+	wg.Wait()
+}
+
+// copyBounded moves bytes with a fixed buffer and an idle deadline that is
+// refreshed only when progress is made, so a stalled peer is dropped instead of
+// held open forever.
+func copyBounded(dst, src net.Conn) {
+	buffer := make([]byte, copyBufferBytes)
+	for {
+		if err := src.SetReadDeadline(time.Now().Add(idleTimeout)); err != nil {
+			return
+		}
+		read, readErr := src.Read(buffer)
+		if read > 0 {
+			if err := dst.SetWriteDeadline(time.Now().Add(idleTimeout)); err != nil {
+				return
+			}
+			if _, writeErr := dst.Write(buffer[:read]); writeErr != nil {
+				return
+			}
+		}
+		if readErr != nil {
+			// Any error, including a clean EOF and an idle-deadline expiry, ends
+			// this direction; the caller then half-closes the peer. Nothing is
+			// retried.
+			return
+		}
+	}
+}
+
+// readyPipe returns the inherited readiness pipe (fd 3).
+func readyPipe() *os.File {
+	return os.NewFile(ReadyFD, "awf-relay-ready")
+}
+
+// signalReady tells the parent shim that every listener is bound. Writing the
+// token is the only thing that lets the boot proceed, so a failure here must
+// abort the relay rather than be ignored.
+func signalReady(pipe *os.File) error {
+	if pipe == nil {
+		return errors.New("ready pipe (fd 3) was not inherited")
+	}
+	defer pipe.Close()
+	if _, err := pipe.WriteString(ReadyToken + "\n"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/guest/apple-container-init/relay_test.go
+++ b/guest/apple-container-init/relay_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCapabilitiesAreWellFormed(t *testing.T) {
+	seenIDs := map[string]bool{}
+	seenPorts := map[int]bool{}
+	seenSockets := map[string]bool{}
+	for _, capability := range Capabilities {
+		if seenIDs[capability.ID] {
+			t.Fatalf("duplicate capability id %q", capability.ID)
+		}
+		if seenPorts[capability.GuestPort] {
+			t.Fatalf("duplicate guest port %d", capability.GuestPort)
+		}
+		if seenSockets[capability.SocketName] {
+			t.Fatalf("duplicate socket name %q", capability.SocketName)
+		}
+		if capability.GuestPort < 1 || capability.GuestPort > 65535 {
+			t.Fatalf("capability %q port out of range: %d", capability.ID, capability.GuestPort)
+		}
+		if capability.SocketName != capability.ID+".sock" {
+			t.Fatalf("capability %q socket name %q does not follow <id>.sock", capability.ID, capability.SocketName)
+		}
+		if got, want := capability.SocketPath(), GuestDirectory+"/"+capability.SocketName; got != want {
+			t.Fatalf("socket path = %q, want %q", got, want)
+		}
+		seenIDs[capability.ID] = true
+		seenPorts[capability.GuestPort] = true
+		seenSockets[capability.SocketName] = true
+	}
+	if !seenIDs["squid"] {
+		t.Fatal("the squid capability is mandatory: it is the guest's only egress path")
+	}
+}
+
+func TestGuestDirectoryEmbedsContractVersion(t *testing.T) {
+	want := "/run/awf/transport/v" + strconv.Itoa(ContractVersion)
+	if GuestDirectory != want {
+		t.Fatalf("GuestDirectory = %q, want %q", GuestDirectory, want)
+	}
+}
+
+// bindRelays must be all-or-nothing so the shim never execs the real init with
+// a partial capability set.
+func TestBindRelaysIsAllOrNothing(t *testing.T) {
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer blocker.Close()
+	blocked := blocker.Addr().(*net.TCPAddr).Port
+
+	free, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	freePort := free.Addr().(*net.TCPAddr).Port
+	free.Close()
+
+	_, err = bindRelays([]Capability{
+		{ID: "first", SocketName: "first.sock", GuestPort: freePort},
+		{ID: "second", SocketName: "second.sock", GuestPort: blocked},
+	})
+	if err == nil {
+		t.Fatal("expected bindRelays to fail on the occupied port")
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(blocked)) {
+		t.Fatalf("error should name the port that failed: %v", err)
+	}
+
+	// The first listener must have been released, not leaked.
+	reclaim, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(freePort))
+	if err != nil {
+		t.Fatalf("first listener was leaked after a partial bind: %v", err)
+	}
+	reclaim.Close()
+}
+
+func TestRelayForwardsBytesOverPublishedSocket(t *testing.T) {
+	socketPath := filepath.Join(shortTempDir(t), "squid.sock")
+
+	upstream, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer upstream.Close()
+
+	go func() {
+		conn, acceptErr := upstream.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		buffer := make([]byte, 32)
+		read, readErr := conn.Read(buffer)
+		if readErr != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("echo:" + string(buffer[:read])))
+	}()
+
+	r := newTestRelay(t, socketPath)
+	defer r.close()
+
+	client, err := net.Dial("tcp", r.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial relay: %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buffer := make([]byte, 64)
+	read, err := client.Read(buffer)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := string(buffer[:read]); got != "echo:hello" {
+		t.Fatalf("relayed payload = %q, want %q", got, "echo:hello")
+	}
+}
+
+// A capability whose host socket was never published must fail closed: the
+// connection is closed with no data, never routed anywhere else.
+func TestRelayClosesConnectionWhenSocketIsAbsent(t *testing.T) {
+	r := newTestRelay(t, filepath.Join(shortTempDir(t), "absent.sock"))
+	defer r.close()
+
+	client, err := net.Dial("tcp", r.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial relay: %v", err)
+	}
+	defer client.Close()
+
+	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buffer := make([]byte, 8)
+	if _, err := client.Read(buffer); err == nil {
+		t.Fatal("expected the relay to close the connection with no data")
+	}
+}
+
+func TestRelayHalfCloseDeliversFullResponse(t *testing.T) {
+	socketPath := filepath.Join(shortTempDir(t), "cap.sock")
+	upstream, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer upstream.Close()
+
+	go func() {
+		conn, acceptErr := upstream.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		// Read to EOF (the client half-closes), then answer.
+		buffer := make([]byte, 64)
+		for {
+			_, readErr := conn.Read(buffer)
+			if readErr != nil {
+				break
+			}
+		}
+		_, _ = conn.Write([]byte("response-after-eof"))
+	}()
+
+	r := newTestRelay(t, socketPath)
+	defer r.close()
+
+	client, err := net.Dial("tcp", r.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial relay: %v", err)
+	}
+	defer client.Close()
+	if _, err := client.Write([]byte("request")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := client.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("close write: %v", err)
+	}
+
+	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buffer := make([]byte, 64)
+	read, err := client.Read(buffer)
+	if err != nil {
+		t.Fatalf("read after half-close: %v", err)
+	}
+	if got := string(buffer[:read]); got != "response-after-eof" {
+		t.Fatalf("payload = %q, want %q", got, "response-after-eof")
+	}
+}
+
+func TestRelayCloseStopsAcceptingConnections(t *testing.T) {
+	r := newTestRelay(t, filepath.Join(shortTempDir(t), "cap.sock"))
+	address := r.listener.Addr().String()
+	r.close()
+	// close() is idempotent.
+	r.close()
+
+	if conn, err := net.DialTimeout("tcp", address, time.Second); err == nil {
+		conn.Close()
+		t.Fatal("relay accepted a connection after close")
+	}
+}
+
+func TestSignalReadyWritesExactToken(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer read.Close()
+
+	if err := signalReady(write); err != nil {
+		t.Fatalf("signalReady: %v", err)
+	}
+	buffer := make([]byte, 64)
+	n, err := read.Read(buffer)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := strings.TrimRight(string(buffer[:n]), "\n"); got != ReadyToken {
+		t.Fatalf("token = %q, want %q", got, ReadyToken)
+	}
+}
+
+func TestAwaitReadyRejectsUnexpectedToken(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer read.Close()
+	go func() {
+		_, _ = write.WriteString("not-the-token\n")
+		write.Close()
+	}()
+
+	if err := awaitReady(read, 5*time.Second); err == nil {
+		t.Fatal("expected awaitReady to reject an unexpected token")
+	}
+}
+
+func TestAwaitReadyFailsWhenRelayDiesSilently(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer read.Close()
+	write.Close()
+
+	err = awaitReady(read, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected awaitReady to fail when the pipe closes without a token")
+	}
+	if !strings.Contains(err.Error(), "before reporting ready") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAwaitReadyTimesOut(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer read.Close()
+	defer write.Close()
+
+	err = awaitReady(read, 50*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "did not report ready") {
+		t.Fatalf("expected a timeout error, got %v", err)
+	}
+}
+
+func TestAwaitReadyAcceptsToken(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer read.Close()
+	go func() {
+		_, _ = write.WriteString(ReadyToken + "\n")
+		write.Close()
+	}()
+	if err := awaitReady(read, 5*time.Second); err != nil {
+		t.Fatalf("awaitReady: %v", err)
+	}
+}
+
+func TestResolveRealInitRejectsUnsafeBinaries(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := resolveRealInit(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("expected a missing init binary to fail")
+	}
+
+	target := filepath.Join(dir, "vminitd.apple")
+	if err := os.WriteFile(target, []byte("#!/bin/true\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := resolveRealInit(target); err != nil {
+		t.Fatalf("expected a well-formed init binary to be accepted: %v", err)
+	}
+
+	link := filepath.Join(dir, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := resolveRealInit(link); err == nil {
+		t.Fatal("expected a symlinked init binary to be rejected")
+	}
+
+	notExecutable := filepath.Join(dir, "plain")
+	if err := os.WriteFile(notExecutable, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := resolveRealInit(notExecutable); err == nil {
+		t.Fatal("expected a non-executable init binary to be rejected")
+	}
+
+	worldWritable := filepath.Join(dir, "loose")
+	if err := os.WriteFile(worldWritable, []byte("x"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Written through the umask, so the loose bits are set explicitly.
+	if err := os.Chmod(worldWritable, 0o777); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, err := resolveRealInit(worldWritable); err == nil {
+		t.Fatal("expected a world-writable init binary to be rejected")
+	}
+
+	directory := filepath.Join(dir, "sub")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := resolveRealInit(directory); err == nil {
+		t.Fatal("expected a directory to be rejected")
+	}
+}
+
+// shortTempDir keeps socket paths inside the 104-byte sun_path limit; the
+// default t.TempDir() path on macOS is long enough to overflow it, which is the
+// same constraint the host side enforces up front.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "awfrelay")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func newTestRelay(t *testing.T, socketPath string) *relay {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	capability := Capability{
+		ID:         "test",
+		SocketName: filepath.Base(socketPath),
+		GuestPort:  listener.Addr().(*net.TCPAddr).Port,
+	}
+	r := &relay{capability: capability, listener: listener, socketPath: socketPath}
+	go r.serve()
+	return r
+}
+
+func TestSignalReadyRequiresAnInheritedPipe(t *testing.T) {
+	if err := signalReady(nil); err == nil {
+		t.Fatal("expected signalReady to fail without an inherited pipe")
+	}
+}

--- a/src/apple-container/transport-capabilities.test.ts
+++ b/src/apple-container/transport-capabilities.test.ts
@@ -1,0 +1,162 @@
+import {
+  APPLE_CONTAINER_INIT_ENTRYPOINT,
+  APPLE_CONTAINER_TRANSPORT_CAPABILITIES,
+  APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION,
+  APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY,
+  APPLE_CONTAINER_TRANSPORT_MAX_CLI_VERSION_EXCLUSIVE,
+  APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION,
+  APPLE_CONTAINER_VMINITD_PATH,
+  appleContainerGuestEndpointUrl,
+  appleContainerGuestSocketPath,
+  assertAppleContainerTransportCliVersion,
+  assertAppleContainerUpstreamEndpoint,
+  getAppleContainerCapability,
+  isAppleContainerCapabilityId,
+} from './transport-capabilities';
+
+describe('Apple Container transport capability allowlist', () => {
+  it('is a closed set with unique ids, ports, and socket names', () => {
+    const ids = new Set<string>();
+    const ports = new Set<number>();
+    const sockets = new Set<string>();
+    for (const capability of APPLE_CONTAINER_TRANSPORT_CAPABILITIES) {
+      expect(ids.has(capability.id)).toBe(false);
+      expect(ports.has(capability.guestPort)).toBe(false);
+      expect(sockets.has(capability.socketName)).toBe(false);
+      ids.add(capability.id);
+      ports.add(capability.guestPort);
+      sockets.add(capability.socketName);
+    }
+    expect([...ids].sort()).toEqual([
+      'api-proxy-anthropic',
+      'api-proxy-copilot',
+      'api-proxy-gemini',
+      'api-proxy-openai',
+      'cli-proxy',
+      'mcp-gateway',
+      'squid',
+    ]);
+  });
+
+  it('bridges only the four discrete API proxy provider ports', () => {
+    const apiPorts = APPLE_CONTAINER_TRANSPORT_CAPABILITIES
+      .filter((capability) => capability.id.startsWith('api-proxy-'))
+      .map((capability) => capability.guestPort)
+      .sort((a, b) => a - b);
+    expect(apiPorts).toEqual([10000, 10001, 10002, 10003]);
+  });
+
+  it('rejects capabilities that are not in the allowlist', () => {
+    expect(() => getAppleContainerCapability('docker')).toThrow(/not in the allowlist/);
+    expect(() => getAppleContainerCapability('host-network')).toThrow(/not in the allowlist/);
+    expect(() => getAppleContainerCapability('')).toThrow(/not in the allowlist/);
+    expect(isAppleContainerCapabilityId('docker')).toBe(false);
+    expect(isAppleContainerCapabilityId('squid')).toBe(true);
+  });
+
+  it('cannot be mutated at runtime', () => {
+    expect(Object.isFrozen(APPLE_CONTAINER_TRANSPORT_CAPABILITIES)).toBe(true);
+    expect(Object.isFrozen(APPLE_CONTAINER_TRANSPORT_CAPABILITIES[0])).toBe(true);
+  });
+
+  it('places every socket inside the versioned guest directory', () => {
+    expect(APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY)
+      .toBe(`/run/awf/transport/v${APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION}`);
+    for (const capability of APPLE_CONTAINER_TRANSPORT_CAPABILITIES) {
+      expect(appleContainerGuestSocketPath(capability.id))
+        .toBe(`${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/${capability.socketName}`);
+    }
+  });
+
+  it('exposes guest endpoints on loopback only', () => {
+    for (const capability of APPLE_CONTAINER_TRANSPORT_CAPABILITIES) {
+      expect(appleContainerGuestEndpointUrl(capability.id))
+        .toBe(`http://127.0.0.1:${capability.guestPort}`);
+    }
+  });
+
+  it('keeps the init entrypoint distinct from the relocated Apple init', () => {
+    expect(APPLE_CONTAINER_INIT_ENTRYPOINT).toBe('/sbin/vminitd');
+    expect(APPLE_CONTAINER_VMINITD_PATH).toBe('/sbin/vminitd.apple');
+    expect(APPLE_CONTAINER_VMINITD_PATH).not.toBe(APPLE_CONTAINER_INIT_ENTRYPOINT);
+  });
+});
+
+describe('assertAppleContainerUpstreamEndpoint', () => {
+  it('accepts loopback and private IPv4 literals', () => {
+    for (const host of ['127.0.0.1', '10.1.2.3', '172.30.0.10', '192.168.1.5']) {
+      expect(assertAppleContainerUpstreamEndpoint({ host, port: 3128 }, 'test').host).toBe(host);
+    }
+  });
+
+  it('accepts IPv6 loopback and unique-local addresses', () => {
+    expect(assertAppleContainerUpstreamEndpoint({ host: '::1', port: 1 }, 'test').host).toBe('::1');
+    expect(assertAppleContainerUpstreamEndpoint({ host: 'fd00::1', port: 1 }, 'test').host)
+      .toBe('fd00::1');
+  });
+
+  it('rejects the cloud metadata address and other link-local addresses', () => {
+    expect(() => assertAppleContainerUpstreamEndpoint(
+      { host: '169.254.169.254', port: 80 },
+      'metadata',
+    )).toThrow(/not a loopback or private address/);
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: 'fe80::1', port: 80 }, 'metadata'))
+      .toThrow(/not an IPv6 loopback or unique-local address/);
+  });
+
+  it('rejects public addresses', () => {
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: '8.8.8.8', port: 53 }, 'dns'))
+      .toThrow(/not a loopback or private address/);
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: '2001:db8::1', port: 80 }, 'x'))
+      .toThrow(/not an IPv6 loopback or unique-local address/);
+  });
+
+  it('rejects hostnames so the relay never resolves a name', () => {
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: 'localhost', port: 3128 }, 'x'))
+      .toThrow(/must be an IP literal, not a name/);
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: 'awf-squid', port: 3128 }, 'x'))
+      .toThrow(/must be an IP literal, not a name/);
+  });
+
+  it('rejects ambiguous octal-looking and out-of-range octets', () => {
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: '010.0.0.1', port: 1 }, 'x'))
+      .toThrow(/must be an IP literal, not a name/);
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: '127.0.0.999', port: 1 }, 'x'))
+      .toThrow(/must be an IP literal, not a name/);
+  });
+
+  it('rejects out-of-range and non-integer ports', () => {
+    for (const port of [0, -1, 65_536, 1.5, Number.NaN]) {
+      expect(() => assertAppleContainerUpstreamEndpoint({ host: '127.0.0.1', port }, 'x'))
+        .toThrow(/port must be in 1\.\.65535/);
+    }
+  });
+
+  it('rejects empty and non-string hosts', () => {
+    expect(() => assertAppleContainerUpstreamEndpoint({ host: '', port: 1 }, 'x'))
+      .toThrow(/must be an IP literal/);
+    expect(() => assertAppleContainerUpstreamEndpoint(
+      { host: undefined as unknown as string, port: 1 },
+      'x',
+    )).toThrow(/must be an IP literal/);
+  });
+});
+
+describe('assertAppleContainerTransportCliVersion', () => {
+  it('accepts versions inside the pinned window', () => {
+    expect(assertAppleContainerTransportCliVersion(APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION))
+      .toBe(APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION);
+    expect(assertAppleContainerTransportCliVersion('0.9.9')).toBe('0.9.9');
+  });
+
+  it('rejects versions below the pinned minimum', () => {
+    expect(() => assertAppleContainerTransportCliVersion('0.3.9')).toThrow(/or newer/);
+  });
+
+  it('rejects versions at or above the exclusive maximum', () => {
+    expect(() => assertAppleContainerTransportCliVersion(
+      APPLE_CONTAINER_TRANSPORT_MAX_CLI_VERSION_EXCLUSIVE,
+    )).toThrow(/has not been validated/);
+    expect(() => assertAppleContainerTransportCliVersion('2.0.0')).toThrow(/has not been validated/);
+  });
+});

--- a/src/apple-container/transport-capabilities.ts
+++ b/src/apple-container/transport-capabilities.ts
@@ -1,0 +1,300 @@
+/**
+ * The AWF capability transport contract for no-NIC Apple Container guests.
+ *
+ * An Apple Container agent VM is launched with `--network none`, so it has
+ * **zero network interfaces** other than loopback. Direct IP egress, DNS, DoH,
+ * IPv6, raw sockets, the cloud metadata address, and every host network path
+ * are unreachable by construction rather than by rule. Apple Container has no
+ * daemon-side forced-proxy setting, so an advisory `HTTP_PROXY` alone would not
+ * confine anything; the confinement here comes from the missing NIC.
+ *
+ * The guest still needs to reach a small, fixed set of AWF services that keep
+ * running under Docker Compose (Squid, the API proxy, the CLI proxy, the
+ * enclave MCP gateway). The only capability transport Apple Container offers a
+ * NIC-less VM is `--publish-socket host_path:container_path`, which exposes one
+ * host Unix socket at one guest path. This module is the single source of truth
+ * for *which* sockets may be published and what they map to:
+ *
+ * ```
+ *  host TCP service   <-- AWF host relay --  Unix socket  --publish-socket-->
+ *  guest Unix socket  <-- AWF guest relay --  127.0.0.1:<fixed port>  --> workload
+ * ```
+ *
+ * Three properties make this an allowlist rather than a tunnel:
+ *
+ * 1. **Closed set.** {@link APPLE_CONTAINER_TRANSPORT_CAPABILITIES} is the
+ *    complete list. There is no "custom capability" escape hatch, no generic
+ *    host-network capability, and no Docker socket capability. A caller can
+ *    only select a subset of these entries; it cannot invent one.
+ * 2. **Fixed guest shape.** Both the guest socket path and the guest loopback
+ *    port are compiled into the contract on both sides, so the host and the
+ *    guest agree without any dynamic configuration channel crossing the VM
+ *    boundary at boot.
+ * 3. **Constrained upstreams.** Each capability is bound to a host TCP endpoint
+ *    that must be an IP literal on loopback or a private range. Hostnames are
+ *    rejected outright, so the relay never performs a DNS lookup and cannot be
+ *    steered at a public or link-local address (including 169.254.169.254).
+ *
+ * Credentials never appear here. The API proxy capabilities carry *no* auth
+ * material: the guest speaks to an unauthenticated relay, and the real key is
+ * injected by the host-side API proxy sidecar, exactly as in the Docker
+ * topology.
+ */
+
+import { apiProxyPorts, CLI_PROXY_PORT, SQUID_PORT } from '../config/network-policy';
+import { ENCLAVE_MCP_CONTROL_PORT } from '../enclave/network';
+import { compareAppleContainerVersions } from './preflight';
+
+/**
+ * Version of the host/guest transport contract.
+ *
+ * Bumped whenever the guest directory layout, the socket naming scheme, or the
+ * capability-to-port mapping changes. The version is embedded in the guest
+ * directory path so a host and a guest init image that disagree cannot silently
+ * half-work: the guest simply finds no sockets where it expects them.
+ */
+export const APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION = 1;
+
+/**
+ * Directory inside the guest that holds every published capability socket.
+ *
+ * `/run` is a tmpfs in the guest, so this stays writable for vminitd even when
+ * the workload rootfs is mounted read-only.
+ */
+export const APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY =
+  `/run/awf/transport/v${APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION}`;
+
+/**
+ * Apple Container / containerization releases this contract is pinned against.
+ *
+ * `--publish-socket` and `--init-image` are the two load-bearing features and
+ * both are only guaranteed from this release line onward. The upper bound is
+ * exclusive and deliberately conservative: a major version bump may change the
+ * init image layout (where the real `vminitd` lives), which would silently
+ * break the guest handoff rather than fail loudly.
+ */
+export const APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION = '0.4.0';
+export const APPLE_CONTAINER_TRANSPORT_MAX_CLI_VERSION_EXCLUSIVE = '1.0.0';
+
+/**
+ * Where Apple's containerization runtime executes the init binary from inside
+ * the init image. The AWF init image installs the guest relay shim here.
+ */
+export const APPLE_CONTAINER_INIT_ENTRYPOINT = '/sbin/vminitd';
+
+/**
+ * Apple's unmodified `vminitd`, relocated at init-image build time.
+ *
+ * The shim execs this once the relay is confirmed listening, so Apple's own
+ * init keeps PID 1 and its reaping, signal, and lifecycle semantics are exactly
+ * what Apple shipped.
+ */
+export const APPLE_CONTAINER_VMINITD_PATH = '/sbin/vminitd.apple';
+
+/**
+ * Fails closed when the installed `container` CLI is outside the version range
+ * this init-image contract was validated against.
+ *
+ * The guest relay execs Apple's real `vminitd` from a path inside the init
+ * image. A release outside this window may move that binary or change how the
+ * init image is consumed, which would turn into a mysterious boot failure — or,
+ * worse, a container that starts without the relay and therefore without any
+ * capability at all. Refusing up front is the only safe answer.
+ */
+export function assertAppleContainerTransportCliVersion(version: string): string {
+  if (compareAppleContainerVersions(version, APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION) < 0) {
+    throw new Error(
+      `Apple Container transport contract v${APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION} ` +
+      `requires container CLI ${APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION} or newer; ` +
+      `found ${version}`,
+    );
+  }
+  if (
+    compareAppleContainerVersions(version, APPLE_CONTAINER_TRANSPORT_MAX_CLI_VERSION_EXCLUSIVE) >= 0
+  ) {
+    throw new Error(
+      `Apple Container transport contract v${APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION} has ` +
+      `not been validated against container CLI ${version}; the supported range is ` +
+      `>=${APPLE_CONTAINER_TRANSPORT_MIN_CLI_VERSION} ` +
+      `<${APPLE_CONTAINER_TRANSPORT_MAX_CLI_VERSION_EXCLUSIVE}`,
+    );
+  }
+  return version;
+}
+
+/** Every capability AWF is willing to bridge into a NIC-less guest. */
+export type AppleContainerCapabilityId =
+  | 'squid'
+  | 'api-proxy-openai'
+  | 'api-proxy-anthropic'
+  | 'api-proxy-copilot'
+  | 'api-proxy-gemini'
+  | 'cli-proxy'
+  | 'mcp-gateway';
+
+export interface AppleContainerCapabilityDefinition {
+  readonly id: AppleContainerCapabilityId;
+  /** Basename of the published socket, within the versioned guest directory. */
+  readonly socketName: string;
+  /** Loopback TCP port the guest relay serves for this capability. */
+  readonly guestPort: number;
+  /**
+   * Environment variable through which the workload learns the guest endpoint.
+   * Provider-specific aliasing (for example `ANTHROPIC_BASE_URL`) is deliberately
+   * left to the layer that owns agent environment policy.
+   */
+  readonly endpointEnvName: string;
+  readonly description: string;
+}
+
+function define(
+  id: AppleContainerCapabilityId,
+  guestPort: number,
+  description: string,
+): AppleContainerCapabilityDefinition {
+  return {
+    id,
+    socketName: `${id}.sock`,
+    guestPort,
+    endpointEnvName: `AWF_APPLE_TRANSPORT_${id.toUpperCase().replace(/-/g, '_')}_URL`,
+    description,
+  };
+}
+
+/**
+ * The complete capability allowlist.
+ *
+ * Guest ports intentionally mirror the Docker-topology ports so the agent
+ * environment differs only in host (127.0.0.1 instead of a sidecar IP). The API
+ * proxy set is the four discrete provider ports AWF publishes today (10000
+ * OpenAI, 10001 Anthropic, 10002 Copilot, 10003 Gemini); no port range is ever
+ * bridged, only these exact endpoints.
+ */
+export const APPLE_CONTAINER_TRANSPORT_CAPABILITIES: readonly AppleContainerCapabilityDefinition[] =
+  Object.freeze([
+    define('squid', SQUID_PORT, 'Squid forward proxy (sole HTTP/HTTPS egress path)'),
+    define('api-proxy-openai', apiProxyPorts().openai, 'API proxy: OpenAI provider'),
+    define('api-proxy-anthropic', apiProxyPorts().anthropic, 'API proxy: Anthropic provider'),
+    define('api-proxy-copilot', apiProxyPorts().copilot, 'API proxy: Copilot provider'),
+    define('api-proxy-gemini', apiProxyPorts().gemini, 'API proxy: Gemini provider'),
+    define('cli-proxy', CLI_PROXY_PORT, 'CLI proxy (DIFC-mediated safe outputs)'),
+    define('mcp-gateway', ENCLAVE_MCP_CONTROL_PORT, 'Enclave MCP gateway streamable HTTP endpoint'),
+  ].map((capability) => Object.freeze(capability)));
+
+const CAPABILITIES_BY_ID = new Map<string, AppleContainerCapabilityDefinition>(
+  APPLE_CONTAINER_TRANSPORT_CAPABILITIES.map((capability) => [capability.id, capability]),
+);
+
+/**
+ * Resolves a capability by id.
+ *
+ * @throws when the id is not in the allowlist. There is no permissive fallback:
+ * an unknown capability must never resolve to a usable socket.
+ */
+export function getAppleContainerCapability(id: string): AppleContainerCapabilityDefinition {
+  const capability = CAPABILITIES_BY_ID.get(id);
+  if (!capability) {
+    throw new Error(
+      `Apple Container transport capability "${id}" is not in the allowlist ` +
+      `(${APPLE_CONTAINER_TRANSPORT_CAPABILITIES.map((entry) => entry.id).join(', ')})`,
+    );
+  }
+  return capability;
+}
+
+/** Type guard form of {@link getAppleContainerCapability}. */
+export function isAppleContainerCapabilityId(value: string): value is AppleContainerCapabilityId {
+  return CAPABILITIES_BY_ID.has(value);
+}
+
+/** Absolute guest path a capability's socket is published at. */
+export function appleContainerGuestSocketPath(id: AppleContainerCapabilityId): string {
+  return `${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/${getAppleContainerCapability(id).socketName}`;
+}
+
+/** URL the workload uses to reach a capability from inside the guest. */
+export function appleContainerGuestEndpointUrl(id: AppleContainerCapabilityId): string {
+  return `http://127.0.0.1:${getAppleContainerCapability(id).guestPort}`;
+}
+
+/** A host TCP service a capability relays to. */
+export interface AppleContainerUpstreamEndpoint {
+  readonly host: string;
+  readonly port: number;
+}
+
+const IPV4_LITERAL = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+function ipv4Octets(host: string): readonly number[] | undefined {
+  const match = IPV4_LITERAL.exec(host);
+  if (!match) return undefined;
+  const octets = match.slice(1, 5).map(Number);
+  // Reject `010.0.0.1`-style octal-looking octets and out-of-range values; both
+  // are parsed inconsistently across resolvers and are a classic SSRF vector.
+  for (let index = 0; index < 4; index += 1) {
+    const text = match[index + 1];
+    if (text.length > 1 && text.startsWith('0')) return undefined;
+    if (octets[index] > 255) return undefined;
+  }
+  return octets;
+}
+
+/** IPv6 loopback and unique-local addresses, the only IPv6 forms accepted. */
+function isAllowedIpv6(host: string): boolean {
+  const normalized = host.toLowerCase();
+  if (normalized === '::1') return true;
+  // fc00::/7 (unique local). Everything else — including fe80::/10 link-local
+  // and any global unicast address — is rejected.
+  return /^f[cd][0-9a-f]{2}:/.test(normalized);
+}
+
+/**
+ * Validates a relay upstream.
+ *
+ * Only IP literals are accepted, so the relay performs no name resolution and
+ * an attacker-controlled DNS answer cannot repoint a capability. The address
+ * must be loopback or private; link-local (and therefore the 169.254.169.254
+ * metadata address), multicast, and public addresses are refused.
+ */
+export function assertAppleContainerUpstreamEndpoint(
+  endpoint: AppleContainerUpstreamEndpoint,
+  label: string,
+): AppleContainerUpstreamEndpoint {
+  const { host, port } = endpoint;
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Apple Container transport ${label} port must be in 1..65535; got ${port}`);
+  }
+  if (typeof host !== 'string' || host.length === 0 || host.length > 45) {
+    throw new Error(`Apple Container transport ${label} host must be an IP literal`);
+  }
+
+  const octets = ipv4Octets(host);
+  if (octets) {
+    const [a, b] = octets;
+    const loopback = a === 127;
+    const privateRange = a === 10
+      || (a === 172 && b >= 16 && b <= 31)
+      || (a === 192 && b === 168);
+    if (!loopback && !privateRange) {
+      throw new Error(
+        `Apple Container transport ${label} upstream ${host} is not a loopback or private ` +
+        'address; only AWF-owned host services may be bridged into a NIC-less guest',
+      );
+    }
+    return { host, port };
+  }
+
+  if (host.includes(':')) {
+    if (!isAllowedIpv6(host)) {
+      throw new Error(
+        `Apple Container transport ${label} upstream ${host} is not an IPv6 loopback or ` +
+        'unique-local address',
+      );
+    }
+    return { host, port };
+  }
+
+  throw new Error(
+    `Apple Container transport ${label} upstream host must be an IP literal, not a name: ${host}`,
+  );
+}

--- a/src/apple-container/transport-contract-sync.test.ts
+++ b/src/apple-container/transport-contract-sync.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Keeps the two halves of the transport contract in lockstep.
+ *
+ * The host half lives in `transport-capabilities.ts` and the guest half is
+ * compiled into `guest/apple-container-init/contract.go`. Neither side can
+ * discover the other at runtime — that is the point, since no configuration
+ * crosses the VM boundary at boot — so a silent divergence would surface only
+ * as a capability that mysteriously does not work inside a real VM. This test
+ * turns that into a build failure instead.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  APPLE_CONTAINER_INIT_ENTRYPOINT,
+  APPLE_CONTAINER_TRANSPORT_CAPABILITIES,
+  APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION,
+  APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY,
+  APPLE_CONTAINER_VMINITD_PATH,
+} from './transport-capabilities';
+
+const CONTRACT_GO = path.join(
+  __dirname,
+  '..',
+  '..',
+  'guest',
+  'apple-container-init',
+  'contract.go',
+);
+
+function readContract(): string {
+  return fs.readFileSync(CONTRACT_GO, 'utf8');
+}
+
+function goStringConstant(source: string, name: string): string {
+  const match = new RegExp(`const ${name} = "([^"]*)"`).exec(source);
+  if (!match) throw new Error(`contract.go does not declare a string constant ${name}`);
+  return match[1];
+}
+
+function goIntConstant(source: string, name: string): number {
+  const match = new RegExp(`const ${name} = (\\d+)`).exec(source);
+  if (!match) throw new Error(`contract.go does not declare an integer constant ${name}`);
+  return Number(match[1]);
+}
+
+interface GoCapability {
+  readonly id: string;
+  readonly socketName: string;
+  readonly guestPort: number;
+}
+
+function goCapabilities(source: string): GoCapability[] {
+  const block = /var Capabilities = \[\]Capability\{([\s\S]*?)\n\}/.exec(source);
+  if (!block) throw new Error('contract.go does not declare a Capabilities slice');
+  const entry = /\{ID: "([^"]+)", SocketName: "([^"]+)", GuestPort: (\d+)\}/g;
+  const capabilities: GoCapability[] = [];
+  let match = entry.exec(block[1]);
+  while (match) {
+    capabilities.push({ id: match[1], socketName: match[2], guestPort: Number(match[3]) });
+    match = entry.exec(block[1]);
+  }
+  if (capabilities.length === 0) throw new Error('contract.go declares no capabilities');
+  return capabilities;
+}
+
+describe('Apple Container transport host/guest contract', () => {
+  const source = readContract();
+
+  it('agrees on the contract version and guest directory', () => {
+    expect(goIntConstant(source, 'ContractVersion'))
+      .toBe(APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION);
+    expect(goStringConstant(source, 'GuestDirectory'))
+      .toBe(APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY);
+  });
+
+  it('agrees on the init entrypoint and the relocated Apple init path', () => {
+    expect(goStringConstant(source, 'InitEntrypoint')).toBe(APPLE_CONTAINER_INIT_ENTRYPOINT);
+    expect(goStringConstant(source, 'RealInitPath')).toBe(APPLE_CONTAINER_VMINITD_PATH);
+  });
+
+  it('agrees on the exact capability set, socket names, and guest ports', () => {
+    const guest = goCapabilities(source)
+      .map((capability) => `${capability.id}|${capability.socketName}|${capability.guestPort}`)
+      .sort();
+    const host = APPLE_CONTAINER_TRANSPORT_CAPABILITIES
+      .map((capability) => `${capability.id}|${capability.socketName}|${capability.guestPort}`)
+      .sort();
+    expect(guest).toEqual(host);
+  });
+
+  it('serves no guest port that the host cannot publish a socket for', () => {
+    const hostIds = new Set<string>(APPLE_CONTAINER_TRANSPORT_CAPABILITIES.map((c) => c.id));
+    for (const capability of goCapabilities(source)) {
+      expect(hostIds.has(capability.id)).toBe(true);
+    }
+  });
+});

--- a/src/apple-container/transport-manager.test.ts
+++ b/src/apple-container/transport-manager.test.ts
@@ -1,0 +1,381 @@
+import * as fs from 'fs';
+import * as net from 'net';
+import * as path from 'path';
+
+import {
+  APPLE_CONTAINER_TRANSPORT_DEFAULT_HEALTH,
+  probeAppleContainerUpstream,
+  startAppleContainerTransport,
+  type AppleContainerTransportDependencies,
+} from './transport-manager';
+import { AppleContainerCapabilityRelay } from './transport-relay';
+
+const INIT_IMAGE = 'ghcr.io/github/gh-aw-firewall/apple-init:v1';
+
+interface Upstream {
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+async function startUpstream(): Promise<Upstream> {
+  const server = net.createServer((socket) => socket.on('data', (chunk: Buffer) => {
+    socket.write(chunk);
+  }));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return {
+    port: (server.address() as net.AddressInfo).port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function silentLogger(): AppleContainerTransportDependencies['logger'] {
+  return { debug: jest.fn(), warn: jest.fn() };
+}
+
+describe('startAppleContainerTransport', () => {
+  const bases: string[] = [];
+  const upstreams: Upstream[] = [];
+
+  function newBase(): string {
+    const base = fs.mkdtempSync('/tmp/awfmg');
+    bases.push(base);
+    return base;
+  }
+
+  afterEach(async () => {
+    for (const upstream of upstreams.splice(0)) await upstream.close();
+    for (const base of bases.splice(0)) fs.rmSync(base, { recursive: true, force: true });
+  });
+
+  it('binds, verifies, and reports every capability', async () => {
+    const squid = await startUpstream();
+    const api = await startUpstream();
+    upstreams.push(squid, api);
+    const base = newBase();
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [
+        { id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } },
+        { id: 'api-proxy-openai', upstream: { host: '127.0.0.1', port: api.port } },
+      ],
+    }, { logger: silentLogger() });
+
+    try {
+      const stats = transport.stats();
+      expect(Object.keys(stats).sort()).toEqual(['api-proxy-openai', 'squid']);
+      expect(stats.squid.established).toBe(1);
+      for (const entry of transport.plan.entries) {
+        expect(fs.lstatSync(entry.hostSocketPath).isSocket()).toBe(true);
+        expect(fs.lstatSync(entry.hostSocketPath).mode & 0o777).toBe(0o600);
+      }
+      expect(fs.lstatSync(transport.directory.path).mode & 0o777).toBe(0o700);
+      await expect(transport.verify()).resolves.toBeUndefined();
+    } finally {
+      await transport.stop();
+    }
+  });
+
+  it('waits for an upstream that is not healthy yet', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+    const probe = jest.fn()
+      .mockRejectedValueOnce(new Error('not up'))
+      .mockResolvedValue(undefined);
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+      health: { attempts: 3, retryDelayMs: 1, timeoutMs: 50 },
+    }, { logger: silentLogger(), probeUpstream: probe, sleep });
+
+    try {
+      expect(probe).toHaveBeenCalledTimes(2);
+      expect(sleep).toHaveBeenCalledWith(1);
+    } finally {
+      await transport.stop();
+    }
+  });
+
+  it('never binds a relay when an upstream stays unhealthy', async () => {
+    const base = newBase();
+    const createRelay = jest.fn();
+
+    await expect(startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } }],
+      health: { attempts: 2, retryDelayMs: 0, timeoutMs: 10 },
+    }, {
+      logger: silentLogger(),
+      probeUpstream: jest.fn().mockRejectedValue(new Error('refused')),
+      sleep: jest.fn().mockResolvedValue(undefined),
+      createRelay: createRelay as never,
+    })).rejects.toThrow(/never became healthy after 2 attempts/);
+
+    expect(createRelay).not.toHaveBeenCalled();
+    expect(fs.readdirSync(base)).toEqual([]);
+  });
+
+  it('rolls back completely when a later relay fails to bind', async () => {
+    const squid = await startUpstream();
+    const api = await startUpstream();
+    upstreams.push(squid, api);
+    const base = newBase();
+
+    let created = 0;
+    const createRelay: AppleContainerTransportDependencies['createRelay'] = (options) => {
+      created += 1;
+      if (created === 2) {
+        // Simulate a bind failure on the second capability.
+        const relay = new AppleContainerCapabilityRelay(options);
+        jest.spyOn(relay, 'start').mockRejectedValue(new Error('bind refused'));
+        return relay;
+      }
+      return new AppleContainerCapabilityRelay(options);
+    };
+
+    await expect(startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [
+        { id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } },
+        { id: 'api-proxy-openai', upstream: { host: '127.0.0.1', port: api.port } },
+      ],
+    }, { logger: silentLogger(), createRelay })).rejects.toThrow('bind refused');
+
+    // Nothing survives a partial startup: no sockets, no run directory.
+    expect(fs.readdirSync(base)).toEqual([]);
+  });
+
+  // Regression: start() binds the listener and *then* verifies its mode and
+  // ownership. A failure in that tail must not strand a bound, still-accepting
+  // relay that nothing holds a reference to.
+  it('rolls back a relay that bound but failed its post-bind verification', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+
+    let leaked: AppleContainerCapabilityRelay | undefined;
+    const createRelay: AppleContainerTransportDependencies['createRelay'] = (options) => {
+      const relay = new AppleContainerCapabilityRelay(options);
+      const realStart = relay.start.bind(relay);
+      jest.spyOn(relay, 'start').mockImplementation(async () => {
+        await realStart();
+        leaked = relay;
+        throw new Error('post-bind verification failed');
+      });
+      return relay;
+    };
+
+    await expect(startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger(), createRelay }))
+      .rejects.toThrow('post-bind verification failed');
+
+    expect(leaked).toBeDefined();
+    expect(leaked!.isBound).toBe(true);
+    // Nothing bound survives: no socket, no run directory, no live listener.
+    expect(fs.readdirSync(base)).toEqual([]);
+    await expect(new Promise((resolve, reject) => {
+      const client = net.connect({ path: leaked!.socketPath });
+      client.once('connect', () => { client.destroy(); resolve('connected'); });
+      client.once('error', reject);
+    })).rejects.toThrow();
+  });
+
+  it('leaves a pre-existing file alone when a relay fails before binding', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+    const runId = 'aaaabbbbcccc';
+    // Plant a file exactly where the squid relay would bind.
+    const runDirectory = path.join(base, `awf-apple-${runId}`);
+
+    const createRelay: AppleContainerTransportDependencies['createRelay'] = (options) => {
+      fs.mkdirSync(runDirectory, { recursive: true });
+      fs.writeFileSync(options.socketPath, 'planted');
+      return new AppleContainerCapabilityRelay(options);
+    };
+
+    await expect(startAppleContainerTransport({
+      baseDirectory: base,
+      runId,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger(), createRelay })).rejects.toThrow(/already exists/);
+
+    expect(fs.readFileSync(path.join(runDirectory, 'squid.sock'), 'utf8')).toBe('planted');
+  });
+
+  it('rolls back when end-to-end verification fails, even though binding worked', async () => {
+    const squid = await startUpstream();
+    const api = await startUpstream();
+    upstreams.push(squid, api);
+    const deadPort = api.port;
+    await api.close();
+    upstreams.pop();
+    const base = newBase();
+
+    await expect(startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [
+        { id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } },
+        { id: 'api-proxy-openai', upstream: { host: '127.0.0.1', port: deadPort } },
+      ],
+      // The upstream health gate is bypassed so the failure lands on the
+      // end-to-end probe rather than on the pre-flight check.
+      health: { attempts: 1, retryDelayMs: 0, timeoutMs: 10 },
+    }, {
+      logger: silentLogger(),
+      probeUpstream: jest.fn().mockResolvedValue(undefined),
+    })).rejects.toThrow(/could not reach 127\.0\.0\.1:/);
+
+    expect(fs.readdirSync(base)).toEqual([]);
+  });
+
+  it('forwards data end to end through a published socket', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger() });
+
+    try {
+      const socketPath = transport.plan.entries[0].hostSocketPath;
+      const echoed = await new Promise<string>((resolve, reject) => {
+        const client = net.connect({ path: socketPath });
+        client.on('connect', () => client.write('ping'));
+        client.on('data', (chunk: Buffer) => {
+          client.destroy();
+          resolve(chunk.toString());
+        });
+        client.on('error', reject);
+      });
+      expect(echoed).toBe('ping');
+    } finally {
+      await transport.stop();
+    }
+  });
+
+  it('removes every socket and the run directory on stop, idempotently', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger() });
+
+    await transport.stop();
+    expect(fs.existsSync(transport.directory.path)).toBe(false);
+    await expect(transport.stop()).resolves.toBeUndefined();
+    await expect(transport.verify()).rejects.toThrow(/has been stopped/);
+    expect(() => transport.applyTo({ image: 'x' })).toThrow(/has been stopped/);
+  });
+
+  it('shares one shutdown between concurrent stop() calls', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger() });
+
+    await Promise.all([transport.stop(), transport.stop(), transport.stop()]);
+    expect(fs.existsSync(transport.directory.path)).toBe(false);
+  });
+
+  it('preserves diagnostics without leaving an active access path', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger() });
+
+    const socketPath = transport.plan.entries[0].hostSocketPath;
+    await transport.stop({ preserveDiagnostics: true });
+
+    expect(fs.existsSync(transport.directory.path)).toBe(true);
+    expect(fs.existsSync(socketPath)).toBe(false);
+
+    const summaryPath = path.join(transport.directory.path, 'transport-summary.json');
+    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+    expect(summary.capabilities[0].id).toBe('squid');
+    expect(summary.capabilities[0].stats.established).toBe(1);
+    expect(fs.lstatSync(summaryPath).mode & 0o777).toBe(0o600);
+    expect(JSON.stringify(summary).toLowerCase()).not.toContain('key');
+  });
+
+  it('applies the plan to a run spec and keeps the guest isolated', async () => {
+    const squid = await startUpstream();
+    upstreams.push(squid);
+    const base = newBase();
+
+    const transport = await startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: squid.port } }],
+    }, { logger: silentLogger() });
+
+    try {
+      const spec = transport.applyTo({ image: 'ghcr.io/github/gh-aw-firewall/agent:latest' });
+      expect(spec.network).toEqual({ kind: 'none' });
+      expect(spec.initImage).toBe(INIT_IMAGE);
+      expect(spec.capDrop).toEqual(expect.arrayContaining(['NET_RAW']));
+    } finally {
+      await transport.stop();
+    }
+  });
+
+  it('rejects nonsensical health options before touching the filesystem', async () => {
+    const base = newBase();
+    await expect(startAppleContainerTransport({
+      baseDirectory: base,
+      initImage: INIT_IMAGE,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } }],
+      health: { attempts: 0 },
+    }, { logger: silentLogger() })).rejects.toThrow(/health attempts must be an integer/);
+    expect(fs.readdirSync(base)).toEqual([]);
+  });
+
+  it('exposes sensible default health settings', () => {
+    expect(APPLE_CONTAINER_TRANSPORT_DEFAULT_HEALTH.attempts).toBeGreaterThan(1);
+    expect(APPLE_CONTAINER_TRANSPORT_DEFAULT_HEALTH.timeoutMs).toBeGreaterThan(0);
+  });
+});
+
+describe('probeAppleContainerUpstream', () => {
+  it('resolves for a listening service and rejects for a dead one', async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as net.AddressInfo).port;
+
+    await expect(probeAppleContainerUpstream({ host: '127.0.0.1', port }, 2_000))
+      .resolves.toBeUndefined();
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await expect(probeAppleContainerUpstream({ host: '127.0.0.1', port }, 2_000))
+      .rejects.toThrow();
+  });
+});

--- a/src/apple-container/transport-manager.ts
+++ b/src/apple-container/transport-manager.ts
@@ -1,0 +1,396 @@
+/**
+ * Lifecycle owner for the Apple Container capability transport.
+ *
+ * Startup is strictly ordered and fails closed at every step:
+ *
+ * 1. **Plan.** The capability set is validated against the allowlist before any
+ *    filesystem or network side effect happens.
+ * 2. **Upstream health.** Every upstream is TCP-probed first. Relays are only
+ *    bound once the services they front are actually accepting connections, so
+ *    a guest can never observe a socket that leads nowhere.
+ * 3. **Private directory.** A fresh `0700` run directory is created.
+ * 4. **Bind.** Relays are started one at a time.
+ * 5. **End-to-end verification.** Each relay is probed through its own Unix
+ *    socket, which exercises accept → dial → establish. Only after every
+ *    capability passes is the transport declared ready.
+ *
+ * Any failure at any step triggers a full rollback: every relay that was
+ * started is stopped, its socket is unlinked, the run directory is removed, and
+ * the *original* error propagates. The transport is never returned in a partial
+ * state, so a caller that awaits {@link startAppleContainerTransport} and gets a
+ * value knows the agent may start; if it throws, agent execution must not begin.
+ *
+ * Shutdown is deterministic and idempotent: relays are closed and their live
+ * connections destroyed, only sockets this run created are unlinked, and the
+ * directory is removed non-recursively. With `preserveDiagnostics` the
+ * directory and a small JSON summary survive for triage, but every socket is
+ * still unlinked first — diagnostics never leave an active access path into the
+ * guest's capabilities.
+ */
+
+import * as fs from 'fs/promises';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+
+import { logger } from '../logger';
+import type { AppleContainerRunSpec } from './run-args';
+import type { AppleContainerUpstreamEndpoint } from './transport-capabilities';
+import {
+  applyAppleContainerTransportToRunSpec,
+  planAppleContainerTransport,
+  type AppleContainerTransportCapabilityRequest,
+  type AppleContainerTransportPlan,
+} from './transport-plan';
+import {
+  AppleContainerCapabilityRelay,
+  type AppleContainerRelayDependencies,
+  type AppleContainerRelayLimits,
+  type AppleContainerRelayStats,
+} from './transport-relay';
+import {
+  createAppleContainerSocketDirectory,
+  removeAppleContainerSocketDirectory,
+  type AppleContainerSocketDirectoryHandle,
+} from './transport-socket-dir';
+
+export interface AppleContainerTransportHealthOptions {
+  /** Total connect attempts per upstream, including the first. */
+  readonly attempts: number;
+  readonly timeoutMs: number;
+  readonly retryDelayMs: number;
+}
+
+export const APPLE_CONTAINER_TRANSPORT_DEFAULT_HEALTH: AppleContainerTransportHealthOptions =
+  Object.freeze({ attempts: 10, timeoutMs: 2_000, retryDelayMs: 500 });
+
+interface TransportLogger {
+  debug(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+}
+
+export interface AppleContainerTransportDependencies {
+  probeUpstream(endpoint: AppleContainerUpstreamEndpoint, timeoutMs: number): Promise<void>;
+  createRelay(
+    options: ConstructorParameters<typeof AppleContainerCapabilityRelay>[0],
+  ): AppleContainerCapabilityRelay;
+  sleep(milliseconds: number): Promise<void>;
+  logger: TransportLogger;
+  relayDependencies?: Partial<AppleContainerRelayDependencies>;
+}
+
+export interface AppleContainerTransportStartOptions {
+  readonly capabilities: readonly AppleContainerTransportCapabilityRequest[];
+  readonly initImage: string;
+  readonly baseDirectory?: string;
+  readonly runId?: string;
+  readonly readOnlyRootfs?: boolean;
+  readonly limits?: Partial<AppleContainerRelayLimits>;
+  readonly health?: Partial<AppleContainerTransportHealthOptions>;
+}
+
+export interface AppleContainerTransportStopOptions {
+  /**
+   * Keep the run directory and write a `transport-summary.json` describing what
+   * ran. Sockets are unlinked either way.
+   */
+  readonly preserveDiagnostics?: boolean;
+}
+
+/** Default TCP reachability probe for an upstream AWF service. */
+export async function probeAppleContainerUpstream(
+  endpoint: AppleContainerUpstreamEndpoint,
+  timeoutMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const socket = net.connect({ host: endpoint.host, port: endpoint.port });
+    let done = false;
+    const finish = (error?: Error): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      socket.destroy();
+      if (error) reject(error); else resolve();
+    };
+    const timer = setTimeout(
+      () => finish(new Error(`connect timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    timer.unref?.();
+    socket.once('connect', () => finish());
+    socket.once('error', (error: Error) => finish(error));
+  });
+}
+
+function defaultDependencies(): AppleContainerTransportDependencies {
+  return {
+    probeUpstream: probeAppleContainerUpstream,
+    createRelay: (options) => new AppleContainerCapabilityRelay(options),
+    sleep: (milliseconds) => new Promise((resolve) => {
+      const timer = setTimeout(resolve, milliseconds);
+      timer.unref?.();
+    }),
+    logger,
+  };
+}
+
+/** A started, verified transport. Only produced when every capability works. */
+export class AppleContainerTransport {
+  private stopped = false;
+  private stopping?: Promise<void>;
+
+  constructor(
+    readonly plan: AppleContainerTransportPlan,
+    readonly directory: AppleContainerSocketDirectoryHandle,
+    private readonly relays: readonly AppleContainerCapabilityRelay[],
+    private readonly deps: AppleContainerTransportDependencies,
+  ) {}
+
+  /** Per-capability counters, safe to log: no payload bytes are retained. */
+  stats(): Readonly<Record<string, AppleContainerRelayStats>> {
+    const result: Record<string, AppleContainerRelayStats> = {};
+    for (const relay of this.relays) {
+      result[relay.capability.id] = relay.stats;
+    }
+    return result;
+  }
+
+  /** Merges this transport's plan into a run spec (see {@link applyAppleContainerTransportToRunSpec}). */
+  applyTo(spec: AppleContainerRunSpec): AppleContainerRunSpec {
+    if (this.stopped) {
+      throw new Error('Apple Container transport has been stopped; refusing to build a run spec');
+    }
+    return applyAppleContainerTransportToRunSpec(spec, this.plan);
+  }
+
+  /** Re-runs the end-to-end probe for every capability. */
+  async verify(): Promise<void> {
+    if (this.stopped) {
+      throw new Error('Apple Container transport has been stopped');
+    }
+    for (const relay of this.relays) {
+      await relay.probe();
+    }
+  }
+
+  /** Deterministic, idempotent teardown. Concurrent calls share one shutdown. */
+  async stop(options: AppleContainerTransportStopOptions = {}): Promise<void> {
+    if (this.stopping) return this.stopping;
+    this.stopping = this.runStop(options);
+    return this.stopping;
+  }
+
+  private async runStop(options: AppleContainerTransportStopOptions): Promise<void> {
+    const summary = options.preserveDiagnostics ? this.buildSummary() : undefined;
+    this.stopped = true;
+
+    const failures: string[] = [];
+    for (const relay of this.relays) {
+      try {
+        await relay.stop();
+      } catch (error) {
+        failures.push(`${relay.capability.id}: ${describe(error)}`);
+      }
+    }
+
+      const socketPaths = ownedSocketPaths(this.relays);
+    if (summary) {
+      // relay.stop() already unlinked these; the sweep is a belt-and-braces
+      // guarantee that preserving the directory cannot preserve a live path.
+      // A socket that cannot be removed is fatal rather than ignored: leaving
+      // it behind would be exactly the access path diagnostics must not keep.
+      for (const socketPath of socketPaths) {
+        try {
+          await fs.unlink(socketPath);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw new Error(
+              `Apple Container transport could not remove ${socketPath} while preserving ` +
+              `diagnostics: ${describe(error)}`,
+            );
+          }
+        }
+      }
+      const summaryPath = path.posix.join(this.directory.path, 'transport-summary.json');
+      await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+    } else {
+      await removeAppleContainerSocketDirectory(this.directory, socketPaths);
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Apple Container transport shutdown failed for ${failures.length} relay(s): ` +
+        failures.join('; '),
+      );
+    }
+  }
+
+  private buildSummary(): Record<string, unknown> {
+    return {
+      contractVersion: this.plan.contractVersion,
+      runId: this.directory.runId,
+      initImage: this.plan.initImage,
+      guestDirectory: this.plan.guestDirectory,
+      capabilities: this.relays.map((relay) => ({
+        id: relay.capability.id,
+        guestPort: relay.capability.guestPort,
+        upstream: `${relay.upstream.host}:${relay.upstream.port}`,
+        stats: relay.stats,
+      })),
+    };
+  }
+}
+
+/**
+ * Starts and verifies the transport.
+ *
+ * @throws on any unmet precondition or partial startup. Callers must treat a
+ * throw as fatal: without a verified transport the agent has no egress and must
+ * not be launched.
+ */
+export async function startAppleContainerTransport(
+  options: AppleContainerTransportStartOptions,
+  overrides: Partial<AppleContainerTransportDependencies> = {},
+): Promise<AppleContainerTransport> {
+  const deps: AppleContainerTransportDependencies = { ...defaultDependencies(), ...overrides };
+  const health = { ...APPLE_CONTAINER_TRANSPORT_DEFAULT_HEALTH, ...options.health };
+  assertHealthOptions(health);
+
+  const directory = await createAppleContainerSocketDirectory({
+    baseDirectory: options.baseDirectory ?? os.tmpdir(),
+    ...(options.runId !== undefined ? { runId: options.runId } : {}),
+  });
+
+  const started: AppleContainerCapabilityRelay[] = [];
+  try {
+    const plan = planAppleContainerTransport({
+      directory,
+      capabilities: options.capabilities,
+      initImage: options.initImage,
+      ...(options.readOnlyRootfs !== undefined ? { readOnlyRootfs: options.readOnlyRootfs } : {}),
+    });
+
+    for (const entry of plan.entries) {
+      await waitForUpstream(entry.capability.id, entry.upstream, health, deps);
+    }
+
+    for (const entry of plan.entries) {
+      const relay = deps.createRelay({
+        capability: entry.capability,
+        socketPath: entry.hostSocketPath,
+        upstream: entry.upstream,
+        ...(options.limits ? { limits: options.limits } : {}),
+        ...(deps.relayDependencies ? { dependencies: deps.relayDependencies } : {}),
+      });
+      // Registered for rollback *before* it is started: `start()` binds the
+      // listener and then verifies its mode and ownership, so a failure in that
+      // tail would otherwise strand a live, still-accepting relay that nothing
+      // holds a reference to.
+      started.push(relay);
+      await relay.start();
+    }
+
+    for (const relay of started) {
+      await relay.probe();
+      deps.logger.debug(
+        `Apple Container transport capability ${relay.capability.id} verified ` +
+        `(guest 127.0.0.1:${relay.capability.guestPort})`,
+      );
+    }
+
+    return new AppleContainerTransport(plan, directory, started, deps);
+  } catch (error) {
+    await rollback(started, directory, deps);
+    throw error;
+  }
+}
+
+async function waitForUpstream(
+  capabilityId: string,
+  endpoint: AppleContainerUpstreamEndpoint,
+  health: AppleContainerTransportHealthOptions,
+  deps: AppleContainerTransportDependencies,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= health.attempts; attempt += 1) {
+    try {
+      await deps.probeUpstream(endpoint, health.timeoutMs);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < health.attempts) {
+        await deps.sleep(health.retryDelayMs);
+      }
+    }
+  }
+  throw new Error(
+    `Apple Container transport upstream for capability "${capabilityId}" ` +
+    `(${endpoint.host}:${endpoint.port}) never became healthy after ${health.attempts} ` +
+    `attempts: ${describe(lastError)}`,
+  );
+}
+
+/**
+ * Undoes a partial startup.
+ *
+ * Rollback failures are logged rather than thrown so they cannot mask the real
+ * cause; the caller always sees the original error.
+ */
+async function rollback(
+  started: readonly AppleContainerCapabilityRelay[],
+  directory: AppleContainerSocketDirectoryHandle,
+  deps: AppleContainerTransportDependencies,
+): Promise<void> {
+  for (const relay of started) {
+    try {
+      await relay.stop();
+    } catch (error) {
+      deps.logger.warn(
+        `Apple Container transport rollback could not stop relay ${relay.capability.id}: ` +
+        describe(error),
+      );
+    }
+  }
+  try {
+    await removeAppleContainerSocketDirectory(directory, ownedSocketPaths(started));
+  } catch (error) {
+    deps.logger.warn(
+      `Apple Container transport rollback could not remove ${directory.path}: ${describe(error)}`,
+    );
+  }
+}
+
+/**
+ * Socket paths this run actually bound.
+ *
+ * A relay that never reached `listen()` does not own its path — it may be the
+ * pre-existing file that made `start()` fail — so it is excluded and left
+ * untouched.
+ */
+function ownedSocketPaths(
+  relays: readonly AppleContainerCapabilityRelay[],
+): readonly string[] {
+  return relays.filter((relay) => relay.isBound).map((relay) => relay.socketPath);
+}
+
+function assertHealthOptions(health: AppleContainerTransportHealthOptions): void {
+  const checks: ReadonlyArray<readonly [keyof AppleContainerTransportHealthOptions, number]> = [
+    ['attempts', 1_000],
+    ['timeoutMs', 600_000],
+    ['retryDelayMs', 600_000],
+  ];
+  for (const [key, maximum] of checks) {
+    const value = health[key];
+    const minimum = key === 'retryDelayMs' ? 0 : 1;
+    if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+      throw new Error(
+        `Apple Container transport health ${key} must be an integer in ` +
+        `${minimum}..${maximum}; got ${value}`,
+      );
+    }
+  }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/apple-container/transport-plan.test.ts
+++ b/src/apple-container/transport-plan.test.ts
@@ -1,0 +1,324 @@
+import { buildAppleContainerRunArgs, type AppleContainerRunSpec } from './run-args';
+import {
+  APPLE_CONTAINER_TRANSPORT_CAPABILITIES,
+  APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION,
+  APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY,
+} from './transport-capabilities';
+import {
+  APPLE_CONTAINER_REQUIRED_CAP_DROPS,
+  applyAppleContainerTransportToRunSpec,
+  planAppleContainerTransport,
+  type AppleContainerTransportPlan,
+} from './transport-plan';
+import type { AppleContainerSocketDirectoryHandle } from './transport-socket-dir';
+
+const DIRECTORY: AppleContainerSocketDirectoryHandle = {
+  path: '/tmp/awf-apple-abc123def456',
+  runId: 'abc123def456',
+};
+
+const INIT_IMAGE = 'ghcr.io/github/gh-aw-firewall/apple-init:v1';
+
+function plan(
+  capabilities = [
+    { id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } },
+    { id: 'api-proxy-anthropic', upstream: { host: '127.0.0.1', port: 10001 } },
+  ],
+): AppleContainerTransportPlan {
+  return planAppleContainerTransport({
+    directory: DIRECTORY,
+    capabilities,
+    initImage: INIT_IMAGE,
+  });
+}
+
+describe('planAppleContainerTransport', () => {
+  it('produces one publish-socket pair per capability', () => {
+    const result = plan();
+    expect(result.socketMounts).toEqual([
+      {
+        hostPath: '/tmp/awf-apple-abc123def456/squid.sock',
+        containerPath: `${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/squid.sock`,
+      },
+      {
+        hostPath: '/tmp/awf-apple-abc123def456/api-proxy-anthropic.sock',
+        containerPath: `${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/api-proxy-anthropic.sock`,
+      },
+    ]);
+    expect(result.contractVersion).toBe(APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION);
+  });
+
+  it('points every proxy variable at the guest-side Squid endpoint', () => {
+    const result = plan();
+    expect(result.env.HTTP_PROXY).toBe('http://127.0.0.1:3128');
+    expect(result.env.HTTPS_PROXY).toBe('http://127.0.0.1:3128');
+    expect(result.env.http_proxy).toBe('http://127.0.0.1:3128');
+    expect(result.env.https_proxy).toBe('http://127.0.0.1:3128');
+    expect(result.env.SQUID_PROXY_HOST).toBe('127.0.0.1');
+    expect(result.env.SQUID_PROXY_PORT).toBe('3128');
+  });
+
+  it('exempts loopback from the proxy so relayed endpoints are reachable', () => {
+    const result = plan();
+    expect(result.env.NO_PROXY).toContain('127.0.0.1');
+    expect(result.env.no_proxy).toBe(result.env.NO_PROXY);
+  });
+
+  it('publishes an endpoint variable for each capability and nothing more', () => {
+    const result = plan();
+    expect(result.env.AWF_APPLE_TRANSPORT_SQUID_URL).toBe('http://127.0.0.1:3128');
+    expect(result.env.AWF_APPLE_TRANSPORT_API_PROXY_ANTHROPIC_URL)
+      .toBe('http://127.0.0.1:10001');
+    expect(result.env.AWF_APPLE_TRANSPORT_CLI_PROXY_URL).toBeUndefined();
+  });
+
+  it('never places a credential in the guest environment', () => {
+    const result = planAppleContainerTransport({
+      directory: DIRECTORY,
+      capabilities: APPLE_CONTAINER_TRANSPORT_CAPABILITIES.map((capability) => ({
+        id: capability.id,
+        upstream: { host: '127.0.0.1', port: capability.guestPort },
+      })),
+      initImage: INIT_IMAGE,
+    });
+    const serialized = JSON.stringify(result).toLowerCase();
+    for (const secretish of ['api_key', 'apikey', 'token', 'secret', 'authorization', 'bearer']) {
+      expect(serialized).not.toContain(secretish);
+    }
+  });
+
+  it('drops the mandatory capabilities', () => {
+    expect(plan().capDrop).toEqual(APPLE_CONTAINER_REQUIRED_CAP_DROPS);
+    expect(plan().capDrop).toEqual(expect.arrayContaining(['NET_RAW', 'NET_ADMIN', 'SYS_ADMIN']));
+  });
+
+  it('defaults the guest rootfs to read-only but honours an explicit choice', () => {
+    expect(plan().readOnlyRootfs).toBe(true);
+    const writable = planAppleContainerTransport({
+      directory: DIRECTORY,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } }],
+      initImage: INIT_IMAGE,
+      readOnlyRootfs: false,
+    });
+    expect(writable.readOnlyRootfs).toBe(false);
+  });
+
+  it('requires the squid capability', () => {
+    expect(() => planAppleContainerTransport({
+      directory: DIRECTORY,
+      capabilities: [{ id: 'cli-proxy', upstream: { host: '127.0.0.1', port: 11000 } }],
+      initImage: INIT_IMAGE,
+    })).toThrow(/must include the "squid" capability/);
+  });
+
+  it('rejects an empty capability set', () => {
+    expect(() => planAppleContainerTransport({
+      directory: DIRECTORY,
+      capabilities: [],
+      initImage: INIT_IMAGE,
+    })).toThrow(/at least one capability/);
+  });
+
+  it('rejects duplicates and unknown capabilities', () => {
+    expect(() => plan([
+      { id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } },
+      { id: 'squid', upstream: { host: '127.0.0.1', port: 3129 } },
+    ])).toThrow(/is duplicated/);
+    expect(() => plan([
+      { id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } },
+      { id: 'host-network', upstream: { host: '127.0.0.1', port: 1 } },
+    ])).toThrow(/not in the allowlist/);
+  });
+
+  it('rejects an upstream outside the AWF-owned address space', () => {
+    expect(() => plan([
+      { id: 'squid', upstream: { host: '169.254.169.254', port: 80 } },
+    ])).toThrow(/not a loopback or private address/);
+  });
+
+  it('rejects an init image reference that could split argv', () => {
+    expect(() => planAppleContainerTransport({
+      directory: DIRECTORY,
+      capabilities: [{ id: 'squid', upstream: { host: '127.0.0.1', port: 3128 } }],
+      initImage: '--privileged',
+    })).toThrow(/image reference/);
+  });
+});
+
+describe('applyAppleContainerTransportToRunSpec', () => {
+  const baseSpec: AppleContainerRunSpec = { image: 'ghcr.io/github/gh-aw-firewall/agent:latest' };
+
+  it('keeps the guest on no network', () => {
+    const merged = applyAppleContainerTransportToRunSpec(baseSpec, plan());
+    expect(merged.network).toEqual({ kind: 'none' });
+    expect(buildAppleContainerRunArgs(merged)).toContain('none');
+  });
+
+  it('always emits --network none in the argv', () => {
+    const argv = buildAppleContainerRunArgs(
+      applyAppleContainerTransportToRunSpec(baseSpec, plan()),
+    );
+    const index = argv.indexOf('--network');
+    expect(index).toBeGreaterThan(-1);
+    expect(argv[index + 1]).toBe('none');
+    expect(argv.filter((token) => token === '--network')).toHaveLength(1);
+  });
+
+  it('refuses a run spec that attaches a network', () => {
+    expect(() => applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, network: { kind: 'attach', networks: ['bridge'] } },
+      plan(),
+    )).toThrow(/cannot be combined with the capability transport/);
+  });
+
+  it('refuses forbidden capability additions in any spelling', () => {
+    for (const capability of ['ALL', 'all', 'CAP_NET_ADMIN', 'net_raw', 'SYS_ADMIN']) {
+      expect(() => applyAppleContainerTransportToRunSpec(
+        { ...baseSpec, capAdd: [capability] },
+        plan(),
+      )).toThrow(/refuses capAdd/);
+    }
+  });
+
+  it('permits a benign capability addition', () => {
+    const merged = applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, capAdd: ['CHOWN'] },
+      plan(),
+    );
+    expect(merged.capAdd).toEqual(['CHOWN']);
+  });
+
+  it('unions cap drops without duplicating an existing one', () => {
+    const merged = applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, capDrop: ['CAP_NET_RAW', 'MKNOD'] },
+      plan(),
+    );
+    expect(merged.capDrop).toEqual([
+      'CAP_NET_RAW',
+      'MKNOD',
+      'NET_ADMIN',
+      'SYS_ADMIN',
+      'SYS_MODULE',
+      'SYS_RAWIO',
+    ]);
+  });
+
+  it('emits every publish-socket token in the argv', () => {
+    const argv = buildAppleContainerRunArgs(
+      applyAppleContainerTransportToRunSpec(baseSpec, plan()),
+    );
+    expect(argv).toContain(
+      `/tmp/awf-apple-abc123def456/squid.sock:${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/squid.sock`,
+    );
+    expect(argv.filter((token) => token === '--publish-socket')).toHaveLength(2);
+  });
+
+  it('pins the init image and refuses a conflicting one', () => {
+    expect(applyAppleContainerTransportToRunSpec(baseSpec, plan()).initImage).toBe(INIT_IMAGE);
+    expect(() => applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, initImage: 'ghcr.io/other/init:latest' },
+      plan(),
+    )).toThrow(/requires init image/);
+  });
+
+  it('refuses a conflicting transport environment variable', () => {
+    expect(() => applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, env: { HTTPS_PROXY: 'http://evil.example:8080' } },
+      plan(),
+    )).toThrow(/already set to a different value/);
+  });
+
+  it('accepts an identical environment variable', () => {
+    const merged = applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, env: { HTTPS_PROXY: 'http://127.0.0.1:3128', EXTRA: 'ok' } },
+      plan(),
+    );
+    expect(merged.env?.EXTRA).toBe('ok');
+    expect(merged.env?.HTTPS_PROXY).toBe('http://127.0.0.1:3128');
+  });
+
+  it('refuses to publish any socket the plan did not authorise', () => {
+    // The headline case: a Docker socket published into the guest would be a
+    // direct escape to host root that every other guarantee here survives.
+    expect(() => applyAppleContainerTransportToRunSpec(
+      {
+        ...baseSpec,
+        socketMounts: [{
+          hostPath: '/var/run/docker.sock',
+          containerPath: '/var/run/docker.sock',
+        }],
+      },
+      plan(),
+    )).toThrow(/only allowlisted capability sockets may cross the VM boundary/);
+
+    // Rebinding an allowlisted guest path to a different host socket is equally
+    // refused.
+    expect(() => applyAppleContainerTransportToRunSpec(
+      {
+        ...baseSpec,
+        socketMounts: [{
+          hostPath: '/tmp/other.sock',
+          containerPath: `${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/squid.sock`,
+        }],
+      },
+      plan(),
+    )).toThrow(/only allowlisted capability sockets may cross the VM boundary/);
+  });
+
+  it('tolerates a socket mount that is byte-identical to a planned one', () => {
+    const identical = applyAppleContainerTransportToRunSpec(
+      {
+        ...baseSpec,
+        socketMounts: [{
+          hostPath: '/tmp/awf-apple-abc123def456/squid.sock',
+          containerPath: `${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/squid.sock`,
+        }],
+      },
+      plan(),
+    );
+    expect(identical.socketMounts).toEqual(plan().socketMounts);
+  });
+
+  it('refuses a bind mount that would shadow the published sockets', () => {
+    for (const target of [
+      APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY,
+      `${APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY}/squid.sock`,
+    ]) {
+      expect(() => applyAppleContainerTransportToRunSpec(
+        { ...baseSpec, mounts: [{ source: '/tmp/decoy', target }] },
+        plan(),
+      )).toThrow(/would shadow the published capability sockets/);
+    }
+  });
+
+  it('leaves unrelated bind mounts alone', () => {
+    const merged = applyAppleContainerTransportToRunSpec(
+      { ...baseSpec, mounts: [{ source: '/tmp/workspace', target: '/workspace' }] },
+      plan(),
+    );
+    expect(merged.mounts).toEqual([{ source: '/tmp/workspace', target: '/workspace' }]);
+  });
+
+  it('does not mutate the input spec', () => {
+    const spec: AppleContainerRunSpec = { ...baseSpec, env: { EXTRA: 'ok' }, socketMounts: [] };
+    applyAppleContainerTransportToRunSpec(spec, plan());
+    expect(spec.env).toEqual({ EXTRA: 'ok' });
+    expect(spec.socketMounts).toEqual([]);
+    expect(spec.network).toBeUndefined();
+  });
+
+  it('never publishes a Docker socket or a host network capability', () => {
+    const argv = buildAppleContainerRunArgs(
+      applyAppleContainerTransportToRunSpec(
+        { ...baseSpec, mounts: [{ source: '/tmp/workspace', target: '/workspace' }] },
+        plan(),
+      ),
+    );
+    expect(argv.join(' ')).not.toContain('docker.sock');
+    expect(argv.join(' ')).not.toContain('--cap-add');
+    for (const token of argv) {
+      if (!token.includes(':') || !token.endsWith('.sock')) continue;
+      expect(token.startsWith('/tmp/awf-apple-abc123def456/')).toBe(true);
+    }
+  });
+});

--- a/src/apple-container/transport-plan.ts
+++ b/src/apple-container/transport-plan.ts
@@ -1,0 +1,308 @@
+/**
+ * Turns a set of allowlisted capabilities into the exact launch surface an
+ * Apple Container agent needs, and merges it into a layer-1
+ * {@link AppleContainerRunSpec} without ever weakening the isolation the run
+ * spec already guarantees.
+ *
+ * The plan is the only place that decides:
+ *
+ * - which `--publish-socket host:guest` pairs exist (one per capability, no
+ *   generic host-network or Docker-socket mount is representable);
+ * - which environment variables tell the workload where the guest-side loopback
+ *   endpoints are;
+ * - which capabilities are dropped from the workload;
+ * - which pinned init image supplies the guest relay;
+ * - that networking stays `{ kind: 'none' }`.
+ *
+ * The merge is intentionally hostile to its caller. It refuses a run spec that
+ * asks for a network, that adds a forbidden capability, that publishes a
+ * conflicting socket, or that sets one of the transport environment variables
+ * to a different value. A caller cannot end up with a launch that looks planned
+ * but silently differs from the plan.
+ *
+ * No credential ever appears in this module. API proxy capabilities are
+ * unauthenticated from the guest's point of view; the real key is injected by
+ * the host-side API proxy sidecar and never enters guest env, argv, files, or
+ * logs.
+ */
+
+import type {
+  AppleContainerRunSpec,
+  AppleContainerSocketMount,
+} from './run-args';
+import type {
+  AppleContainerCapabilityDefinition,
+  AppleContainerCapabilityId,
+  AppleContainerUpstreamEndpoint,
+} from './transport-capabilities';
+import {
+  APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION,
+  APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY,
+  appleContainerGuestEndpointUrl,
+  appleContainerGuestSocketPath,
+  assertAppleContainerUpstreamEndpoint,
+  getAppleContainerCapability,
+} from './transport-capabilities';
+import {
+  appleContainerHostSocketPath,
+  type AppleContainerSocketDirectoryHandle,
+} from './transport-socket-dir';
+import { assertAppleContainerImageReference } from './validation';
+
+/**
+ * Capabilities the workload must never hold.
+ *
+ * `NET_RAW` and `NET_ADMIN` would let the workload craft link-layer traffic or
+ * bring up an interface; `SYS_ADMIN`, `SYS_MODULE`, and `SYS_RAWIO` are generic
+ * escape primitives. They are dropped unconditionally, and adding any of them —
+ * or the `ALL` wildcard — is refused rather than silently overridden.
+ */
+export const APPLE_CONTAINER_REQUIRED_CAP_DROPS: readonly string[] = Object.freeze([
+  'NET_ADMIN',
+  'NET_RAW',
+  'SYS_ADMIN',
+  'SYS_MODULE',
+  'SYS_RAWIO',
+]);
+
+const FORBIDDEN_CAP_ADDS = new Set([
+  'ALL',
+  'NET_ADMIN',
+  'NET_RAW',
+  'SYS_ADMIN',
+  'SYS_MODULE',
+  'SYS_RAWIO',
+]);
+
+/** Squid is the guest's only egress path, so a plan without it is not viable. */
+const REQUIRED_CAPABILITY: AppleContainerCapabilityId = 'squid';
+
+/** Destinations the workload must reach directly rather than through Squid. */
+const GUEST_NO_PROXY = '127.0.0.1,localhost,::1';
+
+export interface AppleContainerTransportEntry {
+  readonly capability: AppleContainerCapabilityDefinition;
+  readonly hostSocketPath: string;
+  readonly guestSocketPath: string;
+  readonly guestPort: number;
+  readonly upstream: AppleContainerUpstreamEndpoint;
+}
+
+export interface AppleContainerTransportCapabilityRequest {
+  readonly id: string;
+  readonly upstream: AppleContainerUpstreamEndpoint;
+}
+
+export interface AppleContainerTransportPlanInput {
+  readonly directory: AppleContainerSocketDirectoryHandle;
+  readonly capabilities: readonly AppleContainerTransportCapabilityRequest[];
+  /** Pinned AWF init image carrying the guest relay and Apple's real vminitd. */
+  readonly initImage: string;
+  /**
+   * Whether the guest rootfs is mounted read-only. Defaults to `true`: the
+   * transport itself needs nothing writable, and `/run` stays a tmpfs, so the
+   * published sockets are unaffected.
+   */
+  readonly readOnlyRootfs?: boolean;
+}
+
+export interface AppleContainerTransportPlan {
+  readonly contractVersion: number;
+  readonly guestDirectory: string;
+  readonly initImage: string;
+  readonly readOnlyRootfs: boolean;
+  readonly entries: readonly AppleContainerTransportEntry[];
+  readonly socketMounts: readonly AppleContainerSocketMount[];
+  readonly env: Readonly<Record<string, string>>;
+  readonly capDrop: readonly string[];
+}
+
+/**
+ * Builds the transport plan.
+ *
+ * @throws when a capability is unknown or duplicated, when Squid is absent,
+ * when an upstream is not an AWF-owned loopback/private endpoint, or when a
+ * socket path would not fit in `sun_path`.
+ */
+export function planAppleContainerTransport(
+  input: AppleContainerTransportPlanInput,
+): AppleContainerTransportPlan {
+  if (input.capabilities.length === 0) {
+    throw new Error('Apple Container transport plan requires at least one capability');
+  }
+
+  const seen = new Set<string>();
+  const entries: AppleContainerTransportEntry[] = [];
+  for (const request of input.capabilities) {
+    const capability = getAppleContainerCapability(request.id);
+    if (seen.has(capability.id)) {
+      throw new Error(`Apple Container transport capability "${capability.id}" is duplicated`);
+    }
+    seen.add(capability.id);
+    entries.push({
+      capability,
+      hostSocketPath: appleContainerHostSocketPath(input.directory, capability.socketName),
+      guestSocketPath: appleContainerGuestSocketPath(capability.id),
+      guestPort: capability.guestPort,
+      upstream: assertAppleContainerUpstreamEndpoint(
+        request.upstream,
+        `capability ${capability.id}`,
+      ),
+    });
+  }
+
+  if (!seen.has(REQUIRED_CAPABILITY)) {
+    throw new Error(
+      `Apple Container transport plan must include the "${REQUIRED_CAPABILITY}" capability; ` +
+      'a NIC-less guest has no other egress path',
+    );
+  }
+
+  const squid = entries.find((entry) => entry.capability.id === REQUIRED_CAPABILITY)!;
+  const squidUrl = appleContainerGuestEndpointUrl(REQUIRED_CAPABILITY);
+
+  const env: Record<string, string> = {
+    AWF_APPLE_TRANSPORT_CONTRACT_VERSION: String(APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION),
+    HTTP_PROXY: squidUrl,
+    HTTPS_PROXY: squidUrl,
+    // Unlike the Docker topology there is no iptables DNAT fallback here: with
+    // no NIC, an unproxied HTTP request has nowhere to go, so the lowercase
+    // forms are set too rather than relying on interception.
+    http_proxy: squidUrl,
+    https_proxy: squidUrl,
+    NO_PROXY: GUEST_NO_PROXY,
+    no_proxy: GUEST_NO_PROXY,
+    SQUID_PROXY_HOST: '127.0.0.1',
+    SQUID_PROXY_PORT: String(squid.guestPort),
+  };
+  for (const entry of entries) {
+    env[entry.capability.endpointEnvName] = appleContainerGuestEndpointUrl(entry.capability.id);
+  }
+
+  return Object.freeze({
+    contractVersion: APPLE_CONTAINER_TRANSPORT_CONTRACT_VERSION,
+    guestDirectory: APPLE_CONTAINER_TRANSPORT_GUEST_DIRECTORY,
+    initImage: assertAppleContainerImageReference(input.initImage),
+    readOnlyRootfs: input.readOnlyRootfs ?? true,
+    entries: Object.freeze(entries),
+    socketMounts: Object.freeze(entries.map((entry) => Object.freeze({
+      hostPath: entry.hostSocketPath,
+      containerPath: entry.guestSocketPath,
+    }))),
+    env: Object.freeze(env),
+    capDrop: APPLE_CONTAINER_REQUIRED_CAP_DROPS,
+  });
+}
+
+/**
+ * Merges a transport plan into a run spec.
+ *
+ * Returns a new spec; the input is never mutated.
+ *
+ * @throws when the spec would weaken isolation (any network other than `none`,
+ * a forbidden `capAdd`, a conflicting socket publication, a conflicting init
+ * image, or a conflicting transport environment variable).
+ */
+export function applyAppleContainerTransportToRunSpec(
+  spec: AppleContainerRunSpec,
+  plan: AppleContainerTransportPlan,
+): AppleContainerRunSpec {
+  if (spec.network !== undefined && spec.network.kind !== 'none') {
+    throw new Error(
+      'Apple Container transport requires an isolated guest; a run spec attaching a network ' +
+      'cannot be combined with the capability transport',
+    );
+  }
+
+  for (const capability of spec.capAdd ?? []) {
+    if (FORBIDDEN_CAP_ADDS.has(normalizeCapability(capability))) {
+      throw new Error(
+        `Apple Container transport refuses capAdd "${capability}"; the workload must never ` +
+        'hold ALL, NET_ADMIN, NET_RAW, SYS_ADMIN, SYS_MODULE, or SYS_RAWIO',
+      );
+    }
+  }
+
+  if (spec.initImage !== undefined && spec.initImage !== plan.initImage) {
+    throw new Error(
+      `Apple Container transport requires init image ${plan.initImage}; run spec asked for ` +
+      `${spec.initImage}`,
+    );
+  }
+
+  const env: Record<string, string> = { ...(spec.env ?? {}) };
+  for (const [name, value] of Object.entries(plan.env)) {
+    const existing = env[name];
+    if (existing !== undefined && existing !== value) {
+      throw new Error(
+        `Apple Container transport environment variable ${name} is already set to a different ` +
+        'value; refusing to launch with an endpoint the transport does not serve',
+      );
+    }
+    env[name] = value;
+  }
+
+  // The plan is the *sole* source of published sockets. A caller-supplied entry
+  // is accepted only when it is byte-identical to a planned one; anything else
+  // — a Docker socket, an arbitrary host socket, a rebound capability path — is
+  // refused. Merging caller entries through would make the capability allowlist
+  // advisory, and publishing `/var/run/docker.sock` into the guest is a direct
+  // escape to host root that every other guarantee here would survive.
+  for (const mount of spec.socketMounts ?? []) {
+    const planned = plan.socketMounts.find(
+      (entry) => entry.hostPath === mount.hostPath && entry.containerPath === mount.containerPath,
+    );
+    if (!planned) {
+      throw new Error(
+        `Apple Container transport refuses to publish ${mount.hostPath}:${mount.containerPath}; ` +
+        'only allowlisted capability sockets may cross the VM boundary',
+      );
+    }
+  }
+  const socketMounts: AppleContainerSocketMount[] = [...plan.socketMounts];
+
+  // A bind mount over the transport directory would shadow the published
+  // sockets and silently disable every capability.
+  for (const mount of spec.mounts ?? []) {
+    if (
+      mount.target === plan.guestDirectory
+      || mount.target.startsWith(`${plan.guestDirectory}/`)
+    ) {
+      throw new Error(
+        `Apple Container transport refuses a bind mount at ${mount.target}, which would shadow ` +
+        'the published capability sockets',
+      );
+    }
+  }
+
+  const capDrop = mergeCapDrops(spec.capDrop ?? [], plan.capDrop);
+
+  return {
+    ...spec,
+    env,
+    socketMounts,
+    capDrop,
+    initImage: plan.initImage,
+    readOnlyRootfs: spec.readOnlyRootfs ?? plan.readOnlyRootfs,
+    network: { kind: 'none' },
+  };
+}
+
+function mergeCapDrops(
+  existing: readonly string[],
+  required: readonly string[],
+): readonly string[] {
+  const merged = [...existing];
+  const present = new Set(existing.map(normalizeCapability));
+  for (const capability of required) {
+    if (!present.has(capability)) {
+      present.add(capability);
+      merged.push(capability);
+    }
+  }
+  return merged;
+}
+
+function normalizeCapability(value: string): string {
+  return value.toUpperCase().replace(/^CAP_/, '');
+}

--- a/src/apple-container/transport-relay.test.ts
+++ b/src/apple-container/transport-relay.test.ts
@@ -1,0 +1,354 @@
+import * as fs from 'fs';
+import * as net from 'net';
+import * as path from 'path';
+
+import {
+  APPLE_CONTAINER_RELAY_DEFAULT_LIMITS,
+  AppleContainerCapabilityRelay,
+} from './transport-relay';
+import { getAppleContainerCapability } from './transport-capabilities';
+
+const SQUID = getAppleContainerCapability('squid');
+
+function shortBase(): string {
+  return fs.mkdtempSync('/tmp/awfrl');
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('condition never became true');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+/** A stand-in for an AWF sidecar: echoes back what it receives. */
+async function startEchoUpstream(): Promise<{ port: number; close(): Promise<void> }> {
+  const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+    socket.on('data', (chunk: Buffer) => socket.write(Buffer.concat([Buffer.from('echo:'), chunk])));
+    socket.on('end', () => socket.end());
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function connectAndExchange(socketPath: string, payload: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const client = net.connect({ path: socketPath });
+    const chunks: Buffer[] = [];
+    const timer = setTimeout(() => {
+      client.destroy();
+      reject(new Error('timed out'));
+    }, 5_000);
+    client.on('connect', () => client.write(payload));
+    client.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+      clearTimeout(timer);
+      client.destroy();
+      resolve(Buffer.concat(chunks).toString());
+    });
+    client.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    client.on('close', () => {
+      clearTimeout(timer);
+      if (chunks.length === 0) reject(new Error('closed with no data'));
+    });
+  });
+}
+
+describe('AppleContainerCapabilityRelay', () => {
+  const bases: string[] = [];
+  const relays: AppleContainerCapabilityRelay[] = [];
+
+  afterEach(async () => {
+    for (const relay of relays.splice(0)) {
+      await relay.stop().catch(() => undefined);
+    }
+    for (const base of bases.splice(0)) {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  function newRelay(
+    socketPath: string,
+    port: number,
+    limits?: Partial<typeof APPLE_CONTAINER_RELAY_DEFAULT_LIMITS>,
+  ): AppleContainerCapabilityRelay {
+    const relay = new AppleContainerCapabilityRelay({
+      capability: SQUID,
+      socketPath,
+      upstream: { host: '127.0.0.1', port },
+      ...(limits ? { limits } : {}),
+    });
+    relays.push(relay);
+    return relay;
+  }
+
+  it('rejects an upstream that is not an AWF-owned address at construction time', () => {
+    expect(() => new AppleContainerCapabilityRelay({
+      capability: SQUID,
+      socketPath: '/tmp/x.sock',
+      upstream: { host: '169.254.169.254', port: 80 },
+    })).toThrow(/not a loopback or private address/);
+  });
+
+  it('binds a 0600 socket and forwards bytes to the upstream', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const socketPath = path.join(base, 'squid.sock');
+      const relay = newRelay(socketPath, upstream.port);
+      await relay.start();
+
+      expect(fs.lstatSync(socketPath).isSocket()).toBe(true);
+      expect(fs.lstatSync(socketPath).mode & 0o777).toBe(0o600);
+
+      await expect(connectAndExchange(socketPath, 'hello')).resolves.toBe('echo:hello');
+      expect(relay.stats.established).toBe(1);
+      expect(relay.stats.bytesToUpstream).toBe(5);
+      expect(relay.stats.bytesToGuest).toBe(10);
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it('verifies end to end with probe() when the upstream is reachable', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const relay = newRelay(path.join(base, 'squid.sock'), upstream.port);
+      await relay.start();
+      await expect(relay.probe()).resolves.toBeUndefined();
+      expect(relay.stats.established).toBe(1);
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it('fails probe() when the upstream is gone, with no fallback path', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    const port = upstream.port;
+    await upstream.close();
+
+    const relay = newRelay(path.join(base, 'squid.sock'), port);
+    await relay.start();
+    await expect(relay.probe()).rejects.toThrow(/could not reach 127\.0\.0\.1:/);
+    expect(relay.stats.dialFailures).toBe(1);
+    expect(relay.stats.established).toBe(0);
+  });
+
+  it('times out a hanging upstream dial instead of pinning the connection', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const socketPath = path.join(base, 'squid.sock');
+    const relay = new AppleContainerCapabilityRelay({
+      capability: SQUID,
+      socketPath,
+      upstream: { host: '127.0.0.1', port: 3128 },
+      limits: { connectTimeoutMs: 30 },
+      dependencies: {
+        // A socket that never connects and never errors.
+        connectUpstream: () => new net.Socket(),
+      },
+    });
+    relays.push(relay);
+    await relay.start();
+    await expect(relay.probe(2_000)).rejects.toThrow(/connect timed out after 30ms/);
+    expect(relay.stats.dialFailures).toBe(1);
+  });
+
+  it('refuses to bind over a stale or planted socket path', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const socketPath = path.join(base, 'squid.sock');
+    fs.writeFileSync(socketPath, 'stale');
+
+    const relay = newRelay(socketPath, 1);
+    await expect(relay.start()).rejects.toThrow(/already exists/);
+    // The planted file must survive: binding never unlinks.
+    expect(fs.readFileSync(socketPath, 'utf8')).toBe('stale');
+
+    // ...and stopping a relay that never bound must not delete it either.
+    await relay.stop();
+    expect(fs.readFileSync(socketPath, 'utf8')).toBe('stale');
+  });
+
+  it('fails every probe after the listener errors, instead of reporting healthy', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const relay = newRelay(path.join(base, 'squid.sock'), upstream.port);
+      await relay.start();
+      await expect(relay.probe()).resolves.toBeUndefined();
+
+      // Simulate a post-listen listener fault by emitting on the underlying
+      // server; the relay records it and must never report healthy again.
+      const server = (relay as unknown as { server: NodeJS.EventEmitter }).server;
+      server.emit('error', new Error('listener exploded'));
+      await expect(relay.probe()).rejects.toThrow(/listener failed: listener exploded/);
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it('refuses to start twice', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const relay = newRelay(path.join(base, 'squid.sock'), upstream.port);
+      await relay.start();
+      await expect(relay.start()).rejects.toThrow(/already started/);
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it('drops connections beyond the concurrency cap', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const socketPath = path.join(base, 'squid.sock');
+      const relay = newRelay(socketPath, upstream.port, { maxConnections: 1 });
+      await relay.start();
+
+      const held = net.connect({ path: socketPath });
+      await new Promise<void>((resolve, reject) => {
+        held.once('connect', resolve);
+        held.once('error', reject);
+      });
+      // Give the relay time to establish the first pair.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      await expect(connectAndExchange(socketPath, 'second')).rejects.toThrow();
+      expect(relay.stats.rejected).toBeGreaterThanOrEqual(1);
+      held.destroy();
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it('tears down a pair whose peer stops reading, bounding buffered bytes', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const socketPath = path.join(base, 'squid.sock');
+
+    // A controllable upstream: the relay's dial resolves when we emit
+    // 'connect', and payload is injected on demand, so the buffer cap is
+    // exercised deterministically rather than by racing a real flood.
+    const upstream = new net.Socket();
+    upstream.on('error', () => undefined);
+    const relay = new AppleContainerCapabilityRelay({
+      capability: SQUID,
+      socketPath,
+      upstream: { host: '127.0.0.1', port: 3128 },
+      limits: { maxBufferedBytes: 1024 },
+      dependencies: {
+        connectUpstream: () => {
+          // The relay attaches its 'connect' listener synchronously after this
+          // returns, so the event is deferred by one tick.
+          setImmediate(() => upstream.emit('connect'));
+          return upstream;
+        },
+      },
+    });
+    relays.push(relay);
+    await relay.start();
+
+    const client = net.connect({ path: socketPath });
+    client.pause(); // never read, so the relay must buffer
+    client.on('error', () => undefined); // the relay resets the pair
+    await new Promise<void>((resolve) => client.once('connect', () => resolve()));
+
+    await waitFor(() => relay.stats.established === 1);
+    const blob = Buffer.alloc(64 * 1024, 0x61);
+    let emitted = 0;
+    for (let index = 0; index < 512 && !upstream.destroyed; index += 1) {
+      upstream.emit('data', blob);
+      emitted += 1;
+    }
+    // The relay must have cut the pair off long before the whole flood landed.
+    expect(emitted).toBeLessThan(512);
+
+    // The paused client never processes EOF, so readiness is observed on the
+    // relay side: the pair is gone and only a bounded prefix was copied.
+    await waitFor(() => relay.stats.active === 0);
+    expect(relay.stats.bytesToGuest).toBeLessThan(512 * blob.length);
+    client.destroy();
+  });
+
+  it('stops deterministically, unlinks its own socket, and is idempotent', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const socketPath = path.join(base, 'squid.sock');
+      const relay = newRelay(socketPath, upstream.port);
+      await relay.start();
+
+      const held = net.connect({ path: socketPath });
+      await new Promise<void>((resolve) => held.once('connect', () => resolve()));
+
+      await relay.stop();
+      expect(fs.existsSync(socketPath)).toBe(false);
+      expect(relay.stats.active).toBe(0);
+      await expect(relay.stop()).resolves.toBeUndefined();
+      await expect(relay.probe()).rejects.toThrow(/is not running/);
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it('leaves a socket it never bound alone when stopped', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const socketPath = path.join(base, 'squid.sock');
+    fs.writeFileSync(socketPath, 'not-ours');
+    const relay = newRelay(socketPath, 1);
+    await relay.stop();
+    expect(fs.readFileSync(socketPath, 'utf8')).toBe('not-ours');
+  });
+
+  it('rejects out-of-range limits', () => {
+    for (const limits of [
+      { maxConnections: 0 },
+      { connectTimeoutMs: 0 },
+      { idleTimeoutMs: -1 },
+      { maxBufferedBytes: 1.5 },
+    ]) {
+      expect(() => new AppleContainerCapabilityRelay({
+        capability: SQUID,
+        socketPath: '/tmp/x.sock',
+        upstream: { host: '127.0.0.1', port: 3128 },
+        limits,
+      })).toThrow(/must be an integer in/);
+    }
+  });
+
+  it('refuses concurrent probes', async () => {
+    const base = shortBase();
+    bases.push(base);
+    const upstream = await startEchoUpstream();
+    try {
+      const relay = newRelay(path.join(base, 'squid.sock'), upstream.port);
+      await relay.start();
+      const first = relay.probe();
+      await expect(relay.probe()).rejects.toThrow(/probe already in flight/);
+      await first;
+    } finally {
+      await upstream.close();
+    }
+  });
+});

--- a/src/apple-container/transport-relay.ts
+++ b/src/apple-container/transport-relay.ts
@@ -1,0 +1,435 @@
+/**
+ * One capability relay: a host Unix socket that forwards to exactly one host
+ * TCP service.
+ *
+ * The relay is deliberately dumb. It performs **no protocol parsing** — no HTTP
+ * framing, no CONNECT handling, no header rewriting — because parsing attacker
+ * influenced bytes on the host side of the VM boundary would be the single most
+ * dangerous thing this layer could do. It is a byte pump with hard bounds:
+ *
+ * - a fixed maximum number of concurrent connections, beyond which new guest
+ *   connections are dropped immediately rather than queued;
+ * - a connect timeout on the upstream dial, so a wedged sidecar cannot pin a
+ *   guest connection open forever;
+ * - an idle timeout on both halves;
+ * - a hard cap on bytes buffered in either direction, on top of ordinary
+ *   backpressure, so a slow reader cannot grow host memory without limit.
+ *
+ * Half-close is preserved in both directions (`allowHalfOpen`), which HTTP
+ * proxying depends on: a client that shuts down its write side after a request
+ * must still receive the full response.
+ *
+ * A failed upstream dial closes the guest connection with no data. There is no
+ * retry, no queue, and no fallback path — a capability is either connected to
+ * its real upstream or it is dead.
+ */
+
+import * as fs from 'fs/promises';
+import * as net from 'net';
+
+import type {
+  AppleContainerCapabilityDefinition,
+  AppleContainerUpstreamEndpoint,
+} from './transport-capabilities';
+import { assertAppleContainerUpstreamEndpoint } from './transport-capabilities';
+import {
+  assertPrivateSocket,
+  assertSocketPathUnused,
+} from './transport-socket-dir';
+
+export interface AppleContainerRelayLimits {
+  readonly maxConnections: number;
+  readonly connectTimeoutMs: number;
+  readonly idleTimeoutMs: number;
+  readonly maxBufferedBytes: number;
+}
+
+export const APPLE_CONTAINER_RELAY_DEFAULT_LIMITS: AppleContainerRelayLimits = Object.freeze({
+  maxConnections: 64,
+  connectTimeoutMs: 5_000,
+  // Long-running agent turns hold an idle proxy connection open between
+  // requests; five minutes is well past any sidecar keep-alive but still bounds
+  // a leaked connection.
+  idleTimeoutMs: 300_000,
+  maxBufferedBytes: 4 * 1024 * 1024,
+});
+
+export interface AppleContainerRelayStats {
+  readonly accepted: number;
+  readonly rejected: number;
+  readonly established: number;
+  readonly dialFailures: number;
+  readonly active: number;
+  readonly bytesToUpstream: number;
+  readonly bytesToGuest: number;
+}
+
+/** Injectable socket factories, so tests never need a real Apple VM. */
+export interface AppleContainerRelayDependencies {
+  connectUpstream(endpoint: AppleContainerUpstreamEndpoint): net.Socket;
+  connectLocal(socketPath: string): net.Socket;
+}
+
+const defaultDependencies: AppleContainerRelayDependencies = {
+  connectUpstream: (endpoint) =>
+    net.connect({ host: endpoint.host, port: endpoint.port, allowHalfOpen: true }),
+  connectLocal: (socketPath) => net.connect({ path: socketPath, allowHalfOpen: true }),
+};
+
+export interface AppleContainerRelayOptions {
+  readonly capability: AppleContainerCapabilityDefinition;
+  readonly socketPath: string;
+  readonly upstream: AppleContainerUpstreamEndpoint;
+  readonly limits?: Partial<AppleContainerRelayLimits>;
+  readonly dependencies?: Partial<AppleContainerRelayDependencies>;
+}
+
+type ProbeSettler = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
+export class AppleContainerCapabilityRelay {
+  readonly capability: AppleContainerCapabilityDefinition;
+  readonly socketPath: string;
+  readonly upstream: AppleContainerUpstreamEndpoint;
+
+  private readonly limits: AppleContainerRelayLimits;
+  private readonly deps: AppleContainerRelayDependencies;
+  private readonly live = new Set<net.Socket>();
+  private server?: net.Server;
+  private started = false;
+  /**
+   * Set only after `listen()` succeeds. `stop()` unlinks the socket path only
+   * when this is true, so a `start()` that aborted on a pre-existing path never
+   * deletes a file this relay did not create.
+   */
+  private bound = false;
+  private stopped = false;
+  private serverError?: Error;
+  private pendingProbe?: ProbeSettler;
+
+  private pairs = 0;
+  private accepted = 0;
+  private rejected = 0;
+  private established = 0;
+  private dialFailures = 0;
+  private bytesToUpstream = 0;
+  private bytesToGuest = 0;
+
+  constructor(options: AppleContainerRelayOptions) {
+    this.capability = options.capability;
+    this.socketPath = options.socketPath;
+    this.upstream = assertAppleContainerUpstreamEndpoint(
+      options.upstream,
+      `capability ${options.capability.id}`,
+    );
+    this.limits = normalizeLimits(options.limits);
+    this.deps = { ...defaultDependencies, ...options.dependencies };
+  }
+
+  /**
+   * Whether the listening socket was actually bound.
+   *
+   * Cleanup uses this to remove only paths this relay created: a `start()` that
+   * aborted before `listen()` must never cause an unlink.
+   */
+  get isBound(): boolean {
+    return this.bound;
+  }
+
+  get stats(): AppleContainerRelayStats {
+    return {
+      accepted: this.accepted,
+      rejected: this.rejected,
+      established: this.established,
+      dialFailures: this.dialFailures,
+      active: this.pairs,
+      bytesToUpstream: this.bytesToUpstream,
+      bytesToGuest: this.bytesToGuest,
+    };
+  }
+
+  /**
+   * Binds the Unix socket.
+   *
+   * The path must not already exist: binding never unlinks, so a stale or
+   * planted socket is a hard failure rather than a hijack opportunity.
+   */
+  async start(): Promise<void> {
+    if (this.started) {
+      throw new Error(`Apple Container relay ${this.capability.id} is already started`);
+    }
+    this.started = true;
+
+    await assertSocketPathUnused(this.socketPath);
+
+    const server = net.createServer({ allowHalfOpen: true }, (guest) => {
+      this.handleConnection(guest);
+    });
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => {
+        server.removeListener('listening', onListening);
+        reject(new Error(
+          `Apple Container relay ${this.capability.id} could not bind ${this.socketPath}: ` +
+          error.message,
+        ));
+      };
+      const onListening = (): void => {
+        server.removeListener('error', onError);
+        resolve();
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      server.listen(this.socketPath);
+    });
+
+    this.bound = true;
+
+    // The listening socket inherits the process umask, so the mode is forced
+    // here. The enclosing directory is already 0700, so the intervening window
+    // is not reachable by another user.
+    await fs.chmod(this.socketPath, 0o600);
+    await assertPrivateSocket(this.socketPath);
+
+    // A post-listen server error must not become an unhandled 'error' event,
+    // but it must not be swallowed either: it is recorded and makes every
+    // subsequent probe fail, so a degraded listener can never be reported ready.
+    server.on('error', (error: Error) => {
+      this.serverError = error;
+    });
+  }
+
+  /**
+   * End-to-end self test: connects to this relay's own Unix socket and waits
+   * for the upstream dial to complete.
+   *
+   * This is what lets startup assert that a capability actually works instead of
+   * merely that a socket file exists.
+   */
+  async probe(timeoutMs = this.limits.connectTimeoutMs): Promise<void> {
+    if (!this.server || this.stopped) {
+      throw new Error(`Apple Container relay ${this.capability.id} is not running`);
+    }
+    if (this.serverError) {
+      throw new Error(
+        `Apple Container relay ${this.capability.id} listener failed: ${this.serverError.message}`,
+      );
+    }
+    if (this.pendingProbe) {
+      throw new Error(`Apple Container relay ${this.capability.id} probe already in flight`);
+    }
+
+    const client = this.deps.connectLocal(this.socketPath);
+    client.on('error', () => { /* settled through the probe promise */ });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let done = false;
+        // `settle` is referenced by the timer callback, which can only run on a
+        // later tick, so the const is always initialised by then.
+        const timer = setTimeout(() => settle(new Error(
+          `Apple Container relay ${this.capability.id} probe timed out after ${timeoutMs}ms`,
+        )), timeoutMs);
+        timer.unref?.();
+
+        const settle = (error?: Error): void => {
+          if (done) return;
+          done = true;
+          clearTimeout(timer);
+          this.pendingProbe = undefined;
+          if (error) reject(error); else resolve();
+        };
+
+        this.pendingProbe = {
+          resolve: () => settle(),
+          reject: (error) => settle(error),
+        };
+        client.once('error', (error: Error) => settle(new Error(
+          `Apple Container relay ${this.capability.id} probe could not reach ` +
+          `${this.socketPath}: ${error.message}`,
+        )));
+      });
+    } finally {
+      client.destroy();
+    }
+  }
+
+  /**
+   * Closes the listener, tears down every live connection, and unlinks the
+   * socket this relay created. Safe to call repeatedly and safe to call on a
+   * relay that never started.
+   */
+  async stop(): Promise<void> {
+    this.stopped = true;
+
+    this.pendingProbe?.reject(
+      new Error(`Apple Container relay ${this.capability.id} stopped during probe`),
+    );
+    this.pendingProbe = undefined;
+
+    const server = this.server;
+    this.server = undefined;
+    if (server) {
+      // `close()` only completes once every connection is gone, so the close is
+      // initiated first and the live sockets are destroyed immediately after;
+      // awaiting close before destroying would deadlock.
+      const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+      for (const socket of [...this.live]) {
+        socket.destroy();
+      }
+      this.live.clear();
+      await closed;
+    }
+
+    for (const socket of [...this.live]) {
+      socket.destroy();
+    }
+    this.live.clear();
+
+    if (this.bound) {
+      try {
+        await fs.unlink(this.socketPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+  }
+
+  private handleConnection(guest: net.Socket): void {
+    const probe = this.pendingProbe;
+    this.pendingProbe = undefined;
+
+    this.accepted += 1;
+    if (this.stopped || this.pairs >= this.limits.maxConnections) {
+      this.rejected += 1;
+      guest.destroy();
+      probe?.reject(new Error(
+        `Apple Container relay ${this.capability.id} refused a connection at capacity`,
+      ));
+      return;
+    }
+
+    this.pairs += 1;
+    let released = false;
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      this.pairs -= 1;
+    };
+
+    this.track(guest);
+    const upstream = this.deps.connectUpstream(this.upstream);
+    this.track(upstream);
+
+    let connected = false;
+    // `failDial` is referenced by the timer callback, which can only run on a
+    // later tick, so the const is always initialised by then.
+    const connectTimer = setTimeout(
+      () => failDial(`upstream connect timed out after ${this.limits.connectTimeoutMs}ms`),
+      this.limits.connectTimeoutMs,
+    );
+    connectTimer.unref?.();
+
+    const failDial = (reason: string): void => {
+      clearTimeout(connectTimer);
+      if (!connected) {
+        connected = true;
+        this.dialFailures += 1;
+        probe?.reject(new Error(
+          `Apple Container relay ${this.capability.id} could not reach ` +
+          `${this.upstream.host}:${this.upstream.port}: ${reason}`,
+        ));
+      }
+      release();
+      upstream.destroy();
+      guest.destroy();
+    };
+
+    guest.on('error', (error: Error) => failDial(`guest connection failed: ${error.message}`));
+    upstream.on('error', (error: Error) => failDial(error.message));
+    guest.on('close', release);
+
+    upstream.on('connect', () => {
+      clearTimeout(connectTimer);
+      if (connected) {
+        // The dial already failed or timed out; do not resurrect the pair.
+        upstream.destroy();
+        return;
+      }
+      connected = true;
+      this.established += 1;
+      probe?.resolve();
+
+      guest.setTimeout(this.limits.idleTimeoutMs);
+      upstream.setTimeout(this.limits.idleTimeoutMs);
+      const onIdle = (): void => {
+        guest.destroy();
+        upstream.destroy();
+      };
+      guest.on('timeout', onIdle);
+      upstream.on('timeout', onIdle);
+
+      this.pump(guest, upstream, 'toUpstream');
+      this.pump(upstream, guest, 'toGuest');
+    });
+  }
+
+  private track(socket: net.Socket): void {
+    this.live.add(socket);
+    socket.on('close', () => this.live.delete(socket));
+  }
+
+  /**
+   * Copies one direction with explicit backpressure plus a hard buffer cap.
+   *
+   * `write()` returning false pauses the source, which is ordinary
+   * backpressure; the additional `writableLength` check destroys the pair if a
+   * peer stops reading entirely, bounding host memory per connection.
+   */
+  private pump(from: net.Socket, to: net.Socket, direction: 'toUpstream' | 'toGuest'): void {
+    from.on('data', (chunk: Buffer) => {
+      if (from.destroyed || to.destroyed) return;
+      if (direction === 'toUpstream') {
+        this.bytesToUpstream += chunk.length;
+      } else {
+        this.bytesToGuest += chunk.length;
+      }
+      const flushed = to.write(chunk);
+      if (to.writableLength > this.limits.maxBufferedBytes) {
+        from.destroy();
+        to.destroy();
+        return;
+      }
+      if (!flushed) from.pause();
+    });
+    to.on('drain', () => from.resume());
+    from.on('end', () => {
+      if (!to.writableEnded) to.end();
+    });
+    from.on('close', () => {
+      if (!to.writableEnded) to.destroy();
+    });
+  }
+}
+
+function normalizeLimits(
+  overrides: Partial<AppleContainerRelayLimits> | undefined,
+): AppleContainerRelayLimits {
+  const merged = { ...APPLE_CONTAINER_RELAY_DEFAULT_LIMITS, ...overrides };
+  assertPositive(merged.maxConnections, 'maxConnections', 4096);
+  assertPositive(merged.connectTimeoutMs, 'connectTimeoutMs', 600_000);
+  assertPositive(merged.idleTimeoutMs, 'idleTimeoutMs', 86_400_000);
+  assertPositive(merged.maxBufferedBytes, 'maxBufferedBytes', 256 * 1024 * 1024);
+  return Object.freeze(merged);
+}
+
+function assertPositive(value: number, label: string, maximum: number): void {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new Error(
+      `Apple Container relay ${label} must be an integer in 1..${maximum}; got ${value}`,
+    );
+  }
+}

--- a/src/apple-container/transport-socket-dir.test.ts
+++ b/src/apple-container/transport-socket-dir.test.ts
@@ -1,0 +1,272 @@
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  MAX_UNIX_SOCKET_PATH_BYTES,
+  appleContainerHostSocketPath,
+  assertPrivateDirectory,
+  assertPrivateSocket,
+  assertSocketPathBudget,
+  assertSocketPathUnused,
+  createAppleContainerSocketDirectory,
+  generateAppleContainerTransportRunId,
+  removeAppleContainerSocketDirectory,
+} from './transport-socket-dir';
+
+/**
+ * macOS `os.tmpdir()` is already long, so tests bind under a short `/tmp` base
+ * to stay inside the 104-byte `sun_path` limit — the same constraint the module
+ * enforces for real runs.
+ */
+function shortBase(): string {
+  return fs.mkdtempSync('/tmp/awfsd');
+}
+
+describe('createAppleContainerSocketDirectory', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const directory of created.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('creates a private, self-owned directory', async () => {
+    const base = shortBase();
+    created.push(base);
+    const handle = await createAppleContainerSocketDirectory({ baseDirectory: base });
+
+    const stats = await fsp.lstat(handle.path);
+    expect(stats.isDirectory()).toBe(true);
+    expect(stats.mode & 0o777).toBe(0o700);
+    expect(stats.uid).toBe(process.getuid!());
+    expect(path.basename(handle.path)).toBe(`awf-apple-${handle.runId}`);
+  });
+
+  it('refuses to reuse an existing directory, so runs cannot collide', async () => {
+    const base = shortBase();
+    created.push(base);
+    const runId = 'abc123def456';
+    await createAppleContainerSocketDirectory({ baseDirectory: base, runId });
+    await expect(createAppleContainerSocketDirectory({ baseDirectory: base, runId }))
+      .rejects.toThrow(/could not be created/);
+  });
+
+  it('rejects a base directory that does not exist', async () => {
+    await expect(createAppleContainerSocketDirectory({ baseDirectory: '/tmp/awf-absent-base-xyz' }))
+      .rejects.toThrow(/is not usable/);
+  });
+
+  it('rejects a base directory that is a file', async () => {
+    const base = shortBase();
+    created.push(base);
+    const file = path.join(base, 'file');
+    fs.writeFileSync(file, 'x');
+    await expect(createAppleContainerSocketDirectory({ baseDirectory: file }))
+      .rejects.toThrow(/is not a directory|could not be created/);
+  });
+
+  it('rejects relative, unnormalized, and colon-bearing base paths', async () => {
+    for (const baseDirectory of ['relative/path', '/tmp/../tmp', '/tmp/a:b']) {
+      await expect(createAppleContainerSocketDirectory({ baseDirectory }))
+        .rejects.toThrow();
+    }
+  });
+
+  it('rejects a malformed run id', async () => {
+    const base = shortBase();
+    created.push(base);
+    for (const runId of ['', 'UPPER123', '../escape', 'short', 'g'.repeat(12)]) {
+      await expect(createAppleContainerSocketDirectory({ baseDirectory: base, runId }))
+        .rejects.toThrow(/run id must be 8-16 lowercase hex/);
+    }
+  });
+
+  it('resolves a symlinked base to its real path before creating anything', async () => {
+    const base = shortBase();
+    created.push(base);
+    const real = path.join(base, 'real');
+    const link = path.join(base, 'link');
+    fs.mkdirSync(real, { mode: 0o700 });
+    fs.symlinkSync(real, link);
+
+    const handle = await createAppleContainerSocketDirectory({ baseDirectory: link });
+    expect(handle.path.startsWith(fs.realpathSync(real))).toBe(true);
+    expect(await fsp.realpath(handle.path)).toBe(handle.path);
+  });
+
+  it('generates distinct run ids', () => {
+    const ids = new Set(Array.from({ length: 50 }, generateAppleContainerTransportRunId));
+    expect(ids.size).toBe(50);
+    for (const id of ids) expect(id).toMatch(/^[a-f0-9]{12}$/);
+  });
+});
+
+describe('appleContainerHostSocketPath', () => {
+  it('builds a direct child of the run directory', () => {
+    const directory = { path: '/tmp/awf-apple-abc123def456', runId: 'abc123def456' };
+    expect(appleContainerHostSocketPath(directory, 'squid.sock'))
+      .toBe('/tmp/awf-apple-abc123def456/squid.sock');
+  });
+
+  it('rejects traversal and non-socket names', () => {
+    const directory = { path: '/tmp/awf-apple-abc123def456', runId: 'abc123def456' };
+    for (const name of ['../escape.sock', 'nested/one.sock', 'squid.txt', '/abs.sock', '.sock']) {
+      expect(() => appleContainerHostSocketPath(directory, name)).toThrow();
+    }
+  });
+
+  it('rejects a path the kernel would truncate', () => {
+    const directory = { path: `/tmp/${'d'.repeat(95)}`, runId: 'abc123def456' };
+    expect(() => appleContainerHostSocketPath(directory, 'squid.sock'))
+      .toThrow(/sun_path limit/);
+  });
+});
+
+describe('assertSocketPathBudget', () => {
+  it('accepts a path at the limit and rejects one byte more', () => {
+    const atLimit = `/tmp/${'a'.repeat(MAX_UNIX_SOCKET_PATH_BYTES - 5)}`;
+    expect(Buffer.byteLength(atLimit)).toBe(MAX_UNIX_SOCKET_PATH_BYTES);
+    expect(assertSocketPathBudget(atLimit)).toBe(atLimit);
+    expect(() => assertSocketPathBudget(`${atLimit}b`)).toThrow(/sun_path limit/);
+  });
+});
+
+describe('assertPrivateDirectory', () => {
+  const cleanup: string[] = [];
+  afterEach(() => {
+    for (const target of cleanup.splice(0)) fs.rmSync(target, { recursive: true, force: true });
+  });
+
+  it('rejects a group- or world-accessible directory', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const loose = path.join(base, 'loose');
+    fs.mkdirSync(loose);
+    fs.chmodSync(loose, 0o755);
+    await expect(assertPrivateDirectory(loose)).rejects.toThrow(/group\/world accessible/);
+  });
+
+  it('rejects a symlink standing in for the directory', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const real = path.join(base, 'real');
+    const link = path.join(base, 'link');
+    fs.mkdirSync(real, { mode: 0o700 });
+    fs.symlinkSync(real, link);
+    await expect(assertPrivateDirectory(link)).rejects.toThrow(/is not a directory/);
+  });
+
+  it('rejects a file', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const file = path.join(base, 'file');
+    fs.writeFileSync(file, 'x', { mode: 0o600 });
+    await expect(assertPrivateDirectory(file)).rejects.toThrow(/is not a directory/);
+  });
+});
+
+describe('assertPrivateSocket and assertSocketPathUnused', () => {
+  const cleanup: string[] = [];
+  afterEach(() => {
+    for (const target of cleanup.splice(0)) fs.rmSync(target, { recursive: true, force: true });
+  });
+
+  it('accepts a 0600 socket and rejects a loosened one', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const socketPath = path.join(base, 's.sock');
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+    try {
+      fs.chmodSync(socketPath, 0o600);
+      await expect(assertPrivateSocket(socketPath)).resolves.toBeUndefined();
+      fs.chmodSync(socketPath, 0o666);
+      await expect(assertPrivateSocket(socketPath)).rejects.toThrow(/group\/world accessible/);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('rejects a regular file masquerading as a socket', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const file = path.join(base, 'not.sock');
+    fs.writeFileSync(file, 'x', { mode: 0o600 });
+    await expect(assertPrivateSocket(file)).rejects.toThrow(/is not a Unix socket/);
+  });
+
+  it('treats an absent path as unused and any existing entry as fatal', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const absent = path.join(base, 'absent.sock');
+    await expect(assertSocketPathUnused(absent)).resolves.toBeUndefined();
+
+    fs.writeFileSync(absent, 'stale');
+    await expect(assertSocketPathUnused(absent)).rejects.toThrow(/already exists/);
+  });
+
+  it('treats a dangling symlink as an existing entry rather than an absent path', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const link = path.join(base, 'planted.sock');
+    fs.symlinkSync(path.join(base, 'nowhere'), link);
+    await expect(assertSocketPathUnused(link)).rejects.toThrow(/already exists/);
+  });
+});
+
+describe('removeAppleContainerSocketDirectory', () => {
+  const cleanup: string[] = [];
+  afterEach(() => {
+    for (const target of cleanup.splice(0)) fs.rmSync(target, { recursive: true, force: true });
+  });
+
+  it('removes owned sockets and the directory, and is idempotent', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const handle = await createAppleContainerSocketDirectory({ baseDirectory: base });
+    const socketPath = appleContainerHostSocketPath(handle, 'squid.sock');
+    fs.writeFileSync(socketPath, '');
+
+    await removeAppleContainerSocketDirectory(handle, [socketPath]);
+    expect(fs.existsSync(handle.path)).toBe(false);
+
+    await expect(removeAppleContainerSocketDirectory(handle, [socketPath]))
+      .resolves.toBeUndefined();
+  });
+
+  it('refuses to delete a path outside the run directory', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const handle = await createAppleContainerSocketDirectory({ baseDirectory: base });
+    const outsider = path.join(base, 'outside.sock');
+    fs.writeFileSync(outsider, '');
+
+    await expect(removeAppleContainerSocketDirectory(handle, [outsider]))
+      .rejects.toThrow(/outside/);
+    expect(fs.existsSync(outsider)).toBe(true);
+  });
+
+  it('never recurses into unexpected content', async () => {
+    const base = shortBase();
+    cleanup.push(base);
+    const handle = await createAppleContainerSocketDirectory({ baseDirectory: base });
+    fs.writeFileSync(path.join(handle.path, 'unexpected'), 'x');
+
+    // rmdir on a non-empty directory fails loudly rather than deleting content
+    // this run did not create.
+    await expect(removeAppleContainerSocketDirectory(handle, [])).rejects.toThrow();
+    expect(fs.existsSync(path.join(handle.path, 'unexpected'))).toBe(true);
+  });
+});
+
+describe('default base directory', () => {
+  it('is the process temporary directory', () => {
+    // Documents the default used by the manager; kept here so a change to the
+    // default is a deliberate, visible edit.
+    expect(typeof os.tmpdir()).toBe('string');
+  });
+});

--- a/src/apple-container/transport-socket-dir.ts
+++ b/src/apple-container/transport-socket-dir.ts
@@ -1,0 +1,274 @@
+/**
+ * Run-scoped, private directory that holds the host ends of the published
+ * capability sockets.
+ *
+ * Every socket AWF publishes into an Apple Container guest lives in exactly one
+ * of these directories. The directory is the primary access-control boundary:
+ * it is created fresh per run with mode `0700` and is owned by the invoking
+ * user, so no other local user can reach a capability socket even during the
+ * brief window between `listen()` and the follow-up `chmod`.
+ *
+ * The defences implemented here, and why each one exists:
+ *
+ * - **Cross-run collision.** The directory is created with a non-recursive
+ *   `mkdir`, so an existing path is an error rather than a silent reuse. Two
+ *   concurrent runs can never share a socket namespace.
+ * - **Symlink substitution.** The base directory is resolved with `realpath`
+ *   *before* the run directory is created, the run directory is then verified
+ *   to be a real directory (not a symlink) that resolves to itself, and its
+ *   ownership and mode are re-read from the filesystem rather than assumed.
+ * - **Path traversal.** Socket basenames come from the compiled-in capability
+ *   allowlist, never from caller input, and the joined path is re-checked to
+ *   still be a direct child of the run directory.
+ * - **Stale socket reuse.** A socket path must not exist before it is bound;
+ *   binding never unlinks a pre-existing file, so a planted socket produces a
+ *   hard failure instead of a hijacked capability.
+ * - **`sun_path` truncation.** macOS caps a Unix socket path at 104 bytes
+ *   including the NUL terminator. A path over that limit is silently truncated
+ *   by the kernel, which would bind a *different* path than the one published
+ *   into the guest, so the limit is enforced up front.
+ *
+ * Removal only ever touches paths this module created, is idempotent, and never
+ * recurses.
+ */
+
+import { randomBytes } from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import { assertAppleContainerPath } from './validation';
+
+/** macOS `sun_path` is `char[104]`; the usable path is one byte shorter. */
+export const MAX_UNIX_SOCKET_PATH_BYTES = 103;
+
+/** `--publish-socket` packs `host_path:container_path` into one argv token. */
+const SOCKET_PATH_DELIMITERS = [':'] as const;
+
+const RUN_ID_PATTERN = /^[a-f0-9]{8,16}$/;
+
+const DIRECTORY_PREFIX = 'awf-apple-';
+
+/** Generates a short, collision-resistant run id that keeps `sun_path` short. */
+export function generateAppleContainerTransportRunId(): string {
+  return randomBytes(6).toString('hex');
+}
+
+export interface AppleContainerSocketDirectoryOptions {
+  /** Parent directory. Defaults to the process temporary directory. */
+  readonly baseDirectory: string;
+  /** Lowercase hex run id; generated when omitted. */
+  readonly runId?: string;
+}
+
+export interface AppleContainerSocketDirectoryHandle {
+  readonly path: string;
+  readonly runId: string;
+}
+
+/**
+ * Creates the private run directory.
+ *
+ * @throws when the base directory is unusable, the run directory already
+ * exists, or the created directory fails its post-creation ownership/mode/type
+ * verification. Nothing is retried and nothing degrades to a shared location.
+ */
+export async function createAppleContainerSocketDirectory(
+  options: AppleContainerSocketDirectoryOptions,
+): Promise<AppleContainerSocketDirectoryHandle> {
+  const runId = options.runId ?? generateAppleContainerTransportRunId();
+  if (!RUN_ID_PATTERN.test(runId)) {
+    throw new Error(
+      `Apple Container transport run id must be 8-16 lowercase hex characters; got ${runId}`,
+    );
+  }
+
+  const base = assertAppleContainerPath(
+    options.baseDirectory,
+    'transport socket base directory',
+    SOCKET_PATH_DELIMITERS,
+  );
+
+  let resolvedBase: string;
+  try {
+    resolvedBase = await fs.realpath(base);
+  } catch (error) {
+    throw new Error(
+      `Apple Container transport socket base directory ${base} is not usable: ${describe(error)}`,
+    );
+  }
+  // `realpath` may resolve through a symlink (`/tmp` -> `/private/tmp` on
+  // macOS), so the resolved form is re-validated before it is used to build
+  // argv tokens.
+  const validatedBase = assertAppleContainerPath(
+    resolvedBase,
+    'transport socket base directory',
+    SOCKET_PATH_DELIMITERS,
+  );
+
+  const baseStats = await fs.lstat(validatedBase);
+  if (!baseStats.isDirectory()) {
+    throw new Error(
+      `Apple Container transport socket base ${validatedBase} is not a directory`,
+    );
+  }
+
+  const directory = path.posix.join(validatedBase, `${DIRECTORY_PREFIX}${runId}`);
+  assertSocketPathBudget(directory);
+
+  try {
+    await fs.mkdir(directory, { mode: 0o700, recursive: false });
+  } catch (error) {
+    throw new Error(
+      `Apple Container transport socket directory ${directory} could not be created: ` +
+      `${describe(error)}`,
+    );
+  }
+
+  try {
+    // `mkdir` masks its mode with the process umask, so the mode is forced
+    // afterwards rather than trusted.
+    await fs.chmod(directory, 0o700);
+    await assertPrivateDirectory(directory);
+  } catch (error) {
+    await removeAppleContainerSocketDirectory({ path: directory, runId }, []);
+    throw error;
+  }
+
+  return { path: directory, runId };
+}
+
+/**
+ * Builds the host path for one capability socket inside the run directory.
+ *
+ * `socketName` always originates from the compiled-in capability allowlist; the
+ * containment re-check exists so a future caller cannot turn it into an
+ * attacker-influenced value without the check failing.
+ */
+export function appleContainerHostSocketPath(
+  directory: AppleContainerSocketDirectoryHandle,
+  socketName: string,
+): string {
+  if (!/^[a-z0-9][a-z0-9-]*\.sock$/.test(socketName)) {
+    throw new Error(`Apple Container transport socket name is not valid: ${socketName}`);
+  }
+  const candidate = path.posix.join(directory.path, socketName);
+  if (path.posix.dirname(candidate) !== directory.path) {
+    throw new Error(
+      `Apple Container transport socket ${socketName} would escape ${directory.path}`,
+    );
+  }
+  assertSocketPathBudget(candidate);
+  return assertAppleContainerPath(candidate, 'transport socket path', SOCKET_PATH_DELIMITERS);
+}
+
+/** Rejects a path the kernel would silently truncate when binding. */
+export function assertSocketPathBudget(candidate: string): string {
+  const bytes = Buffer.byteLength(candidate);
+  if (bytes > MAX_UNIX_SOCKET_PATH_BYTES) {
+    throw new Error(
+      `Apple Container transport socket path is ${bytes} bytes, over the ` +
+      `${MAX_UNIX_SOCKET_PATH_BYTES}-byte sun_path limit: ${candidate}`,
+    );
+  }
+  return candidate;
+}
+
+/** Verifies a directory is a real, self-owned, group/other-inaccessible directory. */
+export async function assertPrivateDirectory(directory: string): Promise<void> {
+  const stats = await fs.lstat(directory);
+  if (!stats.isDirectory()) {
+    throw new Error(`Apple Container transport socket directory ${directory} is not a directory`);
+  }
+  if ((stats.mode & 0o077) !== 0) {
+    throw new Error(
+      `Apple Container transport socket directory ${directory} is group/world accessible ` +
+      `(mode ${(stats.mode & 0o7777).toString(8)})`,
+    );
+  }
+  assertOwnedBySelf(stats.uid, directory);
+
+  const resolved = await fs.realpath(directory);
+  if (resolved !== directory) {
+    throw new Error(
+      `Apple Container transport socket directory ${directory} resolves to ${resolved}; ` +
+      'refusing to publish sockets through a substituted path',
+    );
+  }
+}
+
+/** Verifies a bound socket is a real socket owned by this user and private. */
+export async function assertPrivateSocket(socketPath: string): Promise<void> {
+  const stats = await fs.lstat(socketPath);
+  if (!stats.isSocket()) {
+    throw new Error(`Apple Container transport path ${socketPath} is not a Unix socket`);
+  }
+  if ((stats.mode & 0o077) !== 0) {
+    throw new Error(
+      `Apple Container transport socket ${socketPath} is group/world accessible ` +
+      `(mode ${(stats.mode & 0o7777).toString(8)})`,
+    );
+  }
+  assertOwnedBySelf(stats.uid, socketPath);
+}
+
+/** Fails when a socket path is already occupied, rather than unlinking it. */
+export async function assertSocketPathUnused(socketPath: string): Promise<void> {
+  try {
+    await fs.lstat(socketPath);
+  } catch (error) {
+    if (isNotFound(error)) return;
+    throw error;
+  }
+  throw new Error(
+    `Apple Container transport socket ${socketPath} already exists; refusing to reuse or ` +
+    'unlink a path this run did not create',
+  );
+}
+
+/**
+ * Removes the sockets this run created and then the run directory itself.
+ *
+ * Idempotent and non-recursive: missing entries are fine, and anything the run
+ * did not create is left untouched so a partially-cleaned directory fails to
+ * `rmdir` loudly instead of deleting a stranger's files.
+ */
+export async function removeAppleContainerSocketDirectory(
+  directory: AppleContainerSocketDirectoryHandle,
+  socketPaths: readonly string[],
+): Promise<void> {
+  for (const socketPath of socketPaths) {
+    if (path.posix.dirname(socketPath) !== directory.path) {
+      throw new Error(
+        `Apple Container transport refusing to remove ${socketPath}, which is outside ` +
+        `${directory.path}`,
+      );
+    }
+    try {
+      await fs.unlink(socketPath);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
+  try {
+    await fs.rmdir(directory.path);
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+  }
+}
+
+function assertOwnedBySelf(uid: number, target: string): void {
+  const self = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  if (self !== undefined && uid !== self) {
+    throw new Error(
+      `Apple Container transport path ${target} is owned by uid ${uid}, not ${self}`,
+    );
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
**Stack layer 2 of 3.** Depends on #7760 (`lpcox-apple-container-runtime-primitives`) and targets that branch, not `main`. Review #7760 first.

Still **no user-visible runtime selection**: no CLI option, no runtime registry entry, no config schema enum, no backend resolver entry. Everything here is internal and unreferenced by the existing Docker, Cloud Hypervisor, and sbx paths, which are untouched.

## Why this layer exists

The Apple Container agent VM is launched with `--network none`, so it has **zero NICs**. That is not a hardening flag that can be traded away — omitting `--network` attaches Apple's default vmnet network, so the flag is the only thing between the agent and unfiltered egress. Apple Container has no daemon-side forced-proxy setting either, so an advisory `HTTP_PROXY` would confine nothing on its own. The confinement is structural: direct IP, DNS, DoH, IPv6, raw sockets, `169.254.169.254`, and every host network path do not exist inside the VM.

A NIC-less guest still has to reach a handful of AWF services that keep running under Docker Compose. The only transport Apple Container offers such a guest is `--publish-socket host_path:container_path`. Most tooling speaks TCP to a proxy endpoint and cannot be pointed at a Unix socket, so both ends need a relay.

```
 host (macOS)                        │ VM boundary │            guest (Linux)

 AWF sidecar (Docker)                │             │
   127.0.0.1:3128  ◀── host relay ───┤             │
                       squid.sock ───┼──publish────┼──▶ /run/awf/transport/v1/squid.sock
                                     │   socket    │                │
                                     │             │          guest relay
                                     │             │                │
                                     │             │          127.0.0.1:3128 ──▶ agent
```

## What's here

**Host** (`src/apple-container/transport-*.ts`)

- **`transport-capabilities`** — the closed, frozen allowlist: Squid, the four discrete API proxy provider ports (10000 OpenAI, 10001 Anthropic, 10002 Copilot, 10003 Gemini), the CLI proxy, and the enclave MCP gateway. Ports are read from the existing `sandbox-network-policy.json`, so they cannot drift. Upstreams must be loopback or private **IP literals** — hostnames are rejected, so the relay never resolves a name and no DNS answer can repoint a capability. Also pins the init-image contract to a `container` CLI version range.
- **`transport-socket-dir`** — a run-scoped `0700` directory created with a non-recursive `mkdir`, then verified from the filesystem for real-directory type, ownership, mode, and self-resolution. Covers cross-run collision, symlink substitution, path traversal, stale/planted socket reuse, and `sun_path` truncation (macOS caps a socket path at 104 bytes; silent truncation would bind a *different* path than the one published).
- **`transport-relay`** — a byte pump with **no protocol parsing at all** (no HTTP framing, no `CONNECT`, no header inspection), bounded by a concurrency cap, dial timeout, idle timeout, and a hard buffered-bytes cap on top of ordinary backpressure. Half-close is preserved in both directions, which HTTP proxying requires. `probe()` verifies a capability end to end through its own socket.
- **`transport-plan`** — emits the exact `--publish-socket` pairs, guest endpoint environment, cap drops, read-only rootfs setting, and pinned init image. The merge into the layer-1 `AppleContainerRunSpec` is deliberately hostile to its caller.
- **`transport-manager`** — ordered startup, complete rollback, deterministic idempotent shutdown.

**Guest** (`guest/apple-container-init/`, static Linux arm64 Go binary, stdlib only)

The AWF init image relocates Apple's binary to `/sbin/vminitd.apple` and installs the shim at `/sbin/vminitd`. The shim re-execs itself as a relay child, waits for an exact readiness token on fd 3, then `syscall.Exec`s Apple's real init. That is an **exec, not a supervision tree**, so `vminitd` keeps PID 1 and its reaping, signal, and lifecycle semantics are exactly what Apple shipped. Every loopback port is bound before the exec, and therefore before the workload starts, which removes any relay/workload race. Every failure path exits non-zero *without* exec'ing.

Both halves of the contract are compiled in — nothing is negotiated at boot, so no configuration crosses the VM boundary — and `transport-contract-sync.test.ts` parses `contract.go`, so a divergence fails the build instead of surfacing as an unreachable capability inside a VM nobody can reproduce.

## Security properties, and how each is enforced

| Property | Enforcement |
| --- | --- |
| Guest never gains a NIC | `applyAppleContainerTransportToRunSpec` rejects any spec carrying a network and always re-emits `{ kind: 'none' }`; tests assert `--network none` appears exactly once in the argv |
| Only named capabilities cross the boundary | Frozen allowlist with no extension point; the **plan is the sole source** of `--publish-socket` pairs, so `/var/run/docker.sock` cannot be published, and a bind mount that would shadow the transport directory is refused |
| Relays cannot be repointed | IP literals only; loopback/private only; link-local, metadata, multicast, public, and `0`-prefixed octets all rejected |
| Sockets private to the run identity | `0700` directory, `0600` sockets, ownership verified from `lstat` |
| No stale/planted socket reuse | Binding never unlinks; an occupied path is a hard failure and the planted file survives |
| Correct capabilities | `NET_ADMIN`, `NET_RAW`, `SYS_ADMIN`, `SYS_MODULE`, `SYS_RAWIO` dropped unconditionally; adding any of them or `ALL` is refused, in any case or `CAP_` spelling |
| Credentials never enter the guest | API proxy capabilities are unauthenticated from the guest's view; the real key stays in the host-side sidecar. Nothing secret-shaped appears in env, argv, files, or the diagnostics summary (asserted by test) |
| Fail closed | Every failure throws; partial startup rolls back completely and the *original* error propagates. If the transport cannot be started and verified, agent execution must not begin |
| Cleanup | Only sockets this run actually bound are unlinked; `rmdir` is non-recursive; `stop()` is idempotent and concurrent calls share one shutdown; `preserveDiagnostics` unlinks every socket **before** keeping the directory |

## Security self-review

A dedicated security review of the staged diff found three issues, all fixed here with regression tests:

1. **Caller-supplied socket mounts passed through the merge.** Any `spec.socketMounts` entry that did not *collide* with a planned one reached the argv — including `/var/run/docker.sock`, a direct escape to host root that survived every other guarantee. Now the plan is the sole source, a caller entry is accepted only when byte-identical to a planned one, and shadowing bind mounts are refused.
2. **Incomplete rollback.** A relay was registered for rollback only *after* `start()` fully resolved, but `start()` binds the listener and then verifies its mode and ownership — a failure in that tail stranded a live, still-accepting relay with no reference that could stop it. Relays are now registered before starting, and cleanup removes only paths that actually reached `listen()` (so a pre-existing file is still never unlinked).
3. **Swallowed unlink failure during diagnostics preservation.** Fixed to fail closed rather than keep a live socket.

Two smaller issues were caught in my own pass: a failed `start()` could unlink a foreign file (now gated on a separate `bound` flag), and a post-`listen` server error was silently ignored (now recorded, and every subsequent probe fails).

## Validation

- `npm test` — 337 suites, 5601 tests, all passing
- `npm run type-check`, `npm run build` — clean
- `npx eslint src/apple-container` — 0 errors (warnings are the repo-wide `security/detect-non-literal-fs-filename` advisories, in line with `src/cloud-hypervisor`)
- `go vet ./...` and `go test ./...` in `guest/apple-container-init` — passing
- `./build.sh` produces a **statically linked ELF 64-bit ARM aarch64** binary, and the same digest across repeated builds (verified locally and asserted in CI)
- New `.github/workflows/test-apple-container.yml` runs the Go vet/test/build/determinism/arch checks plus the host type-check, lint, and unit tests

There is deliberately no live-VM job: Apple Container needs Virtualization.framework, and GitHub-hosted macOS reports `kern.hv_support=0`. This targets self-hosted bare-metal Apple Silicon macOS 26 runners, and hosted macOS must fail preflight (layer 1 already does this, with a distinct `hypervisor` cause code).

## What layer 3 still owns

Runtime registry/resolver/CLI flag/schema entry; building and publishing the pinned init image; deriving the capability set from `WrapperConfig`; mapping `AWF_APPLE_TRANSPORT_*_URL` onto provider-specific variables; workspace mounts, uid/gid, and the rest of agent launch policy.

See `docs/apple-container-transport.md` for the internal architecture note (not published to the docs site).
