### PR TITLE
Pin ESLint 10.9.0 and typescript-eslint 8.67.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "execa": "^5.1.1",
-        "js-yaml": "^5.4.0"
+        "js-yaml": "5.3.0"
       },
       "bin": {
         "awf": "dist/cli.js"
@@ -29,8 +29,8 @@
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.9.5",
-        "@typescript-eslint/eslint-plugin": "8.67.1-alpha.25",
-        "@typescript-eslint/parser": "8.67.1-alpha.25",
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
         "babel-jest": "^30.2.0",
         "esbuild": "^0.28.1",
         "eslint": "10.9.0",
@@ -42,7 +42,7 @@
         "markdownlint-cli2": "^0.23.2",
         "ts-jest": "^29.4.12",
         "typescript": "^5.9.3",
-        "typescript-eslint": "8.67.1-alpha.25"
+        "typescript-eslint": "8.67.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3712,17 +3712,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-rXQ/I35cfVPEPbS9mN1xQZU2fdM=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha1-Uvnw5H1adXHEM25pv+6lgVCe8s8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.67.1-alpha.25",
-        "@typescript-eslint/type-utils": "8.67.1-alpha.25",
-        "@typescript-eslint/utils": "8.67.1-alpha.25",
-        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3735,22 +3735,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.67.1-alpha.25",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-GzzBI4J2twqu5qX7PKl2n9y4DvU=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha1-AVgCLsmSfgr81YqMwq1X4B2JL1w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.67.1-alpha.25",
-        "@typescript-eslint/types": "8.67.1-alpha.25",
-        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25",
-        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3766,14 +3766,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-O7yiE9yD7paw04MMlRLUOwTx61E=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha1-FVLbAHypIGocbHrPSeIQvReoxW8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.67.1-alpha.25",
-        "@typescript-eslint/types": "^8.67.1-alpha.25",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3788,14 +3788,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-+J6aI4gFxn3c/jUnQuLwge1XLi0=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha1-TUwtoJVg0Q3X2UfLotKdFNJa8W0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.1-alpha.25",
-        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3806,9 +3806,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-Ae0xWISGkKkEPch1DWMLNhX71HM=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha1-9Fo+umuRMvtHFB7APOLydfHqmR0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3823,15 +3823,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-sL/XArv3+pU4Dt384MLj1sK3r7A=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha1-lr7RBSdVWd87zwRJtzpkFNNcWc4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.1-alpha.25",
-        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25",
-        "@typescript-eslint/utils": "8.67.1-alpha.25",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3848,9 +3848,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-id+5ImQxRQt2LMJU0E106ErEn6M=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha1-So0AzB+rpcFP6rxg+Ft6MmUvNLY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3862,16 +3862,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-dXgy054TA5raUQ0TDJV8oDu52FI=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha1-EWw6R8BhGcWgUOiFGGHWSX3WS8I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.67.1-alpha.25",
-        "@typescript-eslint/tsconfig-utils": "8.67.1-alpha.25",
-        "@typescript-eslint/types": "8.67.1-alpha.25",
-        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3903,16 +3903,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-VSCqaOvNasAiJqv4Tl1evlXV3AI=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha1-PkeKPWnTMKH8UMEnRswu4HMsz80=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.67.1-alpha.25",
-        "@typescript-eslint/types": "8.67.1-alpha.25",
-        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3927,13 +3927,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-UekcFKb4GC7cdDluOD5FMEyZ6fQ=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha1-YB1Ar5rPgqKNoihvPtr8abupAX8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.1-alpha.25",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3946,7 +3946,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -5667,7 +5667,7 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -7117,9 +7117,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.0.tgz",
-      "integrity": "sha512-jE7vUJIebKzYQI5xu4co5CRBDlDEYnHrdzsxs4O2giCz4v2SbVMYKpmt1D9L38OKQAeCWmrOTRiCV93u0UkaJA==",
+      "version": "5.3.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha1-UmQwptoxBlEnUormlc4WjPxfkfA=",
       "funding": [
         {
           "type": "github",
@@ -9077,7 +9077,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -9263,16 +9263,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.67.1-alpha.25",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.67.1-alpha.25.tgz",
-      "integrity": "sha1-yyE8jZ9/o2eoQkTIL2B1dMchrPk=",
+      "version": "8.67.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha1-HpLeCe4P8tlswISPXp80Xqkw2WM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.67.1-alpha.25",
-        "@typescript-eslint/parser": "8.67.1-alpha.25",
-        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25",
-        "@typescript-eslint/utils": "8.67.1-alpha.25"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,11 @@
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.9.5",
-        "@typescript-eslint/eslint-plugin": "^8.68.0",
-        "@typescript-eslint/parser": "^8.68.0",
+        "@typescript-eslint/eslint-plugin": "8.67.1-alpha.25",
+        "@typescript-eslint/parser": "8.67.1-alpha.25",
         "babel-jest": "^30.2.0",
         "esbuild": "^0.28.1",
-        "eslint": "^10.9.1",
+        "eslint": "10.9.0",
         "eslint-plugin-security": "^3.0.1",
         "glob": "^13.0.6",
         "globals": "^17.9.0",
@@ -42,7 +42,7 @@
         "markdownlint-cli2": "^0.23.2",
         "ts-jest": "^29.4.12",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.68.0"
+        "typescript-eslint": "8.67.1-alpha.25"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3712,17 +3712,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
-      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-rXQ/I35cfVPEPbS9mN1xQZU2fdM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/type-utils": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/scope-manager": "8.67.1-alpha.25",
+        "@typescript-eslint/type-utils": "8.67.1-alpha.25",
+        "@typescript-eslint/utils": "8.67.1-alpha.25",
+        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3735,22 +3735,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.68.0",
+        "@typescript-eslint/parser": "^8.67.1-alpha.25",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
-      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-GzzBI4J2twqu5qX7PKl2n9y4DvU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/scope-manager": "8.67.1-alpha.25",
+        "@typescript-eslint/types": "8.67.1-alpha.25",
+        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25",
+        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3766,14 +3766,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
-      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-O7yiE9yD7paw04MMlRLUOwTx61E=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.68.0",
-        "@typescript-eslint/types": "^8.68.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.1-alpha.25",
+        "@typescript-eslint/types": "^8.67.1-alpha.25",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3788,14 +3788,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
-      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-+J6aI4gFxn3c/jUnQuLwge1XLi0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0"
+        "@typescript-eslint/types": "8.67.1-alpha.25",
+        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3806,9 +3806,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
-      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-Ae0xWISGkKkEPch1DWMLNhX71HM=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3823,15 +3823,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
-      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-sL/XArv3+pU4Dt384MLj1sK3r7A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/types": "8.67.1-alpha.25",
+        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25",
+        "@typescript-eslint/utils": "8.67.1-alpha.25",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3848,9 +3848,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
-      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-id+5ImQxRQt2LMJU0E106ErEn6M=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3862,16 +3862,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
-      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-dXgy054TA5raUQ0TDJV8oDu52FI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.68.0",
-        "@typescript-eslint/tsconfig-utils": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/project-service": "8.67.1-alpha.25",
+        "@typescript-eslint/tsconfig-utils": "8.67.1-alpha.25",
+        "@typescript-eslint/types": "8.67.1-alpha.25",
+        "@typescript-eslint/visitor-keys": "8.67.1-alpha.25",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3891,8 +3891,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3903,16 +3903,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
-      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-VSCqaOvNasAiJqv4Tl1evlXV3AI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0"
+        "@typescript-eslint/scope-manager": "8.67.1-alpha.25",
+        "@typescript-eslint/types": "8.67.1-alpha.25",
+        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3927,13 +3927,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
-      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-UekcFKb4GC7cdDluOD5FMEyZ6fQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/types": "8.67.1-alpha.25",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3946,8 +3946,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5249,9 +5249,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+      "version": "10.9.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha1-PYYGigbGx4FhpAYuaYdNOPWdSYs=",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -5667,8 +5667,8 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9077,8 +9077,8 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9263,16 +9263,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
-      "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
+      "version": "8.67.1-alpha.25",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.67.1-alpha.25.tgz",
+      "integrity": "sha1-yyE8jZ9/o2eoQkTIL2B1dMchrPk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.68.0",
-        "@typescript-eslint/parser": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0"
+        "@typescript-eslint/eslint-plugin": "8.67.1-alpha.25",
+        "@typescript-eslint/parser": "8.67.1-alpha.25",
+        "@typescript-eslint/typescript-estree": "8.67.1-alpha.25",
+        "@typescript-eslint/utils": "8.67.1-alpha.25"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.5",
-    "@typescript-eslint/eslint-plugin": "^8.68.0",
-    "@typescript-eslint/parser": "^8.68.0",
+    "@typescript-eslint/eslint-plugin": "8.67.1-alpha.25",
+    "@typescript-eslint/parser": "8.67.1-alpha.25",
     "babel-jest": "^30.2.0",
     "esbuild": "^0.28.1",
-    "eslint": "^10.9.1",
+    "eslint": "10.9.0",
     "eslint-plugin-security": "^3.0.1",
     "glob": "^13.0.6",
     "globals": "^17.9.0",
@@ -76,7 +76,7 @@
     "markdownlint-cli2": "^0.23.2",
     "ts-jest": "^29.4.12",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.68.0"
+    "typescript-eslint": "8.67.1-alpha.25"
   },
   "overrides": {
     "test-exclude": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "execa": "^5.1.1",
-    "js-yaml": "^5.4.0"
+    "js-yaml": "5.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
@@ -63,8 +63,8 @@
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.5",
-    "@typescript-eslint/eslint-plugin": "8.67.1-alpha.25",
-    "@typescript-eslint/parser": "8.67.1-alpha.25",
+    "@typescript-eslint/eslint-plugin": "8.67.0",
+    "@typescript-eslint/parser": "8.67.0",
     "babel-jest": "^30.2.0",
     "esbuild": "^0.28.1",
     "eslint": "10.9.0",
@@ -76,7 +76,7 @@
     "markdownlint-cli2": "^0.23.2",
     "ts-jest": "^29.4.12",
     "typescript": "^5.9.3",
-    "typescript-eslint": "8.67.1-alpha.25"
+    "typescript-eslint": "8.67.0"
   },
   "overrides": {
     "test-exclude": "^7.0.1",


### PR DESCRIPTION
## Summary

- pin `eslint` to `10.9.0`
- pin `typescript-eslint` to `8.67.0`
- align `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` to `8.67.0`
- pin `js-yaml` to `5.3.0`
- update `package-lock.json`

## Testing

- `npm install --no-audit --no-fund`
- `npm test` — 329 suites and 5,266 tests passed