### PR TITLE
feat: verify virtiofsd sandbox confinement before VM boot

### DIFF
--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -159,8 +159,9 @@ configuration, AWF verifies the live parent and worker through `/proc`:
   exact socket, export, sandbox, and seccomp arguments;
 - parent and worker UIDs/GIDs match the reviewed root namespace identity;
 - every parent capability set is empty, while the worker effective and
-  permitted masks equal the pinned minimal virtiofsd set and its ambient set is
-  empty;
+  permitted masks equal the pinned minimal virtiofsd set, its inheritable and
+  ambient sets are empty, and its bounding set contains the capabilities
+  needed during sandbox setup (rendered non-acquirable after `NoNewPrivs`);
 - the worker has `NoNewPrivs: 1` and seccomp filter mode `2`;
 - the worker mount, PID, and network namespaces differ from the host;
 - the worker root inode is the inode of the declared export, proving the

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -74,7 +74,8 @@ AWF performs these steps for each run:
    run directory.
 6. Create a bounded cgroup v2 leaf and launch Cloud Hypervisor as the invoking
    non-root identity.
-7. Start one sandboxed `virtiofsd` process for each validated export.
+7. Start one sandboxed `virtiofsd` process for each validated export and verify
+   its live confinement state from procfs.
 8. Create and boot the VM, connect to the guest supervisor over VSOCK, verify
    loopback plus the configured guest interface, address, and route, and probe
    each trusted infrastructure service with bounded retries. An exhausted
@@ -122,6 +123,39 @@ shell. The process:
 The private run directory is under
 `/run/awf-cloud-hypervisor/<binary>/<runId>/`. Its per-run leaf is accessible
 only to the selected non-root identity and root.
+
+### virtiofsd confinement
+
+AWF launches the pinned `virtiofsd` binary as root because its namespace
+sandbox must create the export mount tree, unshare namespaces, and pivot its
+worker root. Root launch is not treated as proof that the sandbox succeeded.
+Before any virtio-fs socket is included in the Cloud Hypervisor VM
+configuration, AWF verifies the live parent and worker through `/proc`:
+
+- the parent PID still has its launch-time start value, trusted executable, and
+  exact socket, export, sandbox, and seccomp arguments;
+- parent and worker UIDs/GIDs match the reviewed root namespace identity;
+- every parent capability set is empty, while the worker effective and
+  permitted masks equal the pinned minimal virtiofsd set and its ambient set is
+  empty;
+- the worker has `NoNewPrivs: 1` and seccomp filter mode `2`;
+- the worker mount, PID, and network namespaces differ from the host;
+- the worker root inode is the inode of the declared export, proving the
+  namespace sandbox pivoted to the intended tree;
+- parent and worker belong only to the run's bounded cgroup v2 leaf; and
+- parent and worker environments contain only `PATH`, `HOME`, `LANG`, and
+  `LC_ALL`, with no inherited provider credentials or other host variables.
+
+Any mismatch terminates all partially started daemons and aborts startup before
+`vm.create`. The observations are written with mode `0600` to
+`virtiofs-<index>-confinement.json` in the private run directory and copied into
+the diagnostic bundle as
+`virtiofs-<index>-<tag>-confinement.json`. When verification itself rejects
+startup, AWF preserves the failure record under
+`<workDir>/diagnostics/cloud-hypervisor/startup-<runId>/` before partial-start
+cleanup removes the private run directory. This verification follows the
+proven post-launch model from `agent-microvm` v0.9.0 rather than relying only on
+`--sandbox=namespace` and socket existence.
 
 ### Credential isolation
 

--- a/src/cloud-hypervisor/diagnostics.ts
+++ b/src/cloud-hypervisor/diagnostics.ts
@@ -103,6 +103,24 @@ export async function stageDiagnosticFile(
   await dependencies.chown(destination, identity.uid, identity.gid);
 }
 
