### PR TITLE
Add fail-closed Docker sbx egress verification

### DIFF
--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -206,6 +206,7 @@ AWF settings MAY be supplied via config files, including stdin (`--config -`).
 - `network.dnsServers[]` → `--dns-servers <csv>`
 - `network.upstreamProxy` → `--upstream-proxy`
 - `network.isolation` → `--network-isolation` *(experimental; enforces egress via Docker network topology instead of host iptables)*
+- `network.verifySbxEgress` → `--verify-sbx-egress` *(fail-closed verification that Docker sbx direct traffic cannot bypass Squid; requires the sbx runtime)*
 - `network.topologyAttach[]` → `--topology-attach <name>` *(repeatable; requires `network.isolation: true`)*
 - `apiProxy.enabled` → `--enable-api-proxy` *([DEPRECATED] API proxy is always enabled; this flag is ignored)*
 - `apiProxy.caCert` → `--api-proxy-ca-cert <path>` *(mounts an additional CA certificate into the api-proxy sidecar and sets `NODE_EXTRA_CA_CERTS` for upstream TLS verification)*

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -44,6 +44,10 @@
           "type": "boolean",
           "description": "Experimental: enforce egress via Docker network topology (an internal network with no internet route plus a dual-homed Squid proxy) instead of host iptables. Requires no sudo/NET_ADMIN, so it works inside ARC/Kubernetes DinD runners. Not yet supported together with dnsOverHttps or enableHostAccess. Maps to the --network-isolation CLI flag."
         },
+        "verifySbxEgress": {
+          "type": "boolean",
+          "description": "Fail before agent startup unless Docker sbx blocks a direct request made with all proxy environment variables removed. Intended for orchestrators that start the sbx daemon with DOCKER_SANDBOXES_PROXY chained to AWF Squid. Maps to --verify-sbx-egress."
+        },
         "topologyAttach": {
           "type": "array",
           "items": {

--- a/docs/sbx-integration.md
+++ b/docs/sbx-integration.md
@@ -67,6 +67,15 @@ matter to AWF:
 This upstream-proxy hook is the single most important integration point for AWF:
 it lets AWF interpose its own Squid proxy *underneath* Docker's sandbox proxy.
 
+When an orchestrator starts the daemon with that setting, pass
+`--verify-sbx-egress` (or set `network.verifySbxEgress: true`) to make AWF run a
+fail-closed preflight before the agent starts. The preflight removes all standard
+proxy environment variables and attempts direct HTTPS connections to domains
+outside the allowlist and to a stable public IP address. Any successful
+connection aborts startup. The IP probe ensures that blocking only direct DNS is
+not mistaken for complete egress enforcement. This verifies the daemon-level
+control independently of cooperative client proxy settings.
+
 ### Lifecycle and CLI surface
 
 | Command | Purpose |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,6 +78,8 @@ Options:
                                proxy) instead of host iptables. Requires no sudo / NET_ADMIN, so it
                                works inside ARC / Kubernetes DinD runners. Not yet supported with
                                --dns-over-https or --enable-host-access. (default: false)
+  --verify-sbx-egress          Fail before agent startup unless Docker sbx blocks direct
+                               non-proxy HTTPS egress. Requires --container-runtime sbx.
   --topology-attach <name>     With --network-isolation, attach an externally-launched trusted
                                container (by name) to the internal network so the agent can reach
                                it without giving it an egress path. Repeatable. Example:

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -44,6 +44,10 @@
           "type": "boolean",
           "description": "Experimental: enforce egress via Docker network topology (an internal network with no internet route plus a dual-homed Squid proxy) instead of host iptables. Requires no sudo/NET_ADMIN, so it works inside ARC/Kubernetes DinD runners. Not yet supported together with dnsOverHttps or enableHostAccess. Maps to the --network-isolation CLI flag."
         },
