### PR TITLE
feat: reserve microVM network resources atomically

### DIFF
--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -131,12 +131,36 @@ proxy endpoint and non-secret execution settings.
 
 ### Network egress
 
-Each run uses deterministic, length-bounded resource names:
+Before creating network resources, each run acquires an OS-held `flock` on the
+root-owned `0700` directory `/run/awf-microvm-network/`. While holding that
+lock, AWF atomically chooses an unused `/30` guest subnet, bridge-side source
+address, and random resource token after checking durable reservations plus
+live namespaces, interfaces, addresses, and routes in every named namespace.
+It writes a mode `0600` reservation containing
+the kernel boot ID, owner PID, process start time, and a unique lease ID before
+releasing the lock. The kernel releases the allocation lock automatically if
+the allocator exits, so there is no stale lock file ownership protocol or
+TOCTOU cleanup window.
+
+Each reservation produces length-bounded resource names:
 
 - namespace: `awfvm-<token>`
 - host veth: `vmh<token>`
 - namespace veth: `vmn<token>`
 - TAP device: `vmt<token>`
+
+Allocation is intentionally not deterministic: diagnostics record the selected
+token, subnet, and reservation path in `network-plan.json`. This keeps incident
+diagnostics reproducible without making concurrency depend on a hash collision
+not occurring.
+
+Cleanup removes only resources named by that run and deletes the reservation
+only when its lease and process identity still match the durable record.
+Per-run `DOCKER-USER` rules carry the reservation token in an iptables comment,
+so one concurrent run cannot delete another run's otherwise-identical bridge
+rule. A dead owner's reservation is reclaimed only after its boot/PID/start-time
+identity is stale and none of its namespace, interfaces, or subnet routes
+remain live.
 
 The namespace connects the guest TAP to AWF's host-side infrastructure.
 nftables permits only the required paths to Squid and the API proxy and denies

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -125,7 +125,108 @@ assert_no_residue() {
     echo "Cloud Hypervisor run-directory residue detected" >&2
     return 1
   fi
+  if sudo find /run/awf-microvm-network/reservations -name '*.json' -print -quit \
+    2>/dev/null | grep -q .; then
+    sudo find /run/awf-microvm-network/reservations -name '*.json' -print >&2
+    echo "Cloud Hypervisor network reservation residue detected" >&2
+    return 1
+  fi
 }
+
+# Exercise the real root-owned registry and kernel-held flock from independent
+# processes before booting a VM. Using the same run ID deliberately gives both
+# allocators the same first-choice subnet; the second must select another one.
+reservation_probe() {
+  local output=$1
+  exec env AWF_ROOT="$ROOT" sudo -E node -e '
+    const path = require("path");
+    const { reserveMicrovmNetworkPlan } = require(
+      path.join(process.env.AWF_ROOT, "dist/microvm/network.js")
+    );
+    (async () => {
+      const reservation = await reserveMicrovmNetworkPlan(
+        "live-concurrent-reservation",
+        {
+          infrastructureBridge: "awfbr0",
+          enableApiProxy: true,
+          tapOwnerUid: 1000,
+          tapOwnerGid: 1000,
+        },
+        { ip: "ip", nft: "nft", sysctl: "sysctl", flock: "flock" },
+      );
+      const stop = async () => {
+        await reservation.release();
+        process.exit(0);
+      };
+      process.on("SIGTERM", () => {
+        void stop().catch((error) => {
+          console.error(error);
+          process.exit(1);
+        });
+      });
+      process.stdout.write(JSON.stringify(reservation.plan) + "\n");
+      setInterval(() => {}, 1000);
+    })().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  ' >"$output" 2>"$output.stderr"
+}
+
+reservation_first_pid=
+reservation_second_pid=
+cleanup_reservation_probes() {
+  for pid in "$reservation_first_pid" "$reservation_second_pid"; do
+    if [ -n "$pid" ]; then
+      kill -TERM "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup_reservation_probes EXIT
+reservation_probe "$RUN_ROOT/reservation-first.json" &
+reservation_first_pid=$!
+reservation_probe "$RUN_ROOT/reservation-second.json" &
+reservation_second_pid=$!
+for _ in $(seq 1 100); do
+  [ -s "$RUN_ROOT/reservation-first.json" ] \
+    && [ -s "$RUN_ROOT/reservation-second.json" ] && break
+  sleep 0.1
+done
+[ -s "$RUN_ROOT/reservation-first.json" ] || {
+  cat "$RUN_ROOT/reservation-first.json.stderr" >&2
+  exit 1
+}
+[ -s "$RUN_ROOT/reservation-second.json" ] || {
+  cat "$RUN_ROOT/reservation-second.json.stderr" >&2
+  exit 1
+}
+node -e '
+  const fs = require("fs");
+  const first = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const second = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+  if (first.guestSubnet === second.guestSubnet) throw new Error("concurrent subnet collision");
+  if (first.infrastructureIp === second.infrastructureIp) {
+    throw new Error("concurrent infrastructure address collision");
+  }
+  if (first.resourceToken === second.resourceToken) throw new Error("concurrent token collision");
+' "$RUN_ROOT/reservation-first.json" "$RUN_ROOT/reservation-second.json"
+second_reservation=$(node -e '
+  const fs = require("fs");
+  process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).reservationPath);
+' "$RUN_ROOT/reservation-second.json")
+kill -TERM "$reservation_first_pid"
+wait "$reservation_first_pid"
+reservation_first_pid=
+sudo test -f "$second_reservation" || {
+  echo "first allocator removed the second allocator reservation" >&2
+  exit 1
+}
+kill -TERM "$reservation_second_pid"
+wait "$reservation_second_pid"
+reservation_second_pid=
+trap - EXIT
+assert_no_residue
 
 run_case() {
   local name=$1
@@ -485,6 +586,10 @@ while read -r namespace _; do
     awfvm-*) sudo ip netns delete "$namespace" ;;
   esac
 done < <(sudo ip netns list)
+# The preserved CLI process has exited, so these owner identities are stale.
+# This is explicit test-harness teardown, analogous to the forced run-directory
+# cleanup below; normal runtime cleanup uses the lease-checked release path.
+sudo find /run/awf-microvm-network/reservations -name '*.json' -delete 2>/dev/null || true
 sudo docker compose -f "$keep_work/docker-compose.yml" down --volumes --remove-orphans
 # --keep-containers intentionally preserves the private run directory (see
 # CLOUD_HYPERVISOR_RUN_ROOT in src/cloud-hypervisor/manager.ts); clean it up
@@ -612,16 +717,9 @@ esac
 # startup and could fail on a valid but slower runner; polling for "Running"
 # also proves these assertions inspect a live VM, not merely a launched VMM.
 #
-# The expected TAP name is derived exactly like
-# createMicrovmNetworkPlan() (src/microvm/network.ts): `vmt` + the first 12
-# hex characters of sha256(runId). The per-run network namespace shares
-# the same token (`awfvm-` + token) and is where the TAP device actually
-# lives -- checking for it in the root/default namespace, which is what
-# actually hosts this script, would never find a namespace-scoped
-# interface regardless of whether it truly exists.
-run_token=$(printf '%s' "$run_id" | sha256sum | cut -c1-12)
-expected_tap="vmt$run_token"
-expected_namespace="awfvm-$run_token"
+# Resource tokens are reservation-selected rather than deterministically
+# derived from runId. Read the selected TAP from the live VMM config below,
+# validate its shape, then derive the namespace sharing that token.
 expected_rootfs_path="$run_directory/rootfs.ext4"
 expected_vsock_socket="$run_directory/awf-vsock.socket"
 
@@ -636,6 +734,22 @@ for _ in $(seq 1 30); do
   sleep 1
 done
 [ -n "$vm_info" ] || fail_security "vm.info never reported state \"Running\" within the poll window"
