### PR TITLE
Configure npm to use the public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

- configure npm to use `https://registry.npmjs.org/` at the repository level
- avoid relying on the machine-level Microsoft package feed proxy

## Testing

- `npm install --no-audit --no-fund` *(blocked locally: connection to `registry.npmjs.org` failed with `ENOTCONN`)*
- `npm test` *(not run because dependencies could not be installed)*