+        "verifySbxEgress": {
+          "type": "boolean",
+          "description": "Fail before agent startup unless Docker sbx blocks a direct request made with all proxy environment variables removed. Intended for orchestrators that start the sbx daemon with DOCKER_SANDBOXES_PROXY chained to AWF Squid. Maps to --verify-sbx-egress."
+        },
         "topologyAttach": {
           "type": "array",
           "items": {

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -299,6 +299,11 @@ program
     'Disable network-isolation mode (requires --legacy-security).'
   )
   .option(
+    '--verify-sbx-egress',
+    'Fail before agent startup unless Docker sbx blocks direct non-proxy egress.',
+    false
+  )
+  .option(
     '--topology-attach <name>',
     'With --network-isolation, attach an externally-launched trusted container\n' +
     '                                       (by name) to the internal network so the agent can reach it.\n' +

--- a/src/commands/build-config.ts
+++ b/src/commands/build-config.ts
@@ -169,6 +169,7 @@ export function buildConfig(inputs: BuildConfigInputs): WrapperConfig {
     runnerToolCachePath: options.runnerToolCachePath as string | undefined,
     enableHostAccess: options.enableHostAccess as boolean,
     networkIsolation: options.networkIsolation as boolean | undefined,
+    verifySbxEgress: options.verifySbxEgress as boolean | undefined,
     topologyAttach: options.topologyAttach as string[] | undefined,
     localhostDetected,
     allowHostPorts: options.allowHostPorts as string | undefined,

--- a/src/commands/validators/config-assembly-flags.test.ts
+++ b/src/commands/validators/config-assembly-flags.test.ts
@@ -26,6 +26,28 @@ describe('config-assembly', () => {
         '--enable-token-steering requires --enable-api-proxy',
       );
     });
+
+    it('should exit if sbx egress verification is used with another runtime', () => {
+      mockBuildConfigOnce({ verifySbxEgress: true, containerRuntime: 'gvisor' });
+
+      expect(() => {
+        callAssembleWith();
+      }).toThrow('process.exit(1)');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('--verify-sbx-egress requires --container-runtime sbx'),
+      );
+    });
+
+    it('should accept sbx egress verification with the sbx runtime', () => {
+      mockBuildConfigOnce({ verifySbxEgress: true, containerRuntime: 'sbx' });
+
+      expect(() => {
+        callAssembleWith();
+      }).not.toThrow();
+
+      expect(getMockExit()).not.toHaveBeenCalled();
+    });
   });
 
   describe('network-isolation validation', () => {

--- a/src/commands/validators/infrastructure-validator.ts
+++ b/src/commands/validators/infrastructure-validator.ts
@@ -89,6 +89,11 @@ export function validateFeatureFlagCompatibility(config: WrapperConfig): void {
     process.exit(1);
   }
 
+  if (config.verifySbxEgress && config.containerRuntime !== 'sbx') {
+    logger.error('❌ --verify-sbx-egress requires --container-runtime sbx.');
+    process.exit(1);
+  }
+
   // Warn if --env-all is used
   if (config.envAll) {
     logger.warn('⚠️  Using --env-all: All host environment variables will be passed to container');

--- a/src/config-file-mapping.test.ts
+++ b/src/config-file-mapping.test.ts
@@ -21,12 +21,17 @@ describe('mapAwfFileConfigToCliOptions', () => {
     expect(result.rateLimitRpm).toBe('60');
   });
 
-  it('maps network-isolation and topology-attach', () => {
+  it('maps network-isolation, sbx egress verification, and topology-attach', () => {
     const result = mapAwfFileConfigToCliOptions({
-      network: { isolation: true, topologyAttach: ['mcp-gateway', 'difc-proxy'] },
+      network: {
+        isolation: true,
+        verifySbxEgress: true,
+        topologyAttach: ['mcp-gateway', 'difc-proxy'],
+      },
     });
 
     expect(result.networkIsolation).toBe(true);
+    expect(result.verifySbxEgress).toBe(true);
     expect(result.topologyAttach).toEqual(['mcp-gateway', 'difc-proxy']);
   });
 
@@ -47,6 +52,7 @@ describe('mapAwfFileConfigToCliOptions', () => {
     expect(result.dnsServers).toBeUndefined();
     expect(result.upstreamProxy).toBeUndefined();
     expect(result.networkIsolation).toBeUndefined();
+    expect(result.verifySbxEgress).toBeUndefined();
     expect(result.topologyAttach).toBeUndefined();
     expect(result.enableApiProxy).toBeUndefined();
     expect(result.sslBump).toBeUndefined();

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -18,6 +18,7 @@ export interface AwfFileConfig {
     dnsServers?: string[];
     upstreamProxy?: string;
     isolation?: boolean;
+    verifySbxEgress?: boolean;
     topologyAttach?: string[];
   };
   filesystem?: {

--- a/src/config-mapper.ts
+++ b/src/config-mapper.ts
@@ -25,6 +25,7 @@ export function mapAwfFileConfigToCliOptions(config: AwfFileConfig): Record<stri
     dnsServers: joinComma(config.network?.dnsServers),
     upstreamProxy: config.network?.upstreamProxy,
     networkIsolation: config.network?.isolation,
+    verifySbxEgress: config.network?.verifySbxEgress,
     topologyAttach: config.network?.topologyAttach,
     filesystemAllowWrite: config.filesystem?.allowWrite,
 

--- a/src/sbx-manager.test.ts
+++ b/src/sbx-manager.test.ts
@@ -153,7 +153,7 @@ describe('sbx-manager', () => {
   });
 
   describe('assertSbxEgressEnforced', () => {
-    it('probes denied domains with every proxy environment variable removed', async () => {
+    it('probes denied domains without proxy environment variables or curl configuration', async () => {
       mockExecaFn.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
 
       await expect(assertSbxEgressEnforced(
@@ -168,9 +168,23 @@ describe('sbx-manager', () => {
       expect(command).toContain('env -u HTTP_PROXY -u HTTPS_PROXY');
       expect(command).toContain('-u ALL_PROXY -u all_proxy');
       expect(command).toContain('https://1.1.1.1/');
-      expect(command).toContain('curl --fail --insecure --silent');
+      expect(command).toContain('curl --disable --fail --insecure --silent');
       expect(command).toContain('exit 86');
       expect(spawnSync('bash', ['-n', '-c', command]).status).toBe(0);
+    });
+
+    it('does not select a probe covered by a mixed-case plain-domain allowlist', async () => {
+      mockExecaFn.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await expect(assertSbxEgressEnforced(
+        'awf-agent-test',
+        {},
+        ['EXAMPLE.COM'],
+      )).resolves.toBeUndefined();
+
+      const args: string[] = mockExecaFn.mock.calls[0][1];
+      const command = args[args.length - 1];
+      expect(command).not.toContain('https://example.com/');
     });
 
     it('rejects startup when a direct request reaches the internet', async () => {

--- a/src/sbx-manager.test.ts
+++ b/src/sbx-manager.test.ts
@@ -1,5 +1,6 @@
 import {
   assertSbxApiProxyReflect,
+  assertSbxEgressEnforced,
   createSandbox,
   execInSandbox,
   isSbxAvailable,
@@ -148,6 +149,58 @@ describe('sbx-manager', () => {
   describe('SBX_DEFAULT_NAME', () => {
     it('has awf-agent prefix and process pid', () => {
       expect(SBX_DEFAULT_NAME).toMatch(/^awf-agent-\d+$/);
+    });
+  });
+
+  describe('assertSbxEgressEnforced', () => {
+    it('probes denied domains with every proxy environment variable removed', async () => {
+      mockExecaFn.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await expect(assertSbxEgressEnforced(
+        'awf-agent-test',
+        { HTTPS_PROXY: 'http://host.docker.internal:3128' },
+        ['github.com'],
+        '/workspace',
+      )).resolves.toBeUndefined();
+
+      const args: string[] = mockExecaFn.mock.calls[0][1];
+      const command = args[args.length - 1];
+      expect(command).toContain('env -u HTTP_PROXY -u HTTPS_PROXY');
+      expect(command).toContain('-u ALL_PROXY -u all_proxy');
+      expect(command).toContain('https://1.1.1.1/');
+      expect(command).toContain('curl --fail --insecure --silent');
+      expect(command).toContain('exit 86');
+      expect(spawnSync('bash', ['-n', '-c', command]).status).toBe(0);
+    });
+
+    it('rejects startup when a direct request reaches the internet', async () => {
+      mockExecaFn.mockResolvedValueOnce({ exitCode: 86, stdout: '', stderr: '' });
+
+      await expect(assertSbxEgressEnforced(
+        'awf-agent-test',
+        {},
+        ['github.com'],
+      )).rejects.toThrow('direct egress bypassed Squid');
+    });
+
+    it('fails closed when the probe cannot execute', async () => {
+      mockExecaFn.mockResolvedValueOnce({ exitCode: 127, stdout: '', stderr: '' });
+
+      await expect(assertSbxEgressEnforced(
+        'awf-agent-test',
+        {},
+        ['github.com'],
+      )).rejects.toThrow('Could not verify Docker sbx egress enforcement');
+    });
+
+    it('fails when the allowlist covers every built-in probe domain', async () => {
+      await expect(assertSbxEgressEnforced(
+        'awf-agent-test',
+        {},
+        ['1.1.1.1', '*.com', '*.org', '*.net'],
+      )).rejects.toThrow('allowlist covers every built-in probe domain');
+
+      expect(mockExecaFn).not.toHaveBeenCalled();
     });
   });
 

--- a/src/sbx-manager.ts
+++ b/src/sbx-manager.ts
@@ -33,9 +33,19 @@ import {
 } from './config/mount-policy';
 import { assertRealDirectory } from './fs-utils';
 import { getRealUserHome } from './host-identity';
+import { isDomainMatchedByPattern, parseDomainList } from './domain-matchers';
 
 /** Name prefix for AWF-managed sandboxes. */
 const SBX_NAME_PREFIX = 'awf-agent';
+const SBX_EGRESS_PROBE_DOMAINS = [
+  '1.1.1.1',
+  'example.com',
+  'example.org',
+  'example.net',
+  'iana.org',
+  'microsoft.com',
+  'google.com',
+] as const;
 
 /**
  * Env vars that must NEVER reach the sbx CLI or sandbox interior.
@@ -544,6 +554,75 @@ export async function assertSbxApiProxyReflect(
   if (result.exitCode !== 0) {
     throw new Error('sbx sandbox cannot reach the API proxy /reflect endpoint');
   }
+}
+
+/**
+ * Fails closed when an sbx guest can reach a domain that Squid policy denies
+ * after every conventional proxy environment variable has been removed.
+ *
+ * The check is opt-in because AWF does not own the long-lived sbx daemon.
+ * An orchestrator must start that daemon with DOCKER_SANDBOXES_PROXY chained
+ * to AWF's published Squid endpoint before enabling this verification.
+ */
+export async function assertSbxEgressEnforced(
+  name: string,
+  environment: Record<string, string>,
+  allowedDomains: string[],
+  workDir?: string,
+): Promise<void> {
+  const probeDomains = selectDeniedProbeDomains(allowedDomains);
+  if (probeDomains.length === 0) {
+    throw new Error(
+      'Cannot verify Docker sbx egress: the allowlist covers every built-in probe domain',
+    );
+  }
+
+  // Ignore certificate trust so TLS interception cannot masquerade as blocked
+  // transport; HTTP error responses still count as blocked via --fail.
+  const probeCommands = probeDomains.map(domain =>
+    `if env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy ` +
+    `-u ALL_PROXY -u all_proxy -u NO_PROXY -u no_proxy ` +
+    `curl --fail --insecure --silent --show-error --connect-timeout 5 --max-time 10 ` +
+    `--output /dev/null "https://${domain}/"; then ` +
+    `echo "Direct sbx egress reached ${domain} without proxy environment variables" >&2; ` +
+    'exit 86; fi'
+  );
+  const command = [
+    'command -v curl >/dev/null || exit 127',
+    ...probeCommands,
+  ].join(' && ');
+
+  const result = await execInSandbox(name, command, {
+    timeoutMinutes: 1,
+    workDir,
+    environment,
+  });
+  if (result.exitCode === 86) {
+    throw new Error(
+      'Docker sbx direct egress bypassed Squid; ensure the sbx daemon was started with ' +
+      'DOCKER_SANDBOXES_PROXY pointing to AWF Squid',
+    );
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Could not verify Docker sbx egress enforcement (probe exit ${result.exitCode})`,
+    );
+  }
+}
+
+function selectDeniedProbeDomains(allowedDomains: string[]): string[] {
+  const parsed = parseDomainList(allowedDomains);
+  return SBX_EGRESS_PROBE_DOMAINS
+    .filter(domain => {
+      const entry = { domain, protocol: 'https' as const };
+      const plainMatch = parsed.plainDomains.some(allowed => {
+        if (allowed.protocol !== 'both' && allowed.protocol !== 'https') return false;
+        const allowedDomain = allowed.domain.replace(/^\./, '');
+        return domain === allowedDomain || domain.endsWith(`.${allowedDomain}`);
+      });
+      return !plainMatch && !isDomainMatchedByPattern(entry, parsed.patterns);
+    })
+    .slice(0, 3);
 }
 
 /**

--- a/src/sbx-manager.ts
+++ b/src/sbx-manager.ts
@@ -582,7 +582,7 @@ export async function assertSbxEgressEnforced(
   const probeCommands = probeDomains.map(domain =>
     `if env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy ` +
     `-u ALL_PROXY -u all_proxy -u NO_PROXY -u no_proxy ` +
-    `curl --fail --insecure --silent --show-error --connect-timeout 5 --max-time 10 ` +
+    `curl --disable --fail --insecure --silent --show-error --connect-timeout 5 --max-time 10 ` +
     `--output /dev/null "https://${domain}/"; then ` +
     `echo "Direct sbx egress reached ${domain} without proxy environment variables" >&2; ` +
     'exit 86; fi'
@@ -617,7 +617,7 @@ function selectDeniedProbeDomains(allowedDomains: string[]): string[] {
       const entry = { domain, protocol: 'https' as const };
       const plainMatch = parsed.plainDomains.some(allowed => {
         if (allowed.protocol !== 'both' && allowed.protocol !== 'https') return false;
-        const allowedDomain = allowed.domain.replace(/^\./, '');
+        const allowedDomain = allowed.domain.replace(/^\./, '').toLowerCase();
         return domain === allowedDomain || domain.endsWith(`.${allowedDomain}`);
       });
       return !plainMatch && !isDomainMatchedByPattern(entry, parsed.patterns);

--- a/src/sbx-runtime-backend.test.ts
+++ b/src/sbx-runtime-backend.test.ts
@@ -35,6 +35,7 @@ function createDependencies(
     createSandbox: jest.fn().mockResolvedValue('awf-agent-created'),
     execInSandbox: jest.fn().mockResolvedValue({ exitCode: 0 }),
     assertApiProxyReflect: jest.fn().mockResolvedValue(undefined),
+    assertEgressEnforced: jest.fn().mockResolvedValue(undefined),
     removeSandbox: jest.fn().mockResolvedValue(undefined),
     execHostCommand: jest.fn()
       .mockReturnValueOnce('proxy log\n')
@@ -150,6 +151,44 @@ describe('SbxRuntimeBackend', () => {
 
     await expect(backend.exec('/tmp/awf-test', ['github.com'])).rejects.toThrow(
       'Sandbox not created',
+    );
+  });
+
+  it('verifies direct egress before agent execution when requested', async () => {
+    const dependencies = createDependencies();
+    const backend = new SbxRuntimeBackend(
+      createConfig({
+        verifySbxEgress: true,
+        sensitiveAllowedDomains: ['private.example.com'],
+      }),
+      dependencies,
+    );
+
+    await backend.start('/tmp/awf-test', ['github.com']);
+
+    expect(dependencies.assertEgressEnforced).toHaveBeenCalledWith(
+      'awf-agent-created',
+      expect.objectContaining({
+        HTTPS_PROXY: `http://${SBX_GATEWAY_HOST}:3128`,
+      }),
+      ['github.com', 'private.example.com'],
+      '/workspace',
+    );
+  });
+
+  it('fails startup when direct egress verification fails', async () => {
+    const dependencies = createDependencies({
+      assertEgressEnforced: jest.fn().mockRejectedValue(
+        new Error('Docker sbx direct egress bypassed Squid'),
+      ),
+    });
+    const backend = new SbxRuntimeBackend(
+      createConfig({ verifySbxEgress: true }),
+      dependencies,
+    );
+
+    await expect(backend.start('/tmp/awf-test', ['github.com'])).rejects.toThrow(
+      'Docker sbx direct egress bypassed Squid',
     );
   });
 

--- a/src/sbx-runtime-backend.ts
+++ b/src/sbx-runtime-backend.ts
@@ -4,6 +4,7 @@ import type { ExternalAgentRuntimeBackend } from './external-runtime-backend';
 import { logger } from './logger';
 import {
   assertSbxApiProxyReflect,
+  assertSbxEgressEnforced,
   createSandbox,
   execInSandbox,
   isSbxAvailable,
@@ -41,6 +42,7 @@ export interface SbxRuntimeBackendDependencies {
   createSandbox: typeof createSandbox;
   execInSandbox: typeof execInSandbox;
   assertApiProxyReflect: typeof assertSbxApiProxyReflect;
+  assertEgressEnforced: typeof assertSbxEgressEnforced;
   removeSandbox: typeof removeSandbox;
   execHostCommand(command: string, options: HostCommandOptions): string;
   getWorkspaceDir(): string;
@@ -56,6 +58,7 @@ function defaultDependencies(
     createSandbox,
     execInSandbox,
     assertApiProxyReflect: assertSbxApiProxyReflect,
+    assertEgressEnforced: assertSbxEgressEnforced,
     removeSandbox,
     execHostCommand: (command, options) => execSync(command, options),
     getWorkspaceDir: () => process.env.GITHUB_WORKSPACE || process.cwd(),
@@ -173,6 +176,17 @@ export class SbxRuntimeBackend implements ExternalAgentRuntimeBackend {
     this.dependencies.logger.info(
       `[sbx-diag] Connectivity check exited with code ${diagnosticResult.exitCode}`,
     );
+
+    if (this.config.verifySbxEgress) {
+      this.dependencies.logger.info('[sbx] Verifying direct egress cannot bypass Squid...');
+      await this.dependencies.assertEgressEnforced(
+        this.sandboxName,
+        this.environment,
+        [...allowedDomains, ...(this.config.sensitiveAllowedDomains ?? [])],
+        this.config.containerWorkDir,
+      );
+      this.dependencies.logger.info('[sbx] Direct egress verification passed');
+    }
   };
 
   readonly exec: WorkflowDependencies['runAgentCommand'] = async (

--- a/src/types/network-options.ts
+++ b/src/types/network-options.ts
@@ -132,6 +132,18 @@ export interface NetworkOptions {
   networkIsolation?: boolean;
 
   /**
+   * Verify that Docker sbx prevents direct egress when proxy environment
+   * variables are removed.
+   *
+   * This is intended for orchestrators that start the sbx daemon with
+   * DOCKER_SANDBOXES_PROXY chained to AWF's Squid proxy. When enabled, AWF
+   * performs a fail-closed preflight before starting the agent.
+   *
+   * @default false
+   */
+  verifySbxEgress?: boolean;
+
+  /**
    * Externally-launched trusted containers to attach to the internal topology
    * network when `networkIsolation` is enabled.
    *


### PR DESCRIPTION
## Summary

- add opt-in `--verify-sbx-egress` and `network.verifySbxEgress`
- probe Docker sbx with all client proxy variables removed before agent startup
- abort when denied-policy domains or a stable public IP remain directly reachable
- account for both public and sensitive Squid allowlist entries when selecting probes
- document the compiler/orchestrator contract for `DOCKER_SANDBOXES_PROXY`

## Motivation

The Playwright smoke work in #7938 proved that cooperative Chromium traffic can use Squid, but client proxy configuration is not an enforceable Docker sbx boundary. This change gives the `gh-aw` compiler a fail-closed AWF contract: after starting the sbx daemon with `DOCKER_SANDBOXES_PROXY` chained to AWF Squid, it can enable this verification and prevent the agent from starting if direct traffic bypasses that chain.

This is the AWF portion of github/gh-aw#57581. The option remains opt-in until the compiler owns the corresponding daemon startup sequence.