+expected_tap=$(node -e '
+  const info = JSON.parse(process.argv[1]);
+  process.stdout.write(info.config?.net?.[0]?.tap || "");
+' "$vm_info")
+case "$expected_tap" in
+  vmt[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *) fail_security "reservation-selected TAP has unsafe shape: $expected_tap" ;;
+esac
+run_token=${expected_tap#vmt}
+expected_namespace="awfvm-$run_token"
+reservation_path="/run/awf-microvm-network/reservations/$run_token.json"
+sudo test -f "$reservation_path" \
+  || fail_security "live network reservation is missing: $reservation_path"
+reservation_owner=$(sudo stat -c '%u:%a' "$reservation_path")
+[ "$reservation_owner" = "0:600" ] \
+  || fail_security "network reservation ownership/mode is not root:600: $reservation_owner"
 
 node -e '
   const [

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -98,6 +98,7 @@ const preflightResult = {
     ip: '/usr/bin/ip',
     nft: '/usr/sbin/nft',
     sysctl: '/usr/sbin/sysctl',
+    flock: '/usr/bin/flock',
     mke2fs: '/usr/sbin/mke2fs',
     debugfs: '/usr/sbin/debugfs',
     e2fsck: '/usr/sbin/e2fsck',

--- a/src/cloud-hypervisor/manager-start.ts
+++ b/src/cloud-hypervisor/manager-start.ts
@@ -2,10 +2,9 @@ import * as path from 'path';
 import type { ExecaChildProcess } from 'execa';
 import type { CloudHypervisorOptions } from '../types/runtime-options';
 import type { MicrovmRootfsPreparer } from '../microvm/rootfs';
-import {
-  createMicrovmNetworkPlan,
-  type MicrovmNetworkLifecycle,
-  type MicrovmNetworkPlan,
+import type {
+  MicrovmNetworkLifecycle,
+  MicrovmNetworkPlan,
 } from '../microvm/network';
 import type { CloudHypervisorApiClient } from './api-client';
 import {
@@ -68,14 +67,15 @@ export async function startCloudHypervisor(
   try {
     const artifacts = await dependencies.preflight(config);
     const identity = guestConfig?.identity ?? dependencies.resolveIdentity();
-    const networkPlan = createMicrovmNetworkPlan(paths.runId, {
+    const reservation = await dependencies.reserveNetwork(paths.runId, {
       ...networkConfig,
       tapOwnerUid: identity.uid,
       tapOwnerGid: identity.gid,
       tapVnetHdr: true,
-    });
+    }, artifacts.tools);
+    const networkPlan = reservation.plan;
     context.setNetworkPlan(networkPlan);
-    const network = dependencies.createNetwork(networkPlan, artifacts.tools);
+    const network = dependencies.createNetwork(networkPlan, artifacts.tools, reservation);
     context.setNetwork(network);
     await network.setup();
     let rootfsSource = artifacts.rootfsPath;

--- a/src/cloud-hypervisor/manager-types.ts
+++ b/src/cloud-hypervisor/manager-types.ts
@@ -7,6 +7,8 @@ import {
   type MicrovmControlPeer,
   type MicrovmNetworkLifecycle,
   type MicrovmNetworkPlan,
+  type MicrovmNetworkPlanOptions,
+  type MicrovmNetworkReservation,
 } from '../microvm/network';
 import type { MicrovmVsockClient } from '../microvm/vsock-client';
 import type { MicrovmRootfsConfig, MicrovmRootfsPreparer } from '../microvm/rootfs';
@@ -79,7 +81,16 @@ export interface CloudHypervisorManagerDependencies {
   rm(directory: string, options: { recursive: true; force: true }): Promise<void>;
   sleep(milliseconds: number): Promise<void>;
   createClient(socketPath: string, timeoutMs: number): CloudHypervisorApiClient;
-  createNetwork(plan: MicrovmNetworkPlan, tools: CloudHypervisorHostToolPaths): MicrovmNetworkLifecycle;
+  reserveNetwork(
+    runId: string,
+    options: MicrovmNetworkPlanOptions,
+    tools: CloudHypervisorHostToolPaths,
+  ): Promise<MicrovmNetworkReservation>;
+  createNetwork(
+    plan: MicrovmNetworkPlan,
+    tools: CloudHypervisorHostToolPaths,
+    reservation: MicrovmNetworkReservation,
+  ): MicrovmNetworkLifecycle;
   createRootfsPreparer(
     config: MicrovmRootfsConfig,
     tools: CloudHypervisorHostToolPaths,

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -4,6 +4,7 @@ import type {
   MicrovmNetworkLifecycle,
   MicrovmNetworkPlan,
 } from '../microvm/network';
+import { createMicrovmNetworkPlan } from '../microvm/network';
 import type { MicrovmVsockClient } from '../microvm/vsock-client';
 import type { MicrovmRootfsPreparer } from '../microvm/rootfs';
 import type { CloudHypervisorOptions } from '../types/runtime-options';
@@ -25,6 +26,7 @@ const hostTools: CloudHypervisorHostToolPaths = {
   ip: '/usr/bin/ip',
   nft: '/usr/sbin/nft',
   sysctl: '/usr/sbin/sysctl',
+  flock: '/usr/bin/flock',
   mke2fs: '/usr/sbin/mke2fs',
   debugfs: '/usr/sbin/debugfs',
   e2fsck: '/usr/sbin/e2fsck',
@@ -156,6 +158,10 @@ function dependencies(
     rm: jest.fn().mockResolvedValue(undefined),
     sleep: jest.fn().mockResolvedValue(undefined),
     createClient: jest.fn().mockReturnValue(client),
+    reserveNetwork: jest.fn(async (runId, options) => {
+      const plan = createMicrovmNetworkPlan(runId, options);
+      return { plan, release: jest.fn().mockResolvedValue(undefined) };
+    }),
     createNetwork: jest.fn((plan) => networkLifecycle(plan)),
     createRootfsPreparer: jest.fn(() => rootfsPreparerMock()),
     createVirtiofsdManager: jest.fn(() => virtiofsdManagerMock()),
@@ -178,7 +184,11 @@ describe('CloudHypervisorManager', () => {
     await expect(child).resolves.toMatchObject({ exitCode: 0 });
     await expect(defaults.sleep(0)).resolves.toBeUndefined();
     expect(defaults.createClient('/tmp/api.socket', 100)).toBeDefined();
-    expect(defaults.createNetwork({} as MicrovmNetworkPlan, hostTools)).toBeDefined();
+    expect(defaults.createNetwork(
+      {} as MicrovmNetworkPlan,
+      hostTools,
+      { plan: {} as MicrovmNetworkPlan, release: jest.fn() },
+    )).toBeDefined();
     expect(defaults.createRootfsPreparer({
       runDirectory: '/work/rootfs',
       baseRootfsPath: '/opt/rootfs',
@@ -316,6 +326,7 @@ describe('CloudHypervisorManager', () => {
         tapVnetHdr: true,
       }),
       hostTools,
+      expect.objectContaining({ plan: expect.objectContaining({ runId: 'run-1' }) }),
     );
     const lifecycle = (deps.createNetwork as jest.Mock).mock.results[0]
       .value as MicrovmNetworkLifecycle;
@@ -457,6 +468,7 @@ describe('CloudHypervisorManager', () => {
         ]),
       }),
       hostTools,
+      expect.objectContaining({ plan: expect.objectContaining({ runId: 'guest' }) }),
     );
     expect(client.vmCreate).toHaveBeenCalledWith(expect.objectContaining({
       payload: expect.objectContaining({ cmdline: expect.stringContaining('init=/usr/sbin/awf-supervisor') }),
@@ -852,6 +864,7 @@ describe('CloudHypervisorManager', () => {
   it('builds explicit supervisor boot cmdline with PCI-required root/interface naming', () => {
     const args = buildSupervisorBootArgs({
       runId: 'run',
+      resourceToken: '000000000000',
       namespaceName: 'ns',
       netnsPath: '/var/run/netns/ns',
       nftTableName: 'table',

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -5,6 +5,7 @@ import { getSafeHostGid, getSafeHostUid } from '../host-identity';
 import {
   LinuxNetworkCommands,
   MicrovmNetworkManager,
+  reserveMicrovmNetworkPlan,
   type MicrovmNetworkLifecycle,
   type MicrovmNetworkPlan,
 } from '../microvm/network';
@@ -77,9 +78,12 @@ const defaultDependencies: CloudHypervisorManagerDependencies = {
   rm: fs.rm,
   sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   createClient: (socketPath, timeoutMs) => new CloudHypervisorApiClient({ socketPath, timeoutMs }),
-  createNetwork: (plan, tools) => new MicrovmNetworkManager(
+  reserveNetwork: reserveMicrovmNetworkPlan,
+  createNetwork: (plan, tools, reservation) => new MicrovmNetworkManager(
     plan,
     new LinuxNetworkCommands(undefined, tools),
+    undefined,
+    reservation,
   ),
   createRootfsPreparer: (config, tools) => new MicrovmRootfsPreparer(config, {
     runTool: async (command, args) => {

--- a/src/cloud-hypervisor/preflight.test.ts
+++ b/src/cloud-hypervisor/preflight.test.ts
@@ -199,12 +199,13 @@ describe('Cloud Hypervisor preflight (foundation only)', () => {
       constants.R_OK | constants.W_OK,
     );
     expect(deps.sha256).toHaveBeenCalledTimes(5);
-    expect(deps.assertToolAvailable).toHaveBeenCalledTimes(11);
+    expect(deps.assertToolAvailable).toHaveBeenCalledTimes(12);
     expect(deps.assertDockerInfrastructure).toHaveBeenCalledWith('/usr/bin/docker');
     expect(result.tools).toEqual({
       ip: '/usr/bin/ip',
       nft: '/usr/bin/nft',
       sysctl: '/usr/bin/sysctl',
+      flock: '/usr/bin/flock',
       mke2fs: '/usr/bin/mke2fs',
       debugfs: '/usr/bin/debugfs',
       e2fsck: '/usr/bin/e2fsck',

--- a/src/cloud-hypervisor/preflight.ts
+++ b/src/cloud-hypervisor/preflight.ts
@@ -47,6 +47,8 @@ export type CloudHypervisorHostToolPaths = Readonly<{
   ip: string;
   nft: string;
   sysctl: string;
+  /** util-linux `flock`, used to serialize durable microVM network reservations. */
+  flock: string;
   mke2fs: string;
   debugfs: string;
   e2fsck: string;
@@ -62,7 +64,7 @@ export type CloudHypervisorHostToolPaths = Readonly<{
   setpriv: string;
 }>;
 const CLOUD_HYPERVISOR_HOST_TOOLS: (keyof CloudHypervisorHostToolPaths)[] = [
-  'ip', 'nft', 'sysctl', 'mke2fs', 'debugfs', 'e2fsck', 'rsync', 'mount', 'umount', 'setpriv',
+  'ip', 'nft', 'sysctl', 'flock', 'mke2fs', 'debugfs', 'e2fsck', 'rsync', 'mount', 'umount', 'setpriv',
 ];
 
 const defaultDependencies: CloudHypervisorPreflightDependencies = {

--- a/src/cloud-hypervisor/vm-config-builder.test.ts
+++ b/src/cloud-hypervisor/vm-config-builder.test.ts
@@ -20,6 +20,7 @@ function config(overrides: Partial<CloudHypervisorOptions> = {}): CloudHyperviso
 function networkPlan(): MicrovmNetworkPlan {
   return {
     runId: 'run',
+    resourceToken: '000000000000',
     namespaceName: 'ns',
     netnsPath: '/var/run/netns/ns',
     nftTableName: 'table',

--- a/src/microvm/network-commands.ts
+++ b/src/microvm/network-commands.ts
@@ -47,6 +47,7 @@ export class LinuxNetworkCommands {
       ip: 'ip',
       nft: 'nft',
       sysctl: 'sysctl',
+      flock: 'flock',
     },
     private readonly rulesetFile: MicrovmNetworkRulesetFile = defaultRulesetFile,
   ) {}
@@ -128,34 +129,55 @@ export class LinuxNetworkCommands {
    * nftables allowlist (which still restricts what the guest can send in
    * the first place).
    */
-  async ensureBridgeForwardAcceptRule(bridgeName: string): Promise<void> {
+  async ensureBridgeForwardAcceptRule(bridgeName: string, resourceToken: string): Promise<void> {
+    const ownership = ['-m', 'comment', '--comment', `awf-microvm-${resourceToken}`];
     const checkResult = await this.execute(
       'iptables',
-      ['-t', 'filter', '-C', 'DOCKER-USER', '-i', bridgeName, '-o', bridgeName, '-j', 'ACCEPT'],
+      [
+        '-t', 'filter', '-C', 'DOCKER-USER',
+        '-i', bridgeName, '-o', bridgeName,
+        ...ownership, '-j', 'ACCEPT',
+      ],
       { reject: false },
     );
     const exitCode = (checkResult as { exitCode?: number } | undefined)?.exitCode;
     if (exitCode === 0) return;
     await this.execute(
       'iptables',
-      ['-t', 'filter', '-I', 'DOCKER-USER', '1', '-i', bridgeName, '-o', bridgeName, '-j', 'ACCEPT'],
+      [
+        '-t', 'filter', '-I', 'DOCKER-USER', '1',
+        '-i', bridgeName, '-o', bridgeName,
+        ...ownership, '-j', 'ACCEPT',
+      ],
       { reject: true },
     );
   }
 
-  /** Removes the rule `ensureBridgeForwardAcceptRule` installs, if present. Tolerant of it already being gone or the underlying command failing outright. */
-  async removeBridgeForwardAcceptRule(bridgeName: string): Promise<void> {
-    try {
-      await this.execute(
-        'iptables',
-        ['-t', 'filter', '-D', 'DOCKER-USER', '-i', bridgeName, '-o', bridgeName, '-j', 'ACCEPT'],
-        { reject: false },
-      );
-    } catch {
-      // Best-effort cleanup: an already-removed rule, or the iptables
-      // binary itself being unavailable, must not fail the caller's own
-      // cleanup sequence.
-    }
+  /** Removes only this reservation's rule and verifies a failed delete means it was already absent. */
+  async removeBridgeForwardAcceptRule(bridgeName: string, resourceToken: string): Promise<void> {
+    const rule = [
+      '-t', 'filter', 'DOCKER-USER',
+      '-i', bridgeName, '-o', bridgeName,
+      '-m', 'comment', '--comment', `awf-microvm-${resourceToken}`,
+      '-j', 'ACCEPT',
+    ];
+    const deletion = await this.execute(
+      'iptables',
+      [rule[0], rule[1], '-D', ...rule.slice(2)],
+      { reject: false },
+    ) as { exitCode?: number; stderr?: string } | undefined;
+    if (deletion?.exitCode === 0) return;
+
+    const check = await this.execute(
+      'iptables',
+      [rule[0], rule[1], '-C', ...rule.slice(2)],
+      { reject: false },
+    ) as { exitCode?: number; stderr?: string } | undefined;
+    if (check?.exitCode === 1) return;
+    throw new Error(
+      `Failed to remove owned DOCKER-USER rule awf-microvm-${resourceToken}: ` +
+      (deletion?.stderr ?? check?.stderr ?? 'iptables returned an unknown status'),
+    );
   }
 
   /**

--- a/src/microvm/network-manager.ts
+++ b/src/microvm/network-manager.ts
@@ -7,6 +7,7 @@ import type {
   MicrovmConnectivityProbe,
   MicrovmNetworkLifecycle,
   MicrovmNetworkPlan,
+  MicrovmNetworkReservation,
 } from './network-types';
 
 export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
@@ -14,11 +15,13 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
   private namespaceCreated = false;
   private hostVethCreated = false;
   private dockerUserRuleInserted = false;
+  private reservationReleased = false;
 
   constructor(
     readonly plan: MicrovmNetworkPlan,
     private readonly commands = new LinuxNetworkCommands(),
     private readonly probe?: MicrovmConnectivityProbe,
+    private readonly reservation?: MicrovmNetworkReservation,
   ) {}
 
   async setup(): Promise<MicrovmNetworkPlan> {
@@ -53,7 +56,10 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
       // default-drop policy. Must happen before any guest traffic can
       // possibly flow (i.e. before the tap/guest side is even brought
       // up below).
-      await this.commands.ensureBridgeForwardAcceptRule(this.plan.infrastructureBridge);
+      await this.commands.ensureBridgeForwardAcceptRule(
+        this.plan.infrastructureBridge,
+        this.plan.resourceToken,
+      );
       this.dockerUserRuleInserted = true;
 
       await this.commands.ipInNamespace(this.plan.namespaceName, [
@@ -140,7 +146,10 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
 
     if (this.dockerUserRuleInserted) {
       await attempt(async () => {
-        await this.commands.removeBridgeForwardAcceptRule(this.plan.infrastructureBridge);
+        await this.commands.removeBridgeForwardAcceptRule(
+          this.plan.infrastructureBridge,
+          this.plan.resourceToken,
+        );
         this.dockerUserRuleInserted = false;
       });
     }
@@ -154,6 +163,18 @@ export class MicrovmNetworkManager implements MicrovmNetworkLifecycle {
       await attempt(async () => {
         await this.commands.ip(['netns', 'delete', this.plan.namespaceName]);
         this.namespaceCreated = false;
+      });
+    }
+    if (
+      !this.namespaceCreated
+      && !this.hostVethCreated
+      && !this.dockerUserRuleInserted
+      && this.reservation
+      && !this.reservationReleased
+    ) {
+      await attempt(async () => {
+        await this.reservation!.release();
+        this.reservationReleased = true;
       });
     }
     this.setupComplete = false;

--- a/src/microvm/network-plan.ts
+++ b/src/microvm/network-plan.ts
@@ -11,6 +11,7 @@ import {
 import type {
   MicrovmAllowedEndpoint,
   MicrovmControlPeer,
+  MicrovmNetworkPlanAllocation,
   MicrovmNetworkPlan,
   MicrovmNetworkPlanOptions,
 } from './network-types';
@@ -25,6 +26,7 @@ const BLOCKED_MULTICAST_CIDR = '224.0.0.0/4';
 export function createMicrovmNetworkPlan(
   runId: string,
   options: MicrovmNetworkPlanOptions,
+  allocation?: MicrovmNetworkPlanAllocation,
 ): MicrovmNetworkPlan {
   assertSafeMicrovmRunId(runId);
   assertInterfaceName(options.infrastructureBridge, 'infrastructure bridge');
@@ -32,8 +34,15 @@ export function createMicrovmNetworkPlan(
   assertPositiveIdentity(options.tapOwnerGid, 'tap owner gid');
 
   const digest = createHash('sha256').update(runId).digest();
-  const token = digest.toString('hex').slice(0, 12);
-  const subnetIndex = digest.readUInt32BE(0) & (GUEST_SUBNET_COUNT - 1);
+  const token = allocation?.resourceToken ?? digest.toString('hex').slice(0, 12);
+  if (!/^[0-9a-f]{12}$/.test(token)) {
+    throw new Error(`Unsafe microVM resource token: ${token}`);
+  }
+  const subnetIndex = allocation?.subnetIndex
+    ?? (digest.readUInt32BE(0) & (GUEST_SUBNET_COUNT - 1));
+  if (!Number.isInteger(subnetIndex) || subnetIndex < 0 || subnetIndex >= GUEST_SUBNET_COUNT) {
+    throw new Error(`Invalid microVM subnet index: ${subnetIndex}`);
+  }
   const subnetBase = GUEST_NETWORK_BASE + subnetIndex * 4;
   const guestGatewayIp = integerToIpv4(subnetBase + 1);
   const guestIp = integerToIpv4(subnetBase + 2);
@@ -68,6 +77,8 @@ export function createMicrovmNetworkPlan(
   );
   const plan: MicrovmNetworkPlan = {
     runId,
+    resourceToken: token,
+    ...(allocation?.reservationPath ? { reservationPath: allocation.reservationPath } : {}),
     namespaceName,
     netnsPath: `${NETNS_DIRECTORY}/${namespaceName}`,
     nftTableName,
@@ -75,7 +86,7 @@ export function createMicrovmNetworkPlan(
     hostVethName,
     namespaceVethName,
     tapName,
-    infrastructureIp: AGENT_IP,
+    infrastructureIp: allocation?.infrastructureIp ?? AGENT_IP,
     infrastructureCidr: NETWORK_SUBNET,
     hostGatewayIp: HOST_GATEWAY,
     guestSubnet: `${integerToIpv4(subnetBase)}/${GUEST_PREFIX_LENGTH}`,
@@ -248,6 +259,12 @@ function validatePlan(plan: MicrovmNetworkPlan): void {
   assertIpv4(plan.infrastructureIp, 'infrastructure IP');
   assertCidr(plan.infrastructureCidr, 'infrastructure CIDR');
   assertIpv4(plan.hostGatewayIp, 'host gateway IP');
+  if (!isInCidr(plan.infrastructureIp, plan.infrastructureCidr)) {
+    throw new Error(
+      `microVM infrastructure IP ${plan.infrastructureIp} is outside ` +
+      plan.infrastructureCidr,
+    );
+  }
   assertCidr(plan.guestSubnet, 'guest subnet');
   assertIpv4(plan.guestIp, 'guest IP');
   assertIpv4(plan.guestGatewayIp, 'guest gateway IP');

--- a/src/microvm/network-reservation.test.ts
+++ b/src/microvm/network-reservation.test.ts
@@ -1,0 +1,171 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  MicrovmNetworkReservationRegistry,
+  type MicrovmNetworkReservationDependencies,
+} from './network-reservation';
+import type { MicrovmNetworkHostTools, MicrovmNetworkPlanOptions } from './network-types';
+
+const tools: MicrovmNetworkHostTools = {
+  ip: '/usr/bin/ip',
+  nft: '/usr/sbin/nft',
+  sysctl: '/usr/sbin/sysctl',
+  flock: '/usr/bin/flock',
+};
+const options: MicrovmNetworkPlanOptions = {
+  infrastructureBridge: 'awfbr0',
+  enableApiProxy: true,
+  tapOwnerUid: 1000,
+  tapOwnerGid: 1000,
+};
+
+function serializedLock(): <T>(operation: () => Promise<T>) => Promise<T> {
+  let tail = Promise.resolve();
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    const previous = tail;
+    let unlock!: () => void;
+    tail = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      unlock();
+    }
+  };
+}
+
+describe('microVM network reservation registry', () => {
+  let root: string;
+  let alive: boolean;
+  let namespaces: Set<string>;
+  let interfaces: Set<string>;
+  let routes: string[];
+  let addresses: Set<string>;
+  let firewallTokens: Set<string>;
+  let dependencies: MicrovmNetworkReservationDependencies;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'awf-network-reservation-'));
+    alive = true;
+    namespaces = new Set();
+    interfaces = new Set();
+    routes = [];
+    addresses = new Set();
+    firewallTokens = new Set();
+    dependencies = {
+      expectedOwnerUid: process.getuid?.() ?? 0,
+      readProcessIdentity: jest.fn().mockResolvedValue({
+        bootId: 'boot-a',
+        pid: 4242,
+        startTimeTicks: '98765',
+      }),
+      isProcessIdentityAlive: jest.fn(async () => alive),
+      withLock: serializedLock(),
+      inspectLiveResources: jest.fn(async () => ({
+        namespaces,
+        interfaces,
+        routes,
+        addresses,
+        firewallTokens,
+      })),
+    };
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('atomically gives concurrent independent runs disjoint subnets and tokens', async () => {
+    const firstRegistry = new MicrovmNetworkReservationRegistry(tools, root, dependencies);
+    const secondRegistry = new MicrovmNetworkReservationRegistry(tools, root, dependencies);
+
+    const [first, second] = await Promise.all([
+      firstRegistry.reserve('same-hash-input', options),
+      secondRegistry.reserve('same-hash-input', options),
+    ]);
+
+    expect(first.plan.guestSubnet).not.toBe(second.plan.guestSubnet);
+    expect(first.plan.infrastructureIp).not.toBe(second.plan.infrastructureIp);
+    expect(first.plan.resourceToken).not.toBe(second.plan.resourceToken);
+    expect(first.plan.namespaceName).not.toBe(second.plan.namespaceName);
+    expect(await fs.readdir(path.join(root, 'reservations'))).toHaveLength(2);
+
+    await first.release();
+    expect(await fs.readdir(path.join(root, 'reservations'))).toEqual([
+      `${second.plan.resourceToken}.json`,
+    ]);
+    await second.release();
+    expect(await fs.readdir(path.join(root, 'reservations'))).toEqual([]);
+  });
+
+  it('never releases a reservation after its durable lease identity changes', async () => {
+    const reservation = await new MicrovmNetworkReservationRegistry(
+      tools,
+      root,
+      dependencies,
+    ).reserve('owner-a', options);
+    const reservationPath = reservation.plan.reservationPath!;
+    const record = JSON.parse(await fs.readFile(reservationPath, 'utf8')) as {
+      leaseId: string;
+    };
+    record.leaseId = 'different-owner';
+    await fs.writeFile(reservationPath, `${JSON.stringify(record)}\n`);
+
+    await expect(reservation.release()).rejects.toThrow(/not owned/);
+    await expect(fs.access(reservationPath)).resolves.toBeUndefined();
+  });
+
+  it('recovers a dead owner only after its namespace, interfaces, and route are gone', async () => {
+    const registry = new MicrovmNetworkReservationRegistry(tools, root, dependencies);
+    const stale = await registry.reserve('recover-stale', options);
+    alive = false;
+    namespaces.add(stale.plan.namespaceName);
+    interfaces.add(stale.plan.hostVethName);
+    routes.push(stale.plan.guestSubnet);
+    firewallTokens.add(stale.plan.resourceToken);
+
+    const whileLive = await registry.reserve('recover-stale', options);
+    expect(whileLive.plan.guestSubnet).not.toBe(stale.plan.guestSubnet);
+
+    namespaces.clear();
+    interfaces.clear();
+    routes = [];
+    firewallTokens.clear();
+    addresses.clear();
+    const recovered = await registry.reserve('recover-stale', options);
+    expect(recovered.plan.guestSubnet).toBe(stale.plan.guestSubnet);
+    const files = await fs.readdir(path.join(root, 'reservations'));
+    expect(files).not.toContain(`${stale.plan.resourceToken}.json`);
+  });
+
+  it('does not claim a live or reserved address on the shared infrastructure bridge', async () => {
+    addresses.add('172.30.0.20');
+    const registry = new MicrovmNetworkReservationRegistry(tools, root, dependencies);
+    const first = await registry.reserve('bridge-address-first', options);
+    const second = await registry.reserve('bridge-address-second', options);
+
+    expect(first.plan.infrastructureIp).not.toBe('172.30.0.20');
+    expect(second.plan.infrastructureIp).not.toBe(first.plan.infrastructureIp);
+  });
+
+  it('skips a candidate subnet already covered by a live route', async () => {
+    const baseline = await new MicrovmNetworkReservationRegistry(
+      tools,
+      root,
+      dependencies,
+    ).reserve('route-collision', options);
+    await baseline.release();
+    routes = [baseline.plan.guestSubnet];
+
+    const reservation = await new MicrovmNetworkReservationRegistry(
+      tools,
+      root,
+      dependencies,
+    ).reserve('route-collision', options);
+
+    expect(reservation.plan.guestSubnet).not.toBe(baseline.plan.guestSubnet);
+  });
+});

--- a/src/microvm/network-reservation.ts
+++ b/src/microvm/network-reservation.ts
@@ -1,0 +1,509 @@
+import { createHash, randomBytes } from 'crypto';
+import { constants, promises as fs } from 'fs';
+import * as path from 'path';
+import execa, { type ExecaChildProcess } from 'execa';
+import {
+  AGENT_IP,
+  API_PROXY_IP,
+  CLI_PROXY_IP,
+  DOH_PROXY_IP,
+  HOST_GATEWAY,
+  NETWORK_SUBNET,
+  SQUID_IP,
+} from '../config/network-policy';
+import { createMicrovmNetworkPlan } from './network-plan';
+import type {
+  MicrovmNetworkHostTools,
+  MicrovmNetworkPlanOptions,
+  MicrovmNetworkReservation,
+} from './network-types';
+
+const RESERVATION_ROOT = '/run/awf-microvm-network';
+const RESERVATION_VERSION = 1;
+const SUBNET_COUNT = 1 << 20;
+const LOCK_TIMEOUT_SECONDS = 30;
+
+interface ProcessIdentity {
+  readonly bootId: string;
+  readonly pid: number;
+  readonly startTimeTicks: string;
+}
+
+interface ReservationRecord {
+  readonly version: typeof RESERVATION_VERSION;
+  readonly leaseId: string;
+  readonly owner: ProcessIdentity;
+  readonly runId: string;
+  readonly resourceToken: string;
+  readonly subnetIndex: number;
+  readonly guestSubnet: string;
+  readonly infrastructureBridge: string;
+  readonly infrastructureIp: string;
+  readonly namespaceName: string;
+  readonly hostVethName: string;
+  readonly namespaceVethName: string;
+  readonly tapName: string;
+  readonly createdAt: string;
+}
+
+interface LiveNetworkResources {
+  readonly namespaces: ReadonlySet<string>;
+  readonly interfaces: ReadonlySet<string>;
+  readonly routes: readonly string[];
+  readonly addresses: ReadonlySet<string>;
+  readonly firewallTokens: ReadonlySet<string>;
+}
+
+export interface MicrovmNetworkReservationDependencies {
+  readonly expectedOwnerUid: number;
+  readProcessIdentity(): Promise<ProcessIdentity>;
+  isProcessIdentityAlive(identity: ProcessIdentity): Promise<boolean>;
+  withLock<T>(operation: () => Promise<T>): Promise<T>;
+  inspectLiveResources(): Promise<LiveNetworkResources>;
+}
+
+export class MicrovmNetworkReservationRegistry {
+  private readonly reservationsDirectory: string;
+
+  constructor(
+    private readonly tools: MicrovmNetworkHostTools,
+    private readonly root = RESERVATION_ROOT,
+    private readonly dependencies = createDefaultDependencies(tools, root),
+  ) {
+    this.reservationsDirectory = path.join(root, 'reservations');
+  }
+
+  async reserve(
+    runId: string,
+    options: MicrovmNetworkPlanOptions,
+  ): Promise<MicrovmNetworkReservation> {
+    return this.dependencies.withLock(async () => {
+      await this.assertPrivateRoot();
+      const owner = await this.dependencies.readProcessIdentity();
+      const live = await this.dependencies.inspectLiveResources();
+      const records = await this.loadAndRecoverRecords(live);
+      const reservedSubnets = new Set(records.map(({ record }) => record.guestSubnet));
+      const reservedTokens = new Set(records.map(({ record }) => record.resourceToken));
+      const reservedInfrastructureIps = new Set(
+        records
+          .filter(({ record }) => record.infrastructureBridge === options.infrastructureBridge)
+          .map(({ record }) => record.infrastructureIp),
+      );
+      const infrastructureIp = chooseInfrastructureIp(
+        options,
+        reservedInfrastructureIps,
+        live.addresses,
+      );
+      const initialSubnet = createHash('sha256').update(runId).digest().readUInt32BE(0)
+        & (SUBNET_COUNT - 1);
+
+      for (let offset = 0; offset < SUBNET_COUNT; offset += 1) {
+        const subnetIndex = (initialSubnet + offset) & (SUBNET_COUNT - 1);
+        const resourceToken = this.createUnusedToken(reservedTokens, live);
+        const reservationPath = path.join(
+          this.reservationsDirectory,
+          `${resourceToken}.json`,
+        );
+        const plan = createMicrovmNetworkPlan(runId, options, {
+          resourceToken,
+          subnetIndex,
+          infrastructureIp,
+          reservationPath,
+        });
+        if (
+          reservedSubnets.has(plan.guestSubnet)
+          || live.routes.some((route) => cidrsOverlap(route, plan.guestSubnet))
+        ) {
+          continue;
+        }
+
+        const record: ReservationRecord = {
+          version: RESERVATION_VERSION,
+          leaseId: randomBytes(16).toString('hex'),
+          owner,
+          runId,
+          resourceToken,
+          subnetIndex,
+          guestSubnet: plan.guestSubnet,
+          infrastructureBridge: plan.infrastructureBridge,
+          infrastructureIp: plan.infrastructureIp,
+          namespaceName: plan.namespaceName,
+          hostVethName: plan.hostVethName,
+          namespaceVethName: plan.namespaceVethName,
+          tapName: plan.tapName,
+          createdAt: new Date().toISOString(),
+        };
+        await this.writeRecordAtomically(reservationPath, record);
+        return {
+          plan,
+          release: () => this.release(record, reservationPath),
+        };
+      }
+      throw new Error('No unused microVM guest subnet is available');
+    });
+  }
+
+  private async release(record: ReservationRecord, reservationPath: string): Promise<void> {
+    await this.dependencies.withLock(async () => {
+      await this.assertPrivateRoot();
+      const current = await this.readRecord(reservationPath);
+      if (
+        current.leaseId !== record.leaseId
+        || current.resourceToken !== record.resourceToken
+        || current.owner.bootId !== record.owner.bootId
+        || current.owner.pid !== record.owner.pid
+        || current.owner.startTimeTicks !== record.owner.startTimeTicks
+      ) {
+        throw new Error(
+          `Refusing to release microVM network reservation not owned by lease ${record.leaseId}`,
+        );
+      }
+      await fs.rm(reservationPath);
+    });
+  }
+
+  private async assertPrivateRoot(): Promise<void> {
+    await fs.mkdir(this.reservationsDirectory, { recursive: true, mode: 0o700 });
+    for (const directory of [this.root, this.reservationsDirectory]) {
+      const stat = await fs.lstat(directory);
+      if (!stat.isDirectory() || stat.isSymbolicLink() || stat.uid !== this.dependencies.expectedOwnerUid) {
+        throw new Error(`Unsafe microVM network reservation directory: ${directory}`);
+      }
+      if ((stat.mode & 0o077) !== 0) await fs.chmod(directory, 0o700);
+    }
+  }
+
+  private async loadAndRecoverRecords(
+    live: LiveNetworkResources,
+  ): Promise<Array<{ path: string; record: ReservationRecord }>> {
+    const entries = await fs.readdir(this.reservationsDirectory, { withFileTypes: true });
+    const records: Array<{ path: string; record: ReservationRecord }> = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !/^[0-9a-f]{12}\.json$/.test(entry.name)) continue;
+      const reservationPath = path.join(this.reservationsDirectory, entry.name);
+      const record = await this.readRecord(reservationPath);
+      const ownerAlive = await this.dependencies.isProcessIdentityAlive(record.owner);
+      if (!ownerAlive && !recordHasLiveResources(record, live)) {
+        await fs.rm(reservationPath);
+        continue;
+      }
+      records.push({ path: reservationPath, record });
+    }
+    return records;
+  }
+
+  private async readRecord(reservationPath: string): Promise<ReservationRecord> {
+    const raw = await fs.readFile(reservationPath, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<ReservationRecord>;
+    if (
+      parsed.version !== RESERVATION_VERSION
+      || typeof parsed.leaseId !== 'string'
+      || typeof parsed.runId !== 'string'
+      || typeof parsed.resourceToken !== 'string'
+      || typeof parsed.subnetIndex !== 'number'
+      || typeof parsed.guestSubnet !== 'string'
+      || typeof parsed.infrastructureBridge !== 'string'
+      || typeof parsed.infrastructureIp !== 'string'
+      || typeof parsed.namespaceName !== 'string'
+      || typeof parsed.hostVethName !== 'string'
+      || typeof parsed.namespaceVethName !== 'string'
+      || typeof parsed.tapName !== 'string'
+      || typeof parsed.createdAt !== 'string'
+      || !parsed.owner
+      || typeof parsed.owner.bootId !== 'string'
+      || typeof parsed.owner.pid !== 'number'
+      || typeof parsed.owner.startTimeTicks !== 'string'
+    ) {
+      throw new Error(`Invalid microVM network reservation: ${reservationPath}`);
+    }
+    return parsed as ReservationRecord;
+  }
+
+  private createUnusedToken(
+    reservedTokens: ReadonlySet<string>,
+    live: LiveNetworkResources,
+  ): string {
+    for (let attempt = 0; attempt < 128; attempt += 1) {
+      const token = randomBytes(6).toString('hex');
+      if (reservedTokens.has(token)) continue;
+      const names = [`awfvm-${token}`, `vmh${token}`, `vmn${token}`, `vmt${token}`];
+      if (
+        names.some((name) => live.namespaces.has(name) || live.interfaces.has(name))
+        || live.firewallTokens.has(token)
+      ) continue;
+      return token;
+    }
+    throw new Error('Unable to allocate a unique microVM network resource token');
+  }
+
+  private async writeRecordAtomically(
+    reservationPath: string,
+    record: ReservationRecord,
+  ): Promise<void> {
+    const temporaryPath = `${reservationPath}.${record.leaseId}.tmp`;
+    await fs.writeFile(temporaryPath, `${JSON.stringify(record, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+    try {
+      await fs.rename(temporaryPath, reservationPath);
+    } catch (error) {
+      await fs.rm(temporaryPath, { force: true });
+      throw error;
+    }
+  }
+}
+
+export function reserveMicrovmNetworkPlan(
+  runId: string,
+  options: MicrovmNetworkPlanOptions,
+  tools: MicrovmNetworkHostTools,
+): Promise<MicrovmNetworkReservation> {
+  return new MicrovmNetworkReservationRegistry(tools).reserve(runId, options);
+}
+
+function createDefaultDependencies(
+  tools: MicrovmNetworkHostTools,
+  root: string,
+): MicrovmNetworkReservationDependencies {
+  const lockPath = path.join(root, 'allocation.lock');
+  return {
+    expectedOwnerUid: 0,
+    readProcessIdentity: () => readProcessIdentity(process.pid),
+    isProcessIdentityAlive: async (identity) => {
+      try {
+        const current = await readProcessIdentity(identity.pid);
+        return current.bootId === identity.bootId
+          && current.startTimeTicks === identity.startTimeTicks;
+      } catch {
+        return false;
+      }
+    },
+    withLock: async <T>(operation: () => Promise<T>): Promise<T> => {
+      await fs.mkdir(root, { recursive: true, mode: 0o700 });
+      const rootStat = await fs.lstat(root);
+      if (!rootStat.isDirectory() || rootStat.isSymbolicLink() || rootStat.uid !== 0) {
+        throw new Error(`Unsafe microVM network reservation directory: ${root}`);
+      }
+      if ((rootStat.mode & 0o077) !== 0) await fs.chmod(root, 0o700);
+      const lockFile = await fs.open(lockPath, constants.O_CREAT | constants.O_RDWR, 0o600);
+      await lockFile.close();
+      await fs.chmod(lockPath, 0o600);
+      const child = execa(
+        tools.flock,
+        [
+          '--exclusive',
+          '--wait', String(LOCK_TIMEOUT_SECONDS),
+          lockPath,
+          '/bin/sh', '-c',
+          'printf "locked\\n"; cat >/dev/null',
+        ],
+        { reject: false, stdin: 'pipe', stdout: 'pipe', stderr: 'pipe' },
+      );
+      await waitForLock(child);
+      let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+      try {
+        outcome = { ok: true, value: await operation() };
+      } catch (error) {
+        outcome = { ok: false, error };
+      }
+      child.stdin?.end();
+      const result = await child;
+      if (result.exitCode !== 0) {
+        const lockError = new Error(
+          `microVM network allocation lock exited with code ${result.exitCode}: ${result.stderr.trim()}`,
+        );
+        if (!outcome.ok) {
+          throw new Error(
+            `${formatError(outcome.error)}; additionally, ${lockError.message}`,
+          );
+        }
+        throw lockError;
+      }
+      if (!outcome.ok) throw outcome.error;
+      return outcome.value;
+    },
+    inspectLiveResources: () => inspectLiveResources(tools),
+  };
+}
+
+async function waitForLock(child: ExecaChildProcess<string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let output = '';
+    const timer = setTimeout(() => reject(
+      new Error(`Timed out acquiring microVM network allocation lock after ${LOCK_TIMEOUT_SECONDS}s`),
+    ), (LOCK_TIMEOUT_SECONDS + 1) * 1000);
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      output += chunk.toString();
+      if (output.includes('locked\n')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('exit', (code) => {
+      if (!output.includes('locked\n')) {
+        clearTimeout(timer);
+        reject(new Error(`Failed to acquire microVM network allocation lock (exit ${code})`));
+      }
+    });
+  });
+}
+
+async function readProcessIdentity(pid: number): Promise<ProcessIdentity> {
+  const [bootId, stat] = await Promise.all([
+    fs.readFile('/proc/sys/kernel/random/boot_id', 'utf8'),
+    fs.readFile(`/proc/${pid}/stat`, 'utf8'),
+  ]);
+  const commandEnd = stat.lastIndexOf(') ');
+  if (commandEnd < 0) throw new Error(`Invalid /proc/${pid}/stat`);
+  const fieldsAfterCommand = stat.slice(commandEnd + 2).trim().split(/\s+/);
+  const startTimeTicks = fieldsAfterCommand[19];
+  if (!startTimeTicks) throw new Error(`Missing process start time in /proc/${pid}/stat`);
+  return { bootId: bootId.trim(), pid, startTimeTicks };
+}
+
+async function inspectLiveResources(
+  tools: MicrovmNetworkHostTools,
+): Promise<LiveNetworkResources> {
+  const namespacesResult = await execa(tools.ip, ['netns', 'list'], { reject: false });
+  if (namespacesResult.exitCode !== 0) {
+    throw new Error(`Unable to inspect live network namespaces: ${namespacesResult.stderr.trim()}`);
+  }
+  const namespaces = new Set(
+    namespacesResult.stdout.split('\n').map((line) => line.trim().split(/\s+/)[0]).filter(Boolean),
+  );
+  const interfaces = new Set<string>();
+  const routes: string[] = [];
+  const addresses = new Set<string>();
+  const firewallTokens = new Set<string>();
+  const inspect = async (namespace?: string): Promise<void> => {
+    const linkArgs = namespace
+      ? ['netns', 'exec', namespace, tools.ip, '-o', 'link', 'show']
+      : ['-o', 'link', 'show'];
+    const routeArgs = namespace
+      ? ['netns', 'exec', namespace, tools.ip, '-o', '-4', 'route', 'show', 'table', 'all']
+      : ['-o', '-4', 'route', 'show', 'table', 'all'];
+    const addressArgs = namespace
+      ? ['netns', 'exec', namespace, tools.ip, '-o', '-4', 'addr', 'show']
+      : ['-o', '-4', 'addr', 'show'];
+    const [links, routeOutput, addressOutput] = await Promise.all([
+      execa(tools.ip, linkArgs, { reject: false }),
+      execa(tools.ip, routeArgs, {
+        reject: false,
+      }),
+      execa(tools.ip, addressArgs, { reject: false }),
+    ]);
+    if (links.exitCode !== 0 || routeOutput.exitCode !== 0 || addressOutput.exitCode !== 0) {
+      throw new Error(`Unable to inspect live network resources${namespace ? ` in ${namespace}` : ''}`);
+    }
+    for (const line of links.stdout.split('\n')) {
+      const match = line.match(/^\d+:\s+([^:@]+)(?:@[^:]+)?:/);
+      if (match) interfaces.add(match[1]);
+    }
+    for (const line of routeOutput.stdout.split('\n')) {
+      const destination = line.trim().split(/\s+/)[0];
+      if (/^\d+\.\d+\.\d+\.\d+\/\d+$/.test(destination)) routes.push(destination);
+    }
+    for (const match of addressOutput.stdout.matchAll(/\binet\s+(\d+\.\d+\.\d+\.\d+)\//g)) {
+      addresses.add(match[1]);
+    }
+  };
+  await inspect();
+  for (const namespace of namespaces) await inspect(namespace);
+  const firewall = await execa('iptables', ['-S', 'DOCKER-USER'], { reject: false });
+  if (firewall.exitCode !== 0) {
+    throw new Error(`Unable to inspect live microVM firewall rules: ${firewall.stderr.trim()}`);
+  }
+  for (const match of firewall.stdout.matchAll(/\bawf-microvm-([0-9a-f]{12})\b/g)) {
+    firewallTokens.add(match[1]);
+  }
+  return { namespaces, interfaces, routes, addresses, firewallTokens };
+}
+
+function recordHasLiveResources(
+  record: ReservationRecord,
+  live: LiveNetworkResources,
+): boolean {
+  return live.namespaces.has(record.namespaceName)
+    || live.interfaces.has(record.hostVethName)
+    || live.interfaces.has(record.namespaceVethName)
+    || live.interfaces.has(record.tapName)
+    || live.firewallTokens.has(record.resourceToken)
+    || live.routes.some((route) => cidrsOverlap(route, record.guestSubnet));
+}
+
+function cidrsOverlap(first: string, second: string): boolean {
+  const [firstIp, firstPrefixRaw] = first.split('/');
+  const [secondIp, secondPrefixRaw] = second.split('/');
+  const firstPrefix = Number(firstPrefixRaw);
+  const secondPrefix = Number(secondPrefixRaw);
+  if (!isIpv4(firstIp) || !isIpv4(secondIp)) return false;
+  if (!Number.isInteger(firstPrefix) || !Number.isInteger(secondPrefix)) return false;
+  const prefix = Math.min(firstPrefix, secondPrefix);
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (ipv4ToInteger(firstIp) & mask) === (ipv4ToInteger(secondIp) & mask);
+}
+
+function isIpv4(value: string): boolean {
+  const octets = value.split('.');
+  return octets.length === 4 && octets.every((octet) => (
+    /^\d{1,3}$/.test(octet) && Number(octet) <= 255
+  ));
+}
+
+function ipv4ToInteger(ip: string): number {
+  return ip.split('.').reduce(
+    (value, octet) => ((value << 8) | Number(octet)) >>> 0,
+    0,
+  );
+}
+
+function chooseInfrastructureIp(
+  options: MicrovmNetworkPlanOptions,
+  reserved: ReadonlySet<string>,
+  live: ReadonlySet<string>,
+): string {
+  const [networkIp, rawPrefix] = NETWORK_SUBNET.split('/');
+  const prefix = Number(rawPrefix);
+  if (prefix !== 24) {
+    throw new Error(`Unsupported microVM infrastructure subnet: ${NETWORK_SUBNET}`);
+  }
+  const base = ipv4ToInteger(networkIp);
+  const unavailable = new Set([
+    HOST_GATEWAY,
+    SQUID_IP,
+    API_PROXY_IP,
+    DOH_PROXY_IP,
+    CLI_PROXY_IP,
+    ...reserved,
+    ...live,
+    ...(options.controlPeer ? [options.controlPeer.ip] : []),
+    ...(options.controlPeers ?? []).map((peer) => peer.ip),
+  ]);
+  const preferredOffset = Number(AGENT_IP.split('.')[3]);
+  for (let attempt = 0; attempt < 253; attempt += 1) {
+    const offset = 2 + ((preferredOffset - 2 + attempt) % 253);
+    const candidate = integerToIpv4(base + offset);
+    if (!unavailable.has(candidate)) return candidate;
+  }
+  throw new Error(`No unused microVM infrastructure address is available on ${NETWORK_SUBNET}`);
+}
+
+function integerToIpv4(value: number): string {
+  const normalized = value >>> 0;
+  return [
+    normalized >>> 24,
+    (normalized >>> 16) & 0xff,
+    (normalized >>> 8) & 0xff,
+    normalized & 0xff,
+  ].join('.');
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/microvm/network-types.ts
+++ b/src/microvm/network-types.ts
@@ -2,6 +2,7 @@ export interface MicrovmNetworkHostTools {
   readonly ip: string;
   readonly nft: string;
   readonly sysctl: string;
+  readonly flock: string;
 }
 
 /**
@@ -49,8 +50,17 @@ export interface MicrovmNetworkPlanOptions {
   readonly tapVnetHdr?: boolean;
 }
 
+export interface MicrovmNetworkPlanAllocation {
+  readonly resourceToken: string;
+  readonly subnetIndex: number;
+  readonly infrastructureIp?: string;
+  readonly reservationPath?: string;
+}
+
 export interface MicrovmNetworkPlan {
   readonly runId: string;
+  readonly resourceToken: string;
+  readonly reservationPath?: string;
   readonly namespaceName: string;
   readonly netnsPath: string;
   readonly nftTableName: string;
@@ -88,6 +98,11 @@ export interface MicrovmNetworkLifecycle {
    * `cleanup()`). Not required by every implementer/mock.
    */
   captureDiagnostics?(): Promise<string>;
+}
+
+export interface MicrovmNetworkReservation {
+  readonly plan: MicrovmNetworkPlan;
+  release(): Promise<void>;
 }
 
 export interface MicrovmNetworkCommandOptions {

--- a/src/microvm/network.test.ts
+++ b/src/microvm/network.test.ts
@@ -46,6 +46,7 @@ function commandHarness(failAt?: number): {
       if (options.reject && ++rejectingCall === failAt) {
         throw new Error(`stage ${failAt} failed`);
       }
+      return { exitCode: args.includes('-C') ? 1 : 0 };
     }),
   );
   return { calls, commands };
@@ -279,11 +280,13 @@ describe('microVM network lifecycle', () => {
     expect(calls[5].args).toEqual([
       '-t', 'filter', '-C', 'DOCKER-USER',
       '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-m', 'comment', '--comment', `awf-microvm-${plan.resourceToken}`,
       '-j', 'ACCEPT',
     ]);
     expect(calls[6].args).toEqual([
       '-t', 'filter', '-I', 'DOCKER-USER', '1',
       '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-m', 'comment', '--comment', `awf-microvm-${plan.resourceToken}`,
       '-j', 'ACCEPT',
     ]);
     expect(calls[7].args).toEqual([
@@ -430,6 +433,49 @@ describe('microVM network lifecycle', () => {
     expect(calls.some((call) => call.args.includes('flush'))).toBe(false);
   });
 
+  it('cleans up only its own reservation and bridge rule while another run is active', async () => {
+    const firstPlan = createPlan('concurrent-first');
+    const secondPlan = createPlan('concurrent-second');
+    const { calls, commands } = commandHarness();
+    const firstReservation = {
+      plan: firstPlan,
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+    const secondReservation = {
+      plan: secondPlan,
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+    const first = new MicrovmNetworkManager(
+      firstPlan,
+      commands,
+      undefined,
+      firstReservation,
+    );
+    const second = new MicrovmNetworkManager(
+      secondPlan,
+      commands,
+      undefined,
+      secondReservation,
+    );
+
+    await first.setup();
+    await second.setup();
+    await first.cleanup();
+
+    expect(firstReservation.release).toHaveBeenCalledTimes(1);
+    expect(secondReservation.release).not.toHaveBeenCalled();
+    const deletedRuleComments = calls
+      .filter((call) => call.args.includes('-D'))
+      .map((call) => call.args[call.args.indexOf('--comment') + 1]);
+    expect(deletedRuleComments).toEqual([`awf-microvm-${firstPlan.resourceToken}`]);
+    expect(calls.some((call) => (
+      call.args.includes('delete') && call.args.includes(secondPlan.namespaceName)
+    ))).toBe(false);
+
+    await second.cleanup();
+    expect(secondReservation.release).toHaveBeenCalledTimes(1);
+  });
+
   it('retains the namespace and nft policy for a retry when host veth deletion fails', async () => {
     const plan = createPlan('cleanup-retry');
     let hostVethDeleteFailed = false;
@@ -482,6 +528,7 @@ describe('microVM network lifecycle', () => {
       }
       return originalIp(args, reject);
     });
+
     const manager = new MicrovmNetworkManager(plan, commands);
 
     await manager.setup();
@@ -493,6 +540,27 @@ describe('microVM network lifecycle', () => {
       && call.args[1] === 'delete'
       && call.args[2] === plan.namespaceName
     ))).toHaveLength(1);
+  });
+
+  it('retains its reservation for retry when its owned firewall rule remains', async () => {
+    const plan = createPlan('firewall-cleanup-retry');
+    const { commands } = commandHarness();
+    const reservation = {
+      plan,
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+    const removeRule = jest.spyOn(commands, 'removeBridgeForwardAcceptRule')
+      .mockRejectedValueOnce(new Error('owned rule remains'))
+      .mockResolvedValueOnce(undefined);
+    const manager = new MicrovmNetworkManager(plan, commands, undefined, reservation);
+
+    await manager.setup();
+    await expect(manager.cleanup()).rejects.toThrow('owned rule remains');
+    expect(reservation.release).not.toHaveBeenCalled();
+
+    await expect(manager.cleanup()).resolves.toBeUndefined();
+    expect(removeRule).toHaveBeenCalledTimes(2);
+    expect(reservation.release).toHaveBeenCalledTimes(1);
   });
 
   it('captureDiagnostics delegates to the namespace and host bridge once setup completes, and is empty before/after', async () => {
@@ -538,6 +606,7 @@ describe('microVM network lifecycle', () => {
     expect(insertCall?.args).toEqual([
       '-t', 'filter', '-I', 'DOCKER-USER', '1',
       '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-m', 'comment', '--comment', `awf-microvm-${plan.resourceToken}`,
       '-j', 'ACCEPT',
     ]);
 
@@ -546,6 +615,7 @@ describe('microVM network lifecycle', () => {
     expect(deleteCall?.args).toEqual([
       '-t', 'filter', '-D', 'DOCKER-USER',
       '-i', plan.infrastructureBridge, '-o', plan.infrastructureBridge,
+      '-m', 'comment', '--comment', `awf-microvm-${plan.resourceToken}`,
       '-j', 'ACCEPT',
     ]);
     // Removal must be tolerant of the rule already being gone (e.g. a
@@ -581,11 +651,11 @@ describe('LinuxNetworkCommands.ensureBridgeForwardAcceptRule / removeBridgeForwa
       }),
     );
 
-    await commands.ensureBridgeForwardAcceptRule('awfbr0');
+    await commands.ensureBridgeForwardAcceptRule('awfbr0', '0123456789ab');
 
     expect(calls).toEqual([
-      { args: ['-t', 'filter', '-C', 'DOCKER-USER', '-i', 'awfbr0', '-o', 'awfbr0', '-j', 'ACCEPT'] },
-      { args: ['-t', 'filter', '-I', 'DOCKER-USER', '1', '-i', 'awfbr0', '-o', 'awfbr0', '-j', 'ACCEPT'] },
+      { args: ['-t', 'filter', '-C', 'DOCKER-USER', '-i', 'awfbr0', '-o', 'awfbr0', '-m', 'comment', '--comment', 'awf-microvm-0123456789ab', '-j', 'ACCEPT'] },
+      { args: ['-t', 'filter', '-I', 'DOCKER-USER', '1', '-i', 'awfbr0', '-o', 'awfbr0', '-m', 'comment', '--comment', 'awf-microvm-0123456789ab', '-j', 'ACCEPT'] },
     ]);
   });
 
@@ -598,21 +668,32 @@ describe('LinuxNetworkCommands.ensureBridgeForwardAcceptRule / removeBridgeForwa
       }),
     );
 
-    await commands.ensureBridgeForwardAcceptRule('awfbr0');
+    await commands.ensureBridgeForwardAcceptRule('awfbr0', '0123456789ab');
 
     expect(calls).toEqual([
-      { args: ['-t', 'filter', '-C', 'DOCKER-USER', '-i', 'awfbr0', '-o', 'awfbr0', '-j', 'ACCEPT'] },
+      { args: ['-t', 'filter', '-C', 'DOCKER-USER', '-i', 'awfbr0', '-o', 'awfbr0', '-m', 'comment', '--comment', 'awf-microvm-0123456789ab', '-j', 'ACCEPT'] },
     ]);
   });
 
-  it('removeBridgeForwardAcceptRule never throws even if the rule is already gone', async () => {
+  it('removeBridgeForwardAcceptRule accepts an already-absent owned rule', async () => {
     const commands = new LinuxNetworkCommands(
-      jest.fn(async () => {
-        throw new Error('Bad rule (does a matching rule exist in that chain?)');
-      }),
+      jest.fn(async () => ({ exitCode: 1 })),
     );
 
-    await expect(commands.removeBridgeForwardAcceptRule('awfbr0')).resolves.toBeUndefined();
+    await expect(commands.removeBridgeForwardAcceptRule('awfbr0', '0123456789ab'))
+      .resolves.toBeUndefined();
+  });
+
+  it('removeBridgeForwardAcceptRule reports a deletion that leaves the owned rule live', async () => {
+    const commands = new LinuxNetworkCommands(
+      jest.fn(async (_command, args) => ({
+        exitCode: args.includes('-C') ? 0 : 1,
+        stderr: 'permission denied',
+      })),
+    );
+
+    await expect(commands.removeBridgeForwardAcceptRule('awfbr0', '0123456789ab'))
+      .rejects.toThrow(/permission denied/);
   });
 });
 

--- a/src/microvm/network.ts
+++ b/src/microvm/network.ts
@@ -4,6 +4,10 @@
 export { LinuxNetworkCommands } from './network-commands';
 export { MicrovmNetworkManager } from './network-manager';
 export {
+  MicrovmNetworkReservationRegistry,
+  reserveMicrovmNetworkPlan,
+} from './network-reservation';
+export {
   assertSafeMicrovmRunId,
   createMicrovmNetworkPlan,
   generateMicrovmNftRuleset,
@@ -17,7 +21,9 @@ export type {
   MicrovmNetworkHostTools,
   MicrovmNetworkLifecycle,
   MicrovmNetworkPlan,
+  MicrovmNetworkPlanAllocation,
   MicrovmNetworkPlanOptions,
+  MicrovmNetworkReservation,
   MicrovmNetworkRulesetFile,
   MicrovmTapInterface,
 } from './network-types';


### PR DESCRIPTION
## Summary

- add a root-owned, `flock`-serialized reservation registry for per-run guest subnets, infrastructure addresses, and resource tokens
- validate durable owner identity with boot ID, PID, process start time, and lease ID; reclaim stale records only after matching live namespaces, interfaces, routes, addresses, and firewall rules are gone
- make network cleanup lease-owned and tag shared `DOCKER-USER` rules per reservation so concurrent runs cannot remove each other's resources
- update Cloud Hypervisor diagnostics/docs and add separate-process live smoke coverage for the agent-microvm v0.9.0 concurrency gap

## Validation

- `npm test -- --runInBand` — 330 suites, 5,282 tests passed
- `npm run build`
- `npm run lint -- --quiet`
- `npx markdownlint-cli2 docs/cloud-hypervisor-foundation.md`
- `bash -n scripts/ci/cloud-hypervisor-live-smoke.sh`
- focused reservation/network/manager/preflight suite — 83 tests passed

The KVM live smoke itself requires a GitHub-hosted Ubuntu x86_64 KVM runner; this change adds the real cross-process reservation exercise to that existing CI suite.