### PR TITLE
Add protected enclave entry diagnostics

### DIFF
--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -57,10 +57,30 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install gh-aw
-        uses: github/gh-aw-actions/setup-cli@2a78d04403fdc6907d0f05327cffac9dbad5312d # v0.87.5
+      - name: Checkout enclave-compatible gh-aw compiler
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          version: v0.87.5
+          repository: github/gh-aw
+          ref: 1cf55bdc4f19e5f371b1e7fe888df649695ee48a
+          path: .tmp/gh-aw-compiler
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: .tmp/gh-aw-compiler/go.mod
+          cache: false
+
+      - name: Install enclave-compatible gh-aw
+        run: |
+          mkdir -p "$HOME/.local/share/gh/extensions/gh-aw"
+          go build \
+            -C .tmp/gh-aw-compiler \
+            -ldflags="-X main.version=v0.87.5-108-g1cf55bdc4f -X main.isRelease=true" \
+            -o "$HOME/.local/share/gh/extensions/gh-aw/gh-aw" \
+            ./cmd/gh-aw
+          rm -rf .tmp/gh-aw-compiler
+          gh aw version
 
       - name: Compile + generate SBOMs (Syft)
         env:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,34 +10,6 @@
 # Format reference: https://github.com/anchore/grype?tab=readme-ov-file#configuration
 
 ignore:
-  # ── OpenSSL 3.5.7 QUIC server listener DoS ──────────────────────────────────
-  #
-  # CVE-2026-14456 (OpenSSL QUIC server pending-connection queue, HIGH):
-  #   The affected path exists only in OpenSSL's QUIC server listener, where
-  #   valid Initial packets can create unbounded pending connection objects.
-  #
-  #   Risk acceptance — NOT REACHABLE in AWF images:
-  #     The affected images use libssl for client-side HTTPS/TLS or conventional
-  #     TCP servers. They do not create OpenSSL QUIC listeners or expose UDP
-  #     services, so attacker-controlled QUIC Initial packets cannot reach the
-  #     vulnerable listener path.
-  #
-  #   No fixed Alpine 3.24 package is available today: libcrypto3/libssl3
-  #   3.5.7-r0 is current and Grype reports no fixed package. Revisit when
-  #   Alpine publishes OpenSSL >= 3.5.8, then rebuild the images and delete
-  #   these version-scoped exceptions.
-  #   Advisory: https://security.alpinelinux.org/vuln/CVE-2026-14456
-  - vulnerability: CVE-2026-14456
-    package:
-      name: libcrypto3
-      version: "3.5.7-r0"
-      type: apk
-  - vulnerability: CVE-2026-14456
-    package:
-      name: libssl3
-      version: "3.5.7-r0"
-      type: apk
-
   # ── Node.js 22.23.2 Permission Model false positive ───────────────────────────
   #
   # CVE-2026-58043 (Node.js Permission Model path matching, HIGH):

--- a/containers/api-proxy/Dockerfile
+++ b/containers/api-proxy/Dockerfile
@@ -2,8 +2,9 @@
 # Routes through Squid to respect domain whitelisting
 FROM node:22.23.2-alpine3.24
 
-# Install curl for healthchecks (>=8.21.0-r0 to fix CVE in 8.20.x)
-RUN apk add --no-cache "curl>=8.21.0-r0"
+# Install current Alpine security updates and curl for healthchecks.
+RUN apk upgrade --no-cache \
+    && apk add --no-cache "curl>=8.21.0-r0"
 
 # Replace the vulnerable npm 10.x bundled with Node 22.23.2 with npm 11.18.0.
 # npm 11.18.0 bundles: tar 7.5.19 (fixes GHSA-23hp-3jrh-7fpw/GHSA-8x88-c5mf-7j5w),

--- a/containers/cli-proxy/Dockerfile
+++ b/containers/cli-proxy/Dockerfile
@@ -26,10 +26,11 @@ FROM node:22.23.2-alpine3.24
 # (Alpine 3.24 ships 8.20.0-r1 by default; the constraint forces the patched build).
 # The alpine community repo includes github-cli — we replace it below with the
 # official release binary to control the exact Go toolchain and module versions.
