### PR TITLE
fix: avoid self-matching KVM process probes

### DIFF
--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -279,7 +279,7 @@ jobs:
             echo "::error::Cloud Hypervisor cgroup residue remains after cleanup"
             exit 1
           fi
-          if sudo pgrep -f 'cloud-hypervisor --api-socket' >/dev/null 2>&1; then
+          if sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
             echo "::error::Cloud Hypervisor process residue remains after cleanup"
             exit 1
           fi

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -181,7 +181,33 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain("grep -q '^awfvm-'");
     expect(source).toContain('(vmh|vmn|vmt)');
     expect(source).toContain('CGROUP_ROOT');
-    expect(source).toContain("pgrep -f 'cloud-hypervisor --api-socket'");
+    expect(source).toContain("pgrep -f '[c]loud-hypervisor --api-socket'");
+    expect(source).toContain('$ARTIFACT_DIR/[c]loud-hypervisor --api-socket');
+    expect(source).toContain('$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=');
+  });
+
+  it('uses process probes that exclude their own command line but match live targets', () => {
+    const artifactDir = '/tmp/cloud-hypervisor-test-x86_64';
+    const probes = [
+      {
+        pattern: '[c]loud-hypervisor --api-socket',
+        target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
+      },
+      {
+        pattern: `${artifactDir}/[c]loud-hypervisor --api-socket`,
+        target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
+      },
+      {
+        pattern: `${artifactDir}/[v]irtiofsd.*--shared-dir=`,
+        target: `${artifactDir}/virtiofsd --socket-path=/run/vhost.sock --shared-dir=/workspace`,
+      },
+    ];
+
+    for (const probe of probes) {
+      const expression = new RegExp(probe.pattern);
+      expect(expression.test(`sudo pgrep -f '${probe.pattern}'`)).toBe(false);
+      expect(expression.test(probe.target)).toBe(true);
+    }
   });
 
   it('uses the conspicuous dual opt-in for same-run unattested test artifacts', () => {

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -120,13 +120,13 @@ assert_no_residue() {
     echo "Cloud Hypervisor cgroup residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f 'cloud-hypervisor --api-socket' >/dev/null 2>&1; then
-    sudo pgrep -af 'cloud-hypervisor --api-socket' >&2
+  if sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
+    sudo pgrep -af '[c]loud-hypervisor --api-socket' >&2
     echo "Cloud Hypervisor process residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f "$ARTIFACT_DIR/virtiofsd.*--shared-dir=" >/dev/null 2>&1; then
-    sudo pgrep -af "$ARTIFACT_DIR/virtiofsd.*--shared-dir=" >&2
+  if sudo pgrep -f "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=" >/dev/null 2>&1; then
+    sudo pgrep -af "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=" >&2
     echo "Cloud Hypervisor virtiofsd process residue detected" >&2
     return 1
   fi
@@ -569,7 +569,7 @@ for _ in $(seq 1 90); do
      sudo ip netns list | grep -q '^awfvm-' &&
      sudo find /run/awf-cloud-hypervisor/pending-cleanup -maxdepth 1 -name '*.json' | grep -q . &&
      sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 -type d | grep -q . &&
-     sudo pgrep -f "$ARTIFACT_DIR/cloud-hypervisor --api-socket" >/dev/null; then
+     sudo pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket" >/dev/null; then
     break
   fi
   sleep 1
@@ -591,7 +591,7 @@ sudo ip netns list | grep -q '^awfvm-' || {
   echo "process-death: abrupt exit did not leave the expected recovery fixture" >&2
   exit 1
 }
-sudo pgrep -f "$ARTIFACT_DIR/cloud-hypervisor --api-socket" >/dev/null || {
+sudo pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket" >/dev/null || {
   echo "process-death: VMM did not survive abrupt owner death" >&2
   exit 1
 }

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -138,6 +138,12 @@ describe('Cloud Hypervisor CI workflow', () => {
     expect(cleanupStep?.if).toBe('always()');
     expect(cleanupStep?.run).toContain('awfvm-');
     expect(cleanupStep?.run).toContain('awf-cloud-hypervisor');
+    expect(cleanupStep?.run).toContain(
+      "pgrep -f '[c]loud-hypervisor --api-socket'",
+    );
+    expect(cleanupStep?.run).not.toContain(
+      "pgrep -f 'cloud-hypervisor --api-socket'",
+    );
 
     const diagnosticsStep = steps.find((step) => step.name === 'Collect redacted diagnostics');
     expect(diagnosticsStep?.if).toBe('always()');


### PR DESCRIPTION
## Summary

- make Cloud Hypervisor residue and liveness `pgrep` expressions self-excluding
- apply the analogous correction to virtiofsd residue probes
- add regression coverage showing probe expressions reject their own command lines while matching real target command lines

## Validation

- `npm test -- --runInBand scripts/ci/cloud-hypervisor-ci-scripts.test.ts scripts/ci/test-cloud-hypervisor-workflow.test.ts`
- `bash -n scripts/ci/cloud-hypervisor-live-smoke.sh`
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand`

Fixes the false residue detection observed in the post-merge live-KVM run for #7922.