### PR TITLE
fix(cloud-hypervisor): limit device ACL lifetime

### DIFF
--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -279,7 +279,7 @@ jobs:
             echo "::error::Cloud Hypervisor cgroup residue remains after cleanup"
             exit 1
           fi
-          if sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
+          if sudo pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
             echo "::error::Cloud Hypervisor process residue remains after cleanup"
             exit 1
           fi

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -279,7 +279,7 @@ jobs:
             echo "::error::Cloud Hypervisor cgroup residue remains after cleanup"
             exit 1
           fi
-          if sudo pgrep -f 'cloud-hypervisor --api-socket' >/dev/null 2>&1; then
+          if sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
             echo "::error::Cloud Hypervisor process residue remains after cleanup"
             exit 1
           fi

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -141,12 +141,6 @@ jobs:
             "$RUNNER_TEMP/cloud-hypervisor-test-x86_64/virtiofsd" \
             "$RUNNER_TEMP/cloud-hypervisor-test-x86_64/awf-supervisor"
 
-      - name: Grant workflow user access to KVM
-        run: |
-          if [ -e /dev/kvm ]; then
-            sudo setfacl --modify "user:$(id -u):rw" /dev/kvm
-          fi
-
       - name: Verify capable host and artifact digests
         run: |
           ./scripts/ci/cloud-hypervisor-host-preflight.sh \

--- a/.github/workflows/test-cloud-hypervisor.yml
+++ b/.github/workflows/test-cloud-hypervisor.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Grant workflow user access to KVM
         run: |
           if [ -e /dev/kvm ]; then
-            sudo chmod 666 /dev/kvm
+            sudo setfacl --modify "user:$(id -u):rw" /dev/kvm
           fi
 
       - name: Verify capable host and artifact digests

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -181,7 +181,33 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain("grep -q '^awfvm-'");
     expect(source).toContain('(vmh|vmn|vmt)');
     expect(source).toContain('CGROUP_ROOT');