+export async function preserveVirtiofsdStartupEvidence(
+  dependencies: CloudHypervisorManagerDependencies,
+  devices: readonly VirtiofsdDevice[],
+  directory: string,
+): Promise<void> {
+  if (devices.length === 0) return;
+  await dependencies.mkdir(directory, { recursive: true, mode: 0o700 });
+  for (const device of devices) {
+    try {
+      const destination = path.join(directory, path.basename(device.evidencePath));
+      await dependencies.copyFile(device.evidencePath, destination, constants.COPYFILE_EXCL);
+      await dependencies.chmod(destination, 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+}
+
 async function copyBoundedDiagnostic(
   dependencies: CloudHypervisorManagerDependencies,
   source: string,
@@ -213,6 +231,11 @@ export async function collectCloudHypervisorDiagnostics(
       dependencies,
       device.logPath,
       path.join(directory, `virtiofs-${index}-${device.export.tag}.log`),
+    );
+    await copyBoundedDiagnostic(
+      dependencies,
+      device.evidencePath,
+      path.join(directory, `virtiofs-${index}-${device.export.tag}-confinement.json`),
     );
   }
   await dependencies.writeFile(

--- a/src/cloud-hypervisor/manager-start.ts
+++ b/src/cloud-hypervisor/manager-start.ts
@@ -10,6 +10,7 @@ import {
 import type { CloudHypervisorApiClient } from './api-client';
 import {
   prepareRunDirectory,
+  preserveVirtiofsdStartupEvidence,
   stageArtifact,
   stageDiagnosticFile,
   waitForApiSocket,
@@ -145,7 +146,14 @@ export async function startCloudHypervisor(
         identity, cgroup, { mount: artifacts.tools.mount, umount: artifacts.tools.umount },
       );
       context.setVirtiofsd(virtiofsd);
-      context.setFsDevices(await virtiofsd.start(guestConfig.exports, guestConfig.mountEnforcement));
+      try {
+        context.setFsDevices(
+          await virtiofsd.start(guestConfig.exports, guestConfig.mountEnforcement),
+        );
+      } catch (error) {
+        context.setFsDevices(virtiofsd.getDiagnosticDevices());
+        throw error;
+      }
     }
     await client.vmCreate(buildCloudHypervisorVmConfig({
       config, paths, networkPlan, ...(guestConfig ? { guestConfig } : {}),
@@ -156,6 +164,24 @@ export async function startCloudHypervisor(
     startupError = error;
   }
 
+  const startupEvidenceDirectory = path.join(
+    workDir,
+    'diagnostics',
+    'cloud-hypervisor',
+    `startup-${paths.runId}`,
+  );
+  try {
+    await preserveVirtiofsdStartupEvidence(
+      dependencies,
+      context.getFsDevices(),
+      startupEvidenceDirectory,
+    );
+  } catch (evidenceError) {
+    startupError = new Error(
+      `${formatError(startupError)}; preserving virtiofsd confinement evidence failed: ` +
+      formatError(evidenceError),
+    );
+  }
   try {
     await context.stop();
   } catch (cleanupError) {

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -1,4 +1,5 @@
 import type { ExecaChildProcess } from 'execa';
+import { constants } from 'fs';
 import { PassThrough } from 'stream';
 import type {
   MicrovmNetworkLifecycle,
@@ -46,13 +47,18 @@ function rootfsPreparerMock(): MicrovmRootfsPreparer {
 }
 
 function virtiofsdManagerMock(): VirtiofsdManager {
+  const devices = exportsConfig.map((item, index) => ({
+    export: item,
+    socketPath: `/run/virtiofs-${index}.sock`,
+    logPath: `/run/virtiofs-${index}.log`,
+    evidencePath: `/run/virtiofs-${index}-confinement.json`,
+  }));
   return {
-    start: jest.fn(async (exports: readonly CloudHypervisorDirectoryExport[]) => exports.map((item, index) => ({
-      export: item,
-      socketPath: `/run/virtiofs-${index}.sock`,
-      logPath: `/run/virtiofs-${index}.log`,
-    }))),
+    start: jest.fn(async (exports: readonly CloudHypervisorDirectoryExport[]) => devices.map(
+      (device, index) => ({ ...device, export: exports[index] }),
+    )),
     stop: jest.fn().mockResolvedValue(undefined),
+    getDiagnosticDevices: jest.fn(() => devices),
   } as unknown as VirtiofsdManager;
 }
 
@@ -407,6 +413,7 @@ describe('CloudHypervisorManager', () => {
       order.push('virtiofsd');
       expect(child.exitCode).toBe(0);
     });
+
     const guestClient = {
       connect: jest.fn().mockResolvedValue({
         version: 1,
@@ -496,6 +503,41 @@ describe('CloudHypervisorManager', () => {
     expect(client.vmmShutdown).toHaveBeenCalledTimes(1);
     expect(virtiofsd.stop).toHaveBeenCalledTimes(1);
     expect(order).toEqual(['virtiofsd']);
+  });
+
+  it('preserves failed virtiofsd confinement evidence before partial-start cleanup', async () => {
+    const virtiofsd = virtiofsdManagerMock();
+    (virtiofsd.start as jest.Mock).mockRejectedValue(
+      new Error('virtiofsd sandbox verification failed'),
+    );
+    const deps = dependencies({
+      createVirtiofsdManager: jest.fn().mockReturnValue(virtiofsd),
+    });
+    const manager = new CloudHypervisorManager(
+      config(),
+      '/tmp/awf',
+      deps,
+      'virtiofs-failure',
+      networkConfig(),
+      guestConfig(),
+    );
+
+    await expect(manager.start()).rejects.toThrow(/sandbox verification failed/);
+    expect(deps.copyFile).toHaveBeenCalledWith(
+      '/run/virtiofs-0-confinement.json',
+      expect.stringMatching(
+        /^\/tmp\/awf\/diagnostics\/cloud-hypervisor\/startup-.*\/virtiofs-0-confinement\.json$/,
+      ),
+      constants.COPYFILE_EXCL,
+    );
+    const copyCallOrder = (deps.copyFile as jest.Mock).mock.invocationCallOrder;
+    const evidenceCopyOrder = copyCallOrder[copyCallOrder.length - 1];
+    const runRemoval = (deps.rm as jest.Mock).mock.calls.findIndex(
+      ([target]) => String(target).startsWith('/run/awf-cloud-hypervisor/'),
+    );
+    expect(evidenceCopyOrder).toBeLessThan(
+      (deps.rm as jest.Mock).mock.invocationCallOrder[runRemoval],
+    );
   });
 
   it('starts virtiofsd without an enforcement argument when no write policy applies', async () => {

--- a/src/cloud-hypervisor/virtiofsd-sandbox.ts
+++ b/src/cloud-hypervisor/virtiofsd-sandbox.ts
@@ -1,0 +1,352 @@
+import * as path from 'path';
+
+const WORKER_READY_TIMEOUT_MS = 5_000;
+const WORKER_READY_INTERVAL_MS = 50;
+const REVIEWED_WORKER_CAPABILITIES = '00000000880000db';
+const ZERO_CAPABILITIES = /^0+$/;
+const REQUIRED_NAMESPACES = ['mnt', 'pid', 'net'] as const;
+const CAPABILITY_FIELDS = ['CapInh', 'CapPrm', 'CapEff', 'CapBnd', 'CapAmb'] as const;
+const CGROUP_ROOT = '/sys/fs/cgroup';
+
+export const VIRTIOFSD_ENVIRONMENT = Object.freeze({
+  PATH: '/usr/sbin:/usr/bin:/sbin:/bin',
+  HOME: '/nonexistent',
+  LANG: 'C.UTF-8',
+  LC_ALL: 'C.UTF-8',
+});
+
+export interface VirtiofsdProcessIdentity {
+  readonly pid: number;
+  readonly startTime: string;
+  readonly executable: string;
+  readonly commandLine: readonly string[];
+}
+
+export interface VirtiofsdSandboxDependencies {
+  readFile(filePath: string, encoding: BufferEncoding): Promise<string>;
+  readlink(filePath: string): Promise<string>;
+  statIdentity(filePath: string): Promise<{ dev: number | bigint; ino: number | bigint }>;
+  writeFile(filePath: string, contents: string, options: { mode: number }): Promise<void>;
+  sleep(milliseconds: number): Promise<void>;
+}
+
+export interface VirtiofsdSandboxVerificationOptions {
+  readonly exportTag: string;
+  readonly parentIdentity: VirtiofsdProcessIdentity;
+  readonly expectedExecutable: string;
+  readonly socketPath: string;
+  readonly sharedDirectory: string;
+  readonly cgroupPath: string;
+  readonly evidencePath: string;
+  readonly assignToCgroup: (pid: number) => Promise<void>;
+}
+
+interface ProcessEvidence {
+  pid: number;
+  startTime: string;
+  executable: string;
+  uid: string;
+  gid: string;
+  capabilities: Record<string, string>;
+  noNewPrivs: number;
+  seccomp: number;
+  environment: string[];
+  environmentValuesMatch: boolean;
+  cgroup: string;
+}
+
+/**
+ * Captures the immutable process identity used to reject PID reuse between
+ * spawn, readiness, sandbox verification, and cleanup.
+ */
+export async function captureVirtiofsdProcessIdentity(
+  pid: number,
+  dependencies: Pick<VirtiofsdSandboxDependencies, 'readFile' | 'readlink'>,
+): Promise<VirtiofsdProcessIdentity> {
+  if (!Number.isSafeInteger(pid) || pid <= 1) {
+    throw new Error(`virtiofsd exposed an invalid PID: ${pid}`);
+  }
+  const stat = await dependencies.readFile(`/proc/${pid}/stat`, 'utf8');
+  const end = stat.lastIndexOf(')');
+  if (end < 0) throw new Error(`virtiofsd PID ${pid} has malformed /proc stat data`);
+  const fields = stat.slice(end + 2).trim().split(/\s+/);
+  const startTime = fields[19];
+  if (!startTime || !/^\d+$/.test(startTime)) {
+    throw new Error(`virtiofsd PID ${pid} has no valid process start time`);
+  }
+  const executable = await dependencies.readlink(`/proc/${pid}/exe`);
+  const commandLine = parseNullDelimited(
+    await dependencies.readFile(`/proc/${pid}/cmdline`, 'utf8'),
+  );
+  return { pid, startTime, executable, commandLine };
+}
+
+/**
+ * Verifies virtiofsd's namespace sandbox from host procfs and persists the
+ * observations before the socket can be passed to Cloud Hypervisor.
+ */
+export async function verifyVirtiofsdSandbox(
+  options: VirtiofsdSandboxVerificationOptions,
+  dependencies: VirtiofsdSandboxDependencies,
+): Promise<void> {
+  const evidence: Record<string, unknown> = {
+    version: 1,
+    verified: false,
+    exportTag: options.exportTag,
+    expectedExecutable: options.expectedExecutable,
+    expectedCgroup: options.cgroupPath,
+    expectedRoot: options.sharedDirectory,
+    expectedEnvironment: Object.keys(VIRTIOFSD_ENVIRONMENT).sort(),
+    parent: null,
+    worker: null,
+    namespaces: null,
+    root: null,
+  };
+  let verificationError: unknown;
+
+  try {
+    const currentParent = await captureVirtiofsdProcessIdentity(
+      options.parentIdentity.pid,
+      dependencies,
+    );
+    assertSameIdentity(options.parentIdentity, currentParent, 'parent');
+    assertLaunchCommand(currentParent, options);
+
+    const workerPid = await waitForWorker(options.parentIdentity.pid, dependencies);
+    const workerIdentity = await captureVirtiofsdProcessIdentity(workerPid, dependencies);
+    assertExecutable(workerIdentity.executable, options.expectedExecutable, 'worker');
+    await options.assignToCgroup(workerPid);
+    const currentWorker = await captureVirtiofsdProcessIdentity(workerPid, dependencies);
+    assertSameIdentity(workerIdentity, currentWorker, 'worker');
+
+    const parent = await collectProcessEvidence(currentParent, options.cgroupPath, dependencies);
+    const worker = await collectProcessEvidence(currentWorker, options.cgroupPath, dependencies);
+    evidence.parent = parent;
+    evidence.worker = worker;
+
+    assertRootIdentity(parent, 'parent');
+    assertRootIdentity(worker, 'worker');
+    for (const field of CAPABILITY_FIELDS) {
+      if (!ZERO_CAPABILITIES.test(parent.capabilities[field] ?? '')) {
+        throw new Error(`virtiofsd parent ${field} is not empty`);
+      }
+    }
+    if (
+      worker.capabilities.CapEff !== REVIEWED_WORKER_CAPABILITIES ||
+      worker.capabilities.CapPrm !== REVIEWED_WORKER_CAPABILITIES ||
+      !ZERO_CAPABILITIES.test(worker.capabilities.CapAmb ?? '')
+    ) {
+      throw new Error('virtiofsd worker capabilities differ from the reviewed sandbox set');
+    }
+    if (worker.noNewPrivs !== 1 || worker.seccomp !== 2) {
+      throw new Error('virtiofsd worker is missing NoNewPrivs or seccomp filtering');
+    }
+    const expectedEnvironment = Object.keys(VIRTIOFSD_ENVIRONMENT).sort();
+    for (const [role, processEvidence] of [['parent', parent], ['worker', worker]] as const) {
+      if (
+        !arraysEqual(processEvidence.environment, expectedEnvironment) ||
+        !processEvidence.environmentValuesMatch
+      ) {
+        throw new Error(
+          `virtiofsd ${role} inherited unexpected environment variables: ` +
+          processEvidence.environment.join(', '),
+        );
+      }
+      assertCgroup(processEvidence.cgroup, options.cgroupPath, role);
+    }
+
+    const namespaces: Record<string, { host: string; worker: string }> = {};
+    for (const name of REQUIRED_NAMESPACES) {
+      const host = await dependencies.readlink(`/proc/self/ns/${name}`);
+      const sandbox = await dependencies.readlink(`/proc/${workerPid}/ns/${name}`);
+      if (host === sandbox) {
+        throw new Error(`virtiofsd worker did not isolate its ${name} namespace`);
+      }
+      namespaces[name] = { host, worker: sandbox };
+    }
+    evidence.namespaces = namespaces;
+
+    const actualRoot = await inodeIdentity(`/proc/${workerPid}/root`, dependencies);
+    const expectedRoot = await inodeIdentity(options.sharedDirectory, dependencies);
+    evidence.root = { actual: actualRoot, expected: expectedRoot };
+    if (actualRoot !== expectedRoot) {
+      throw new Error('virtiofsd worker root is not its declared export');
+    }
+
+    assertSameIdentity(
+      options.parentIdentity,
+      await captureVirtiofsdProcessIdentity(options.parentIdentity.pid, dependencies),
+      'parent',
+    );
+    assertSameIdentity(
+      workerIdentity,
+      await captureVirtiofsdProcessIdentity(workerPid, dependencies),
+      'worker',
+    );
+    evidence.verified = true;
+  } catch (error) {
+    verificationError = error;
+    evidence.error = formatError(error);
+  }
+
+  try {
+    await dependencies.writeFile(
+      options.evidencePath,
+      `${JSON.stringify(evidence, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+  } catch (error) {
+    if (verificationError !== undefined) {
+      throw new Error(
+        `virtiofsd sandbox verification failed: ${formatError(verificationError)}; ` +
+        `writing confinement evidence failed: ${formatError(error)}`,
+      );
+    }
+    throw new Error(`writing virtiofsd confinement evidence failed: ${formatError(error)}`);
+  }
+  if (verificationError !== undefined) {
+    throw new Error(`virtiofsd sandbox verification failed: ${formatError(verificationError)}`);
+  }
+}
+
+async function waitForWorker(
+  parentPid: number,
+  dependencies: VirtiofsdSandboxDependencies,
+): Promise<number> {
+  const deadline = Date.now() + WORKER_READY_TIMEOUT_MS;
+  do {
+    const children = (
+      await dependencies.readFile(`/proc/${parentPid}/task/${parentPid}/children`, 'utf8')
+    ).trim().split(/\s+/).filter(Boolean);
+    for (const value of children) {
+      const candidate = Number(value);
+      if (!Number.isSafeInteger(candidate) || candidate <= 1) continue;
+      try {
+        const comm = await dependencies.readFile(`/proc/${candidate}/comm`, 'utf8');
+        if (comm.trim() === 'virtiofsd') return candidate;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+    await dependencies.sleep(WORKER_READY_INTERVAL_MS);
+  } while (Date.now() < deadline);
+  throw new Error('virtiofsd did not create its sandbox worker');
+}
+
+async function collectProcessEvidence(
+  identity: VirtiofsdProcessIdentity,
+  cgroupPath: string,
+  dependencies: VirtiofsdSandboxDependencies,
+): Promise<ProcessEvidence> {
+  const status = parseStatus(await dependencies.readFile(`/proc/${identity.pid}/status`, 'utf8'));
+  const capabilities = Object.fromEntries(
+    CAPABILITY_FIELDS.map((field) => [field, status[field] ?? '']),
+  );
+  const environmentEntries = parseNullDelimited(
+    await dependencies.readFile(`/proc/${identity.pid}/environ`, 'utf8'),
+  ).sort();
+  const expectedEnvironmentEntries = Object.entries(VIRTIOFSD_ENVIRONMENT)
+    .map(([name, value]) => `${name}=${value}`)
+    .sort();
+  return {
+    pid: identity.pid,
+    startTime: identity.startTime,
+    executable: identity.executable,
+    uid: status.Uid ?? '',
+    gid: status.Gid ?? '',
+    capabilities,
+    noNewPrivs: Number(status.NoNewPrivs),
+    seccomp: Number(status.Seccomp),
+    environment: environmentEntries.map(environmentName).sort(),
+    environmentValuesMatch: arraysEqual(environmentEntries, expectedEnvironmentEntries),
+    cgroup: (await dependencies.readFile(`/proc/${identity.pid}/cgroup`, 'utf8')).trim(),
+  };
+}
+
+function assertRootIdentity(evidence: ProcessEvidence, role: string): void {
+  if (evidence.uid !== '0\t0\t0\t0' || evidence.gid !== '0\t0\t0\t0') {
+    throw new Error(
+      `virtiofsd ${role} uid/gid differs from the reviewed namespace-sandbox identity`,
+    );
+  }
+}
+
+function assertCgroup(actual: string, expectedPath: string, role: string): void {
+  const relative = path.relative(CGROUP_ROOT, expectedPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`virtiofsd expected cgroup is outside cgroup v2: ${expectedPath}`);
+  }
+  const expected = `0::/${relative}`;
+  if (actual.split(/\r?\n/).filter(Boolean).length !== 1 || actual !== expected) {
+    throw new Error(`virtiofsd ${role} is not in its expected cgroup`);
+  }
+}
+
+function assertSameIdentity(
+  expected: VirtiofsdProcessIdentity,
+  actual: VirtiofsdProcessIdentity,
+  role: string,
+): void {
+  if (
+    expected.pid !== actual.pid ||
+    expected.startTime !== actual.startTime ||
+    expected.executable !== actual.executable
+  ) {
+    throw new Error(`virtiofsd ${role} process identity changed before sandbox verification`);
+  }
+}
+
+function assertExecutable(actual: string, expected: string, role: string): void {
+  if (actual !== expected) {
+    throw new Error(`virtiofsd ${role} executable differs from the trusted binary`);
+  }
+}
+
+function assertLaunchCommand(
+  identity: VirtiofsdProcessIdentity,
+  options: VirtiofsdSandboxVerificationOptions,
+): void {
+  assertExecutable(identity.executable, options.expectedExecutable, 'parent');
+  const command = identity.commandLine;
+  if (
+    !command.includes(`--socket-path=${options.socketPath}`) ||
+    !command.includes(`--shared-dir=${options.sharedDirectory}`) ||
+    !command.includes('--sandbox=namespace') ||
+    !command.includes('--seccomp=kill')
+  ) {
+    throw new Error('virtiofsd parent command line does not match the requested sandbox export');
+  }
+}
+
+function parseStatus(contents: string): Record<string, string> {
+  const entries = contents.split(/\r?\n/).map((line) => /^([^:]+):\s*(.*)$/.exec(line));
+  return Object.fromEntries(
+    entries.filter((entry): entry is RegExpExecArray => entry !== null)
+      .map((entry) => [entry[1], entry[2]]),
+  );
+}
+
+function parseNullDelimited(contents: string): string[] {
+  return contents.split('\0').filter(Boolean);
+}
+
+function environmentName(entry: string): string {
+  const separator = entry.indexOf('=');
+  return separator < 0 ? entry : entry.slice(0, separator);
+}
+
+async function inodeIdentity(
+  filePath: string,
+  dependencies: Pick<VirtiofsdSandboxDependencies, 'statIdentity'>,
+): Promise<string> {
+  const stat = await dependencies.statIdentity(filePath);
+  return `${stat.dev}:${stat.ino}`;
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/cloud-hypervisor/virtiofsd-sandbox.ts
+++ b/src/cloud-hypervisor/virtiofsd-sandbox.ts
@@ -3,7 +3,9 @@ import * as path from 'path';
 const WORKER_READY_TIMEOUT_MS = 5_000;
 const WORKER_READY_INTERVAL_MS = 50;
 const REVIEWED_WORKER_CAPABILITIES = '00000000880000db';
+const REVIEWED_WORKER_CAPABILITY_BITS = BigInt(`0x${REVIEWED_WORKER_CAPABILITIES}`);
 const ZERO_CAPABILITIES = /^0+$/;
+const CAPABILITY_MASK = /^[0-9a-f]{16}$/;
 const REQUIRED_NAMESPACES = ['mnt', 'pid', 'net'] as const;
 const CAPABILITY_FIELDS = ['CapInh', 'CapPrm', 'CapEff', 'CapBnd', 'CapAmb'] as const;
 const CGROUP_ROOT = '/sys/fs/cgroup';
@@ -134,9 +136,18 @@ export async function verifyVirtiofsdSandbox(
     if (
       worker.capabilities.CapEff !== REVIEWED_WORKER_CAPABILITIES ||
       worker.capabilities.CapPrm !== REVIEWED_WORKER_CAPABILITIES ||
+      !ZERO_CAPABILITIES.test(worker.capabilities.CapInh ?? '') ||
       !ZERO_CAPABILITIES.test(worker.capabilities.CapAmb ?? '')
     ) {
       throw new Error('virtiofsd worker capabilities differ from the reviewed sandbox set');
+    }
+    const workerBounding = worker.capabilities.CapBnd ?? '';
+    if (
+      !CAPABILITY_MASK.test(workerBounding) ||
+      (BigInt(`0x${workerBounding}`) & REVIEWED_WORKER_CAPABILITY_BITS) !==
+        REVIEWED_WORKER_CAPABILITY_BITS
+    ) {
+      throw new Error('virtiofsd worker bounding set excludes reviewed runtime capabilities');
     }
     if (worker.noNewPrivs !== 1 || worker.seccomp !== 2) {
       throw new Error('virtiofsd worker is missing NoNewPrivs or seccomp filtering');

--- a/src/cloud-hypervisor/virtiofsd.test.ts
+++ b/src/cloud-hypervisor/virtiofsd.test.ts
@@ -6,6 +6,7 @@ import {
   buildVirtiofsdArgs,
   type VirtiofsdDependencies,
 } from './virtiofsd';
+import { VIRTIOFSD_ENVIRONMENT } from './virtiofsd-sandbox';
 
 const workspace = {
   tag: 'workspace',
@@ -42,8 +43,49 @@ function dependencies(
   overrides: Partial<VirtiofsdDependencies> = {},
 ): VirtiofsdDependencies {
   let pid = 100;
+  const launches = new Map<number, string[]>();
+  const launch = jest.fn((command: string, args: string[]) => {
+    const nextPid = pid++;
+    launches.set(nextPid, [command, ...args]);
+    return processMock(nextPid);
+  });
+  const readFile = jest.fn(async (filePath: string) => {
+    const match = /^\/proc\/(\d+)\//.exec(filePath);
+    const processPid = match ? Number(match[1]) : 0;
+    const parentPid = processPid >= 1_000 ? processPid - 1_000 : processPid;
+    const isWorker = processPid >= 1_000;
+    if (filePath.endsWith('/stat')) {
+      const fields = Array(20).fill('0');
+      fields[19] = String(processPid * 10);
+      return `${processPid} (virtiofsd) ${fields.join(' ')}`;
+    }
+    if (filePath.endsWith('/children')) return String(parentPid + 1_000);
+    if (filePath.endsWith('/comm')) return 'virtiofsd\n';
+    if (filePath.endsWith('/cmdline')) return `${(launches.get(parentPid) ?? []).join('\0')}\0`;
+    if (filePath.endsWith('/status')) {
+      const zero = '0000000000000000';
+      const reviewed = '00000000880000db';
+      return [
+        'Uid:\t0\t0\t0\t0',
+        'Gid:\t0\t0\t0\t0',
+        `CapInh:\t${zero}`,
+        `CapPrm:\t${isWorker ? reviewed : zero}`,
+        `CapEff:\t${isWorker ? reviewed : zero}`,
+        `CapBnd:\t${isWorker ? reviewed : zero}`,
+        `CapAmb:\t${zero}`,
+        `NoNewPrivs:\t${isWorker ? 1 : 0}`,
+        `Seccomp:\t${isWorker ? 2 : 0}`,
+      ].join('\n');
+    }
+    if (filePath.endsWith('/environ')) {
+      return `${Object.entries(VIRTIOFSD_ENVIRONMENT)
+        .map(([name, value]) => `${name}=${value}`).join('\0')}\0`;
+    }
+    if (filePath.endsWith('/cgroup')) return '0::/awf-cloud-hypervisor/test\n';
+    throw Object.assign(new Error(`unexpected read: ${filePath}`), { code: 'ENOENT' });
+  });
   return {
-    launch: jest.fn(() => processMock(pid++)),
+    launch,
     lstat: jest.fn().mockResolvedValue({ isSocket: () => true }),
     chown: jest.fn().mockResolvedValue(undefined),
     writeFile: jest.fn().mockResolvedValue(undefined),
@@ -58,6 +100,13 @@ function dependencies(
       isSymbolicLink: () => false,
     }),
     realpath: jest.fn(async (filePath: string) => filePath),
+    readFile,
+    readlink: jest.fn(async (filePath: string) => {
+      if (filePath.endsWith('/exe')) return '/opt/virtiofsd';
+      if (filePath.startsWith('/proc/self/ns/')) return `${filePath.split('/').pop()}:[1]`;
+      return `${filePath.split('/').pop()}:[2]`;
+    }),
+    statIdentity: jest.fn().mockResolvedValue({ dev: 8, ino: 42 }),
     readMountInfo: jest
       .fn()
       .mockResolvedValueOnce(`30 29 0:42 / ${STAGED_ROOT} ro,nosuid,nodev - ext4 /dev/root ro`)
@@ -73,13 +122,19 @@ function dependencies(
   };
 }
 
-function manager(deps: VirtiofsdDependencies, cgroup?: Pick<CloudHypervisorCgroup, 'assign'>) {
+function manager(
+  deps: VirtiofsdDependencies,
+  cgroup?: Pick<CloudHypervisorCgroup, 'assign' | 'cgroupPath'>,
+) {
   return new VirtiofsdManager(
     '/opt/virtiofsd',
     '/run/awf/run',
     '/run/awf-shares/run',
     { uid: 1000, gid: 1000 },
-    cgroup ?? { assign: jest.fn().mockResolvedValue(undefined) },
+    cgroup ?? {
+      cgroupPath: '/sys/fs/cgroup/awf-cloud-hypervisor/test',
+      assign: jest.fn().mockResolvedValue(undefined),
+    },
     { mount: '/usr/bin/mount', umount: '/usr/bin/umount' },
     deps,
   );
@@ -114,7 +169,10 @@ describe('VirtiofsdManager', () => {
 
   it('starts one daemon per export, assigns the shared cgroup, and cleans residue', async () => {
     const deps = dependencies();
-    const cgroup = { assign: jest.fn().mockResolvedValue(undefined) } as unknown as CloudHypervisorCgroup;
+    const cgroup = {
+      cgroupPath: '/sys/fs/cgroup/awf-cloud-hypervisor/test',
+      assign: jest.fn().mockResolvedValue(undefined),
+    } as unknown as CloudHypervisorCgroup;
     const manager = new VirtiofsdManager(
       '/opt/virtiofsd',
       '/run/awf/run',
@@ -136,13 +194,20 @@ describe('VirtiofsdManager', () => {
       {
         reject: false,
         stdio: ['ignore', 'pipe', 'pipe'],
-        env: { PATH: '/usr/sbin:/usr/bin:/sbin:/bin' },
+        env: VIRTIOFSD_ENVIRONMENT,
         extendEnv: false,
       },
     );
     expect(cgroup.assign).toHaveBeenNthCalledWith(1, 100);
-    expect(cgroup.assign).toHaveBeenNthCalledWith(2, 101);
+    expect(cgroup.assign).toHaveBeenNthCalledWith(2, 1100);
+    expect(cgroup.assign).toHaveBeenNthCalledWith(3, 101);
+    expect(cgroup.assign).toHaveBeenNthCalledWith(4, 1101);
     expect(deps.chown).toHaveBeenCalledWith('/run/awf/run/virtiofs-0.sock', 1000, 1000);
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/run/awf/run/virtiofs-0-confinement.json',
+      expect.stringContaining('"verified": true'),
+      { mode: 0o600 },
+    );
     expect(deps.runTool).toHaveBeenCalledWith('/usr/bin/mount', [
       '--bind', '/host/cache', '/run/awf-shares/run/1-cache',
     ]);
@@ -151,7 +216,7 @@ describe('VirtiofsdManager', () => {
     ]);
 
     await manager.stop();
-    expect(deps.writeFile).toHaveBeenCalledTimes(2);
+    expect(deps.writeFile).toHaveBeenCalledTimes(4);
     expect(deps.rm).toHaveBeenCalledWith('/run/awf/run/virtiofs-0.sock', { force: true });
     expect(deps.runTool).toHaveBeenCalledWith(
       '/usr/bin/umount',
@@ -168,12 +233,54 @@ describe('VirtiofsdManager', () => {
       '/run/awf/run',
       '/run/awf-shares/run',
       { uid: 1000, gid: 1000 },
-      { assign: jest.fn().mockResolvedValue(undefined) },
+      {
+        cgroupPath: '/sys/fs/cgroup/awf-cloud-hypervisor/test',
+        assign: jest.fn().mockResolvedValue(undefined),
+      },
       { mount: '/usr/bin/mount', umount: '/usr/bin/umount' },
       deps,
     );
     await expect(manager.start([workspace])).rejects.toThrow(/exited before socket readiness/);
     expect(deps.rm).toHaveBeenCalledWith('/run/awf/run/virtiofs-0.sock', { force: true });
+  });
+
+  it('fails closed, records evidence, and withholds the socket when the sandbox is unsafe', async () => {
+    const deps = dependencies();
+    const readFile = deps.readFile;
+    deps.readFile = jest.fn(async (filePath: string, encoding: BufferEncoding) => {
+      if (filePath.endsWith('/environ')) return 'PATH=/usr/bin\0SECRET_TOKEN=exposed\0';
+      return readFile(filePath, encoding);
+    });
+    const started = manager(deps);
+
+    await expect(started.start([workspace])).rejects.toThrow(
+      /inherited unexpected environment variables/,
+    );
+    expect(deps.chown).not.toHaveBeenCalled();
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      '/run/awf/run/virtiofs-0-confinement.json',
+      expect.stringContaining('"verified": false'),
+      { mode: 0o600 },
+    );
+    expect(started.getDiagnosticDevices()).toEqual([
+      expect.objectContaining({
+        evidencePath: '/run/awf/run/virtiofs-0-confinement.json',
+      }),
+    ]);
+    expect(deps.rm).toHaveBeenCalledWith('/run/awf/run/virtiofs-0.sock', { force: true });
+  });
+
+  it('rejects a sandbox worker outside the assigned cgroup', async () => {
+    const deps = dependencies();
+    const readFile = deps.readFile;
+    deps.readFile = jest.fn(async (filePath: string, encoding: BufferEncoding) => {
+      if (filePath.endsWith('/cgroup')) return '0::/system.slice\n';
+      return readFile(filePath, encoding);
+    });
+
+    await expect(manager(deps).start([workspace])).rejects.toThrow(
+      /worker is not in its expected cgroup|parent is not in its expected cgroup/,
+    );
   });
 
   it('retains failed bind cleanup so a later stop can retry it', async () => {
@@ -190,7 +297,10 @@ describe('VirtiofsdManager', () => {
       '/run/awf/run',
       '/run/awf-shares/run',
       { uid: 1000, gid: 1000 },
-      { assign: jest.fn().mockResolvedValue(undefined) },
+      {
+        cgroupPath: '/sys/fs/cgroup/awf-cloud-hypervisor/test',
+        assign: jest.fn().mockResolvedValue(undefined),
+      },
       { mount: '/usr/bin/mount', umount: '/usr/bin/umount' },
       deps,
     );

--- a/src/cloud-hypervisor/virtiofsd.test.ts
+++ b/src/cloud-hypervisor/virtiofsd.test.ts
@@ -332,6 +332,32 @@ describe('VirtiofsdManager', () => {
       error: /worker capabilities differ/,
     },
     {
+      name: 'worker inheritable capabilities',
+      mutate: (deps: VirtiofsdDependencies) => {
+        const readFile = deps.readFile;
+        deps.readFile = jest.fn(async (filePath: string, encoding: BufferEncoding) => {
+          const contents = await readFile(filePath, encoding);
+          return filePath === '/proc/1100/status'
+            ? contents.replace('CapInh:\t0000000000000000', 'CapInh:\t0000000000000001')
+            : contents;
+        });
+      },
+      error: /worker capabilities differ/,
+    },
+    {
+      name: 'worker bounding capabilities',
+      mutate: (deps: VirtiofsdDependencies) => {
+        const readFile = deps.readFile;
+        deps.readFile = jest.fn(async (filePath: string, encoding: BufferEncoding) => {
+          const contents = await readFile(filePath, encoding);
+          return filePath === '/proc/1100/status'
+            ? contents.replace('CapBnd:\t00000000880000db', 'CapBnd:\t0000000000000000')
+            : contents;
+        });
+      },
+      error: /bounding set excludes reviewed runtime capabilities/,
+    },
+    {
       name: 'worker NoNewPrivs',
       mutate: (deps: VirtiofsdDependencies) => {
         const readFile = deps.readFile;

--- a/src/cloud-hypervisor/virtiofsd.ts
+++ b/src/cloud-hypervisor/virtiofsd.ts
@@ -12,6 +12,12 @@ import {
   type VirtiofsdExportMountPlan,
   type VirtiofsdMountEnforcement,
 } from './mount-tree';
+import {
+  VIRTIOFSD_ENVIRONMENT,
+  captureVirtiofsdProcessIdentity,
+  verifyVirtiofsdSandbox,
+  type VirtiofsdSandboxDependencies,
+} from './virtiofsd-sandbox';
 
 export type {
   MountTreeDependencies,
@@ -31,9 +37,11 @@ export interface VirtiofsdDevice {
   readonly export: CloudHypervisorDirectoryExport;
   readonly socketPath: string;
   readonly logPath: string;
+  readonly evidencePath: string;
 }
 
-export interface VirtiofsdDependencies extends MountTreeDependencies {
+export interface VirtiofsdDependencies
+  extends MountTreeDependencies, VirtiofsdSandboxDependencies {
   launch(
     command: string,
     args: string[],
@@ -46,7 +54,7 @@ export interface VirtiofsdDependencies extends MountTreeDependencies {
   ): ExecaChildProcess<string>;
   lstat(filePath: string): Promise<{ isSocket(): boolean }>;
   chown(filePath: string, uid: number, gid: number): Promise<void>;
-  writeFile(filePath: string, contents: Buffer, options: { mode: number }): Promise<void>;
+  writeFile(filePath: string, contents: Buffer | string, options: { mode: number }): Promise<void>;
   rm(filePath: string, options: { force: true }): Promise<void>;
   mkdir(directory: string, options: { recursive: true; mode: number }): Promise<unknown>;
   rmdir(directory: string): Promise<void>;
@@ -55,7 +63,6 @@ export interface VirtiofsdDependencies extends MountTreeDependencies {
   statPath(filePath: string): Promise<MountTreeStats>;
   realpath(filePath: string): Promise<string>;
   readMountInfo(): Promise<string>;
-  sleep(milliseconds: number): Promise<void>;
 }
 
 const defaultDependencies: VirtiofsdDependencies = {
@@ -63,6 +70,9 @@ const defaultDependencies: VirtiofsdDependencies = {
   lstat: fs.lstat,
   chown: fs.chown,
   writeFile: fs.writeFile,
+  readFile: fs.readFile,
+  readlink: fs.readlink,
+  statIdentity: (filePath) => fs.stat(filePath, { bigint: true }),
   rm: (filePath, options) => fs.rm(filePath, options),
   mkdir: fs.mkdir,
   rmdir: fs.rmdir,
@@ -112,6 +122,7 @@ interface RunningDaemon extends VirtiofsdDevice {
 
 export class VirtiofsdManager {
   private readonly running: RunningDaemon[] = [];
+  private readonly diagnosticDevices: VirtiofsdDevice[] = [];
   /** Mount trees whose staging failed with residue that still needs unmounting. */
   private readonly orphanedMountTrees: StagedHostMountTree[] = [];
 
@@ -120,7 +131,7 @@ export class VirtiofsdManager {
     private readonly runDirectory: string,
     private readonly shareDirectory: string,
     private readonly identity: { uid: number; gid: number },
-    private readonly cgroup: Pick<CloudHypervisorCgroup, 'assign'>,
+    private readonly cgroup: Pick<CloudHypervisorCgroup, 'assign' | 'cgroupPath'>,
     private readonly tools: { readonly mount: string; readonly umount: string },
     private readonly dependencies: VirtiofsdDependencies = defaultDependencies,
   ) {}
@@ -141,10 +152,11 @@ export class VirtiofsdManager {
       for (const [index, directoryExport] of exports.entries()) {
         await this.startOne(directoryExport, index, selectMountPlan(enforcement, directoryExport.tag));
       }
-      return this.running.map(({ export: item, socketPath, logPath }) => ({
+      return this.running.map(({ export: item, socketPath, logPath, evidencePath }) => ({
         export: item,
         socketPath,
         logPath,
+        evidencePath,
       }));
     } catch (error) {
       try {
@@ -244,6 +256,10 @@ export class VirtiofsdManager {
     }
   }
 
+  getDiagnosticDevices(): VirtiofsdDevice[] {
+    return this.diagnosticDevices.map((device) => ({ ...device }));
+  }
+
   private async startOne(
     directoryExport: CloudHypervisorDirectoryExport,
     index: number,
@@ -251,6 +267,7 @@ export class VirtiofsdManager {
   ): Promise<void> {
     const socketPath = path.join(this.runDirectory, `virtiofs-${index}.sock`);
     const logPath = path.join(this.runDirectory, `virtiofs-${index}.log`);
+    const evidencePath = path.join(this.runDirectory, `virtiofs-${index}-confinement.json`);
     let sharedDirectory = directoryExport.source;
     let readonlyBindPath: string | undefined;
     let mountTree: StagedHostMountTree | undefined;
@@ -301,10 +318,11 @@ export class VirtiofsdManager {
     const args = buildVirtiofsdArgs(directoryExport, socketPath, sharedDirectory, {
       announceSubmounts: mountTree !== undefined,
     });
+    const expectedExecutable = await this.dependencies.realpath(this.binaryPath);
     const child = this.dependencies.launch(this.binaryPath, args, {
       reject: false,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { PATH: '/usr/sbin:/usr/bin:/sbin:/bin' },
+      env: VIRTIOFSD_ENVIRONMENT,
       extendEnv: false,
     });
     const stdout = new BoundedCapture(CAPTURE_LIMIT_BYTES);
@@ -315,6 +333,7 @@ export class VirtiofsdManager {
       export: directoryExport,
       socketPath,
       logPath,
+      evidencePath,
       process: child,
       stdout,
       stderr,
@@ -323,9 +342,26 @@ export class VirtiofsdManager {
       socketRemoved: false,
     };
     this.running.push(daemon);
+    this.diagnosticDevices.push({
+      export: directoryExport,
+      socketPath,
+      logPath,
+      evidencePath,
+    });
     if (!child.pid) throw new Error(`virtiofsd for "${directoryExport.tag}" did not expose a PID`);
     await this.cgroup.assign(child.pid);
+    const parentIdentity = await captureVirtiofsdProcessIdentity(child.pid, this.dependencies);
     await this.waitForSocket(daemon);
+    await verifyVirtiofsdSandbox({
+      exportTag: directoryExport.tag,
+      parentIdentity,
+      expectedExecutable,
+      socketPath,
+      sharedDirectory,
+      cgroupPath: this.cgroup.cgroupPath,
+      evidencePath,
+      assignToCgroup: (pid) => this.cgroup.assign(pid),
+    }, this.dependencies);
     await this.dependencies.chown(socketPath, this.identity.uid, this.identity.gid);
   }
 

--- a/src/cloud-hypervisor/vm-config-builder.test.ts
+++ b/src/cloud-hypervisor/vm-config-builder.test.ts
@@ -83,6 +83,7 @@ describe('buildCloudHypervisorVmConfig', () => {
         },
         socketPath: '/run/virtiofs.sock',
         logPath: '/run/virtiofs.log',
+        evidencePath: '/run/virtiofs-confinement.json',
       }],
     });
 


### PR DESCRIPTION
## Summary

- verify every Cloud Hypervisor virtiofsd parent and sandbox worker from `/proc` before its socket enters `vm.create`
- enforce launch identity, reviewed UID/GID and capability state, `NoNewPrivs`, seccomp filter mode, isolated mount/PID/network namespaces, pivoted export root, exact cgroup v2 membership, and a scrubbed environment
- explicitly assign identity-checked workers to the run cgroup, persist mode-0600 confinement evidence, and preserve failure evidence before partial-start cleanup
- document the boundary and add fail-closed, cgroup-race, evidence, and orchestration coverage

The verification model follows `github/agent-microvm` v0.9.0 commit `9ca223049a3af490df168cbb74233ab438aceefb`.

## Validation

- `npm test -- --runInBand` (329 suites, 5277 tests)
- `npm run type-check -- --pretty false`
- `npm run build -- --pretty false`
- targeted ESLint and Markdownlint (no errors)