### PR TITLE
chore: upgrade gh-aw prerelease workflows

### DIFF
--- a/.github/workflows/smoke-enclave-issues-read.lock.yml
+++ b/.github/workflows/smoke-enclave-issues-read.lock.yml
@@ -205,13 +205,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          sparse-checkout: |
-            .github
-            .agents
-            .claude
-            .codex
-            .gemini
-            .pi
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Save agent config folders for base branch restoration
@@ -458,8 +451,36 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh" 1.0.34
         env:
           GH_HOST: github.com
-      - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.28.8 --rootless
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - name: Install awf dependencies
+        run: npm ci
+      - name: Build awf
+        run: npm run build
+      - name: Install awf binary (local)
+        run: |
+          WORKSPACE_PATH="${GITHUB_WORKSPACE:-$(pwd)}"
+          NODE_BIN="$(command -v node)"
+          if [ ! -d "$WORKSPACE_PATH" ]; then
+            echo "Workspace path not found: $WORKSPACE_PATH"
+            exit 1
+          fi
+          if [ ! -x "$NODE_BIN" ]; then
+            echo "Node binary not found: $NODE_BIN"
+            exit 1
+          fi
+          if [ ! -d "/usr/local/bin" ]; then
+            echo "/usr/local/bin is missing"
+            exit 1
+          fi
+          sudo tee /usr/local/bin/awf > /dev/null <<EOF
+          #!/bin/bash
+          exec "${NODE_BIN}" "${WORKSPACE_PATH}/dist/cli.js" "\$@"
+          EOF
+          sudo chmod +x /usr/local/bin/awf
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -927,7 +948,16 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh"
+        run: |
+          SESSION_STATE_SRC="/tmp/gh-aw/sandbox/agent/session-state"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          if [ -d "$SESSION_STATE_SRC" ] && [ -n "$(ls -A "$SESSION_STATE_SRC" 2>/dev/null)" ]; then
+            mkdir -p "$LOGS_DIR/session-state"
+            cp -rp "$SESSION_STATE_SRC/." "$LOGS_DIR/session-state/"
+            echo "Copied session state to $LOGS_DIR/session-state"
+          else
+            echo "No session state found at $SESSION_STATE_SRC"
+          fi
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/src/enclave/agent-entrypoint-diagnostics.test.ts
+++ b/src/enclave/agent-entrypoint-diagnostics.test.ts
@@ -117,6 +117,7 @@ function runHarness(scenario: string): HarnessResult {
   try {
     const result = spawnSync('python3', ['-c', harness], {
       encoding: 'utf8',
+      maxBuffer: 8 * 1024 * 1024,
       env: {
         ...process.env,
         ENTRYPOINT: entrypoint,


### PR DESCRIPTION
## Summary
- upgrade/recompile workflows with gh-aw v0.87.5, the latest published prerelease
- post-process the enclave Issues smoke workflow to build and install the repository's local AWF binary
- raise the enclave diagnostics test harness buffer so its bounded 1 MiB transcript can be JSON-wrapped under Node 24

## Validation
- `npm test -- --runInBand` (325 suites, 5205 tests)

## Compiler note
`gh aw compile` regenerated 65 workflows successfully. The newly added `smoke-enclave-issues-read.md` uses the post-v0.87.5 `enclaves[].agent.github.cli` contract, so v0.87.5 reports a validation error for that source even though it emits the updated lock file. The source configuration and its required v0.28.8/v0.4.11 pins remain unchanged.