### PR TITLE
feat: require explicit Cloud Hypervisor tool-cache mounts

### DIFF
--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -153,8 +153,9 @@ the full architecture and security-boundary writeup.
 - `workspace-and-tool-cache` explicitly opts into exporting the whole path
   named by `RUNNER_TOOL_CACHE`, falling back to `AGENT_TOOLSDIRECTORY`. AWF
   requires that value to name an existing real directory and stages it
-  read-only on the host before virtiofsd starts. Missing paths and unknown
-  policy values are errors.
+  recursively read-only on the host before virtiofsd starts. Cache paths that
+  overlap writable export sources, missing paths, and unknown policy values are
+  errors.
 
 AWF forwards `RUNNER_TOOL_CACHE` or `AGENT_TOOLSDIRECTORY` into the guest only
 when the corresponding export exists. gh-aw versions that generate a command

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -144,6 +144,24 @@ for the guest artifact build/verification pipeline. See
 [docs/cloud-hypervisor-foundation.md](./cloud-hypervisor-foundation.md) for
 the full architecture and security-boundary writeup.
 
+`cloudHypervisor.mountPolicy` controls host directory exposure:
+
+- `workspace-only` is the default and recommended secure posture. It does not
+  infer a mount from `RUNNER_TOOL_CACHE` or `AGENT_TOOLSDIRECTORY`. The
+  workspace and the narrow gh-aw runtime directories (`RUNNER_TEMP/gh-aw` and
+  `/tmp/gh-aw`) remain eligible when present so generated workflows can run.
+- `workspace-and-tool-cache` explicitly opts into exporting the whole path
+  named by `RUNNER_TOOL_CACHE`, falling back to `AGENT_TOOLSDIRECTORY`. AWF
+  requires that value to name an existing real directory and stages it
+  read-only on the host before virtiofsd starts. Missing paths and unknown
+  policy values are errors.
+
+AWF forwards `RUNNER_TOOL_CACHE` or `AGENT_TOOLSDIRECTORY` into the guest only
+when the corresponding export exists. gh-aw versions that generate a command
+which scans `RUNNER_TOOL_CACHE` must emit
+`--cloud-hypervisor-mount-policy workspace-and-tool-cache`; workflows that do
+not need runner-installed tools should retain the default.
+
 Release test artifacts (`cloud-hypervisor-test-x86_64`) are x86_64
 test/preview artifacts built and verified by both the release workflow and
 [`test-cloud-hypervisor.yml`](../.github/workflows/test-cloud-hypervisor.yml),
@@ -262,6 +280,7 @@ AWF settings MAY be supplied via config files, including stdin (`--config -`).
 - `container.containerRuntime` → `--container-runtime` *(user-facing runtime name: `"gvisor"` for an OCI runtime in Compose, `"sbx"` for a Docker sbx microVM, or `"cloud-hypervisor"` for the explicit Cloud Hypervisor v53.0 workload preview (GitHub-hosted Ubuntu x86_64 KVM runners only; see §4.2). gVisor translates to `"runsc"` and injects `extra_hosts` for its DNS workaround. For sbx and Cloud Hypervisor, infrastructure stays in Compose while the primary agent runs in a microVM.)*
 - `filesystem.allowWrite[]` → *(config-only; no CLI equivalent; narrows existing writable host binds to the listed guest-visible absolute paths, see §4.1)*
 - `cloudHypervisor.previewEnabled` → `--cloud-hypervisor-preview` *(requires `container.containerRuntime: "cloud-hypervisor"` and a GitHub-hosted Ubuntu x86_64 KVM runner to execute a workload)*
+- `cloudHypervisor.mountPolicy` → `--cloud-hypervisor-mount-policy` *(`workspace-only` by default; use `workspace-and-tool-cache` only when the workload needs the runner tool cache)*
 - `cloudHypervisor.cloudHypervisorBinary` → `--cloud-hypervisor-binary`
 - `cloudHypervisor.kernelPath` → `--cloud-hypervisor-kernel`
 - `cloudHypervisor.rootfsPath` → `--cloud-hypervisor-rootfs`

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -757,6 +757,15 @@
           "default": false,
           "description": "Enable the Cloud Hypervisor v53.0 workload-execution preview. Requires container.containerRuntime: \"cloud-hypervisor\" and a GitHub-hosted Ubuntu x86_64 KVM runner."
         },