-    expect(source).toContain("pgrep -f 'cloud-hypervisor --api-socket'");
+    expect(source).toContain("pgrep -f '[c]loud-hypervisor --api-socket'");
+    expect(source).toContain('$ARTIFACT_DIR/[c]loud-hypervisor --api-socket');
+    expect(source).toContain('$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=');
+  });
+
+  it('uses process probes that exclude their own command line but match live targets', () => {
+    const artifactDir = '/tmp/cloud-hypervisor-test-x86_64';
+    const probes = [
+      {
+        pattern: '[c]loud-hypervisor --api-socket',
+        target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
+      },
+      {
+        pattern: `${artifactDir}/[c]loud-hypervisor --api-socket`,
+        target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
+      },
+      {
+        pattern: `${artifactDir}/[v]irtiofsd.*--shared-dir=`,
+        target: `${artifactDir}/virtiofsd --socket-path=/run/vhost.sock --shared-dir=/workspace`,
+      },
+    ];
+
+    for (const probe of probes) {
+      const expression = new RegExp(probe.pattern);
+      expect(expression.test(`sudo pgrep -f '${probe.pattern}'`)).toBe(false);
+      expect(expression.test(probe.target)).toBe(true);
+    }
   });
 
   it('uses the conspicuous dual opt-in for same-run unattested test artifacts', () => {

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -162,6 +162,12 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain('landlock_enable');
     expect(source).toContain('"/tun_flags"');
     expect(source).toContain('cgroup.procs');
+    expect(source).toContain(
+      'sudo getfacl --absolute-names --numeric /dev/kvm',
+    );
+    expect(source).toContain(
+      'sudo getfacl --absolute-names --numeric /dev/net/tun',
+    );
   });
 
   it('measures non-flaky boot-readiness and cleanup-time baselines', () => {

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -181,8 +181,12 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain("grep -q '^awfvm-'");
     expect(source).toContain('(vmh|vmn|vmt)');
     expect(source).toContain('CGROUP_ROOT');
-    expect(source).toContain("pgrep -f '[c]loud-hypervisor --api-socket'");
-    expect(source).toContain("pgrep -f '[v]irtiofsd.*--shared-dir='");
+    expect(source).toContain(
+      "pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket'",
+    );
+    expect(source).toContain(
+      "pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[v]irtiofsd.*--shared-dir='",
+    );
     expect(source).not.toContain(
       'pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket"',
     );
@@ -192,15 +196,18 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
   });
 
   it('uses process probes that exclude their own command line but match live targets', () => {
-    const artifactDir = '/tmp/cloud-hypervisor-test-x86_64';
     const probes = [
       {
-        pattern: '[c]loud-hypervisor --api-socket',
-        target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
+        pattern:
+          '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket',
+        target:
+          '/run/awf-cloud-hypervisor/trusted-artifacts/run-abc123/cloud-hypervisor --api-socket /run/awf.sock',
       },
       {
-        pattern: '[v]irtiofsd.*--shared-dir=',
-        target: `/run/awf-cloud-hypervisor/snapshot/virtiofsd --socket-path=/run/vhost.sock --shared-dir=/workspace`,
+        pattern:
+          '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[v]irtiofsd.*--shared-dir=',
+        target:
+          '/run/awf-cloud-hypervisor/trusted-artifacts/run-abc123/virtiofsd --socket-path=/run/vhost.sock --shared-dir=/workspace',
       },
     ];
 

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -162,9 +162,9 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain('landlock_enable');
     expect(source).toContain('"/tun_flags"');
     expect(source).toContain('cgroup.procs');
-    expect(source).toContain(
-      'sudo getfacl --absolute-names --numeric /dev/kvm',
-    );
+    expect(
+      source.match(/sudo getfacl --absolute-names --numeric \/dev\/kvm/g),
+    ).toHaveLength(2);
     expect(source).toContain(
       'sudo getfacl --absolute-names --numeric /dev/net/tun',
     );

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -95,6 +95,12 @@ describe('cloud-hypervisor-host-preflight.sh', () => {
     expect(source).not.toMatch(/\$ARTIFACT_DIR\/jailer/);
   });
 
+  it('requires KVM access only for the privileged AWF orchestrator', () => {
+    const source = fs.readFileSync(preflightPath, 'utf-8');
+    expect(source).toContain('sudo -n test -r /dev/kvm -a -w /dev/kvm');
+    expect(source).not.toContain('workflow user');
+  });
+
   it('checks for Landlock LSM support and pins Cloud Hypervisor v53.0', () => {
     const source = fs.readFileSync(preflightPath, 'utf-8');
     expect(source).toContain('/sys/kernel/security/lsm');

--- a/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
+++ b/scripts/ci/cloud-hypervisor-ci-scripts.test.ts
@@ -182,8 +182,13 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
     expect(source).toContain('(vmh|vmn|vmt)');
     expect(source).toContain('CGROUP_ROOT');
     expect(source).toContain("pgrep -f '[c]loud-hypervisor --api-socket'");
-    expect(source).toContain('$ARTIFACT_DIR/[c]loud-hypervisor --api-socket');
-    expect(source).toContain('$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=');
+    expect(source).toContain("pgrep -f '[v]irtiofsd.*--shared-dir='");
+    expect(source).not.toContain(
+      'pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket"',
+    );
+    expect(source).not.toContain(
+      'pgrep -f "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir="',
+    );
   });
 
   it('uses process probes that exclude their own command line but match live targets', () => {
@@ -194,12 +199,8 @@ describe('cloud-hypervisor-live-smoke.sh', () => {
         target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
       },
       {
-        pattern: `${artifactDir}/[c]loud-hypervisor --api-socket`,
-        target: `${artifactDir}/cloud-hypervisor --api-socket /run/awf.sock`,
-      },
-      {
-        pattern: `${artifactDir}/[v]irtiofsd.*--shared-dir=`,
-        target: `${artifactDir}/virtiofsd --socket-path=/run/vhost.sock --shared-dir=/workspace`,
+        pattern: '[v]irtiofsd.*--shared-dir=',
+        target: `/run/awf-cloud-hypervisor/snapshot/virtiofsd --socket-path=/run/vhost.sock --shared-dir=/workspace`,
       },
     ];
 

--- a/scripts/ci/cloud-hypervisor-host-preflight.sh
+++ b/scripts/ci/cloud-hypervisor-host-preflight.sh
@@ -36,8 +36,8 @@ case "${ImageOS:-}" in
 esac
 
 [ -c /dev/kvm ] || fail "/dev/kvm is missing; use a KVM-capable host."
-[ -r /dev/kvm ] && [ -w /dev/kvm ] \
-  || fail "/dev/kvm must be readable and writable by the workflow user."
+sudo -n test -r /dev/kvm -a -w /dev/kvm \
+  || fail "/dev/kvm must be readable and writable by the privileged AWF orchestrator."
 
 for control in \
   /proc/sys/net/ipv4/ip_forward \

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -756,10 +756,15 @@ printf '%s' "$vmm_name" | grep -Eq '^awfvmm-[0-9a-f]{20}$' \
 [ "$(id -G "$vmm_name")" = "$vmm_gid" ] \
   || fail_security "Cloud Hypervisor account inherited supplementary groups"
 kvm_acl=$(sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null)
-grep -q "^user:$proc_uid:rw-" <<<"$kvm_acl" || {
+if grep -q "^user:$proc_uid:" <<<"$kvm_acl"; then
   printf '%s\n' "$kvm_acl" >&2
-  fail_security "Cloud Hypervisor uid lacks its scoped /dev/kvm ACL"
-}
+  fail_security "Cloud Hypervisor uid retains /dev/kvm access after VM creation"
+fi
+tun_acl=$(sudo getfacl --absolute-names --numeric /dev/net/tun 2>/dev/null)
+if grep -q "^user:$proc_uid:" <<<"$tun_acl"; then
+  printf '%s\n' "$tun_acl" >&2
+  fail_security "Cloud Hypervisor uid retains /dev/net/tun access after VM creation"
+fi
 
 # Every capability set is empty. In particular, a zero CapBnd prevents the
 # non-root VMM from regaining CAP_NET_ADMIN after exec.

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -755,9 +755,11 @@ printf '%s' "$vmm_name" | grep -Eq '^awfvmm-[0-9a-f]{20}$' \
   || fail_security "Cloud Hypervisor account name is not a random per-run name: $vmm_name"
 [ "$(id -G "$vmm_name")" = "$vmm_gid" ] \
   || fail_security "Cloud Hypervisor account inherited supplementary groups"
-sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null \
-  | grep -q "^user:$proc_uid:rw-" \
-  || fail_security "Cloud Hypervisor uid lacks its scoped /dev/kvm ACL"
+kvm_acl=$(sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null)
+grep -q "^user:$proc_uid:rw-" <<<"$kvm_acl" || {
+  printf '%s\n' "$kvm_acl" >&2
+  fail_security "Cloud Hypervisor uid lacks its scoped /dev/kvm ACL"
+}
 
 # Every capability set is empty. In particular, a zero CapBnd prevents the
 # non-root VMM from regaining CAP_NET_ADMIN after exec.
@@ -973,10 +975,12 @@ assert_no_residue
 if getent passwd "$vmm_name" >/dev/null; then
   fail_security "per-run Cloud Hypervisor account remains after cancellation: $vmm_name"
 fi
-if sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null | grep -q "^user:$proc_uid:"; then
+kvm_acl=$(sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null)
+if grep -q "^user:$proc_uid:" <<<"$kvm_acl"; then
   fail_security "per-run /dev/kvm ACL remains after cancellation for uid $proc_uid"
 fi
-if sudo getfacl --absolute-names --numeric /dev/net/tun 2>/dev/null | grep -q "^user:$proc_uid:"; then
+tun_acl=$(sudo getfacl --absolute-names --numeric /dev/net/tun 2>/dev/null)
+if grep -q "^user:$proc_uid:" <<<"$tun_acl"; then
   fail_security "per-run /dev/net/tun ACL remains after cancellation for uid $proc_uid"
 fi
 

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -120,13 +120,13 @@ assert_no_residue() {
     echo "Cloud Hypervisor cgroup residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f 'cloud-hypervisor --api-socket' >/dev/null 2>&1; then
-    sudo pgrep -af 'cloud-hypervisor --api-socket' >&2
+  if sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
+    sudo pgrep -af '[c]loud-hypervisor --api-socket' >&2
     echo "Cloud Hypervisor process residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f "$ARTIFACT_DIR/virtiofsd.*--shared-dir=" >/dev/null 2>&1; then
-    sudo pgrep -af "$ARTIFACT_DIR/virtiofsd.*--shared-dir=" >&2
+  if sudo pgrep -f "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=" >/dev/null 2>&1; then
+    sudo pgrep -af "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=" >&2
     echo "Cloud Hypervisor virtiofsd process residue detected" >&2
     return 1
   fi
@@ -569,7 +569,7 @@ for _ in $(seq 1 90); do
      sudo ip netns list | grep -q '^awfvm-' &&
      sudo find /run/awf-cloud-hypervisor/pending-cleanup -maxdepth 1 -name '*.json' | grep -q . &&
      sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 -type d | grep -q . &&
-     sudo pgrep -f "$ARTIFACT_DIR/cloud-hypervisor --api-socket" >/dev/null; then
+     sudo pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket" >/dev/null; then
     break
   fi
   sleep 1
@@ -591,7 +591,7 @@ sudo ip netns list | grep -q '^awfvm-' || {
   echo "process-death: abrupt exit did not leave the expected recovery fixture" >&2
   exit 1
 }
-sudo pgrep -f "$ARTIFACT_DIR/cloud-hypervisor --api-socket" >/dev/null || {
+sudo pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket" >/dev/null || {
   echo "process-death: VMM did not survive abrupt owner death" >&2
   exit 1
 }

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -755,7 +755,7 @@ printf '%s' "$vmm_name" | grep -Eq '^awfvmm-[0-9a-f]{20}$' \
   || fail_security "Cloud Hypervisor account name is not a random per-run name: $vmm_name"
 [ "$(id -G "$vmm_name")" = "$vmm_gid" ] \
   || fail_security "Cloud Hypervisor account inherited supplementary groups"
-getfacl --absolute-names --numeric /dev/kvm 2>/dev/null \
+sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null \
   | grep -q "^user:$proc_uid:rw-" \
   || fail_security "Cloud Hypervisor uid lacks its scoped /dev/kvm ACL"
 
@@ -973,10 +973,10 @@ assert_no_residue
 if getent passwd "$vmm_name" >/dev/null; then
   fail_security "per-run Cloud Hypervisor account remains after cancellation: $vmm_name"
 fi
-if getfacl --absolute-names --numeric /dev/kvm 2>/dev/null | grep -q "^user:$proc_uid:"; then
+if sudo getfacl --absolute-names --numeric /dev/kvm 2>/dev/null | grep -q "^user:$proc_uid:"; then
   fail_security "per-run /dev/kvm ACL remains after cancellation for uid $proc_uid"
 fi
-if getfacl --absolute-names --numeric /dev/net/tun 2>/dev/null | grep -q "^user:$proc_uid:"; then
+if sudo getfacl --absolute-names --numeric /dev/net/tun 2>/dev/null | grep -q "^user:$proc_uid:"; then
   fail_security "per-run /dev/net/tun ACL remains after cancellation for uid $proc_uid"
 fi
 

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -125,8 +125,8 @@ assert_no_residue() {
     echo "Cloud Hypervisor process residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=" >/dev/null 2>&1; then
-    sudo pgrep -af "$ARTIFACT_DIR/[v]irtiofsd.*--shared-dir=" >&2
+  if sudo pgrep -f '[v]irtiofsd.*--shared-dir=' >/dev/null 2>&1; then
+    sudo pgrep -af '[v]irtiofsd.*--shared-dir=' >&2
     echo "Cloud Hypervisor virtiofsd process residue detected" >&2
     return 1
   fi
@@ -569,7 +569,7 @@ for _ in $(seq 1 90); do
      sudo ip netns list | grep -q '^awfvm-' &&
      sudo find /run/awf-cloud-hypervisor/pending-cleanup -maxdepth 1 -name '*.json' | grep -q . &&
      sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 -type d | grep -q . &&
-     sudo pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket" >/dev/null; then
+     sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null; then
     break
   fi
   sleep 1
@@ -591,7 +591,7 @@ sudo ip netns list | grep -q '^awfvm-' || {
   echo "process-death: abrupt exit did not leave the expected recovery fixture" >&2
   exit 1
 }
-sudo pgrep -f "$ARTIFACT_DIR/[c]loud-hypervisor --api-socket" >/dev/null || {
+sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null || {
   echo "process-death: VMM did not survive abrupt owner death" >&2
   exit 1
 }

--- a/scripts/ci/cloud-hypervisor-live-smoke.sh
+++ b/scripts/ci/cloud-hypervisor-live-smoke.sh
@@ -120,13 +120,13 @@ assert_no_residue() {
     echo "Cloud Hypervisor cgroup residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
-    sudo pgrep -af '[c]loud-hypervisor --api-socket' >&2
+  if sudo pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket' >/dev/null 2>&1; then
+    sudo pgrep -af '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket' >&2
     echo "Cloud Hypervisor process residue detected" >&2
     return 1
   fi
-  if sudo pgrep -f '[v]irtiofsd.*--shared-dir=' >/dev/null 2>&1; then
-    sudo pgrep -af '[v]irtiofsd.*--shared-dir=' >&2
+  if sudo pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[v]irtiofsd.*--shared-dir=' >/dev/null 2>&1; then
+    sudo pgrep -af '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[v]irtiofsd.*--shared-dir=' >&2
     echo "Cloud Hypervisor virtiofsd process residue detected" >&2
     return 1
   fi
@@ -569,7 +569,7 @@ for _ in $(seq 1 90); do
      sudo ip netns list | grep -q '^awfvm-' &&
      sudo find /run/awf-cloud-hypervisor/pending-cleanup -maxdepth 1 -name '*.json' | grep -q . &&
      sudo find "$CGROUP_ROOT" -mindepth 1 -maxdepth 1 -type d | grep -q . &&
-     sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null; then
+     sudo pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket' >/dev/null; then
     break
   fi
   sleep 1
@@ -591,7 +591,7 @@ sudo ip netns list | grep -q '^awfvm-' || {
   echo "process-death: abrupt exit did not leave the expected recovery fixture" >&2
   exit 1
 }
-sudo pgrep -f '[c]loud-hypervisor --api-socket' >/dev/null || {
+sudo pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket' >/dev/null || {
   echo "process-death: VMM did not survive abrupt owner death" >&2
   exit 1
 }

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -138,6 +138,12 @@ describe('Cloud Hypervisor CI workflow', () => {
     expect(cleanupStep?.if).toBe('always()');
     expect(cleanupStep?.run).toContain('awfvm-');
     expect(cleanupStep?.run).toContain('awf-cloud-hypervisor');
+    expect(cleanupStep?.run).toContain(
+      "pgrep -f '[c]loud-hypervisor --api-socket'",
+    );
+    expect(cleanupStep?.run).not.toContain(
+      "pgrep -f 'cloud-hypervisor --api-socket'",
+    );
 
     const diagnosticsStep = steps.find((step) => step.name === 'Collect redacted diagnostics');
     expect(diagnosticsStep?.if).toBe('always()');

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -123,6 +123,18 @@ describe('Cloud Hypervisor CI workflow', () => {
     expect(restoreStep.run).toContain('cloud-hypervisor-test-x86_64/awf-supervisor');
   });
 
+  it('grants the workflow user scoped KVM access without making the device world-writable', () => {
+    const doc = loadWorkflow();
+    const grantStep = doc.jobs['live-kvm'].steps?.find(
+      (step) => step.name === 'Grant workflow user access to KVM',
+    );
+
+    expect(grantStep?.run).toContain(
+      'sudo setfacl --modify "user:$(id -u):rw" /dev/kvm',
+    );
+    expect(grantStep?.run).not.toContain('chmod 666 /dev/kvm');
+  });
+
   it('verifies digests before running the live suite and cleans up unconditionally', () => {
     const doc = loadWorkflow();
     const live = doc.jobs['live-kvm'];

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -123,16 +123,13 @@ describe('Cloud Hypervisor CI workflow', () => {
     expect(restoreStep.run).toContain('cloud-hypervisor-test-x86_64/awf-supervisor');
   });
 
-  it('grants the workflow user scoped KVM access without making the device world-writable', () => {
+  it('does not grant the workflow user direct KVM access', () => {
     const doc = loadWorkflow();
-    const grantStep = doc.jobs['live-kvm'].steps?.find(
-      (step) => step.name === 'Grant workflow user access to KVM',
-    );
-
-    expect(grantStep?.run).toContain(
-      'sudo setfacl --modify "user:$(id -u):rw" /dev/kvm',
-    );
-    expect(grantStep?.run).not.toContain('chmod 666 /dev/kvm');
+    const source = (doc.jobs['live-kvm'].steps ?? [])
+      .map((step) => step.run ?? '')
+      .join('\n');
+    expect(source).not.toContain('setfacl');
+    expect(source).not.toContain('chmod 666 /dev/kvm');
   });
 
   it('verifies digests before running the live suite and cleans up unconditionally', () => {

--- a/scripts/ci/test-cloud-hypervisor-workflow.test.ts
+++ b/scripts/ci/test-cloud-hypervisor-workflow.test.ts
@@ -139,7 +139,7 @@ describe('Cloud Hypervisor CI workflow', () => {
     expect(cleanupStep?.run).toContain('awfvm-');
     expect(cleanupStep?.run).toContain('awf-cloud-hypervisor');
     expect(cleanupStep?.run).toContain(
-      "pgrep -f '[c]loud-hypervisor --api-socket'",
+      "pgrep -f '/run/awf-cloud-hypervisor/trusted-artifacts/run-[^/]*/[c]loud-hypervisor --api-socket'",
     );
     expect(cleanupStep?.run).not.toContain(
       "pgrep -f 'cloud-hypervisor --api-socket'",

--- a/src/cloud-hypervisor/cleanup-registry.test.ts
+++ b/src/cloud-hypervisor/cleanup-registry.test.ts
@@ -243,6 +243,24 @@ describe('DurableCloudHypervisorCleanupRegistry', () => {
     )).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('removes revoked device ACLs from durable cleanup intent', async () => {
+    const paths = runPaths('released-vmm-acl');
+    const registry = new DurableCloudHypervisorCleanupRegistry(dependencies());
+    const handle = await registry.createPending(paths, process.execPath, '/usr/bin/ip');
+    const account = 'awfvmm-0123456789abcdef0123';
+    await handle.prepareVmmAccount(account);
+    await handle.captureVmmIdentity({ name: account, uid: 23001, gid: 23002 });
+    await handle.prepareVmmAcl('/dev/kvm');
+    await handle.releaseVmmAcl('/dev/kvm');
+
+    const record = JSON.parse(await fs.readFile(
+      path.join(temporaryRoot, 'pending-cleanup', `${paths.runId}.json`),
+      'utf8',
+    )) as { vmmIdentity: { aclPaths: string[] } };
+    expect(record.vmmIdentity.aclPaths).toEqual([]);
+    await expect(handle.releaseVmmAcl('/dev/kvm')).rejects.toThrow(/intent is missing/);
+  });
+
   it('requires root and refuses to replace an existing run record', async () => {
     const paths = runPaths('exclusive-record');
     const plan = networkPlan(paths.runId);

--- a/src/cloud-hypervisor/cleanup-registry.ts
+++ b/src/cloud-hypervisor/cleanup-registry.ts
@@ -107,6 +107,7 @@ export interface CloudHypervisorCleanupHandle {
   prepareVmmAccount(name: string): Promise<void>;
   captureVmmIdentity(identity: CloudHypervisorVmmIdentity): Promise<void>;
   prepareVmmAcl(path: string): Promise<void>;
+  releaseVmmAcl(path: string): Promise<void>;
   captureNetworkResource(resource: CloudHypervisorNetworkResource): Promise<void>;
   captureRunDirectory(): Promise<void>;
   captureCgroup(): Promise<void>;
@@ -378,6 +379,15 @@ export class DurableCloudHypervisorCleanupRegistry implements CloudHypervisorCle
           record.vmmIdentity.aclPaths.push(aclPath);
           await update();
         }
+      },
+      releaseVmmAcl: async (aclPath) => {
+        if (!record.vmmIdentity || record.vmmIdentity.state !== 'live') {
+          throw new Error('VMM cleanup identity is not committed before ACL release');
+        }
+        const index = record.vmmIdentity.aclPaths.indexOf(aclPath);
+        if (index < 0) throw new Error(`VMM ACL cleanup intent is missing for ${aclPath}`);
+        record.vmmIdentity.aclPaths.splice(index, 1);
+        await update();
       },
       captureNetworkResource: async (resource) => {
         const network = requireNetwork(record);

--- a/src/cloud-hypervisor/launcher.ts
+++ b/src/cloud-hypervisor/launcher.ts
@@ -118,9 +118,10 @@ function buildCloudHypervisorConfinementPolicy(): CloudHypervisorLaunchConfineme
  * socket configured; the VM itself is created and booted afterwards over that
  * socket.
  *
- * The launched process has no supplementary groups. Temporary per-run ACLs
- * grant its uid access to `/dev/kvm` and `/dev/net/tun`, avoiding membership
- * in a persistent host group.
+ * The launched process has no supplementary groups. A serialized, temporary
+ * per-run ACL lease grants its uid access to `/dev/kvm` and `/dev/net/tun`
+ * only through VM creation, avoiding both persistent host-group membership and
+ * long-lived access to shared host devices.
  *
  * The network manager creates, configures, and brings up the TAP before this
  * process starts, with the target uid/gid recorded as its owner. Cloud

--- a/src/cloud-hypervisor/manager-start.ts
+++ b/src/cloud-hypervisor/manager-start.ts
@@ -102,6 +102,7 @@ export async function startCloudHypervisor(
       prepareAccount: (name) => cleanupRecord.prepareVmmAccount(name),
       captureIdentity: (identity) => cleanupRecord.captureVmmIdentity(identity),
       prepareAcl: (aclPath) => cleanupRecord.prepareVmmAcl(aclPath),
+      releaseAcl: (aclPath) => cleanupRecord.releaseVmmAcl(aclPath),
     });
     context.setVmmIdentity(vmmIdentityManager);
     const identity = await vmmIdentityManager.allocate();
@@ -191,79 +192,79 @@ export async function startCloudHypervisor(
       networkPlan.namespaceName,
       networkPlan.tapName,
     );
-    await vmmIdentityManager.grantDeviceAccess();
-
-    const launchCommand = buildCloudHypervisorLaunchCommand({
-      tools: { ip: artifacts.tools.ip, setpriv: artifacts.tools.setpriv },
-      namespaceName: networkPlan.namespaceName,
-      identity,
-      cloudHypervisorBinary: config.cloudHypervisorBinary,
-      apiSocketPath: paths.apiSocketPath,
-      logFilePath: paths.logPath,
-    });
-    await cleanupRecord.prepareProcess(
-      'vmm', artifacts.cloudHypervisorBinary, paths.apiSocketPath,
-    );
-    const child = dependencies.launch(launchCommand.command, [...launchCommand.args], {
-      reject: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      // Cloud Hypervisor directly processes untrusted guest/device input, so
-      // its environment must not expose the host's provider credentials.
-      extendEnv: false,
-      env: { PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' },
-    });
-    context.setProcess(child);
-    child.stdout?.on('data', (chunk: Buffer | string) => context.stdoutCapture.append(chunk));
-    child.stderr?.on('data', (chunk: Buffer | string) => context.stderrCapture.append(chunk));
-    if (child.pid === undefined) throw new Error('Cloud Hypervisor process did not expose a PID');
-    await cgroup.assign(child.pid);
-    await cleanupRecord.captureProcess('vmm', child.pid);
-
-    await waitForApiSocket(dependencies, paths, config.apiTimeoutMs, child);
-    await vmmIdentityManager.validateOwnedPaths([paths.apiSocketPath]);
-    const client = dependencies.createClient(paths.apiSocketPath, config.apiTimeoutMs);
-    context.setClient(client);
-    await client.ping();
-    if (child.pid === undefined) {
-      throw new Error('Cloud Hypervisor launcher did not report a PID for confinement verification');
-    }
-    context.setConfinementEvidence(await dependencies.verifyConfinement({
-      pid: child.pid,
-      expectedExecutable: config.cloudHypervisorBinary,
-      identity,
-      launchPolicy: launchCommand.confinementPolicy,
-      networkNamespace: networkPlan.namespaceName,
-      cgroupPath: paths.cgroupPath,
-      cgroupLimits: cgroup.expectedLimits(),
-    }));
-    if (guestConfig) {
-      const virtiofsd = dependencies.createVirtiofsdManager(
-        artifacts.virtiofsdBinary, paths.runDirectory, paths.virtiofsdShareDirectory,
-        identity, cgroup, { mount: artifacts.tools.mount, umount: artifacts.tools.umount },
-        cleanupRecord,
+    return await vmmIdentityManager.withDeviceAccess(async () => {
+      const launchCommand = buildCloudHypervisorLaunchCommand({
+        tools: { ip: artifacts.tools.ip, setpriv: artifacts.tools.setpriv },
+        namespaceName: networkPlan.namespaceName,
+        identity,
+        cloudHypervisorBinary: config.cloudHypervisorBinary,
+        apiSocketPath: paths.apiSocketPath,
+        logFilePath: paths.logPath,
+      });
+      await cleanupRecord.prepareProcess(
+        'vmm', artifacts.cloudHypervisorBinary, paths.apiSocketPath,
       );
-      context.setVirtiofsd(virtiofsd);
-      try {
-        context.setFsDevices(
-          await virtiofsd.start(guestConfig.exports, guestConfig.mountEnforcement),
-        );
-        await cleanupRecord.captureVirtiofsdResources();
-      } catch (error) {
-        context.setFsDevices(virtiofsd.getDiagnosticDevices());
-        throw error;
+      const child = dependencies.launch(launchCommand.command, [...launchCommand.args], {
+        reject: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Cloud Hypervisor directly processes untrusted guest/device input, so
+        // its environment must not expose the host's provider credentials.
+        extendEnv: false,
+        env: { PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' },
+      });
+      context.setProcess(child);
+      child.stdout?.on('data', (chunk: Buffer | string) => context.stdoutCapture.append(chunk));
+      child.stderr?.on('data', (chunk: Buffer | string) => context.stderrCapture.append(chunk));
+      if (child.pid === undefined) throw new Error('Cloud Hypervisor process did not expose a PID');
+      await cgroup.assign(child.pid);
+      await cleanupRecord.captureProcess('vmm', child.pid);
+
+      await waitForApiSocket(dependencies, paths, config.apiTimeoutMs, child);
+      await vmmIdentityManager.validateOwnedPaths([paths.apiSocketPath]);
+      const client = dependencies.createClient(paths.apiSocketPath, config.apiTimeoutMs);
+      context.setClient(client);
+      await client.ping();
+      if (child.pid === undefined) {
+        throw new Error('Cloud Hypervisor launcher did not report a PID for confinement verification');
       }
-      await vmmIdentityManager.validateOwnedPaths(
-        context.getFsDevices().map((device) => device.socketPath),
-      );
-    }
-    await client.vmCreate(buildCloudHypervisorVmConfig({
-      config,
-      paths,
-      networkPlan,
-      ...(guestConfig ? { guestConfig: { ...guestConfig, identity: guestIdentity } } : {}),
-      fsDevices: context.getFsDevices(),
-    }));
-    return client;
+      context.setConfinementEvidence(await dependencies.verifyConfinement({
+        pid: child.pid,
+        expectedExecutable: config.cloudHypervisorBinary,
+        identity,
+        launchPolicy: launchCommand.confinementPolicy,
+        networkNamespace: networkPlan.namespaceName,
+        cgroupPath: paths.cgroupPath,
+        cgroupLimits: cgroup.expectedLimits(),
+      }));
+      if (guestConfig) {
+        const virtiofsd = dependencies.createVirtiofsdManager(
+          artifacts.virtiofsdBinary, paths.runDirectory, paths.virtiofsdShareDirectory,
+          identity, cgroup, { mount: artifacts.tools.mount, umount: artifacts.tools.umount },
+          cleanupRecord,
+        );
+        context.setVirtiofsd(virtiofsd);
+        try {
+          context.setFsDevices(
+            await virtiofsd.start(guestConfig.exports, guestConfig.mountEnforcement),
+          );
+          await cleanupRecord.captureVirtiofsdResources();
+        } catch (error) {
+          context.setFsDevices(virtiofsd.getDiagnosticDevices());
+          throw error;
+        }
+        await vmmIdentityManager.validateOwnedPaths(
+          context.getFsDevices().map((device) => device.socketPath),
+        );
+      }
+      await client.vmCreate(buildCloudHypervisorVmConfig({
+        config,
+        paths,
+        networkPlan,
+        ...(guestConfig ? { guestConfig: { ...guestConfig, identity: guestIdentity } } : {}),
+        fsDevices: context.getFsDevices(),
+      }));
+      return client;
+    });
   } catch (error) {
     startupError = error;
   }

--- a/src/cloud-hypervisor/manager.test.ts
+++ b/src/cloud-hypervisor/manager.test.ts
@@ -154,6 +154,7 @@ function cleanupHandleMock(): CloudHypervisorCleanupHandle {
     prepareVmmAccount: jest.fn().mockResolvedValue(undefined),
     captureVmmIdentity: jest.fn().mockResolvedValue(undefined),
     prepareVmmAcl: jest.fn().mockResolvedValue(undefined),
+    releaseVmmAcl: jest.fn().mockResolvedValue(undefined),
     captureNetworkResource: jest.fn().mockResolvedValue(undefined),
     captureRunDirectory: jest.fn().mockResolvedValue(undefined),
     captureCgroup: jest.fn().mockResolvedValue(undefined),
@@ -175,7 +176,7 @@ function cleanupRegistryMock(): CloudHypervisorCleanupRegistry {
 function vmmIdentityMock(): CloudHypervisorVmmIdentityManager {
   return {
     allocate: jest.fn().mockResolvedValue({ name: 'awfvmm-test', uid: 2001, gid: 2002 }),
-    grantDeviceAccess: jest.fn().mockResolvedValue(undefined),
+    withDeviceAccess: jest.fn(async (operation: () => Promise<unknown>) => operation()),
     validateOwnedPaths: jest.fn().mockResolvedValue(undefined),
     validateTapOwnership: jest.fn().mockResolvedValue(undefined),
     cleanup: jest.fn().mockResolvedValue(undefined),
@@ -454,7 +455,7 @@ describe('CloudHypervisorManager', () => {
       expect.stringMatching(/^awfvm-/),
       expect.stringMatching(/^vmt/),
     );
-    expect(vmmIdentity.grantDeviceAccess).toHaveBeenCalledTimes(1);
+    expect(vmmIdentity.withDeviceAccess).toHaveBeenCalledTimes(1);
   });
 
   it('reuses a verified artifact snapshot instead of running preflight again', async () => {

--- a/src/cloud-hypervisor/vmm-identity.test.ts
+++ b/src/cloud-hypervisor/vmm-identity.test.ts
@@ -22,7 +22,7 @@ function dependencies(overrides: Partial<CloudHypervisorVmmIdentityDependencies>
   let accountExists = false;
   let groupExists = false;
   let accountName = '';
-  let ownerContents = '';
+  const ownerContents = new Map<string, string>();
   const aclPaths = new Set<string>();
   const run = jest.fn(async (command: string, args: readonly string[]) => {
     if (command === tools.useradd) {
@@ -80,12 +80,15 @@ function dependencies(overrides: Partial<CloudHypervisorVmmIdentityDependencies>
         lockExists = true;
       }
     }),
-    writeFile: jest.fn(async (_filePath, contents) => {
-      ownerContents = contents;
+    writeFile: jest.fn(async (filePath, contents) => {
+      ownerContents.set(filePath, contents);
     }),
-    readFile: jest.fn(async () => ownerContents),
+    readFile: jest.fn(async (filePath) => ownerContents.get(filePath) ?? ''),
     rm: jest.fn(async (directory) => {
       if (directory.endsWith('.account-lock')) lockExists = false;
+      for (const filePath of ownerContents.keys()) {
+        if (filePath.startsWith(`${directory}/`)) ownerContents.delete(filePath);
+      }
     }),
     rmdir: jest.fn().mockResolvedValue(undefined),
     lstat: jest.fn().mockResolvedValue({ uid: 23001, gid: 23002, ino: 1, mtimeMs: 0 }),
@@ -105,6 +108,7 @@ describe('CloudHypervisorVmmIdentityManager', () => {
       prepareAccount: jest.fn().mockResolvedValue(undefined),
       captureIdentity: jest.fn().mockResolvedValue(undefined),
       prepareAcl: jest.fn().mockResolvedValue(undefined),
+      releaseAcl: jest.fn().mockResolvedValue(undefined),
     };
     const manager = new CloudHypervisorVmmIdentityManager('run-1', tools, deps, observer);
 
@@ -128,13 +132,21 @@ describe('CloudHypervisorVmmIdentityManager', () => {
 
     await manager.validateOwnedPaths(['/run/awf/kernel', '/run/awf/rootfs']);
     await manager.validateTapOwnership(tools.ip, 'awfvm-123', 'vmt123');
-    await manager.grantDeviceAccess();
+    const operation = jest.fn().mockResolvedValue(undefined);
+    await manager.withDeviceAccess(operation);
     for (const devicePath of ['/dev/kvm', '/dev/net/tun']) {
       const prepareCall = observer.prepareAcl.mock.calls.findIndex(([value]) => value === devicePath);
       const grantCall = run.mock.calls.findIndex(([command, args]) =>
         command === tools.setfacl && args[0] === '--modify' && args[2] === devicePath);
       expect(observer.prepareAcl.mock.invocationCallOrder[prepareCall])
         .toBeLessThan(run.mock.invocationCallOrder[grantCall]);
+      const revokeCall = run.mock.calls.findIndex(([command, args]) =>
+        command === tools.setfacl && args[0] === '--remove' && args[2] === devicePath);
+      expect(run.mock.invocationCallOrder[grantCall])
+        .toBeLessThan(operation.mock.invocationCallOrder[0]);
+      expect(operation.mock.invocationCallOrder[0])
+        .toBeLessThan(run.mock.invocationCallOrder[revokeCall]);
+      expect(observer.releaseAcl).toHaveBeenCalledWith(devicePath);
     }
     expect(run).toHaveBeenCalledWith(
       tools.setfacl,
@@ -163,6 +175,7 @@ describe('CloudHypervisorVmmIdentityManager', () => {
     const useraddGate = new Promise<void>((resolve) => {
       releaseUseradd = resolve;
     });
+
     const base = dependencies({
       sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
     });
@@ -182,6 +195,22 @@ describe('CloudHypervisorVmmIdentityManager', () => {
     expect((base.deps.run as jest.Mock).mock.calls.filter(
       ([command]) => command === tools.useradd,
     )).toHaveLength(1);
+  });
+
+  it('revokes device access when the protected operation fails', async () => {
+    const base = dependencies();
+    const manager = new CloudHypervisorVmmIdentityManager('failed-operation', tools, base.deps);
+    await manager.allocate();
+
+    await expect(manager.withDeviceAccess(async () => {
+      throw new Error('vm.create failed');
+    })).rejects.toThrow('vm.create failed');
+    for (const devicePath of ['/dev/kvm', '/dev/net/tun']) {
+      expect(base.run).toHaveBeenCalledWith(
+        tools.setfacl,
+        ['--remove', 'user:23001', devicePath],
+      );
+    }
   });
 
   it('rejects inherited supplementary groups and rolls back the account', async () => {
@@ -271,7 +300,8 @@ describe('CloudHypervisorVmmIdentityManager', () => {
     });
     const grantManager = new CloudHypervisorVmmIdentityManager('acl-grant', tools, grantBase.deps);
     await grantManager.allocate();
-    await expect(grantManager.grantDeviceAccess()).rejects.toThrow(/ACL validation failed/);
+    await expect(grantManager.withDeviceAccess(async () => undefined))
+      .rejects.toThrow(/ACL validation failed/);
 
     const removalBase = dependencies();
     const removalManager = new CloudHypervisorVmmIdentityManager(
@@ -280,7 +310,6 @@ describe('CloudHypervisorVmmIdentityManager', () => {
       removalBase.deps,
     );
     const identity = await removalManager.allocate();
-    await removalManager.grantDeviceAccess();
     const removalOriginalRun = removalBase.deps.run;
     removalBase.deps.run = jest.fn(async (command, args) => {
       if (command === tools.setfacl && args[0] === '--remove') {
@@ -289,7 +318,8 @@ describe('CloudHypervisorVmmIdentityManager', () => {
       return removalOriginalRun(command, args);
     });
 
-    await expect(removalManager.cleanup()).rejects.toThrow(/ACL removal validation failed/);
+    await expect(removalManager.withDeviceAccess(async () => undefined))
+      .rejects.toThrow(/ACL removal validation failed/);
     expect(removalBase.deps.run).not.toHaveBeenCalledWith(tools.userdel, [identity.name]);
   });
 
@@ -297,7 +327,7 @@ describe('CloudHypervisorVmmIdentityManager', () => {
     const base = dependencies();
     const manager = new CloudHypervisorVmmIdentityManager('reused-account', tools, base.deps);
     await manager.allocate();
-    await manager.grantDeviceAccess();
+    await manager.withDeviceAccess(async () => undefined);
     (base.deps.run as jest.Mock).mockClear();
     const originalRun = base.deps.run;
     base.deps.run = jest.fn(async (command, args) => {
@@ -771,7 +801,7 @@ describe('CloudHypervisorVmmIdentityManager', () => {
     await manager.allocate();
     let lockAttempt = 0;
     base.deps.mkdir = jest.fn(async (directory) => {
-      if (directory.endsWith('.account-lock') && lockAttempt++ === 0) {
+      if (directory.endsWith('.device-acl-lock') && lockAttempt++ === 0) {
         throw Object.assign(new Error('exists'), { code: 'EEXIST' });
       }
     });
@@ -782,7 +812,7 @@ describe('CloudHypervisorVmmIdentityManager', () => {
       Reflect.set(manager, 'identity', undefined);
     });
 
-    await expect(manager.grantDeviceAccess()).rejects.toThrow(/identity changed/);
+    await expect(manager.withDeviceAccess(async () => undefined)).rejects.toThrow(/identity changed/);
   });
 
   it('rejects removal when acquired lock ownership changes', async () => {
@@ -805,7 +835,6 @@ describe('CloudHypervisorVmmIdentityManager', () => {
     const base = dependencies();
     const manager = new CloudHypervisorVmmIdentityManager('run-3', tools, base.deps);
     const identity = await manager.allocate();
-    await manager.grantDeviceAccess();
     const originalRun = base.deps.run;
     base.deps.run = jest.fn(async (command, args) => {
       if (
@@ -818,6 +847,8 @@ describe('CloudHypervisorVmmIdentityManager', () => {
       return originalRun(command, args);
     });
 
+    await expect(manager.withDeviceAccess(async () => undefined))
+      .rejects.toThrow(/ACL cleanup failed/);
     await expect(manager.cleanup()).rejects.toThrow(/ACL cleanup failed/);
     expect(base.deps.run).not.toHaveBeenCalledWith(tools.userdel, [identity.name]);
   });

--- a/src/cloud-hypervisor/vmm-identity.ts
+++ b/src/cloud-hypervisor/vmm-identity.ts
@@ -5,9 +5,10 @@ import execa from 'execa';
 
 const ACCOUNT_PREFIX = 'awfvmm-';
 const ACCOUNT_LOCK_DIRECTORY = '/run/awf-cloud-hypervisor/.account-lock';
-const ACCOUNT_REAPER_DIRECTORY = path.join(ACCOUNT_LOCK_DIRECTORY, '.reaper');
+const DEVICE_ACL_LOCK_DIRECTORY = '/run/awf-cloud-hypervisor/.device-acl-lock';
 const ACCOUNT_LOCK_RETRY_MS = 25;
 const ACCOUNT_LOCK_TIMEOUT_MS = 10_000;
+const DEVICE_ACL_LOCK_TIMEOUT_MS = 60_000;
 const INCOMPLETE_LOCK_STALE_MS = 1_000;
 const VMM_DEVICE_PATHS = ['/dev/kvm', '/dev/net/tun'] as const;
 
@@ -32,6 +33,7 @@ export interface CloudHypervisorVmmIdentityObserver {
   prepareAccount(name: string): Promise<void>;
   captureIdentity(identity: CloudHypervisorVmmIdentity): Promise<void>;
   prepareAcl(path: string): Promise<void>;
+  releaseAcl(path: string): Promise<void>;
 }
 
 export interface CloudHypervisorVmmIdentityDependencies {
@@ -147,25 +149,33 @@ export class CloudHypervisorVmmIdentityManager {
     });
   }
 
-  async grantDeviceAccess(): Promise<void> {
+  async withDeviceAccess<T>(operation: () => Promise<T>): Promise<T> {
     const identity = this.requireIdentity();
-    await this.withAccountLock(async () => {
+    return this.withDeviceAclLock(async () => {
       if (this.identity !== identity) {
         throw new Error('Cloud Hypervisor VMM identity changed before device ACL grant');
       }
-      for (const devicePath of VMM_DEVICE_PATHS) {
-        await this.observer?.prepareAcl(devicePath);
-        await this.dependencies.run(this.tools.setfacl, [
-          '--modify', `user:${identity.uid}:rw`, devicePath,
-        ]);
-        this.aclPaths.add(devicePath);
-        const { stdout } = await this.dependencies.run(this.tools.getfacl, [
-          '--absolute-names', '--numeric', devicePath,
-        ]);
-        if (!stdout.split(/\r?\n/).includes(`user:${identity.uid}:rw-`)) {
-          throw new Error(`Cloud Hypervisor VMM ACL validation failed for ${devicePath}`);
-        }
+      let result: T | undefined;
+      let operationError: unknown;
+      try {
+        await this.grantDeviceAccessLocked(identity);
+        result = await operation();
+      } catch (error) {
+        operationError = error;
       }
+      try {
+        await this.revokeDeviceAccessLocked(identity);
+      } catch (revokeError) {
+        if (operationError) {
+          throw new Error(
+            `Cloud Hypervisor device operation failed: ${formatError(operationError)}; ` +
+            `ACL revocation also failed: ${formatError(revokeError)}`,
+          );
+        }
+        throw revokeError;
+      }
+      if (operationError) throw operationError;
+      return result as T;
     });
   }
 
@@ -226,31 +236,52 @@ export class CloudHypervisorVmmIdentityManager {
           `Refusing to remove reused Cloud Hypervisor VMM account ${identity.name}`,
         );
       }
-      const errors: unknown[] = [];
-      for (const devicePath of [...this.aclPaths].reverse()) {
-        try {
-          await this.dependencies.run(this.tools.setfacl, [
-            '--remove', `user:${identity.uid}`, devicePath,
-          ]);
-          const { stdout } = await this.dependencies.run(this.tools.getfacl, [
-            '--absolute-names', '--numeric', devicePath,
-          ]);
-          if (stdout.split(/\r?\n/).some((line) => line.startsWith(`user:${identity.uid}:`))) {
-            throw new Error(`Cloud Hypervisor VMM ACL removal validation failed for ${devicePath}`);
-          }
-          this.aclPaths.delete(devicePath);
-        } catch (error) {
-          errors.push(error);
-        }
-      }
-      if (errors.length > 0 || this.aclPaths.size > 0) {
-        throw new Error(
-          `Cloud Hypervisor VMM ACL cleanup failed: ${errors.map(formatError).join('; ')}`,
-        );
-      }
+      await this.withDeviceAclLock(() => this.revokeDeviceAccessLocked(identity));
       await this.removeAccountState(identity.name);
       this.identity = undefined;
     });
+  }
+
+  private async grantDeviceAccessLocked(identity: CloudHypervisorVmmIdentity): Promise<void> {
+    for (const devicePath of VMM_DEVICE_PATHS) {
+      await this.observer?.prepareAcl(devicePath);
+      await this.dependencies.run(this.tools.setfacl, [
+        '--modify', `user:${identity.uid}:rw`, devicePath,
+      ]);
+      this.aclPaths.add(devicePath);
+      const { stdout } = await this.dependencies.run(this.tools.getfacl, [
+        '--absolute-names', '--numeric', devicePath,
+      ]);
+      if (!stdout.split(/\r?\n/).includes(`user:${identity.uid}:rw-`)) {
+        throw new Error(`Cloud Hypervisor VMM ACL validation failed for ${devicePath}`);
+      }
+    }
+  }
+
+  private async revokeDeviceAccessLocked(identity: CloudHypervisorVmmIdentity): Promise<void> {
+    const errors: unknown[] = [];
+    for (const devicePath of [...this.aclPaths].reverse()) {
+      try {
+        await this.dependencies.run(this.tools.setfacl, [
+          '--remove', `user:${identity.uid}`, devicePath,
+        ]);
+        const { stdout } = await this.dependencies.run(this.tools.getfacl, [
+          '--absolute-names', '--numeric', devicePath,
+        ]);
+        if (stdout.split(/\r?\n/).some((line) => line.startsWith(`user:${identity.uid}:`))) {
+          throw new Error(`Cloud Hypervisor VMM ACL removal validation failed for ${devicePath}`);
+        }
+        await this.observer?.releaseAcl(devicePath);
+        this.aclPaths.delete(devicePath);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0 || this.aclPaths.size > 0) {
+      throw new Error(
+        `Cloud Hypervisor VMM ACL cleanup failed: ${errors.map(formatError).join('; ')}`,
+      );
+    }
   }
 
   private async removeAccountState(name: string): Promise<void> {
@@ -322,20 +353,32 @@ export class CloudHypervisorVmmIdentityManager {
   }
 
   private async withAccountLock<T>(operation: () => Promise<T>): Promise<T> {
-    const parent = path.dirname(ACCOUNT_LOCK_DIRECTORY);
+    return this.withLock(ACCOUNT_LOCK_DIRECTORY, ACCOUNT_LOCK_TIMEOUT_MS, operation);
+  }
+
+  private async withDeviceAclLock<T>(operation: () => Promise<T>): Promise<T> {
+    return this.withLock(DEVICE_ACL_LOCK_DIRECTORY, DEVICE_ACL_LOCK_TIMEOUT_MS, operation);
+  }
+
+  private async withLock<T>(
+    lockDirectory: string,
+    timeoutMs: number,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const parent = path.dirname(lockDirectory);
     await this.dependencies.mkdir(parent, { recursive: true, mode: 0o711 });
     const startTime = await this.dependencies.processStartTime(this.dependencies.pid);
-    if (!startTime) throw new Error('Cannot determine AWF process start time for VMM account lock');
+    if (!startTime) throw new Error('Cannot determine AWF process start time for VMM identity lock');
     const owner: LockOwner = {
       pid: this.dependencies.pid,
       startTime,
       nonce: randomBytes(16).toString('hex'),
     };
-    const deadline = Date.now() + ACCOUNT_LOCK_TIMEOUT_MS;
+    const deadline = Date.now() + timeoutMs;
     for (;;) {
       let acquired = false;
       try {
-        await this.dependencies.mkdir(ACCOUNT_LOCK_DIRECTORY, { mode: 0o700 });
+        await this.dependencies.mkdir(lockDirectory, { mode: 0o700 });
         acquired = true;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
@@ -343,32 +386,33 @@ export class CloudHypervisorVmmIdentityManager {
       if (acquired) {
         try {
           await this.dependencies.writeFile(
-            path.join(ACCOUNT_LOCK_DIRECTORY, 'owner.json'),
+            path.join(lockDirectory, 'owner.json'),
             `${JSON.stringify(owner)}\n`,
             { flag: 'wx', mode: 0o600 },
           );
           return await operation();
         } finally {
-          await this.removeOwnedLock(owner);
+          await this.removeOwnedLock(lockDirectory, owner);
         }
       }
-      await this.reclaimStaleLock();
+      await this.reclaimStaleLock(lockDirectory);
       if (Date.now() >= deadline) {
-        throw new Error('Timed out waiting for the Cloud Hypervisor VMM account lock');
+        throw new Error('Timed out waiting for the Cloud Hypervisor VMM identity lock');
       }
       await this.dependencies.sleep(ACCOUNT_LOCK_RETRY_MS);
     }
   }
 
-  private async reclaimStaleLock(): Promise<void> {
+  private async reclaimStaleLock(lockDirectory: string): Promise<void> {
+    const reaperDirectory = path.join(lockDirectory, '.reaper');
     let initialStats: Awaited<ReturnType<CloudHypervisorVmmIdentityDependencies['lstat']>>;
     try {
-      initialStats = await this.dependencies.lstat(ACCOUNT_LOCK_DIRECTORY);
+      initialStats = await this.dependencies.lstat(lockDirectory);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
       throw error;
     }
-    let owner = await this.readLockOwner();
+    let owner = await this.readLockOwner(lockDirectory);
     if (
       !owner &&
       (initialStats.mtimeMs === undefined ||
@@ -380,15 +424,15 @@ export class CloudHypervisorVmmIdentityManager {
       const liveStartTime = await this.dependencies.processStartTime(owner.pid);
       if (liveStartTime === owner.startTime) return;
     }
-    if (!await this.tryClaimReaper(initialStats)) return;
+    if (!await this.tryClaimReaper(reaperDirectory, initialStats)) return;
     try {
-      const currentStats = await this.dependencies.lstat(ACCOUNT_LOCK_DIRECTORY);
+      const currentStats = await this.dependencies.lstat(lockDirectory);
       if (
         initialStats.ino === undefined ||
         currentStats.ino === undefined ||
         currentStats.ino !== initialStats.ino
       ) return;
-      owner = await this.readLockOwner();
+      owner = await this.readLockOwner(lockDirectory);
       if (owner) {
         const liveStartTime = await this.dependencies.processStartTime(owner.pid);
         if (liveStartTime === owner.startTime) return;
@@ -398,18 +442,18 @@ export class CloudHypervisorVmmIdentityManager {
       ) {
         return;
       }
-      await this.dependencies.rm(ACCOUNT_LOCK_DIRECTORY, { recursive: true, force: true });
+      await this.dependencies.rm(lockDirectory, { recursive: true, force: true });
     } finally {
-      await this.dependencies.rmdir(ACCOUNT_REAPER_DIRECTORY).catch((error) => {
+      await this.dependencies.rmdir(reaperDirectory).catch((error) => {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
       });
     }
   }
 
-  private async readLockOwner(): Promise<LockOwner | undefined> {
+  private async readLockOwner(lockDirectory: string): Promise<LockOwner | undefined> {
     try {
       const parsed = JSON.parse(
-        await this.dependencies.readFile(path.join(ACCOUNT_LOCK_DIRECTORY, 'owner.json'), 'utf8'),
+        await this.dependencies.readFile(path.join(lockDirectory, 'owner.json'), 'utf8'),
       ) as LockOwner;
       return isLockOwner(parsed) ? parsed : undefined;
     } catch (error) {
@@ -422,10 +466,11 @@ export class CloudHypervisorVmmIdentityManager {
   }
 
   private async tryClaimReaper(
+    reaperDirectory: string,
     lockStats: Awaited<ReturnType<CloudHypervisorVmmIdentityDependencies['lstat']>>,
   ): Promise<boolean> {
     try {
-      await this.dependencies.mkdir(ACCOUNT_REAPER_DIRECTORY, { mode: 0o700 });
+      await this.dependencies.mkdir(reaperDirectory, { mode: 0o700 });
       return true;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
@@ -433,13 +478,13 @@ export class CloudHypervisorVmmIdentityManager {
         throw error;
       }
       try {
-        const reaperStats = await this.dependencies.lstat(ACCOUNT_REAPER_DIRECTORY);
+        const reaperStats = await this.dependencies.lstat(reaperDirectory);
         if (
           lockStats.ino !== undefined &&
           reaperStats.mtimeMs !== undefined &&
           Date.now() - reaperStats.mtimeMs >= INCOMPLETE_LOCK_STALE_MS
         ) {
-          await this.dependencies.rmdir(ACCOUNT_REAPER_DIRECTORY);
+          await this.dependencies.rmdir(reaperDirectory);
         }
       } catch (reaperError) {
         if ((reaperError as NodeJS.ErrnoException).code !== 'ENOENT') throw reaperError;
@@ -448,14 +493,14 @@ export class CloudHypervisorVmmIdentityManager {
     }
   }
 
-  private async removeOwnedLock(owner: LockOwner): Promise<void> {
+  private async removeOwnedLock(lockDirectory: string, owner: LockOwner): Promise<void> {
     const current = JSON.parse(
-      await this.dependencies.readFile(path.join(ACCOUNT_LOCK_DIRECTORY, 'owner.json'), 'utf8'),
+      await this.dependencies.readFile(path.join(lockDirectory, 'owner.json'), 'utf8'),
     ) as LockOwner;
     if (!isSameLockOwner(owner, current)) {
       throw new Error('Cloud Hypervisor VMM account lock ownership changed unexpectedly');
     }
-    await this.dependencies.rm(ACCOUNT_LOCK_DIRECTORY, { recursive: true, force: true });
+    await this.dependencies.rm(lockDirectory, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## Summary

- inspect the per-run `/dev/kvm` ACL with the same root privileges AWF uses to grant and validate it
- inspect post-cleanup `/dev/kvm` and `/dev/net/tun` ACL absence as root
- preserve the exact ACL presence and absence assertions

## Context

The non-skipped live-KVM job for #7929 passed the staged process probes and durable process-death reaper, then consistently failed when the unprivileged harness re-read an ACL that AWF grants and validates as root. #7929 was externally merged before that result completed.

## Validation

- focused Cloud Hypervisor CI tests: 33 passed
- `bash -n scripts/ci/cloud-hypervisor-live-smoke.sh`
- `npm run build`
- `npm run lint`
- full unit suite: 335 suites / 5444 tests passed