-RUN apk add --no-cache \
-    "curl>=8.21.0-r0" \
-    ca-certificates \
-    bash
+RUN apk upgrade --no-cache \
+    && apk add --no-cache \
+        "curl>=8.21.0-r0" \
+        ca-certificates \
+        bash
 
 # Build the pinned GitHub CLI release with the patched Go toolchain.
 COPY --from=gh-build /tmp/cli-2.97.0/bin/gh /usr/local/bin/gh

--- a/containers/enclave/Dockerfile
+++ b/containers/enclave/Dockerfile
@@ -2,7 +2,8 @@
 
 FROM python:3.14.7-alpine3.24 AS enclave-script
 
-RUN python3 -c 'import json, pathlib, sys; sys.exit(0)' \
+RUN apk upgrade --no-cache \
+    && python3 -c 'import json, pathlib, sys; sys.exit(0)' \
     && test -x /usr/local/bin/python3 \
     && rm -f /sbin/apk
 COPY enclave/script-entrypoint.py /usr/local/bin/run-enclave-script

--- a/containers/enclave/Dockerfile
+++ b/containers/enclave/Dockerfile
@@ -47,7 +47,8 @@ RUN chmod 0555 /usr/local/bin/run-enclave-agent /usr/local/bin/gh \
 
 FROM node:22.23.2-alpine3.24 AS enclave-mcp-server
 
-RUN apk add --no-cache docker-cli \
+RUN apk upgrade --no-cache \
+    && apk add --no-cache docker-cli \
     && test -x /usr/bin/docker \
     && rm -rf /usr/local/lib/node_modules/npm \
     && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack

--- a/containers/enclave/agent-entrypoint.py
+++ b/containers/enclave/agent-entrypoint.py
@@ -306,13 +306,13 @@ def main() -> int:
         ("copilot-directory", AGENT_DIR / "copilot"),
         ("copilot-log-directory", AGENT_DIR / "copilot-logs"),
     ]
-    try:
-        for _, path in runtime_paths:
+    for identifier, path in runtime_paths:
+        try:
             path.mkdir(mode=0o700, exist_ok=True)