+        "mountPolicy": {
+          "type": "string",
+          "enum": [
+            "workspace-only",
+            "workspace-and-tool-cache"
+          ],
+          "default": "workspace-only",
+          "description": "Host directory exposure policy. \"workspace-only\" is the secure default and exports the workspace plus only narrow gh-aw runtime directories when present. \"workspace-and-tool-cache\" additionally requires and mounts RUNNER_TOOL_CACHE or AGENT_TOOLSDIRECTORY read-only with host-enforced staging."
+        },
         "cloudHypervisorBinary": {
           "type": "string",
           "description": "Absolute path to the Cloud Hypervisor v53.0 binary. Defaults to /usr/local/bin/cloud-hypervisor."

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -151,9 +151,32 @@ rootfs. AWF injects the binary built from `guest/microvm-supervisor/` into the
 per-run rootfs.
 
 The workspace is a live read-write virtio-fs export mounted at `/workspace`.
-Validated additional exports use separate sandboxed `virtiofsd` processes.
+The default `workspace-only` mount policy does not infer tool-cache exposure
+from the host environment. Narrow gh-aw runtime directories
+(`RUNNER_TEMP/gh-aw` and `/tmp/gh-aw`) remain eligible when present, and every
+validated export uses a separate sandboxed `virtiofsd` process.
 The workspace path is never exposed directly to the VMM process through its
 Landlock rules.
+
+Use `--cloud-hypervisor-mount-policy workspace-and-tool-cache` (or
+`cloudHypervisor.mountPolicy: workspace-and-tool-cache`) only when the guest
+must execute runner-installed tools. This explicit opt-in selects
+`RUNNER_TOOL_CACHE`, falling back to `AGENT_TOOLSDIRECTORY`, requires the path
+to be an existing real directory, and exports the entire selected directory.
+AWF stages that export read-only in the host VFS before launching virtiofsd;
+guest mount flags alone are never treated as enforcement.
+
+AWF removes `RUNNER_TOOL_CACHE`, `AGENT_TOOLSDIRECTORY`, and `RUNNER_TEMP` from
+the inherited guest environment, then adds back only values backed by mounted
+exports. It never scans a cache to decide whether exposure is safe.
+
+:::caution[Preview migration]
+Earlier preview builds automatically exported a present runner tool cache.
+The secure default is now `workspace-only`. gh-aw-generated commands that scan
+`RUNNER_TOOL_CACHE` must add
+`--cloud-hypervisor-mount-policy workspace-and-tool-cache`; commands that do
+not need cached runner tools require no migration.
+:::
 
 Temporary microVM workspace data lives under:
 

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -163,8 +163,11 @@ Use `--cloud-hypervisor-mount-policy workspace-and-tool-cache` (or
 must execute runner-installed tools. This explicit opt-in selects
 `RUNNER_TOOL_CACHE`, falling back to `AGENT_TOOLSDIRECTORY`, requires the path
 to be an existing real directory, and exports the entire selected directory.
-AWF stages that export read-only in the host VFS before launching virtiofsd;
-guest mount flags alone are never treated as enforcement.
+AWF recursively stages and verifies that export read-only in a private host VFS
+mount tree before launching virtiofsd, including any carried-in submounts;
+guest mount flags alone are never treated as enforcement. The canonical cache
+source must not equal, contain, or be contained by any writable export source,
+so a second guest path cannot alias the cache with write access.
 
 AWF removes `RUNNER_TOOL_CACHE`, `AGENT_TOOLSDIRECTORY`, and `RUNNER_TEMP` from
 the inherited guest environment, then adds back only values backed by mounted

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -757,6 +757,15 @@
           "default": false,
           "description": "Enable the Cloud Hypervisor v53.0 workload-execution preview. Requires container.containerRuntime: \"cloud-hypervisor\" and a GitHub-hosted Ubuntu x86_64 KVM runner."
         },
+        "mountPolicy": {
+          "type": "string",
+          "enum": [
+            "workspace-only",
+            "workspace-and-tool-cache"
+          ],
+          "default": "workspace-only",
+          "description": "Host directory exposure policy. \"workspace-only\" is the secure default and exports the workspace plus only narrow gh-aw runtime directories when present. \"workspace-and-tool-cache\" additionally requires and mounts RUNNER_TOOL_CACHE or AGENT_TOOLSDIRECTORY read-only with host-enforced staging."
+        },
         "cloudHypervisorBinary": {
           "type": "string",
           "description": "Absolute path to the Cloud Hypervisor v53.0 binary. Defaults to /usr/local/bin/cloud-hypervisor."

--- a/src/cli-options.test.ts
+++ b/src/cli-options.test.ts
@@ -16,6 +16,7 @@ describe('cli-options program', () => {
     program.setOptionValueWithSource('env', [], 'default');
     program.setOptionValueWithSource('excludeEnv', [], 'default');
     program.setOptionValueWithSource('mount', [], 'default');
+    program.setOptionValueWithSource('cloudHypervisorMountPolicy', undefined, 'default');
   });
 
   it('exposes the expected metadata', () => {
@@ -79,6 +80,24 @@ describe('cli-options program', () => {
     const opts = program.opts();
     expect(opts.vertexApiTarget).toBe('vertex.internal');
     expect(opts.vertexApiBasePath).toBe('/v1beta1');
+  });
+
+  it('leaves mount-policy defaulting to config assembly and parses explicit tool-cache opt-in', () => {
+    program.parse(['node', 'awf', '--', 'true'], { from: 'node' });
+    expect(program.opts().cloudHypervisorMountPolicy).toBeUndefined();
+
+    program.parse(
+      [
+        'node',
+        'awf',
+        '--cloud-hypervisor-mount-policy',
+        'workspace-and-tool-cache',
+        '--',
+        'true',
+      ],
+      { from: 'node' },
+    );
+    expect(program.opts().cloudHypervisorMountPolicy).toBe('workspace-and-tool-cache');
   });
 
   describe('custom formatHelp', () => {

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -3,7 +3,9 @@ import * as path from 'path';
 import * as os from 'os';
 import { version } from '../package.json';
 import { collectRulesetFile, collectStringArray, formatItem } from './option-parsers';
-import { CLOUD_HYPERVISOR_RELEASE_VERSION } from './types/runtime-options';
+import {
+  CLOUD_HYPERVISOR_RELEASE_VERSION,
+} from './types/runtime-options';
 
 // Option group markers used by the custom help formatter to insert section headers.
 // Each key is the long flag name of the first option in a group.
@@ -187,6 +189,12 @@ program
    '                                       GitHub-hosted Ubuntu x86_64 KVM runners only. Requires local Docker\n' +
    '                                       and pinned guest artifacts.',
    false
+  )
+  .option(
+    '--cloud-hypervisor-mount-policy <policy>',
+    'Host directory exposure policy: "workspace-only" (secure default; also keeps narrow gh-aw\n' +
+    '                                       runtime directories) or "workspace-and-tool-cache" (explicitly mounts\n' +
+    '                                       RUNNER_TOOL_CACHE/AGENT_TOOLSDIRECTORY read-only).',
   )
   .option('--cloud-hypervisor-binary <path>', `Path to the Cloud Hypervisor v${CLOUD_HYPERVISOR_RELEASE_VERSION} binary.`)
   .option('--cloud-hypervisor-kernel <path>', 'Path to the PCI-capable guest Linux kernel image.')

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -21,6 +21,7 @@ function config(overrides: Partial<WrapperConfig> = {}): WrapperConfig {
     containerRuntime: 'cloud-hypervisor',
     cloudHypervisor: {
       previewEnabled: true,
+      mountPolicy: 'workspace-only',
       cloudHypervisorBinary: '/opt/cloud-hypervisor',
       kernelPath: '/opt/kernel',
       rootfsPath: '/opt/rootfs',
@@ -220,7 +221,7 @@ describe('Cloud Hypervisor runtime backend', () => {
     const previousWorkspace = process.env.GITHUB_WORKSPACE;
     process.env.GITHUB_WORKSPACE = process.cwd();
     try {
-      await expect(defaults.resolveExports()).resolves.toEqual(expect.arrayContaining([
+      await expect(defaults.resolveExports('workspace-only')).resolves.toEqual(expect.arrayContaining([
         expect.objectContaining({ tag: 'workspace', target: '/workspace', mode: 'rw' }),
       ]));
       expect(defaults.identity()).toEqual({
@@ -263,6 +264,7 @@ describe('Cloud Hypervisor runtime backend', () => {
 
       await backend.start('/tmp/awf', ['github.com']);
 
+      expect(deps.resolveExports).toHaveBeenCalledWith('workspace-only');
       expect(deps.createManager).toHaveBeenCalledWith(
         expect.anything(),
         '/tmp/awf',
@@ -1011,6 +1013,34 @@ describe('Cloud Hypervisor runtime backend', () => {
     } finally {
       if (previousToolCache === undefined) delete process.env.RUNNER_TOOL_CACHE;
       else process.env.RUNNER_TOOL_CACHE = previousToolCache;
+      if (previousRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
+      else process.env.RUNNER_TEMP = previousRunnerTemp;
+    }
+  });
+
+  it('does not forward runner path variables without matching exports', () => {
+    const previousToolCache = process.env.RUNNER_TOOL_CACHE;
+    const previousAgentTools = process.env.AGENT_TOOLSDIRECTORY;
+    const previousRunnerTemp = process.env.RUNNER_TEMP;
+    try {
+      process.env.RUNNER_TOOL_CACHE = '/opt/hostedtoolcache';
+      process.env.AGENT_TOOLSDIRECTORY = '/opt/agent-tools';
+      process.env.RUNNER_TEMP = '/home/runner/work/_temp';
+      const environment = buildCloudHypervisorGuestEnvironment(
+        config(),
+        infrastructure(),
+        '100.64.0.2',
+        [{ tag: 'workspace', source: '/host/workspace', target: '/workspace', mode: 'rw' }],
+      );
+
+      expect(environment.RUNNER_TOOL_CACHE).toBeUndefined();
+      expect(environment.AGENT_TOOLSDIRECTORY).toBeUndefined();
+      expect(environment.RUNNER_TEMP).toBeUndefined();
+    } finally {
+      if (previousToolCache === undefined) delete process.env.RUNNER_TOOL_CACHE;
+      else process.env.RUNNER_TOOL_CACHE = previousToolCache;
+      if (previousAgentTools === undefined) delete process.env.AGENT_TOOLSDIRECTORY;
+      else process.env.AGENT_TOOLSDIRECTORY = previousAgentTools;
       if (previousRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
       else process.env.RUNNER_TEMP = previousRunnerTemp;
     }

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -113,7 +113,7 @@ export interface CloudHypervisorRuntimeBackendDependencies {
     identity: { uid: number; gid: number },
     mountEnforcement?: VirtiofsdMountEnforcement,
   ): CloudHypervisorManagerAdapter;
-  resolveExports(): Promise<CloudHypervisorDirectoryExport[]>;
+  resolveExports(mountPolicy: CloudHypervisorOptions['mountPolicy']): Promise<CloudHypervisorDirectoryExport[]>;
   identity(): { uid: number; gid: number };
   stdin: Readable & { isTTY?: boolean };
   stdout: Writable;
@@ -154,7 +154,11 @@ function defaultDependencies(
           identity,
         },
       ),
-    resolveExports: () => resolveCloudHypervisorExports(),
+    resolveExports: (mountPolicy) => resolveCloudHypervisorExports(
+      process.env,
+      process.cwd(),
+      mountPolicy,
+    ),
     identity: () => ({
       uid: Number(getSafeHostUid()),
       gid: Number(getSafeHostGid()),
@@ -264,7 +268,7 @@ class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBackend {
       // or the guest is launched, and so every boot attempt reuses one
       // decision instead of re-resolving host paths per attempt.
       const { exports, mountEnforcement, writeBoundary } = planCloudHypervisorFilesystemWriteEnforcement(
-        await this.dependencies.resolveExports(),
+        await this.dependencies.resolveExports(cloudHypervisor.mountPolicy),
         this.config.filesystemAllowWrite,
       );
       if (writeBoundary.length > 0) {

--- a/src/cloud-hypervisor/config.test.ts
+++ b/src/cloud-hypervisor/config.test.ts
@@ -58,6 +58,7 @@ describe('Cloud Hypervisor configuration (foundation only)', () => {
     const mapped = mapAwfFileConfigToCliOptions({
       cloudHypervisor: {
         previewEnabled: true,
+        mountPolicy: 'workspace-and-tool-cache',
         cloudHypervisorBinary: '/opt/cloud-hypervisor',
         kernelPath: '/opt/vmlinux',
         rootfsPath: '/opt/rootfs.ext4',
@@ -71,6 +72,7 @@ describe('Cloud Hypervisor configuration (foundation only)', () => {
 
     expect(mapped).toEqual(expect.objectContaining({
       cloudHypervisorPreview: true,
+      cloudHypervisorMountPolicy: 'workspace-and-tool-cache',
       cloudHypervisorBinary: '/opt/cloud-hypervisor',
       cloudHypervisorKernel: '/opt/vmlinux',
       cloudHypervisorRootfs: '/opt/rootfs.ext4',
@@ -87,6 +89,7 @@ describe('Cloud Hypervisor configuration (foundation only)', () => {
   it('applies explicit safe defaults when Cloud Hypervisor is configured', () => {
     expect(buildCloudHypervisorConfig({ cloudHypervisorPreview: true })).toEqual({
       previewEnabled: true,
+      mountPolicy: 'workspace-only',
       cloudHypervisorBinary: CLOUD_HYPERVISOR_DEFAULT_BINARY,
       kernelPath: undefined,
       rootfsPath: undefined,
@@ -105,6 +108,14 @@ describe('Cloud Hypervisor configuration (foundation only)', () => {
     })).toBeUndefined();
   });
 
+  it('treats an explicitly configured secure mount policy as Cloud Hypervisor configuration', () => {
+    expect(buildCloudHypervisorConfig({
+      cloudHypervisorMountPolicy: 'workspace-only',
+    })).toEqual(expect.objectContaining({
+      mountPolicy: 'workspace-only',
+    }));
+  });
+
   it('validates positive resources, digests, and unknown keys', () => {
     expect(validateAwfFileConfig({
       cloudHypervisor: {
@@ -119,6 +130,17 @@ describe('Cloud Hypervisor configuration (foundation only)', () => {
       .toContain('config.cloudHypervisor.sha256.kernel must match pattern "^[A-Fa-f0-9]{64}$"');
     expect(validateAwfFileConfig({ cloudHypervisor: { unsupported: true } }))
       .toContain('config.cloudHypervisor.unsupported is not supported');
+    expect(validateAwfFileConfig({ cloudHypervisor: { mountPolicy: 'automatic' } }))
+      .toContain('config.cloudHypervisor.mountPolicy must be one of: workspace-only, workspace-and-tool-cache');
+  });
+
+  it('rejects unknown CLI mount policies', () => {
+    expect(() => buildCloudHypervisorConfig({
+      containerRuntime: 'cloud-hypervisor',
+      cloudHypervisorMountPolicy: 'automatic',
+    })).toThrow(
+      '--cloud-hypervisor-mount-policy must be "workspace-only" or "workspace-and-tool-cache"',
+    );
   });
 
   it('accepts "cloud-hypervisor" as a container runtime', () => {

--- a/src/cloud-hypervisor/exports.test.ts
+++ b/src/cloud-hypervisor/exports.test.ts
@@ -66,6 +66,27 @@ describe('Cloud Hypervisor directory exports', () => {
     ]));
   });
 
+  it('rejects a tool cache that aliases a writable export source', async () => {
+    const workspace = path.join(directory, 'workspace');
+    const tools = path.join(workspace, 'tools');
+    await fs.mkdir(tools, { recursive: true });
+
+    await expect(resolveCloudHypervisorExports(
+      { GITHUB_WORKSPACE: workspace, RUNNER_TOOL_CACHE: tools },
+      directory,
+      'workspace-and-tool-cache',
+    )).rejects.toThrow(
+      'Cloud Hypervisor runner tool cache source overlaps writable export "workspace"',
+    );
+    await expect(resolveCloudHypervisorExports(
+      { GITHUB_WORKSPACE: tools, RUNNER_TOOL_CACHE: workspace },
+      directory,
+      'workspace-and-tool-cache',
+    )).rejects.toThrow(
+      'Cloud Hypervisor runner tool cache source overlaps writable export "workspace"',
+    );
+  });
+
   it('uses AGENT_TOOLSDIRECTORY only under the explicit opt-in policy', async () => {
     const workspace = path.join(directory, 'workspace');
     const tools = path.join(directory, 'agent-tools');

--- a/src/cloud-hypervisor/exports.test.ts
+++ b/src/cloud-hypervisor/exports.test.ts
@@ -17,7 +17,7 @@ describe('Cloud Hypervisor directory exports', () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
 
-  it('resolves only the workspace and narrow existing runtime paths', async () => {
+  it('defaults to workspace-only and does not infer tool-cache exposure from the environment', async () => {
     const workspace = path.join(directory, 'workspace');
     const tools = path.join(directory, 'tools');
     const runnerTemp = path.join(directory, 'runner-temp');
@@ -38,7 +38,6 @@ describe('Cloud Hypervisor directory exports', () => {
     });
     expect(exports).toEqual(expect.arrayContaining([
       { tag: 'workspace', source: realWorkspace, target: '/workspace', mode: 'rw' },
-      { tag: 'runner-tool-cache', source: realTools, target: tools, mode: 'ro' },
       {
         tag: 'runner-temp-gh-aw',
         source: path.join(realRunnerTemp, 'gh-aw'),
@@ -48,10 +47,26 @@ describe('Cloud Hypervisor directory exports', () => {
     ]));
     expect(exports).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ source: runnerTemp }),
+      expect.objectContaining({ source: realTools }),
     ]));
   });
 
-  it('uses AGENT_TOOLSDIRECTORY fallback and skips absent optional paths', async () => {
+  it('mounts RUNNER_TOOL_CACHE read-only only under the explicit opt-in policy', async () => {
+    const workspace = path.join(directory, 'workspace');
+    const tools = path.join(directory, 'tools');
+    await Promise.all([fs.mkdir(workspace), fs.mkdir(tools)]);
+    const realTools = await fs.realpath(tools);
+
+    await expect(resolveCloudHypervisorExports(
+      { GITHUB_WORKSPACE: workspace, RUNNER_TOOL_CACHE: tools },
+      directory,
+      'workspace-and-tool-cache',
+    )).resolves.toEqual(expect.arrayContaining([
+      { tag: 'runner-tool-cache', source: realTools, target: tools, mode: 'ro' },
+    ]));
+  });
+
+  it('uses AGENT_TOOLSDIRECTORY only under the explicit opt-in policy', async () => {
     const workspace = path.join(directory, 'workspace');
     const tools = path.join(directory, 'agent-tools');
     await fs.mkdir(workspace);
@@ -60,13 +75,41 @@ describe('Cloud Hypervisor directory exports', () => {
       fs.realpath(workspace),
       fs.realpath(tools),
     ]);
-    await expect(resolveCloudHypervisorExports({
-      GITHUB_WORKSPACE: workspace,
-      AGENT_TOOLSDIRECTORY: tools,
-    })).resolves.toEqual(expect.arrayContaining([
+    await expect(resolveCloudHypervisorExports(
+      {
+        GITHUB_WORKSPACE: workspace,
+        AGENT_TOOLSDIRECTORY: tools,
+      },
+      directory,
+      'workspace-and-tool-cache',
+    )).resolves.toEqual(expect.arrayContaining([
       { tag: 'workspace', source: realWorkspace, target: '/workspace', mode: 'rw' },
       { tag: 'runner-tool-cache', source: realTools, target: tools, mode: 'ro' },
     ]));
+  });
+
+  it('fails closed when tool-cache opt-in has no usable cache path', async () => {
+    const workspace = path.join(directory, 'workspace');
+    await fs.mkdir(workspace);
+
+    await expect(resolveCloudHypervisorExports(
+      { GITHUB_WORKSPACE: workspace },
+      directory,
+      'workspace-and-tool-cache',
+    )).rejects.toThrow(/requires RUNNER_TOOL_CACHE or AGENT_TOOLSDIRECTORY/);
+    await expect(resolveCloudHypervisorExports(
+      { GITHUB_WORKSPACE: workspace, RUNNER_TOOL_CACHE: path.join(directory, 'missing') },
+      directory,
+      'workspace-and-tool-cache',
+    )).rejects.toThrow(/runner-tool-cache.*existing real directory/);
+  });
+
+  it('fails closed on an unsupported policy', async () => {
+    await expect(resolveCloudHypervisorExports(
+      { GITHUB_WORKSPACE: directory },
+      directory,
+      'automatic' as 'workspace-only',
+    )).rejects.toThrow('Unsupported Cloud Hypervisor mount policy: automatic');
   });
 
   it('rejects unsafe, duplicate, and overlapping contracts', () => {

--- a/src/cloud-hypervisor/exports.ts
+++ b/src/cloud-hypervisor/exports.ts
@@ -1,5 +1,10 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import {
+  CLOUD_HYPERVISOR_DEFAULT_MOUNT_POLICY,
+  CLOUD_HYPERVISOR_MOUNT_POLICIES,
+  type CloudHypervisorMountPolicy,
+} from '../types/runtime-options';
 
 export type CloudHypervisorExportMode = 'ro' | 'rw';
 
@@ -49,19 +54,29 @@ export interface CloudHypervisorExportValidationOptions {
 export async function resolveCloudHypervisorExports(
   environment: CloudHypervisorExportEnvironment = process.env,
   cwd = process.cwd(),
+  mountPolicy: CloudHypervisorMountPolicy = CLOUD_HYPERVISOR_DEFAULT_MOUNT_POLICY,
 ): Promise<CloudHypervisorDirectoryExport[]> {
+  if (!CLOUD_HYPERVISOR_MOUNT_POLICIES.includes(mountPolicy)) {
+    throw new Error(`Unsupported Cloud Hypervisor mount policy: ${String(mountPolicy)}`);
+  }
   const workspace = environment.GITHUB_WORKSPACE || cwd;
   const candidates: Array<CloudHypervisorDirectoryExport & { required: boolean }> = [
     { tag: 'workspace', source: workspace, target: '/workspace', mode: 'rw', required: true },
   ];
-  const toolCache = environment.RUNNER_TOOL_CACHE || environment.AGENT_TOOLSDIRECTORY;
-  if (toolCache) {
+  if (mountPolicy === 'workspace-and-tool-cache') {
+    const toolCache = environment.RUNNER_TOOL_CACHE || environment.AGENT_TOOLSDIRECTORY;
+    if (!toolCache) {
+      throw new Error(
+        'Cloud Hypervisor mount policy "workspace-and-tool-cache" requires ' +
+        'RUNNER_TOOL_CACHE or AGENT_TOOLSDIRECTORY',
+      );
+    }
     candidates.push({
       tag: 'runner-tool-cache',
       source: toolCache,
       target: toolCache,
       mode: 'ro',
-      required: false,
+      required: true,
     });
   }
   if (environment.RUNNER_TEMP) {
@@ -92,7 +107,9 @@ export async function resolveCloudHypervisorExports(
     } catch (error) {
       if (!candidate.required && (error as NodeJS.ErrnoException).code === 'ENOENT') continue;
       throw new Error(
-        `${candidate.required ? 'Cloud Hypervisor workspace' : `Cloud Hypervisor export "${candidate.tag}"`} ` +
+        `${candidate.tag === WORKSPACE_EXPORT_TAG
+          ? 'Cloud Hypervisor workspace'
+          : `Cloud Hypervisor export "${candidate.tag}"`} ` +
         `must be an existing real directory: ${candidate.source}: ${
           error instanceof Error ? error.message : String(error)
         }`,

--- a/src/cloud-hypervisor/exports.ts
+++ b/src/cloud-hypervisor/exports.ts
@@ -130,7 +130,25 @@ export async function resolveCloudHypervisorExports(
     seenExports.set(key, exports.length);
     exports.push(resolvedExport);
   }
-  return validateCloudHypervisorExports(exports);
+  const validated = validateCloudHypervisorExports(exports);
+  const runnerToolCache = validated.find((entry) => entry.tag === 'runner-tool-cache');
+  if (runnerToolCache) {
+    const writableAlias = validated.find((entry) => (
+      entry.mode === 'rw' &&
+      (
+        entry.source === runnerToolCache.source ||
+        containsPath(entry.source, runnerToolCache.source) ||
+        containsPath(runnerToolCache.source, entry.source)
+      )
+    ));
+    if (writableAlias) {
+      throw new Error(
+        `Cloud Hypervisor runner tool cache source overlaps writable export "${writableAlias.tag}": ` +
+        `${runnerToolCache.source}`,
+      );
+    }
+  }
+  return validated;
 }
 
 export function validateCloudHypervisorExports(

--- a/src/cloud-hypervisor/filesystem-write-enforcement.test.ts
+++ b/src/cloud-hypervisor/filesystem-write-enforcement.test.ts
@@ -35,17 +35,25 @@ describe('Cloud Hypervisor filesystem write enforcement translation', () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
 
-  it('produces no enforcement and untouched exports when the policy is undefined', () => {
+  it('recursively enforces an opted-in tool cache when the write policy is undefined', () => {
     const result = planCloudHypervisorFilesystemWriteEnforcement(exports, undefined);
 
-    expect(result.mountEnforcement).toBeUndefined();
-    expect('mountEnforcement' in result).toBe(false);
+    expect(result.mountEnforcement).toEqual({
+      plans: [{ tag: 'runner-tool-cache', writableOverlays: [] }],
+    });
     expect(result.exports).toEqual(exports);
-    // Identity matters: the published list must be the resolved exports
-    // verbatim so virtiofsd's legacy staging path stays byte-identical.
     result.exports.forEach((entry, index) => expect(entry).toBe(exports[index]));
     expect(hasReadOnlyWorkspaceMountPlan(result.mountEnforcement)).toBe(false);
     expect(result.writeBoundary).toEqual([]);
+  });
+
+  it('preserves legacy staging without a write policy or tool-cache export', () => {
+    const withoutToolCache = exports.filter((entry) => entry.tag !== 'runner-tool-cache');
+    const result = planCloudHypervisorFilesystemWriteEnforcement(withoutToolCache, undefined);
+
+    expect(result.mountEnforcement).toBeUndefined();
+    expect('mountEnforcement' in result).toBe(false);
+    expect(result.exports).toEqual(withoutToolCache);
   });
 
   it('narrows every writable export for an empty allowlist without exempting /tmp/gh-aw', () => {

--- a/src/cloud-hypervisor/filesystem-write-enforcement.ts
+++ b/src/cloud-hypervisor/filesystem-write-enforcement.ts
@@ -29,9 +29,9 @@ export interface CloudHypervisorFilesystemWriteEnforcement {
    */
   readonly exports: readonly CloudHypervisorDirectoryExport[];
   /**
-   * Host mount-tree enforcement, or `undefined` when `filesystem.allowWrite`
-   * was absent. `undefined` is what preserves byte-identical legacy staging,
-   * including virtiofsd's argument vector.
+   * Host mount-tree enforcement. This is always present for an opted-in runner
+   * tool cache so carried-in submounts are recursively verified read-only, and
+   * may also be present when `filesystem.allowWrite` narrows writable exports.
    */
   readonly mountEnforcement?: VirtiofsdMountEnforcement;
   /**
@@ -53,6 +53,10 @@ export interface CloudHypervisorFilesystemWriteEnforcement {
  * directory, which is not an export at all. In particular `tmp-gh-aw` is *not*
  * internal — the motivating policy allows only `/tmp/gh-aw/agent`, and exempting
  * the whole export would silently widen it back to fully writable.
+ *
+ * The runner tool cache is a separate mandatory boundary: even without an
+ * allowlist it receives a zero-overlay mount plan so nested host mounts cannot
+ * bypass the declared read-only export mode.
  */
 export function planCloudHypervisorFilesystemWriteEnforcement(
   exports: readonly CloudHypervisorDirectoryExport[],
@@ -69,9 +73,17 @@ export function toCloudHypervisorFilesystemWriteEnforcement(
   plan: CloudHypervisorFilesystemWritePlan,
 ): CloudHypervisorFilesystemWriteEnforcement {
   if (!plan.restricted) {
-    // No policy: the exports and the virtiofsd invocation must be exactly what
-    // they were before this feature existed, so no enforcement is produced.
-    return { exports: plan.exports.map((entry) => entry.export), writeBoundary: [] };
+    const exports = plan.exports.map((entry) => entry.export);
+    const mandatoryPlans = exports
+      .filter((entry) => entry.tag === 'runner-tool-cache' && entry.mode === 'ro')
+      .map((entry) => ({ tag: entry.tag, writableOverlays: [] }));
+    return {
+      exports,
+      ...(mandatoryPlans.length > 0
+        ? { mountEnforcement: { plans: mandatoryPlans } }
+        : {}),
+      writeBoundary: [],
+    };
   }
 
   const plans: VirtiofsdExportMountPlan[] = [];

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -59,6 +59,7 @@ function virtiofsdManagerMock(): VirtiofsdManager {
 function config(overrides: Partial<CloudHypervisorOptions> = {}): CloudHypervisorOptions {
   return {
     previewEnabled: true,
+    mountPolicy: 'workspace-only',
     cloudHypervisorBinary: '/opt/cloud-hypervisor',
     kernelPath: '/opt/vmlinux',
     rootfsPath: '/opt/rootfs.ext4',

--- a/src/cloud-hypervisor/preflight.test.ts
+++ b/src/cloud-hypervisor/preflight.test.ts
@@ -22,6 +22,7 @@ const mockedExeca = execa as jest.MockedFunction<typeof execa>;
 function config(overrides: Partial<CloudHypervisorOptions> = {}): CloudHypervisorOptions {
   return {
     previewEnabled: true,
+    mountPolicy: 'workspace-only',
     cloudHypervisorBinary: '/opt/cloud-hypervisor',
     kernelPath: '/opt/vmlinux',
     rootfsPath: '/opt/rootfs.ext4',

--- a/src/cloud-hypervisor/runtime-validation.test.ts
+++ b/src/cloud-hypervisor/runtime-validation.test.ts
@@ -20,6 +20,7 @@ function config(overrides: Partial<WrapperConfig> = {}): WrapperConfig {
     tty: false,
     cloudHypervisor: {
       previewEnabled: true,
+      mountPolicy: 'workspace-only',
       cloudHypervisorBinary: '/opt/cloud-hypervisor',
       kernelPath: '/opt/kernel',
       rootfsPath: '/opt/rootfs',
@@ -101,6 +102,17 @@ describe('Cloud Hypervisor runtime validation', () => {
     expect(() => assertCloudHypervisorRuntimeCompatibility(
       config(overrides as Partial<WrapperConfig>),
     )).toThrow(error);
+  });
+
+  it('fails closed on a mistyped mount policy', () => {
+    expect(() => assertCloudHypervisorRuntimeCompatibility(config({
+      cloudHypervisor: {
+        ...config().cloudHypervisor!,
+        mountPolicy: 'automatic' as 'workspace-only',
+      },
+    }))).toThrow(
+      'Cloud Hypervisor mount policy must be "workspace-only" or "workspace-and-tool-cache"',
+    );
   });
 
   it.each([

--- a/src/cloud-hypervisor/runtime-validation.ts
+++ b/src/cloud-hypervisor/runtime-validation.ts
@@ -1,5 +1,6 @@
 import { getLocalDockerEnv } from '../docker-host';
 import type { CloudHypervisorOptions, WrapperConfig } from '../types';
+import { CLOUD_HYPERVISOR_MOUNT_POLICIES } from '../types/runtime-options';
 import { assertGithubHostedRunnerEligibility } from './host-eligibility';
 
 /**
@@ -28,6 +29,11 @@ export function assertCloudHypervisorRuntimeCompatibility(
   if (!cloudHypervisor.previewEnabled) {
     throw new Error(
       'Cloud Hypervisor workload execution requires explicit --cloud-hypervisor-preview opt-in',
+    );
+  }
+  if (!CLOUD_HYPERVISOR_MOUNT_POLICIES.includes(cloudHypervisor.mountPolicy)) {
+    throw new Error(
+      'Cloud Hypervisor mount policy must be "workspace-only" or "workspace-and-tool-cache"',
     );
   }
   if (!config.networkIsolation || config.legacySecurity) {

--- a/src/cloud-hypervisor/virtiofsd.test.ts
+++ b/src/cloud-hypervisor/virtiofsd.test.ts
@@ -149,6 +149,9 @@ describe('VirtiofsdManager', () => {
     expect(deps.runTool).toHaveBeenCalledWith('/usr/bin/mount', [
       '-o', 'remount,bind,ro,nosuid,nodev', '/run/awf-shares/run/1-cache',
     ]);
+    const launched = (deps.launch as jest.Mock).mock.results[0].value as ExecaChildProcess<string>;
+    launched.stdout?.emit('data', 'virtiofsd stdout');
+    launched.stderr?.emit('data', 'virtiofsd stderr');
 
     await manager.stop();
     expect(deps.writeFile).toHaveBeenCalledTimes(2);

--- a/src/cloud-hypervisor/vm-config-builder.test.ts
+++ b/src/cloud-hypervisor/vm-config-builder.test.ts
@@ -6,6 +6,7 @@ import { buildCloudHypervisorVmConfig } from './vm-config-builder';
 function config(overrides: Partial<CloudHypervisorOptions> = {}): CloudHypervisorOptions {
   return {
     previewEnabled: true,
+    mountPolicy: 'workspace-only',
     cloudHypervisorBinary: '/opt/cloud-hypervisor',
     kernelPath: '/opt/vmlinux',
     rootfsPath: '/opt/rootfs.ext4',

--- a/src/commands/build-config.ts
+++ b/src/commands/build-config.ts
@@ -6,8 +6,11 @@ import { logger } from '../logger';
 import {
   CLOUD_HYPERVISOR_DEFAULT_API_TIMEOUT_MS,
   CLOUD_HYPERVISOR_DEFAULT_BINARY,
+  CLOUD_HYPERVISOR_DEFAULT_MOUNT_POLICY,
   CLOUD_HYPERVISOR_DEFAULT_MEMORY_MIB,
   CLOUD_HYPERVISOR_DEFAULT_VCPU_COUNT,
+  CLOUD_HYPERVISOR_MOUNT_POLICIES,
+  type CloudHypervisorMountPolicy,
 } from '../types/runtime-options';
 
 /**
@@ -263,6 +266,7 @@ function buildCloudHypervisorConfig(
   const selected = options.containerRuntime === 'cloud-hypervisor';
   const configured = options.cloudHypervisorPreview === true
     || [
+      'cloudHypervisorMountPolicy',
       'cloudHypervisorBinary',
       'cloudHypervisorKernel',
       'cloudHypervisorRootfs',
@@ -288,6 +292,7 @@ function buildCloudHypervisorConfig(
 
   return {
     previewEnabled: options.cloudHypervisorPreview === true,
+    mountPolicy: parseCloudHypervisorMountPolicy(options.cloudHypervisorMountPolicy),
     cloudHypervisorBinary:
       (options.cloudHypervisorBinary as string | undefined) ?? CLOUD_HYPERVISOR_DEFAULT_BINARY,
     kernelPath: options.cloudHypervisorKernel as string | undefined,
@@ -312,6 +317,19 @@ function buildCloudHypervisorConfig(
       ? sha256
       : undefined,
   };
+}
+
+function parseCloudHypervisorMountPolicy(value: unknown): CloudHypervisorMountPolicy {
+  const policy = value ?? CLOUD_HYPERVISOR_DEFAULT_MOUNT_POLICY;
+  if (
+    typeof policy !== 'string' ||
+    !CLOUD_HYPERVISOR_MOUNT_POLICIES.includes(policy as CloudHypervisorMountPolicy)
+  ) {
+    throw new Error(
+      '--cloud-hypervisor-mount-policy must be "workspace-only" or "workspace-and-tool-cache"',
+    );
+  }
+  return policy as CloudHypervisorMountPolicy;
 }
 
 function buildChrootIdentity(

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -3,7 +3,10 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { validateWithSchema } from './schema-validator';
 import type { RawEnclavesConfig } from './types/enclave-options';
-import type { CloudHypervisorArtifactDigests } from './types/runtime-options';
+import type {
+  CloudHypervisorArtifactDigests,
+  CloudHypervisorMountPolicy,
+} from './types/runtime-options';
 
 /** @internal Used only by config-file helpers — not part of public API */
 // ts-prune-ignore-next
@@ -140,6 +143,7 @@ export interface AwfFileConfig {
    */
   cloudHypervisor?: {
     previewEnabled?: boolean;
+    mountPolicy?: CloudHypervisorMountPolicy;
     cloudHypervisorBinary?: string;
     kernelPath?: string;
     rootfsPath?: string;

--- a/src/config-mapper.ts
+++ b/src/config-mapper.ts
@@ -119,6 +119,7 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     runnerToolCachePath: config.container?.runnerToolCachePath,
     mount: config.container?.mounts,
     cloudHypervisorPreview: config.cloudHypervisor?.previewEnabled,
+    cloudHypervisorMountPolicy: config.cloudHypervisor?.mountPolicy,
     cloudHypervisorBinary: config.cloudHypervisor?.cloudHypervisorBinary,
     cloudHypervisorKernel: config.cloudHypervisor?.kernelPath,
     cloudHypervisorRootfs: config.cloudHypervisor?.rootfsPath,

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -259,6 +259,15 @@ describe('awf-config.schema.json', () => {
     expect(validate({ container: { runnerToolCachePath: 123 } })).toBe(false);
   });
 
+  it('validates Cloud Hypervisor mount policies', () => {
+    expect(validate({ cloudHypervisor: { mountPolicy: 'workspace-only' } })).toBe(true);
+    expect(validate({
+      cloudHypervisor: { mountPolicy: 'workspace-and-tool-cache' },
+    })).toBe(true);
+    expect(validate({ cloudHypervisor: { mountPolicy: 'automatic' } })).toBe(false);
+    expect(validate({ cloudHypervisor: { mountPolicy: true } })).toBe(false);
+  });
+
   it('accepts valid container.mounts array', () => {
     expect(validate({ container: { mounts: ['/tmp/gh-aw:/tmp/gh-aw:ro'] } })).toBe(true);
     expect(validate({ container: { mounts: ['/tmp/gh-aw:/tmp/gh-aw:rw', '/data:/data'] } })).toBe(true);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,12 +14,15 @@ export { type UpstreamProxyConfig } from './upstream-proxy';
 export { type LogLevel } from './log-level';
 export {
   type CloudHypervisorArtifactDigests,
+  type CloudHypervisorMountPolicy,
   type CloudHypervisorOptions,
   CLOUD_HYPERVISOR_RELEASE_VERSION,
   CLOUD_HYPERVISOR_DEFAULT_BINARY,
   CLOUD_HYPERVISOR_DEFAULT_VCPU_COUNT,
   CLOUD_HYPERVISOR_DEFAULT_MEMORY_MIB,
   CLOUD_HYPERVISOR_DEFAULT_API_TIMEOUT_MS,
+  CLOUD_HYPERVISOR_DEFAULT_MOUNT_POLICY,
+  CLOUD_HYPERVISOR_MOUNT_POLICIES,
 } from './runtime-options';
 export { type RateLimitConfig } from './rate-limit';
 export { type FlagValidationResult } from './validation';

--- a/src/types/runtime-options.ts
+++ b/src/types/runtime-options.ts
@@ -19,6 +19,13 @@ export const CLOUD_HYPERVISOR_DEFAULT_BINARY = '/usr/local/bin/cloud-hypervisor'
 export const CLOUD_HYPERVISOR_DEFAULT_VCPU_COUNT = 2;
 export const CLOUD_HYPERVISOR_DEFAULT_MEMORY_MIB = 512;
 export const CLOUD_HYPERVISOR_DEFAULT_API_TIMEOUT_MS = 5_000;
+export const CLOUD_HYPERVISOR_MOUNT_POLICIES = [
+  'workspace-only',
+  'workspace-and-tool-cache',
+] as const;
+export type CloudHypervisorMountPolicy = typeof CLOUD_HYPERVISOR_MOUNT_POLICIES[number];
+export const CLOUD_HYPERVISOR_DEFAULT_MOUNT_POLICY: CloudHypervisorMountPolicy =
+  'workspace-only';
 
 export interface CloudHypervisorArtifactDigests {
   cloudHypervisor?: string;
@@ -37,6 +44,8 @@ export interface CloudHypervisorArtifactDigests {
  */
 export interface CloudHypervisorOptions {
   previewEnabled: boolean;
+  /** Host exposure policy; runner tool-cache access always requires explicit opt-in. */
+  mountPolicy: CloudHypervisorMountPolicy;
   cloudHypervisorBinary: string;
   kernelPath?: string;
   rootfsPath?: string;


### PR DESCRIPTION
## Summary

- default Cloud Hypervisor preview exports to the `workspace-only` policy instead of automatically exposing `RUNNER_TOOL_CACHE`
- add an explicit `workspace-and-tool-cache` policy through CLI and config schema, with strict validation and mandatory host-side read-only staging
- forward `RUNNER_TOOL_CACHE`, `AGENT_TOOLSDIRECTORY`, and `RUNNER_TEMP` only when their corresponding narrow exports are mounted
- document the preview behavior change and gh-aw generator migration

## Behavior change and migration

Earlier preview builds automatically exported the full runner tool cache whenever `RUNNER_TOOL_CACHE` or `AGENT_TOOLSDIRECTORY` was present. The secure default is now `workspace-only`; narrow gh-aw runtime directories remain available when present.

Workflows that execute or scan runner-installed tools must explicitly add:

```text
--cloud-hypervisor-mount-policy workspace-and-tool-cache
```

or set `cloudHypervisor.mountPolicy` to `workspace-and-tool-cache`. gh-aw generators that emit commands referencing `RUNNER_TOOL_CACHE` should emit this opt-in. Missing cache variables, nonexistent paths, and unknown policy values fail closed.

## Validation

- `npm test -- --runInBand src/cloud-hypervisor/exports.test.ts src/cloud-hypervisor/config.test.ts src/cloud-hypervisor/runtime-validation.test.ts src/cloud-hypervisor-runtime-backend.test.ts src/cloud-hypervisor/virtiofsd.test.ts src/schema.test.ts src/cli-options.test.ts` (155 tests)
- `npm run build`
- `npm run lint --if-present` (passes with existing warnings)