### PR TITLE
fix: preserve sparse rootfs staging

### DIFF
--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -120,9 +120,9 @@ AWF copies the manifest, bundle, VMM, `virtiofsd`, kernel, rootfs, and
 supervisor into a root-owned, non-writable snapshot under
 `/run/awf-cloud-hypervisor/trusted-artifacts/`. Verification and execution use
 only that snapshot, preventing caller-controlled path replacement between
-checking and use. Rootfs snapshot and run staging preserve sparse ext4 holes so
-the trusted copies do not multiply the image's logical size into host disk
-exhaustion. The local bundle
+checking and use. Rootfs snapshot, writable preparation, and run staging
+preserve sparse ext4 holes so the trusted copies do not multiply the image's
+logical size into host disk exhaustion. The local bundle
 avoids a GitHub API lookup. `gh` may still need network access to initialize or
 refresh Sigstore trust-root material unless that material is already cached or
 provisioned on the runner. Missing, mutable, incorrectly owned, renamed, or

--- a/docs/cloud-hypervisor-foundation.md
+++ b/docs/cloud-hypervisor-foundation.md
@@ -120,7 +120,9 @@ AWF copies the manifest, bundle, VMM, `virtiofsd`, kernel, rootfs, and
 supervisor into a root-owned, non-writable snapshot under
 `/run/awf-cloud-hypervisor/trusted-artifacts/`. Verification and execution use
 only that snapshot, preventing caller-controlled path replacement between
-checking and use. The local bundle
+checking and use. Rootfs snapshot and run staging preserve sparse ext4 holes so
+the trusted copies do not multiply the image's logical size into host disk
+exhaustion. The local bundle
 avoids a GitHub API lookup. `gh` may still need network access to initialize or
 refresh Sigstore trust-root material unless that material is already cached or
 provisioned on the runner. Missing, mutable, incorrectly owned, renamed, or

--- a/src/cloud-hypervisor-runtime-backend.test.ts
+++ b/src/cloud-hypervisor-runtime-backend.test.ts
@@ -342,6 +342,18 @@ describe('Cloud Hypervisor runtime backend', () => {
     );
   });
 