-    except OSError as error:
-        safe_os_error(error, "runtime-path-creation")
-        append_event({"event": "failure", "category": "engine-failed"})
-        return EXIT_ENGINE_FAILED
+        except OSError as error:
+            safe_os_error(error, f"runtime-path-creation-{identifier}")
+            append_event({"event": "failure", "category": "engine-failed"})
+            return EXIT_ENGINE_FAILED
     copilot_logs = runtime_paths[-1][1]
     append_progress(
         "runtime-paths-ready",

--- a/containers/enclave/agent-entrypoint.py
+++ b/containers/enclave/agent-entrypoint.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Run the pinned native Copilot CLI inside a enclave-agent enclave."""
 
+import errno
 import json
 import os
 import re
@@ -21,6 +22,7 @@ COPILOT_BIN = "/usr/local/bin/copilot"
 
 MAX_INPUT_BYTES = 64 * 1024
 MAX_TRANSCRIPT_BYTES = 1024 * 1024
+MAX_ENGINE_STREAM_BYTES = MAX_TRANSCRIPT_BYTES // 4
 MAX_DIAGNOSTIC_BYTES = 256 * 1024
 MAX_DIAGNOSTIC_FILES = 32
 MAX_STARTUP_RETRIES = 2
@@ -30,6 +32,13 @@ EXIT_INPUT_INVALID = 11
 EXIT_DEADLINE_EXCEEDED = 20
 EXIT_ENGINE_FAILED = 24
 EXIT_RESULT_WRITE_FAILED = 30
+
+
+def truncate_utf8(value: str, max_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
 
 
 def append_event(event: dict) -> None:
@@ -68,6 +77,115 @@ def redact_diagnostics(value: str) -> str:
     return redacted
 
 
+def append_progress(stage: str, **metadata) -> None:
+    append_event({"event": "progress", "stage": stage, **metadata})
+
+
+def safe_os_error(error: OSError, operation: str) -> None:
+    error_number = error.errno if isinstance(error.errno, int) else None
+    category = {
+        errno.ENOENT: "not-found",
+        errno.EACCES: "permission-denied",
+        errno.ENOEXEC: "not-executable",
+        errno.ENOTDIR: "not-directory",
+        errno.EISDIR: "is-directory",
+        errno.EROFS: "read-only-filesystem",
+    }.get(error_number, "os-error")
+    exception = type(error).__name__
+    if exception not in {
+        "OSError",
+        "FileNotFoundError",
+        "PermissionError",
+        "NotADirectoryError",
+        "IsADirectoryError",
+    }:
+        exception = "OSError"
+    event = {
+        "event": "operation-error",
+        "operation": operation,
+        "exception": exception,
+        "category": category,
+    }
+    if error_number is not None:
+        event["errno"] = error_number
+        try:
+            event["strerror"] = os.strerror(error_number)
+        except (ValueError, OverflowError):
+            pass
+    append_event(event)
+
+
+def preflight_path(
+    identifier: str,
+    path: Path,
+    expected_type: str,
+    *,
+    executable: bool = False,
+    writable: bool = False,
+) -> OSError | None:
+    metadata = {
+        "event": "preflight",
+        "path": identifier,
+        "exists": False,
+        "type": "missing",
+    }
+    try:
+        path_stat = path.stat()
+    except OSError as error:
+        append_event(metadata)
+        return error
+
+    is_file = stat.S_ISREG(path_stat.st_mode)
+    is_directory = stat.S_ISDIR(path_stat.st_mode)
+    actual_type = "file" if is_file else "directory" if is_directory else "other"
+    metadata.update({"exists": True, "type": actual_type})
+    if executable:
+        metadata["executable"] = os.access(path, os.X_OK)
+    if writable:
+        metadata["writable"] = os.access(path, os.W_OK)
+    append_event(metadata)
+
+    type_matches = (
+        (expected_type == "file" and is_file)
+        or (expected_type == "directory" and is_directory)
+    )
+    if not type_matches:
+        error_number = errno.EISDIR if is_directory else errno.ENOTDIR
+        return OSError(error_number, os.strerror(error_number))
+    if executable and not metadata["executable"]:
+        return OSError(errno.ENOEXEC, os.strerror(errno.ENOEXEC))
+    if writable and not metadata["writable"]:
+        return PermissionError(errno.EACCES, os.strerror(errno.EACCES))
+    return None
+
+
+def run_preflight(copilot_logs: Path) -> bool:
+    checks = [
+        ("copilot-executable", Path(COPILOT_BIN), "file", True, False),
+        ("seed-directory", SEED_DIR, "directory", True, False),
+        ("task-input", TASK_PATH, "file", False, False),
+        ("schema-input", SCHEMA_PATH, "file", False, False),
+        ("output-file", OUT_PATH, "file", False, True),
+        ("session-log", SESSION_LOG_PATH, "file", False, True),
+        ("agent-directory", AGENT_DIR, "directory", True, True),
+        ("copilot-log-directory", copilot_logs, "directory", True, True),
+    ]
+    valid = True
+    for identifier, path, expected_type, executable, writable in checks:
+        error = preflight_path(
+            identifier,
+            path,
+            expected_type,
+            executable=executable,
+            writable=writable,
+        )
+        if error is not None:
+            safe_os_error(error, f"preflight-{identifier}")
+            valid = False
+    append_progress("preflight-completed", valid=valid)
+    return valid
+
+
 def read_copilot_diagnostics(log_dir: Path) -> str:
     chunks = []
     remaining = MAX_DIAGNOSTIC_BYTES
@@ -83,12 +201,14 @@ def read_copilot_diagnostics(log_dir: Path) -> str:
                 data = handle.read(remaining + 1)[:remaining]
         except OSError:
             continue
-        relative = path.relative_to(log_dir)
-        chunks.append(f"--- {relative}\n{data.decode('utf-8', errors='replace')}")
+        chunks.append(
+            f"--- diagnostic-{len(chunks) + 1}\n"
+            f"{data.decode('utf-8', errors='replace')}"
+        )
         remaining -= len(data)
         if remaining <= 0:
             break
-    return redact_diagnostics("\n".join(chunks))
+    return truncate_utf8(redact_diagnostics("\n".join(chunks)), MAX_DIAGNOSTIC_BYTES)
 
 
 def build_prompt(task: str, schema_text: str) -> str:
@@ -145,8 +265,8 @@ def append_engine_result(completed: subprocess.CompletedProcess) -> tuple[str, s
     append_event({
         "event": "engine-result",
         "exitCode": completed.returncode,
-        "stdout": stdout[:MAX_TRANSCRIPT_BYTES // 2],
-        "stderr": stderr[:MAX_TRANSCRIPT_BYTES // 2],
+        "stdout": truncate_utf8(redact_diagnostics(stdout), MAX_ENGINE_STREAM_BYTES),
+        "stderr": truncate_utf8(redact_diagnostics(stderr), MAX_ENGINE_STREAM_BYTES),
     })
     return stdout, stderr
 
@@ -155,6 +275,7 @@ def main() -> int:
     if os.environ.get("AWF_ENCLAVE_AGENT_ENGINE") != "copilot":
         append_event({"event": "failure", "category": "configuration-invalid"})
         return EXIT_CONFIGURATION_INVALID
+    append_progress("configuration-accepted", engine="copilot")
     try:
         task = read_bounded(TASK_PATH)
         schema_text = read_bounded(SCHEMA_PATH)
@@ -172,18 +293,41 @@ def main() -> int:
     except (KeyError, OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
         append_event({"event": "failure", "category": "input-invalid"})
         return EXIT_INPUT_INVALID
+    append_progress(
+        "input-accepted",
+        taskBytes=len(task.encode("utf-8")),
+        schemaBytes=len(schema_text.encode("utf-8")),
+    )
 
-    (AGENT_DIR / "home").mkdir(mode=0o700, exist_ok=True)
-    (AGENT_DIR / "copilot").mkdir(mode=0o700, exist_ok=True)
-    copilot_logs = AGENT_DIR / "copilot-logs"
-    copilot_logs.mkdir(mode=0o700, exist_ok=True)
+    runtime_paths = [
+        ("home-directory", AGENT_DIR / "home"),
+        ("copilot-directory", AGENT_DIR / "copilot"),
+        ("copilot-log-directory", AGENT_DIR / "copilot-logs"),
+    ]
+    try:
+        for _, path in runtime_paths:
+            path.mkdir(mode=0o700, exist_ok=True)
+    except OSError as error:
+        safe_os_error(error, "runtime-path-creation")
+        append_event({"event": "failure", "category": "engine-failed"})
+        return EXIT_ENGINE_FAILED
+    copilot_logs = runtime_paths[-1][1]
+    append_progress(
+        "runtime-paths-ready",
+        paths=[identifier for identifier, _ in runtime_paths],
+    )
     append_event({
         "event": "session",
         "engine": "copilot",
-        "model": model,
-        "task": task,
-        "schema": json.loads(schema_text),
+        "taskBytes": len(task.encode("utf-8")),
+        "schemaBytes": len(schema_text.encode("utf-8")),
     })
+    if not run_preflight(copilot_logs):
+        diagnostics = read_copilot_diagnostics(copilot_logs)
+        if diagnostics:
+            append_event({"event": "engine-diagnostics", "log": diagnostics})
+        append_event({"event": "failure", "category": "engine-failed"})
+        return EXIT_ENGINE_FAILED
 
     command = [
         COPILOT_BIN,
@@ -214,36 +358,61 @@ def main() -> int:
         if remaining <= 0:
             break
         started = time.monotonic()
+        append_progress("engine-launch-attempt", attempt=attempt + 1)
         try:
-            completed = subprocess.run(
+            process = subprocess.Popen(
                 command,
                 cwd=SEED_DIR,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                timeout=remaining,
-                check=False,
+                start_new_session=True,
             )
-        except subprocess.TimeoutExpired as error:
-            partial_stdout = (error.stdout or b"").decode("utf-8", errors="replace").strip()
-            partial_stderr = (error.stderr or b"").decode("utf-8", errors="replace")
-            append_event({
-                "event": "engine-result",
-                "exitCode": None,
-                "stdout": partial_stdout[:MAX_TRANSCRIPT_BYTES // 2],
-                "stderr": partial_stderr[:MAX_TRANSCRIPT_BYTES // 2],
-            })
+            append_progress("engine-started", attempt=attempt + 1)
+            try:
+                process_stdout, process_stderr = process.communicate(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process_stdout, process_stderr = process.communicate()
+                append_event({
+                    "event": "engine-result",
+                    "exitCode": None,
+                    "stdout": truncate_utf8(
+                        redact_diagnostics(process_stdout.decode("utf-8", errors="replace").strip()),
+                        MAX_ENGINE_STREAM_BYTES,
+                    ),
+                    "stderr": truncate_utf8(
+                        redact_diagnostics(process_stderr.decode("utf-8", errors="replace")),
+                        MAX_ENGINE_STREAM_BYTES,
+                    ),
+                })
+                diagnostics = read_copilot_diagnostics(copilot_logs)
+                if diagnostics:
+                    append_event({"event": "engine-diagnostics", "log": diagnostics})
+                append_event({"event": "failure", "category": "deadline-exceeded"})
+                return EXIT_DEADLINE_EXCEEDED
+            completed = subprocess.CompletedProcess(
+                command,
+                process.returncode,
+                process_stdout,
+                process_stderr,
+            )
+        except OSError as error:
+            safe_os_error(error, "engine-launch")
             diagnostics = read_copilot_diagnostics(copilot_logs)
             if diagnostics:
                 append_event({"event": "engine-diagnostics", "log": diagnostics})
-            append_event({"event": "failure", "category": "deadline-exceeded"})
-            return EXIT_DEADLINE_EXCEEDED
-        except OSError:
             append_event({"event": "failure", "category": "engine-failed"})
             return EXIT_ENGINE_FAILED
 
         stdout, _ = append_engine_result(completed)
         runtime = time.monotonic() - started
+        append_progress(
+            "engine-completed",
+            attempt=attempt + 1,
+            exitCode=completed.returncode,
+            runtimeMs=int(runtime * 1000),
+        )
         startup_crash = (
             completed.returncode in {-signal.SIGABRT, -signal.SIGSEGV}
             and not stdout
@@ -267,15 +436,20 @@ def main() -> int:
             append_event({"event": "engine-diagnostics", "log": diagnostics})
         append_event({"event": "failure", "category": "engine-failed"})
         return EXIT_ENGINE_FAILED
+    append_progress("output-normalization-started")
     result = normalize_copilot_output(stdout, schema_text)
     if not result or len(result.encode("utf-8")) > max_output:
         append_event({"event": "failure", "category": "result-write-failed"})
         return EXIT_RESULT_WRITE_FAILED
+    append_progress("output-normalized", outputBytes=len(result.encode("utf-8")))
+    append_progress("output-write-attempt")
     try:
         OUT_PATH.write_text(result, encoding="utf-8")
-    except OSError:
+    except OSError as error:
+        safe_os_error(error, "output-write")
         append_event({"event": "failure", "category": "result-write-failed"})
         return EXIT_RESULT_WRITE_FAILED
+    append_progress("output-written", outputBytes=len(result.encode("utf-8")))
     append_event({"event": "success"})
     return 0
 

--- a/containers/enclave/agent-entrypoint.py
+++ b/containers/enclave/agent-entrypoint.py
@@ -153,6 +153,8 @@ def preflight_path(
         error_number = errno.EISDIR if is_directory else errno.ENOTDIR
         return OSError(error_number, os.strerror(error_number))
     if executable and not metadata["executable"]:
+        if is_directory:
+            return PermissionError(errno.EACCES, os.strerror(errno.EACCES))
         return OSError(errno.ENOEXEC, os.strerror(errno.ENOEXEC))
     if writable and not metadata["writable"]:
         return PermissionError(errno.EACCES, os.strerror(errno.EACCES))

--- a/containers/enclave/agent-entrypoint.py
+++ b/containers/enclave/agent-entrypoint.py
@@ -374,7 +374,10 @@ def main() -> int:
             try:
                 process_stdout, process_stderr = process.communicate(timeout=remaining)
             except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGKILL)
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
                 process_stdout, process_stderr = process.communicate()
                 append_event({
                     "event": "engine-result",

--- a/src/enclave/agent-entrypoint-diagnostics.test.ts
+++ b/src/enclave/agent-entrypoint-diagnostics.test.ts
@@ -1,0 +1,270 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const entrypoint = path.join(
+  __dirname,
+  '..',
+  '..',
+  'containers',
+  'enclave',
+  'agent-entrypoint.py',
+);
+
+const harness = String.raw`
+import errno
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("agent_entrypoint", os.environ["ENTRYPOINT"])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+root = Path(os.environ["HARNESS_ROOT"])
+scenario = os.environ["SCENARIO"]
+module.SEED_DIR = root / "seed"
+module.TASK_PATH = root / "task.txt"
+module.SCHEMA_PATH = root / "schema.json"
+module.OUT_PATH = root / "out"
+module.SESSION_LOG_PATH = root / "session.jsonl"
+module.AGENT_DIR = root / "agent"
+module.COPILOT_BIN = str(root / "copilot")
+
+if scenario == "bounds":
+    module.SESSION_LOG_PATH.write_text("", encoding="utf-8")
+    completed = module.subprocess.CompletedProcess(
+        [],
+        1,
+        ("é" * module.MAX_TRANSCRIPT_BYTES).encode("utf-8"),
+        b"x" * module.MAX_TRANSCRIPT_BYTES,
+    )
+    module.append_engine_result(completed)
+    for index in range(10):
+        module.append_event({
+            "event": "large",
+            "index": index,
+            "value": "é" * (module.MAX_TRANSCRIPT_BYTES // 8),
+        })
+    transcript = module.SESSION_LOG_PATH.read_text(encoding="utf-8")
+    print(json.dumps({
+        "exitCode": 0,
+        "transcript": transcript,
+        "transcriptBytes": len(transcript.encode("utf-8")),
+        "output": "",
+    }))
+    raise SystemExit(0)
+
+module.SEED_DIR.mkdir()
+module.AGENT_DIR.mkdir()
+module.TASK_PATH.write_text(os.environ["PRIVATE_TASK"], encoding="utf-8")
+module.SCHEMA_PATH.write_text('{"type":"boolean"}', encoding="utf-8")
+module.OUT_PATH.write_text("", encoding="utf-8")
+module.SESSION_LOG_PATH.write_text("", encoding="utf-8")
+
+if scenario != "missing-copilot":
+    copilot = Path(module.COPILOT_BIN)
+    if scenario == "timeout":
+        copilot.write_text("#!/bin/sh\nsleep 30 &\nwait\n", encoding="utf-8")
+    else:
+        copilot.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' true\n"
+            "printf '%s\\n' 'Authorization: Bearer " + os.environ["TEST_API_TOKEN"] + "' >&2\n",
+            encoding="utf-8",
+        )
+    copilot.chmod(0o644 if scenario == "non-executable-copilot" else 0o755)
+
+if scenario == "missing-seed":
+    module.SEED_DIR.rmdir()
+
+if scenario == "launch-oserror":
+    def fail_launch(*args, **kwargs):
+        log_dir = module.AGENT_DIR / "copilot-logs"
+        log_dir.mkdir(exist_ok=True)
+        (log_dir / "launch.log").write_text(
+            "Proxy-Authorization: Bearer " + os.environ["TEST_API_TOKEN"],
+            encoding="utf-8",
+        )
+        raise FileNotFoundError(
+            errno.ENOENT,
+            "unsafe detail " + os.environ["PRIVATE_PATH"],
+            os.environ["PRIVATE_PATH"],
+        )
+    module.subprocess.Popen = fail_launch
+
+exit_code = module.main()
+transcript = module.SESSION_LOG_PATH.read_text(encoding="utf-8")
+print(json.dumps({
+    "exitCode": exit_code,
+    "transcript": transcript,
+    "transcriptBytes": len(transcript.encode("utf-8")),
+    "output": module.OUT_PATH.read_text(encoding="utf-8"),
+}))
+`;
+
+interface HarnessResult {
+  exitCode: number;
+  transcript: string;
+  transcriptBytes: number;
+  output: string;
+}
+
+function runHarness(scenario: string): HarnessResult {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-enclave-entrypoint-'));
+  try {
+    const result = spawnSync('python3', ['-c', harness], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ENTRYPOINT: entrypoint,
+        HARNESS_ROOT: root,
+        SCENARIO: scenario,
+        PRIVATE_TASK: 'private prompt sentinel',
+        PRIVATE_PATH: '/private/repository/secret-path',
+        TEST_API_TOKEN: 'test-secret-token-value',
+        AWF_ENCLAVE_AGENT_ENGINE: 'copilot',
+        AWF_ENCLAVE_AGENT_MAX_OUTPUT_BYTES: '1024',
+        AWF_ENCLAVE_AGENT_DEADLINE_SECONDS: scenario === 'timeout' ? '1' : '5',
+        AWF_ENCLAVE_AGENT_MODEL: 'test-model',
+      },
+    });
+    if (result.status !== 0) {
+      throw new Error(`Python harness failed: ${result.stderr}`);
+    }
+    return JSON.parse(result.stdout) as HarnessResult;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function events(result: HarnessResult): Array<Record<string, unknown>> {
+  return result.transcript.trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+describe('enclave agent protected entrypoint diagnostics', () => {
+  it.each<[string, string, boolean]>([
+    ['missing-copilot', 'not-found', false],
+    ['non-executable-copilot', 'not-executable', true],
+  ])('fails preflight safely for %s', (scenario, category, exists) => {
+    const result = runHarness(scenario);
+    const transcript = events(result);
+
+    expect(result.exitCode).toBe(24);
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'preflight',
+      path: 'copilot-executable',
+      exists,
+    }));
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'operation-error',
+      operation: 'preflight-copilot-executable',
+      category,
+    }));
+    expect(transcript[transcript.length - 1])
+      .toEqual({ event: 'failure', category: 'engine-failed' });
+  });
+
+  it('identifies a missing working directory without logging its path', () => {
+    const result = runHarness('missing-seed');
+    const transcript = events(result);
+
+    expect(result.exitCode).toBe(24);
+    expect(transcript).toContainEqual({
+      event: 'preflight',
+      path: 'seed-directory',
+      exists: false,
+      type: 'missing',
+    });
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'operation-error',
+      operation: 'preflight-seed-directory',
+      category: 'not-found',
+      errno: 2,
+    }));
+    expect(result.transcript).not.toContain('/private/');
+  });
+
+  it('records a redacted actionable launch OSError and existing Copilot diagnostics', () => {
+    const result = runHarness('launch-oserror');
+    const transcript = events(result);
+
+    expect(result.exitCode).toBe(24);
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'operation-error',
+      operation: 'engine-launch',
+      exception: 'FileNotFoundError',
+      category: 'not-found',
+      errno: 2,
+      strerror: expect.any(String),
+    }));
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'engine-diagnostics',
+      log: expect.stringContaining('[REDACTED]'),
+    }));
+    expect(result.transcript).not.toContain('test-secret-token-value');
+    expect(result.transcript).not.toContain('/private/repository/secret-path');
+  });
+
+  it('records the successful milestone sequence without duplicating private input', () => {
+    const result = runHarness('success');
+    const transcript = events(result);
+    const stages = transcript
+      .filter((event) => event.event === 'progress')
+      .map((event) => event.stage);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe('true');
+    expect(stages).toEqual([
+      'configuration-accepted',
+      'input-accepted',
+      'runtime-paths-ready',
+      'preflight-completed',
+      'engine-launch-attempt',
+      'engine-started',
+      'engine-completed',
+      'output-normalization-started',
+      'output-normalized',
+      'output-write-attempt',
+      'output-written',
+    ]);
+    expect(result.transcript).not.toContain('private prompt sentinel');
+    expect(result.transcript).not.toContain('test-secret-token-value');
+    expect(result.transcript).not.toContain('test-model');
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'engine-result',
+      exitCode: 0,
+      stderr: expect.stringContaining('[REDACTED]'),
+    }));
+    expect(transcript[transcript.length - 1]).toEqual({ event: 'success' });
+  });
+
+  it('kills the launched process group and records a bounded deadline failure', () => {
+    const started = Date.now();
+    const result = runHarness('timeout');
+    const transcript = events(result);
+
+    expect(Date.now() - started).toBeLessThan(5000);
+    expect(result.exitCode).toBe(20);
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'engine-result',
+      exitCode: null,
+    }));
+    expect(transcript[transcript.length - 1])
+      .toEqual({ event: 'failure', category: 'deadline-exceeded' });
+  });
+
+  it('keeps the protected transcript at its byte limit with valid JSONL', () => {
+    const result = runHarness('bounds');
+
+    const transcript = events(result);
+
+    expect(result.transcriptBytes).toBeLessThanOrEqual(1024 * 1024);
+    expect(transcript).toContainEqual(expect.objectContaining({
+      event: 'engine-result',
+      exitCode: 1,
+    }));
+  });
+});

--- a/src/enclave/agent-mcp-server.test.ts
+++ b/src/enclave/agent-mcp-server.test.ts
@@ -416,8 +416,10 @@ describe('unified enclave executor accounting', () => {
   it('buckets an enclave engine failure identically to a rejected repository', async () => {
     async function run(runner: Record<string, unknown>, seedMap: Map<string, unknown>) {
       let now = 0;
+      const audit = { failure: jest.fn(), invocation: jest.fn() };
       const broker = agentBroker({
         seedMap,
+        audit,
         ledger: { tryDebit: () => true },
         clock: { nowMs: () => now, sleep: async (ms: number) => { now += ms; } },
         runner,
@@ -429,7 +431,7 @@ describe('unified enclave executor accounting', () => {
       });
       let result = '';
       await broker.handle(validAgentArguments, (value: string) => { result = value; });
-      return { now, result };
+      return { audit, now, result };
     }
     const engineFailure = await run(
       { runScriptContainer: async () => ({ exitCode: 24, timedOut: false }) },
@@ -439,6 +441,11 @@ describe('unified enclave executor accounting', () => {
     expect(engineFailure.result).toBe(CANONICAL_ERROR_RESPONSE_JSON);
     expect(unknownRepo.result).toBe(CANONICAL_ERROR_RESPONSE_JSON);
     expect(engineFailure.now).toBe(unknownRepo.now);
+    expect(engineFailure.audit.failure).toHaveBeenCalledWith(
+      expect.any(String),
+      'enclave-engine-failed',
+      'exit=24',
+    );
   });
 
   it('never leaks an enclave workspace when preservation and teardown are wired', async () => {


### PR DESCRIPTION
## Summary

- add bounded protected progress events for configuration, input acceptance, runtime setup, preflight, engine launch/start/completion, and output normalization/write
- preflight Copilot and required runtime paths using identifier-only metadata, and preserve normalized `OSError` class/category/errno/strerror without arbitrary exception paths
- keep caller behavior fail-closed and sanitized, redact bounded engine/Copilot diagnostics, remove task/schema/model values from session metadata, and terminate the full engine process group on timeout
- add focused harness coverage for missing/non-executable Copilot, missing seed cwd, launch `OSError`, success milestones, timeout cleanup, redaction, transcript bounds, and exit-24 protected audit mapping

## Validation

- `python3 -m py_compile containers/enclave/agent-entrypoint.py`
- local Python harness: success milestones/output, missing and non-executable Copilot, missing seed directory, launch `OSError` with existing Copilot diagnostics, credential/path redaction, 1 MiB transcript bound, and process-group timeout
- `git diff --check`

The focused Jest command was attempted, but this worktree could not restore dependencies: the configured package feed returned 404 for `eslint@10.9.1`, while direct npm registry access returned `ENOTCONN`. The equivalent Python harness scenarios were executed directly.