+  it('reuses and cleans the snapshot created by the explicit preflight phase', async () => {
+    const { deps } = harness();
+    const backend = createBackend(config(), deps);
+
+    await backend.preflight();
+    await backend.start('/tmp/awf', ['github.com']);
+    await backend.stop();
+
+    expect(deps.preflight).toHaveBeenCalledTimes(1);
+    expect(deps.removeArtifactSnapshot).toHaveBeenCalledWith('/snapshot');
+  });
+
   it('fails closed on an unmatched allowlist path before creating a manager', async () => {
     const { deps } = harness();
     const backend = createBackend(

--- a/src/cloud-hypervisor-runtime-backend.ts
+++ b/src/cloud-hypervisor-runtime-backend.ts
@@ -230,6 +230,7 @@ class CloudHypervisorRuntimeBackend implements ExternalAgentRuntimeBackend {
   ) {}
 
   async preflight(): Promise<void> {
+    if (this.preflightResult) return;
     const cloudHypervisor = requireCloudHypervisorConfig(this.config);
     if (
       this.config.agentTimeout !== undefined &&

--- a/src/cloud-hypervisor/diagnostics.ts
+++ b/src/cloud-hypervisor/diagnostics.ts
@@ -99,8 +99,10 @@ export async function stageArtifact(
   destination: string,
   mode: number,
   identity: CloudHypervisorIdentity,
+  copy?: () => Promise<void>,
 ): Promise<void> {
-  await dependencies.copyFile(source, destination, constants.COPYFILE_EXCL);
+  if (copy) await copy();
+  else await dependencies.copyFile(source, destination, constants.COPYFILE_EXCL);
   await dependencies.chown(destination, identity.uid, identity.gid);
   await dependencies.chmod(destination, mode);
 }

--- a/src/cloud-hypervisor/manager-start.ts
+++ b/src/cloud-hypervisor/manager-start.ts
@@ -128,7 +128,18 @@ export async function startCloudHypervisor(
     context.setCgroup(cgroup);
     await cgroup.setup();
     await stageArtifact(dependencies, artifacts.kernelPath, paths.kernelPath, 0o400, identity);
-    await stageArtifact(dependencies, rootfsSource, paths.rootfsPath, 0o600, identity);
+    await stageArtifact(
+      dependencies,
+      rootfsSource,
+      paths.rootfsPath,
+      0o600,
+      identity,
+      () => dependencies.copySparseFile(
+        artifacts.tools.rsync,
+        rootfsSource,
+        paths.rootfsPath,
+      ),
+    );
     await stageDiagnosticFile(dependencies, paths.logPath, identity);
     await stageDiagnosticFile(dependencies, paths.serialLogPath, identity);
     await vmmIdentityManager.validateOwnedPaths([

--- a/src/cloud-hypervisor/manager-start.ts
+++ b/src/cloud-hypervisor/manager-start.ts
@@ -115,7 +115,8 @@ export async function startCloudHypervisor(
           ...(networkConfig.apiProxyIp ? { 'api-proxy': networkConfig.apiProxyIp } : {}),
           ...(networkConfig.hostAliases ?? {}),
         },
-      }, artifacts.tools);
+      }, artifacts.tools, (source, destination) =>
+        dependencies.copySparseFile(artifacts.tools.rsync, source, destination));
       context.setRootfsPreparer(rootfsPreparer);
       rootfsSource = await rootfsPreparer.prepare();
     }

--- a/src/cloud-hypervisor/manager-types.ts
+++ b/src/cloud-hypervisor/manager-types.ts
@@ -78,6 +78,7 @@ export interface CloudHypervisorManagerDependencies {
   ): ExecaChildProcess<string>;
   mkdir(directory: string, options: { recursive: true; mode: number }): Promise<unknown>;
   copyFile(source: string, destination: string, flags: number): Promise<void>;
+  copySparseFile(rsyncBinaryPath: string, source: string, destination: string): Promise<void>;
   chmod(filePath: string, mode: number): Promise<void>;
   chown(filePath: string, uid: number, gid: number): Promise<void>;
   writeFile: typeof fs.writeFile;

--- a/src/cloud-hypervisor/manager-types.ts
+++ b/src/cloud-hypervisor/manager-types.ts
@@ -100,6 +100,7 @@ export interface CloudHypervisorManagerDependencies {
   createRootfsPreparer(
     config: MicrovmRootfsConfig,
     tools: CloudHypervisorHostToolPaths,
+    copyRootfs: (source: string, destination: string) => Promise<void>,
   ): MicrovmRootfsPreparer;
   createVirtiofsdManager(
     binaryPath: string,

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -180,6 +180,7 @@ function dependencies(
     launch: jest.fn().mockReturnValue(processMock()),
     mkdir: jest.fn().mockResolvedValue(undefined),
     copyFile: jest.fn().mockResolvedValue(undefined),
+    copySparseFile: jest.fn().mockResolvedValue(undefined),
     chmod: jest.fn().mockResolvedValue(undefined),
     chown: jest.fn().mockResolvedValue(undefined),
     writeFile: jest.fn().mockResolvedValue(undefined),
@@ -391,6 +392,11 @@ describe('CloudHypervisorManager', () => {
       '/run/awf-cloud-hypervisor/cloud-hypervisor/run-1',
       2001,
       2002,
+    );
+    expect(deps.copySparseFile).toHaveBeenCalledWith(
+      '/usr/bin/rsync',
+      '/opt/rootfs.ext4',
+      '/run/awf-cloud-hypervisor/cloud-hypervisor/run-1/rootfs.ext4',
     );
     expect(deps.createNetwork).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -255,7 +255,7 @@ describe('CloudHypervisorManager', () => {
       baseRootfsPath: '/opt/rootfs',
       supervisorBinaryPath: '/opt/supervisor',
       supervisorSha256: 'a'.repeat(64),
-    }, hostTools)).toBeDefined();
+    }, hostTools, jest.fn())).toBeDefined();
     expect(defaults.createVirtiofsdManager(
       '/opt/virtiofsd',
       '/run/awf',
@@ -590,6 +590,17 @@ describe('CloudHypervisorManager', () => {
         },
       }),
       hostTools,
+      expect.any(Function),
+    );
+    const writableRootfsCopy = (deps.createRootfsPreparer as jest.Mock).mock.calls[0][2];
+    await writableRootfsCopy(
+      '/snapshot/rootfs.ext4',
+      '/tmp/awf/cloud-hypervisor-rootfs/guest/rootfs.ext4',
+    );
+    expect(deps.copySparseFile).toHaveBeenCalledWith(
+      '/usr/bin/rsync',
+      '/snapshot/rootfs.ext4',
+      '/tmp/awf/cloud-hypervisor-rootfs/guest/rootfs.ext4',
     );
     expect(deps.createNetwork).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -96,7 +96,7 @@ const defaultDependencies: CloudHypervisorManagerDependencies = {
     undefined,
     reservation,
   ),
-  createRootfsPreparer: (config, tools) => new MicrovmRootfsPreparer(config, {
+  createRootfsPreparer: (config, tools, copyRootfs) => new MicrovmRootfsPreparer(config, {
     runTool: async (command, args) => {
       const tool = tools[command as keyof CloudHypervisorHostToolPaths] ?? command;
       const result = await execa(tool, [...args], {
@@ -107,6 +107,7 @@ const defaultDependencies: CloudHypervisorManagerDependencies = {
       if (result.exitCode === 0 || (command === 'e2fsck' && result.exitCode === 1)) return;
       throw new Error(`${tool} exited with code ${result.exitCode}: ${result.stderr.trim()}`);
     },
+    copyRootfs,
   }),
   createVirtiofsdManager: (binaryPath, runDirectory, shareDirectory, identity, cgroup, tools) =>
     new VirtiofsdManager(binaryPath, runDirectory, shareDirectory, identity, cgroup, tools),

--- a/src/cloud-hypervisor/manager.ts
+++ b/src/cloud-hypervisor/manager.ts
@@ -49,6 +49,7 @@ import type {
   CloudHypervisorHostToolPaths,
   CloudHypervisorPreflightResult,
 } from './preflight';
+import { copySparseFileWithRsync } from './preflight';
 import {
   verifyCloudHypervisorConfinement,
   type CloudHypervisorConfinementEvidence,
@@ -79,6 +80,7 @@ const defaultDependencies: CloudHypervisorManagerDependencies = {
   launch: (command, args, options) => execa(command, args, options),
   mkdir: fs.mkdir,
   copyFile: fs.copyFile,
+  copySparseFile: copySparseFileWithRsync,
   chmod: fs.chmod,
   chown: fs.chown,
   writeFile: fs.writeFile,

--- a/src/cloud-hypervisor/preflight.test.ts
+++ b/src/cloud-hypervisor/preflight.test.ts
@@ -88,6 +88,7 @@ function dependencies(
         ? { bundlePath: '/snapshot/manifest.sigstore.jsonl' }
         : {}),
     })),
+    copySparseFile: jest.fn().mockResolvedValue(undefined),
     removeArtifactSnapshot: jest.fn().mockResolvedValue(undefined),
     verifyManifestAttestation: jest.fn().mockResolvedValue(undefined),
     assertToolAvailable: jest.fn(async (tool: string) => `/usr/bin/${tool}`),
@@ -274,6 +275,13 @@ describe('Cloud Hypervisor preflight (foundation only)', () => {
       '/usr/bin/gh',
       '/snapshot/manifest.json',
       '/snapshot/manifest.sigstore.jsonl',
+    );
+    const sparseCopy = (deps.createArtifactSnapshot as jest.Mock).mock.calls[0][1];
+    await sparseCopy('/source/rootfs.ext4', '/snapshot/rootfs.ext4');
+    expect(deps.copySparseFile).toHaveBeenCalledWith(
+      '/usr/bin/rsync',
+      '/source/rootfs.ext4',
+      '/snapshot/rootfs.ext4',
     );
     expect(result.tools).toEqual({
       getfacl: '/usr/bin/getfacl',

--- a/src/cloud-hypervisor/preflight.test.ts
+++ b/src/cloud-hypervisor/preflight.test.ts
@@ -10,6 +10,7 @@ import {
   cloudHypervisorPreflightTestHelpers,
   parseCloudHypervisorVersion,
   parseVirtiofsdVersion,
+  copySparseFileWithRsync,
   runCloudHypervisorPreflight,
   type CloudHypervisorPreflightDependencies,
 } from './preflight';
@@ -247,6 +248,98 @@ describe('Cloud Hypervisor preflight (foundation only)', () => {
   it('parses and pins virtiofsd v1.10.0 output', () => {
     expect(parseVirtiofsdVersion('virtiofsd backend 1.10.0')).toBe('1.10.0');
     expect(() => parseVirtiofsdVersion('virtiofsd unknown')).toThrow(/Could not parse/);
+  });
+
+  it('copies sparse rootfs images with the trusted rsync binary', async () => {
+    mockedExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    } as never);
+
+    await copySparseFileWithRsync(
+      '/usr/bin/rsync',
+      '/source/rootfs.ext4',
+      '/destination/rootfs.ext4',
+    );
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      '/usr/bin/rsync',
+      [
+        '--sparse',
+        '--',
+        '/source/rootfs.ext4',
+        '/destination/rootfs.ext4',
+      ],
+      {
+        reject: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+  });
+
+  it('fails closed when the sparse rootfs copy fails', async () => {
+    mockedExeca.mockResolvedValue({
+      exitCode: 23,
+      stdout: '',
+      stderr: 'No space left on device',
+    } as never);
+
+    await expect(copySparseFileWithRsync(
+      '/usr/bin/rsync',
+      '/source/rootfs.ext4',
+      '/destination/rootfs.ext4',
+    )).rejects.toThrow(
+      'sparse artifact copy failed with code 23: No space left on device',
+    );
+  });
+
+  it('uses sparse copying only for the trusted rootfs snapshot', async () => {
+    const snapshotDirectory = '/run/awf-cloud-hypervisor/trusted-artifacts/snapshot-test';
+    jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+    jest.spyOn(fs, 'mkdtemp').mockResolvedValue(snapshotDirectory);
+    const copyFile = jest.spyOn(fs, 'copyFile').mockResolvedValue(undefined);
+    jest.spyOn(fs, 'chmod').mockResolvedValue(undefined);
+    const copySparseFile = jest.fn().mockResolvedValue(undefined);
+    const sources = {
+      cloudHypervisorBinary: '/source/cloud-hypervisor',
+      virtiofsdBinary: '/source/virtiofsd',
+      kernelPath: '/source/vmlinux.bin',
+      rootfsPath: '/source/rootfs.ext4',
+      supervisorPath: '/source/awf-supervisor',
+      manifestPath: '/source/manifest.json',
+      bundlePath: '/source/manifest.sigstore.jsonl',
+    };
+
+    const snapshot = await cloudHypervisorPreflightTestHelpers.createArtifactSnapshot(
+      sources,
+      copySparseFile,
+    );
+
+    expect(snapshot.rootfsPath).toBe(`${snapshotDirectory}/rootfs.ext4`);
+    expect(copySparseFile).toHaveBeenCalledWith(
+      '/source/rootfs.ext4',
+      `${snapshotDirectory}/rootfs.ext4`,
+    );
+    for (const [source, name] of [
+      [sources.cloudHypervisorBinary, 'cloud-hypervisor'],
+      [sources.virtiofsdBinary, 'virtiofsd'],
+      [sources.kernelPath, 'vmlinux.bin'],
+      [sources.supervisorPath, 'awf-supervisor'],
+      [sources.manifestPath, 'manifest.json'],
+      [sources.bundlePath, 'manifest.sigstore.jsonl'],
+    ]) {
+      expect(copyFile).toHaveBeenCalledWith(
+        source,
+        `${snapshotDirectory}/${name}`,
+        constants.COPYFILE_EXCL,
+      );
+    }
+    expect(copyFile).not.toHaveBeenCalledWith(
+      sources.rootfsPath,
+      expect.any(String),
+      expect.any(Number),
+    );
   });
 
   it('verifies the attested manifest before its five artifact digests', async () => {

--- a/src/cloud-hypervisor/preflight.ts
+++ b/src/cloud-hypervisor/preflight.ts
@@ -46,7 +46,9 @@ export interface CloudHypervisorPreflightDependencies {
   readFile(filePath: string): Promise<string>;
   createArtifactSnapshot(
     sources: CloudHypervisorArtifactSnapshotSources,
+    copySparseFile: (source: string, destination: string) => Promise<void>,
   ): Promise<CloudHypervisorArtifactSnapshot>;
+  copySparseFile(rsyncBinaryPath: string, source: string, destination: string): Promise<void>;
   removeArtifactSnapshot(directory: string): Promise<void>;
   verifyManifestAttestation(
     ghBinaryPath: string,
@@ -132,6 +134,7 @@ const defaultDependencies: CloudHypervisorPreflightDependencies = {
   sha256: calculateSha256,
   readFile: async (filePath) => fs.readFile(filePath, 'utf8'),
   createArtifactSnapshot: createArtifactSnapshot,
+  copySparseFile: copySparseFileWithRsync,
   removeArtifactSnapshot: async (directory) => {
     await fs.rm(directory, { recursive: true, force: true });
   },
@@ -252,6 +255,7 @@ export const CLOUD_HYPERVISOR_MAX_BOOT_ATTEMPTS = 3;
 
 async function createArtifactSnapshot(
   sources: CloudHypervisorArtifactSnapshotSources,
+  copySparseFile: (source: string, destination: string) => Promise<void>,
 ): Promise<CloudHypervisorArtifactSnapshot> {
   await fs.mkdir(CLOUD_HYPERVISOR_ARTIFACT_SNAPSHOT_ROOT, {
     recursive: true,
@@ -267,7 +271,11 @@ async function createArtifactSnapshot(
     mode: number,
   ): Promise<string> => {
     const destination = path.join(directory, name);
-    await fs.copyFile(source, destination, constants.COPYFILE_EXCL);
+    if (name === 'rootfs.ext4') {
+      await copySparseFile(source, destination);
+    } else {
+      await fs.copyFile(source, destination, constants.COPYFILE_EXCL);
+    }
     await fs.chmod(destination, mode);
     return destination;
   };
@@ -287,6 +295,7 @@ async function createArtifactSnapshot(
     if (sources.manifestPath) {
       snapshot.manifestPath = await copy(sources.manifestPath, 'manifest.json', 0o444);
     }
+
     if (sources.bundlePath) {
       snapshot.bundlePath = await copy(
         sources.bundlePath,
@@ -299,6 +308,22 @@ async function createArtifactSnapshot(
   } catch (error) {
     await fs.rm(directory, { recursive: true, force: true });
     throw error;
+  }
+}
+
+export async function copySparseFileWithRsync(
+  rsyncBinaryPath: string,
+  source: string,
+  destination: string,
+): Promise<void> {
+  const result = await execa(rsyncBinaryPath, ['--sparse', '--', source, destination], {
+    reject: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `sparse artifact copy failed with code ${result.exitCode}: ${result.stderr.trim()}`,
+    );
   }
 }
 
@@ -631,19 +656,23 @@ export async function runCloudHypervisorPreflight(
     );
   }
 
-  const snapshot = await dependencies.createArtifactSnapshot({
-    cloudHypervisorBinary: config.cloudHypervisorBinary,
-    virtiofsdBinary,
-    kernelPath: config.kernelPath,
-    rootfsPath: config.rootfsPath,
-    supervisorPath: config.supervisorPath,
-    ...(!developmentBypass
-      ? {
-        manifestPath: config.artifactManifestPath!,
-        bundlePath: config.artifactManifestBundlePath!,
-      }
-      : {}),
-  });
+  const snapshot = await dependencies.createArtifactSnapshot(
+    {
+      cloudHypervisorBinary: config.cloudHypervisorBinary,
+      virtiofsdBinary,
+      kernelPath: config.kernelPath,
+      rootfsPath: config.rootfsPath,
+      supervisorPath: config.supervisorPath,
+      ...(!developmentBypass
+        ? {
+          manifestPath: config.artifactManifestPath!,
+          bundlePath: config.artifactManifestBundlePath!,
+        }
+        : {}),
+    },
+    (source, destination) =>
+      dependencies.copySparseFile(tools.rsync, source, destination),
+  );
   try {
     let artifactDigests: Required<CloudHypervisorArtifactDigests>;
     if (developmentBypass) {

--- a/src/cloud-hypervisor/preflight.ts
+++ b/src/cloud-hypervisor/preflight.ts
@@ -234,7 +234,10 @@ const defaultDependencies: CloudHypervisorPreflightDependencies = {
 };
 
 /** @internal Exposed only for focused host-probe tests. */
-export const cloudHypervisorPreflightTestHelpers = { defaultDependencies };
+export const cloudHypervisorPreflightTestHelpers = {
+  defaultDependencies,
+  createArtifactSnapshot,
+};
 
 export interface CloudHypervisorPreflightResult {
   version: string;

--- a/src/microvm/rootfs.ts
+++ b/src/microvm/rootfs.ts
@@ -14,6 +14,7 @@ export interface MicrovmRootfsConfig {
 
 export interface MicrovmRootfsDependencies {
   runTool(command: string, args: readonly string[]): Promise<void>;
+  copyRootfs(source: string, destination: string): Promise<void>;
 }
 
 export class MicrovmRootfsPreparer {
@@ -41,7 +42,7 @@ export class MicrovmRootfsPreparer {
       );
     }
     await fs.mkdir(this.config.runDirectory, { recursive: true, mode: 0o700 });
-    await fs.copyFile(this.config.baseRootfsPath, this.rootfsImagePath);
+    await this.dependencies.copyRootfs(this.config.baseRootfsPath, this.rootfsImagePath);
     const localSupervisor = path.join(this.config.runDirectory, 'awf-supervisor');
     const guestSupervisor = this.config.supervisorGuestPath ?? '/sbin/awf-supervisor';
     await fs.copyFile(this.config.supervisorBinaryPath, localSupervisor);

--- a/src/microvm/workspace.ts
+++ b/src/microvm/workspace.ts
@@ -314,6 +314,7 @@ export class MicrovmWorkspaceImage {
         this.tools?.[command as keyof MicrovmWorkspaceHostTools] ?? command,
         args,
       ),
+      copyRootfs: fs.copyFile,
     });
     await preparer.prepare();
   }


### PR DESCRIPTION
## Summary

- copy the trusted rootfs snapshot with the preflight-resolved `rsync --sparse`
- preserve sparse ext4 holes during writable guest preparation and per-run staging under `/run`
- retain exclusive `fs.copyFile(..., COPYFILE_EXCL)` staging for binaries and attestation manifests
- add focused coverage for sparse-copy routing, exact rsync arguments, and failure propagation
- document the sparse-staging invariant

## Root cause

The live-KVM run after #7894 copied a sparse ext4 rootfs through regular file-copy paths. The trusted snapshot and writable guest-preparation copies could materialize the rootfs holes before the final per-run staging step, multiplying the image's logical size into host storage and failing with `ENOSPC` before the VM could boot.

## Security rationale

The fix reuses the already preflight-resolved, trusted `rsync` binary and passes `--sparse` with an argument terminator. Only rootfs copies use this path. Executables, kernels, supervisors, manifests, and bundles continue to use exclusive `fs.copyFile` staging, preserving the existing no-overwrite and trusted-snapshot protections.

## Validation

- `npm test -- --runInBand src/cloud-hypervisor/preflight.test.ts src/cloud-hypervisor/manager.test.ts src/microvm/workspace.test.ts` (59 tests)
- `npm run build`
- `npm run lint`
- `npm run lint:md`
- `npm test -- --runInBand` (5,374 tests)
- `bash -n scripts/ci/cloud-hypervisor-host-preflight.sh scripts/ci/cloud-hypervisor-live-smoke.sh guest/cloud-hypervisor/build-test-artifacts.sh guest/cloud-hypervisor/verify-test-artifacts.sh`