### PR TITLE
feat: run dynamic agent enclaves with repository-scoped GitHub MCP identities

### DIFF
--- a/containers/bounded-execution/schema-hash.js
+++ b/containers/bounded-execution/schema-hash.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const crypto = require('crypto');
+
+/**
+ * Canonical hash of an invocation's finite response schema.
+ *
+ * ADR 0001 binds every delegated identity to "the finite schema hash" for the
+ * invocation, and mcpg admits a bounded number of distinct hashes per envelope
+ * (`max_dynamic_schema_hashes`). Two invocations that declare the *same*
+ * schema must therefore produce the same hash regardless of key order or
+ * insignificant JSON formatting, and two different schemas must never
+ * collide into one admitted slot.
+ *
+ * The canonical form is JSON with object keys sorted by their UTF-16 code
+ * units, arrays left in order (order is semantically significant in a finite
+ * schema's `enum`, tuple, and union members), and no insignificant
+ * whitespace. `undefined` values are dropped exactly as `JSON.stringify`
+ * would drop them.
+ */
+function canonicalizeSchema(value) {
+  if (Array.isArray(value)) return value.map(canonicalizeSchema);
+  if (value === null || typeof value !== 'object') return value;
+  const canonical = {};
+  for (const key of Object.keys(value).sort()) {
+    const entry = canonicalizeSchema(value[key]);
+    if (entry !== undefined) canonical[key] = entry;
+  }
+  return canonical;
+}
+
+/** Returns the lowercase hex SHA-256 of a schema's canonical serialization. */
+function finiteSchemaHash(schema) {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(canonicalizeSchema(schema)), 'utf8')
+    .digest('hex');
+}
+
+module.exports = { canonicalizeSchema, finiteSchemaHash };

--- a/containers/enclave/agent-entrypoint.py
+++ b/containers/enclave/agent-entrypoint.py
@@ -23,6 +23,7 @@ TEMP_DIR = Path("/tmp")
 SHARED_MEMORY_DIR = Path("/dev/shm")
 COPILOT_BIN = "/usr/local/bin/copilot"
 GITHUB_AGENT_ID_PATH = Path("/run/awf-enclave-github/agent-id")
+GITHUB_BEARER_PATH = Path("/run/awf-enclave-github/bearer")
 GITHUB_MCP_CONFIG_PATH = AGENT_DIR / "github-mcp.json"
 
 MAX_INPUT_BYTES = 64 * 1024
@@ -84,6 +85,12 @@ def redact_diagnostics(value: str) -> str:
         agent_id = GITHUB_AGENT_ID_PATH.read_text(encoding="ascii").strip()
         if agent_id:
             redacted = redacted.replace(agent_id, "[REDACTED]")
+    except (OSError, UnicodeDecodeError):
+        pass
+    try:
+        bearer = GITHUB_BEARER_PATH.read_text(encoding="ascii").strip()
+        if bearer:
+            redacted = redacted.replace(bearer, "[REDACTED]")
     except (OSError, UnicodeDecodeError):
         pass
     return redacted
@@ -278,9 +285,9 @@ def preflight_path(
 
 
 def run_preflight(copilot_logs: Path) -> bool:
+    dynamic = is_dynamic_enabled()
     checks = [
         ("copilot-executable", Path(COPILOT_BIN), "file", True, False),
-        ("seed-directory", SEED_DIR, "directory", True, False),
         ("task-input", TASK_PATH, "file", False, False),
         ("schema-input", SCHEMA_PATH, "file", False, False),
         ("output-file", OUT_PATH, "file", False, True),
@@ -288,7 +295,18 @@ def run_preflight(copilot_logs: Path) -> bool:
         ("agent-directory", AGENT_DIR, "directory", True, True),
         ("copilot-log-directory", copilot_logs, "directory", True, True),
     ]
+    if not dynamic:
+        checks.insert(1, ("seed-directory", SEED_DIR, "directory", True, False))
     valid = True
+    if dynamic and SEED_DIR.exists() and any(SEED_DIR.iterdir()):
+        # A dynamic invocation must never be handed a repository checkout.
+        append_event({
+            "event": "preflight",
+            "path": "seed-directory",
+            "exists": True,
+            "type": "forbidden-seed-mount",
+        })
+        valid = False
     if shutil.which("gh") is not None:
         append_event({
             "event": "preflight",
@@ -316,6 +334,11 @@ def run_preflight(copilot_logs: Path) -> bool:
         )
         if error is not None:
             safe_os_error(error, "preflight-github-agent-id")
+            valid = False
+    if dynamic:
+        error = preflight_path("github-bearer", GITHUB_BEARER_PATH, "file")
+        if error is not None:
+            safe_os_error(error, "preflight-github-bearer")
             valid = False
     append_progress("preflight-completed", valid=valid)
     return valid
@@ -370,6 +393,33 @@ def build_prompt(task: str, schema_text: str) -> str:
             "available. Use those MCP tools for GitHub reads. GitHub CLI, GraphQL, search, "
             "writes, and all other GitHub tools are unavailable."
         )
+    if is_dynamic_enabled():
+        repository = os.environ.get("AWF_ENCLAVE_AGENT_DYNAMIC_REPO", "")
+        read_mode = os.environ.get("AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE", "live")
+        freshness = (
+            "Reads are live: they reflect the repository's current state at call time, not a "
+            "reproducible snapshot."
+            if read_mode != "pinned"
+            else "Reads are pinned to the admitted default-branch commit."
+        )
+        return (
+            "You are the native GitHub Copilot CLI running in an AWF enclave-agent enclave.\n"
+            "There is no repository checkout: no source tree is cloned, staged, or mounted. "
+            f"Your only source of repository data is the credential-isolated GitHub MCP server, "
+            f"which is scoped to exactly one repository: {repository}. It exposes only "
+            "`list_issues` and `issue_read`; for `issue_read`, only methods `get` and "
+            f"`get_comments` are available. {freshness}\n"
+            "You must not clone or fetch any repository, open arbitrary URLs, use the GitHub CLI "
+            "or GraphQL, perform any write or mutation, run unscoped or organization-wide search, "
+            "enumerate or discover repositories, or read any repository other than "
+            f"{repository}. Those paths are blocked and every attempt fails closed.\n"
+            "/agent is an invocation-private writable runtime directory and /tmp is bounded "
+            "tmpfs. You have no GitHub credentials, no host filesystem, and no network route "
+            "except AWF's model proxy and the repository-scoped GitHub MCP server.\n\n"
+            "Complete this task:\n"
+            f"{task}\n\n"
+            f"{output_contract}"
+        )
     return (
         "You are the native GitHub Copilot CLI running in an AWF enclave-agent enclave.\n"
         "The repository root is your current directory and is mounted read-only at /awf/seed. "
@@ -384,7 +434,15 @@ def build_prompt(task: str, schema_text: str) -> str:
     )
 
 
+def is_dynamic_enabled() -> bool:
+    """Whether this invocation reads live GitHub through a delegated identity."""
+    return os.environ.get("AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED") == "true"
+
+
 def configure_github_mcp() -> None:
+    if is_dynamic_enabled():
+        configure_dynamic_github_mcp()
+        return
     if os.environ.get("AWF_ENCLAVE_AGENT_GITHUB_ENABLED") != "true":
         return
     if os.environ.get("AWF_ENCLAVE_AGENT_GITHUB_PROFILE") != "issues-read-v1":
@@ -401,6 +459,40 @@ def configure_github_mcp() -> None:
                 "type": "http",
                 "url": endpoint,
                 "headers": {"Authorization": agent_id},
+            }
+        }
+    }
+    GITHUB_MCP_CONFIG_PATH.write_text(
+        json.dumps(config, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    GITHUB_MCP_CONFIG_PATH.chmod(0o600)
+
+
+def configure_dynamic_github_mcp() -> None:
+    """Writes the invocation-private, bearer-only GitHub MCP configuration.
+
+    The executor holds exactly one short-lived, repository-scoped bearer minted
+    for this invocation. It never receives the job token, the delegation-control
+    capability, the identity handle, the compiler envelope, mcpg's state path,
+    its policy generation, or a route to the control listener.
+    """
+    endpoint = os.environ.get("AWF_ENCLAVE_AGENT_GITHUB_MCP_URL", "")
+    if not re.fullmatch(r"http://[0-9.]+:[0-9]+/mcp/github", endpoint):
+        raise ValueError("invalid GitHub MCP endpoint")
+    repository = os.environ.get("AWF_ENCLAVE_AGENT_DYNAMIC_REPO", "")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,38}/[a-z0-9._-]{1,100}", repository):
+        raise ValueError("invalid admitted repository selector")
+    bearer = GITHUB_BEARER_PATH.read_text(encoding="ascii").strip()
+    if not re.fullmatch(r"[\x21-\x7e]{16,512}", bearer):
+        raise ValueError("invalid delegated executor bearer")
+    config = {
+        "mcpServers": {
+            "github": {
+                "type": "http",
+                "url": endpoint,
+                "headers": {"Authorization": bearer},
+                "tools": ["list_issues", "issue_read"],
             }
         }
     }
@@ -509,7 +601,7 @@ def main() -> int:
         "--log-level", "all",
         "--log-dir", str(copilot_logs),
     ]
-    if os.environ.get("AWF_ENCLAVE_AGENT_GITHUB_ENABLED") == "true":
+    if os.environ.get("AWF_ENCLAVE_AGENT_GITHUB_ENABLED") == "true" or is_dynamic_enabled():
         command.extend(["--additional-mcp-config", f"@{GITHUB_MCP_CONFIG_PATH}"])
     if max_model_requests is not None:
         command.extend(["--max-model-requests", max_model_requests])
@@ -528,7 +620,7 @@ def main() -> int:
         try:
             process = subprocess.Popen(
                 command,
-                cwd=SEED_DIR,
+                cwd=AGENT_DIR if is_dynamic_enabled() else SEED_DIR,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/containers/enclave/agent-executor/docker-enclave-runner.js
+++ b/containers/enclave/agent-executor/docker-enclave-runner.js
@@ -7,6 +7,7 @@ const {
   buildRemoveArgs,
   deriveEnclaveContainerSpec,
   normalizeTimeoutMs,
+  withDynamicBinding,
 } = require('./enclave-runner-spec');
 
 /**
@@ -26,7 +27,12 @@ class DockerEnclaveRunner {
   async assertNetworkIsolated(requireGithubGateway = true) {
     const proxyMember = 'awf-enclave-agent-api-proxy@172.31.0.30/24,';
     const expectedMemberSets = [[proxyMember]];
-    if (this.config.githubEnabled) {
+    // Both the static issues-read-v1 profile and a dynamic entry attach the
+    // compiler-owned shared gateway to this network: static invocations
+    // authenticate with the job-lifetime agent identity, dynamic ones with a
+    // per-invocation delegated bearer. Either way the steady state has exactly
+    // these two members.
+    if (this.config.githubEnabled || this.config.dynamicEnabled) {
       const steadyStateMembers = [
         proxyMember,
         `${this.config.githubGatewayContainer}@172.31.0.40/24,`,
@@ -64,13 +70,14 @@ class DockerEnclaveRunner {
     await this.assertNetworkIsolated(false);
   }
 
-  spec(runId, invocationId, seedId) {
+  spec(runId, invocationId, seedId, dynamic, launch = true) {
     return deriveEnclaveContainerSpec({
-      config: this.config,
+      config: withDynamicBinding(this.config, dynamic),
       runId,
       invocationId,
       seedId,
       runtimeName: this.runtimeName,
+      launch,
     });
   }
 
@@ -106,12 +113,12 @@ class DockerEnclaveRunner {
 
   /** Deterministic orphan cleanup for every container labelled with this run. */
   async reconcileRun(runId) {
-    const spec = this.spec(runId, 'reconcile', '0'.repeat(32));
+    const spec = this.spec(runId, 'reconcile', '0'.repeat(32), undefined, false);
     await this.serializeCleanup(() => this.removeListed(spec.runListArgs));
   }
 
   async cleanupInvocation(runId, invocationId) {
-    const spec = this.spec(runId, invocationId, '0'.repeat(32));
+    const spec = this.spec(runId, invocationId, '0'.repeat(32), undefined, false);
     await this.serializeCleanup(() => this.removeListed(spec.invocationListArgs));
   }
 
@@ -122,7 +129,7 @@ class DockerEnclaveRunner {
    * sandbox may still hold a mount of private repository content.
    */
   async runEnclaveContainer(params) {
-    const spec = this.spec(params.runId, params.invocationId, params.seedId);
+    const spec = this.spec(params.runId, params.invocationId, params.seedId, params.dynamic);
     const timeoutMs = normalizeTimeoutMs(
       (params.timeoutMs ?? this.config.timeoutSeconds * 1000) + CLI_GRACE_MS,
     );

--- a/containers/enclave/agent-executor/enclave-runner-spec.js
+++ b/containers/enclave/agent-executor/enclave-runner-spec.js
@@ -62,7 +62,10 @@ function freezeArray(values) {
 function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runtimeName }) {
   assertTrustedId('runId', runId);
   assertTrustedId('invocationId', invocationId);
-  assertTrustedSeedId(seedId);
+  // A dynamic entry stages no immutable seed at all: the enclave reads live
+  // GitHub through one repository-scoped delegated identity, so there is no
+  // seed id, no seed directory, and no `/awf/seed` mount.
+  if (!config.dynamicEnabled) assertTrustedSeedId(seedId);
   if (runtimeName !== undefined && runtimeName !== 'runsc') {
     throw new Error(`Unsupported OCI runtime in enclave runner: ${runtimeName}`);
   }
@@ -73,7 +76,6 @@ function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runti
   const containerPrefix = config.containerPrefix || 'awf-enclave-agent';
   const containerName = `${containerPrefix}-${runId.slice(0, 12)}-${invocationId}`;
   const hostInvocationDir = `${config.hostWorkDir}/${invocationId}`;
-  const hostSeedDir = `${config.hostSeedsDir}/${seedId}`;
   const runLabel = `${runLabelKey}=${runId}`;
   const invocationLabel = `${invocationLabelKey}=${invocationId}`;
   const launchArgs = [
@@ -97,7 +99,7 @@ function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runti
     '--shm-size', config.tmpfsLimit,
     '--tmpfs', `/tmp:rw,noexec,nosuid,nodev,size=${config.tmpfsLimit}`,
     '--hostname', config.enclaveHostname || 'enclave-agent',
-    '--workdir', config.enclaveSeedPath,
+    '--workdir', config.dynamicEnabled ? config.enclaveMountDir : config.enclaveSeedPath,
     '--env', `AWF_ENCLAVE_AGENT_ENGINE=${config.engine}`,
     '--env', `HOME=${config.enclaveMountDir}/home`,
     '--env', `COPILOT_HOME=${config.enclaveMountDir}/copilot`,
@@ -114,13 +116,15 @@ function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runti
     '--env', `AWF_ENCLAVE_AGENT_MODEL=${config.model}`,
     '--env', `AWF_ENCLAVE_AGENT_MAX_OUTPUT_BYTES=${config.maxOutputBytes}`,
     '--env', `AWF_ENCLAVE_AGENT_DEADLINE_SECONDS=${config.timeoutSeconds}`,
-    '-v', `${hostSeedDir}:${config.enclaveSeedPath}:ro`,
     '-v', `${hostInvocationDir}/task.txt:${config.enclaveTaskPath}:ro`,
     '-v', `${hostInvocationDir}/schema.json:${config.enclaveSchemaPath}:ro`,
     '-v', `${hostInvocationDir}/out:/awf/out:rw`,
     '-v', `${hostInvocationDir}/session.jsonl:/awf/session.jsonl:rw`,
     '-v', `${hostInvocationDir}/agent:${config.enclaveMountDir}:rw`,
   ];
+  if (!config.dynamicEnabled) {
+    launchArgs.push('-v', `${config.hostSeedsDir}/${seedId}:${config.enclaveSeedPath}:ro`);
+  }
   if (config.githubEnabled) {
     launchArgs.push(
       '--env', 'AWF_ENCLAVE_AGENT_GITHUB_ENABLED=true',
@@ -128,6 +132,16 @@ function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runti
       '--env', `AWF_ENCLAVE_AGENT_GITHUB_MCP_URL=${config.githubMcpUrl}`,
       '-v',
       `${hostInvocationDir}/github-agent-id:${config.enclaveGithubAgentIdPath}:ro`,
+    );
+  }
+  if (config.dynamicEnabled) {
+    launchArgs.push(
+      '--env', 'AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED=true',
+      '--env', `AWF_ENCLAVE_AGENT_GITHUB_MCP_URL=${config.dynamicGithubMcpUrl}`,
+      '--env', `AWF_ENCLAVE_AGENT_DYNAMIC_REPO=${config.dynamicRepository}`,
+      '--env', `AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE=${config.dynamicReadMode}`,
+      '-v',
+      `${hostInvocationDir}/github-bearer:${config.enclaveGithubBearerPath}:ro`,
     );
   }
 

--- a/containers/enclave/agent-executor/enclave-runner-spec.js
+++ b/containers/enclave/agent-executor/enclave-runner-spec.js
@@ -34,6 +34,40 @@ const ENCLAVE_RUN_LABEL = 'awf.enclave.run';
 const ENCLAVE_INVOCATION_LABEL = 'awf.enclave.invocation';
 const TRUSTED_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
+/** Canonical dynamic selector, per ADR 0001. Never widened at runtime. */
+const CANONICAL_DYNAMIC_REPOSITORY_PATTERN =
+  /^[a-z0-9](?:[a-z0-9-]{0,38})\/(?!\.\.?$)(?!.*\.\.)[a-z0-9._-]{1,100}$/;
+
+const DYNAMIC_READ_MODES = new Set(['live', 'pinned']);
+
+/**
+ * Merges one invocation's delegation binding into the trusted broker config.
+ *
+ * Exactly two scalars may vary per invocation — the admitted repository and
+ * its read mode — and both come from AWF's canonical admission, never from the
+ * caller's request. Anything else is rejected so a per-invocation object can
+ * never widen the fixed container specification.
+ */
+function withDynamicBinding(config, dynamic) {
+  if (dynamic === undefined) return config;
+  if (!config.dynamicEnabled) {
+    throw new Error('A delegation binding was supplied for a non-dynamic enclave entry');
+  }
+  if (
+    typeof dynamic !== 'object'
+    || dynamic === null
+    || !CANONICAL_DYNAMIC_REPOSITORY_PATTERN.test(dynamic.repository || '')
+    || !DYNAMIC_READ_MODES.has(dynamic.readMode)
+  ) {
+    throw new Error('The delegation binding is not a canonical admitted repository and read mode');
+  }
+  return {
+    ...config,
+    dynamicRepository: dynamic.repository,
+    dynamicReadMode: dynamic.readMode,
+  };
+}
+
 /** Converts a monotonic-clock duration to the integer milliseconds Node requires. */
 function normalizeTimeoutMs(timeoutMs) {
   return Math.max(1, Math.ceil(timeoutMs));
@@ -59,13 +93,33 @@ function freezeArray(values) {
  * Derives every daemon-facing enclave setting from trusted config and
  * broker-generated identifiers.
  */
-function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runtimeName }) {
+/**
+ * Derives every daemon-facing enclave setting from trusted config and
+ * broker-generated identifiers.
+ *
+ * `launch` distinguishes a real invocation from the reconciliation/cleanup
+ * paths, which only need the label filter vectors. A dynamic entry has no
+ * repository binding while reconciling, so the per-invocation delegation
+ * checks apply to launches only.
+ */
+function deriveEnclaveContainerSpec({ config, runId, invocationId, seedId, runtimeName, launch = true }) {
   assertTrustedId('runId', runId);
   assertTrustedId('invocationId', invocationId);
   // A dynamic entry stages no immutable seed at all: the enclave reads live
   // GitHub through one repository-scoped delegated identity, so there is no
   // seed id, no seed directory, and no `/awf/seed` mount.
   if (!config.dynamicEnabled) assertTrustedSeedId(seedId);
+  if (launch && config.dynamicEnabled) {
+    // The launch vector must never interpolate an unbound selector or read
+    // mode: an executor that received `undefined` would either fail closed at
+    // startup or, worse, misstate the delegation contract in its prompt.
+    if (!CANONICAL_DYNAMIC_REPOSITORY_PATTERN.test(config.dynamicRepository || '')) {
+      throw new Error('dynamicRepository is not an admitted canonical repository');
+    }
+    if (!DYNAMIC_READ_MODES.has(config.dynamicReadMode)) {
+      throw new Error('dynamicReadMode is not an admitted read mode');
+    }
+  }
   if (runtimeName !== undefined && runtimeName !== 'runsc') {
     throw new Error(`Unsupported OCI runtime in enclave runner: ${runtimeName}`);
   }
@@ -181,4 +235,5 @@ module.exports = {
   buildRemoveArgs,
   deriveEnclaveContainerSpec,
   normalizeTimeoutMs,
+  withDynamicBinding,
 };

--- a/containers/enclave/agent-executor/workspace.js
+++ b/containers/enclave/agent-executor/workspace.js
@@ -30,6 +30,7 @@ function invocationLayout(workDir, invocationId) {
     outPath: path.join(root, 'out'),
     sessionLogPath: path.join(root, 'session.jsonl'),
     githubAgentIdPath: path.join(root, 'github-agent-id'),
+    githubBearerPath: path.join(root, 'github-bearer'),
     agentPath: path.join(root, 'agent'),
   };
 }
@@ -42,7 +43,7 @@ function invocationLayout(workDir, invocationId) {
  * it through its `rw` bind mount.
  */
 function createInvocationWorkspace(params) {
-  const { config, invocationId, task, schema, githubAgentId } = params;
+  const { config, invocationId, task, schema, githubAgentId, executorBearer } = params;
   const layout = invocationLayout(config.workDir, invocationId);
 
   fs.mkdirSync(layout.root, { recursive: true, mode: 0o700 });
@@ -67,6 +68,19 @@ function createInvocationWorkspace(params) {
     fs.writeFileSync(layout.githubAgentIdPath, `${githubAgentId}\n`, { mode: 0o600 });
     fs.chownSync(layout.githubAgentIdPath, config.enclaveUid, config.enclaveGid);
     fs.chmodSync(layout.githubAgentIdPath, 0o400);
+  }
+  if (config.dynamicEnabled) {
+    // The single-use executor receives exactly one short-lived, repository
+    // scoped bearer — never the job token, the delegation-control capability,
+    // the identity handle, the compiler envelope, mcpg's state path, or its
+    // policy generation. The file is invocation-private and destroyed with the
+    // workspace.
+    if (typeof executorBearer !== 'string' || !/^[\x21-\x7e]{16,512}$/.test(executorBearer)) {
+      throw new Error('invalid delegated executor bearer');
+    }
+    fs.writeFileSync(layout.githubBearerPath, `${executorBearer}\n`, { mode: 0o600 });
+    fs.chownSync(layout.githubBearerPath, config.enclaveUid, config.enclaveGid);
+    fs.chmodSync(layout.githubBearerPath, 0o400);
   }
 
   return layout;

--- a/containers/enclave/mcp-server/agent-executor.js
+++ b/containers/enclave/mcp-server/agent-executor.js
@@ -58,13 +58,14 @@ function createAgentRequestValidator(maxPromptBytes) {
  * invoked inside the charged timing bucket and before teardown.
  */
 const agentWorkspaceAdapter = {
-  createInvocationWorkspace({ config, invocationId, privateRepo, schema, prompt }) {
+  createInvocationWorkspace({ config, invocationId, privateRepo, schema, prompt, executorBearer }) {
     return agentWorkspace.createInvocationWorkspace({
       config,
       invocationId,
       schema,
       task: prompt,
       githubAgentId: config.githubEnabled ? config.githubAgentId : undefined,
+      executorBearer,
     });
   },
   readQueryOutput(outPath, maxOutputBytes) {
@@ -97,8 +98,16 @@ function createAgentRunner(config, deps = {}) {
   return {
     assertAvailable: () => runner.assertAvailable(),
     reconcileRun: (runId) => runner.reconcileRun(runId),
-    runScriptContainer: ({ runId, invocationId, seedId, timeoutMs }) => runner.runEnclaveContainer({
-      config,
+    runScriptContainer: ({ runId, invocationId, seedId, timeoutMs, dynamic }) => runner.runEnclaveContainer({
+      // Per-invocation delegation binding comes from AWF's canonical
+      // admission, never from the caller's request.
+      config: dynamic
+        ? {
+          ...config,
+          dynamicRepository: dynamic.repository,
+          dynamicReadMode: dynamic.readMode,
+        }
+        : config,
       runId,
       invocationId,
       seedId,

--- a/containers/enclave/mcp-server/agent-executor.js
+++ b/containers/enclave/mcp-server/agent-executor.js
@@ -99,19 +99,15 @@ function createAgentRunner(config, deps = {}) {
     assertAvailable: () => runner.assertAvailable(),
     reconcileRun: (runId) => runner.reconcileRun(runId),
     runScriptContainer: ({ runId, invocationId, seedId, timeoutMs, dynamic }) => runner.runEnclaveContainer({
-      // Per-invocation delegation binding comes from AWF's canonical
-      // admission, never from the caller's request.
-      config: dynamic
-        ? {
-          ...config,
-          dynamicRepository: dynamic.repository,
-          dynamicReadMode: dynamic.readMode,
-        }
-        : config,
+      config,
       runId,
       invocationId,
       seedId,
       timeoutMs,
+      // Per-invocation delegation binding from AWF's canonical admission. The
+      // runner merges only the admitted repository and read mode, after
+      // revalidating both; a caller's request can express neither.
+      dynamic,
     }),
   };
 }

--- a/containers/enclave/mcp-server/config.js
+++ b/containers/enclave/mcp-server/config.js
@@ -272,6 +272,11 @@ function loadAgentConfig(server, files = fs) {
   const githubMcpUrl = process.env.AWF_ENCLAVE_AGENT_GITHUB_MCP_URL;
   const githubAgentIdPath = process.env.AWF_ENCLAVE_AGENT_GITHUB_AGENT_ID_PATH;
   const githubGatewayContainer = process.env.AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER;
+  if (dynamicEnabled && !/^[A-Za-z0-9][A-Za-z0-9_.-]{7,127}$/.test(githubGatewayContainer || '')) {
+    // A dynamic entry reaches the same shared gateway as the static profile,
+    // so the per-launch network-isolation proof needs its real container name.
+    throw new Error('AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER is invalid');
+  }
   let githubAgentId;
   if (githubEnabled) {
     if (githubProfile !== 'issues-read-v1') {
@@ -332,7 +337,7 @@ function loadAgentConfig(server, files = fs) {
     githubProfile: githubEnabled ? githubProfile : undefined,
     githubMcpUrl: githubEnabled ? githubMcpUrl : undefined,
     githubAgentId,
-    githubGatewayContainer: githubEnabled ? githubGatewayContainer : undefined,
+    githubGatewayContainer: githubEnabled || dynamicEnabled ? githubGatewayContainer : undefined,
     enclaveGithubAgentIdPath: '/run/awf-enclave-github/agent-id',
     dynamicEnabled,
     dynamicChannelDir,

--- a/containers/enclave/mcp-server/config.js
+++ b/containers/enclave/mcp-server/config.js
@@ -7,7 +7,7 @@ const {
   MAX_RESULT_BYTES,
   MAX_SCRIPT_BYTES,
 } = require('../../bounded-execution/finite-disclosure');
-const { ENCLAVE_SENSITIVITY_RUN_BITS } = require('../../bounded-execution/sensitivity-policy');
+const { ENCLAVE_SENSITIVITIES, ENCLAVE_SENSITIVITY_RUN_BITS } = require('../../bounded-execution/sensitivity-policy');
 const { parsePrivateRepositorySeedMap } = require('../../bounded-execution/repository-staging');
 const {
   ENCLAVE_INVOCATION_LABEL,
@@ -44,6 +44,11 @@ const AGENT_SUPPORTED_ENGINES = new Set(['copilot']);
 const AGENT_SUPPORTED_PROFILES = new Set(['openai', 'anthropic']);
 const AGENT_CONTAINER_PREFIX = 'awf-enclave-agent';
 const GITHUB_AGENT_ID_FILE = '/run/awf-enclave-mcp/github-agent-id';
+/** Broker-side mount of AWF's private dynamic-admission channel. */
+const DELEGATION_CHANNEL_DIR = '/run/awf-enclave-delegation';
+/** Invocation-private path the executor reads its delegated bearer from. */
+const ENCLAVE_GITHUB_BEARER_PATH = '/run/awf-enclave-github/bearer';
+const DYNAMIC_SENSITIVITIES = new Set(ENCLAVE_SENSITIVITIES);
 
 function requireEnv(name) {
   const value = process.env[name];
@@ -142,6 +147,27 @@ function isAgentExecutorEnabled() {
 }
 
 /**
+ * True when the agent entry admits repositories dynamically (ADR 0001).
+ *
+ * A dynamic entry has no static seed catalog: it never mounts `/awf/seed`,
+ * never reads a seed map, and never holds a job token.
+ */
+function isDynamicAdmissionEnabled() {
+  return process.env.AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED === 'true';
+}
+
+/**
+ * True when AWF staged an immutable seed catalog for this run.
+ *
+ * Absent, the value defaults to `true` so a pinned older AWF release — which
+ * never sets it — keeps its existing static behaviour. A dynamic-only run sets
+ * it explicitly to `false`.
+ */
+function isSeedMapEnabled() {
+  return process.env.AWF_ENCLAVE_SEED_MAP_ENABLED !== 'false';
+}
+
+/**
  * Loads the shared, executor-independent server settings.
  *
  * Used on every start, including agent-only runs where no script-executor
@@ -158,6 +184,8 @@ function loadServerConfig(files = fs) {
   }
   return {
     seedMapPath: SEED_MAP_PATH,
+    seedMapEnabled: isSeedMapEnabled(),
+    runId: resolveRunId(),
     listenHost: process.env.AWF_ENCLAVE_LISTEN_HOST || '0.0.0.0',
     listenPort: MCP_PORT,
     controlDir: CONTROL_DIR,
@@ -166,6 +194,26 @@ function loadServerConfig(files = fs) {
     primaryBackend,
     capability,
   };
+}
+
+/**
+ * Resolves the AWF-generated run id.
+ *
+ * Static runs can also recover it from the seed map, but a dynamic-only run
+ * stages no seed catalog at all, so AWF passes it explicitly.
+ */
+function resolveRunId() {
+  const runId = process.env.AWF_ENCLAVE_RUN_ID;
+  if (runId !== undefined && runId !== '') {
+    if (!/^[0-9a-f]{16,64}$/.test(runId)) {
+      throw new Error('AWF_ENCLAVE_RUN_ID is not an AWF-generated run identifier');
+    }
+    return runId;
+  }
+  if (!isSeedMapEnabled()) {
+    throw new Error('AWF_ENCLAVE_RUN_ID is required when no seed catalog is staged');
+  }
+  return undefined;
 }
 
 /**
@@ -199,6 +247,27 @@ function loadAgentConfig(server, files = fs) {
   }
   const cpuLimit = process.env.AWF_ENCLAVE_AGENT_CPU || '1';
   const githubEnabled = process.env.AWF_ENCLAVE_AGENT_GITHUB_ENABLED === 'true';
+  const dynamicEnabled = isDynamicAdmissionEnabled();
+  if (githubEnabled && dynamicEnabled) {
+    throw new Error('An enclave entry declares a static GitHub profile and a dynamic policy');
+  }
+  let dynamicChannelDir;
+  let dynamicSensitivity;
+  let dynamicGithubMcpUrl;
+  if (dynamicEnabled) {
+    dynamicChannelDir = process.env.AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR;
+    if (dynamicChannelDir !== DELEGATION_CHANNEL_DIR) {
+      throw new Error('AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR is not the fixed private path');
+    }
+    dynamicSensitivity = process.env.AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY;
+    if (!DYNAMIC_SENSITIVITIES.has(dynamicSensitivity)) {
+      throw new Error('AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY is not a supported sensitivity');
+    }
+    dynamicGithubMcpUrl = process.env.AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL;
+    if (!/^http:\/\/[0-9.]+:[0-9]+\/mcp\/github$/.test(dynamicGithubMcpUrl || '')) {
+      throw new Error('AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL must be a fixed IPv4 MCP endpoint');
+    }
+  }
   const githubProfile = process.env.AWF_ENCLAVE_AGENT_GITHUB_PROFILE;
   const githubMcpUrl = process.env.AWF_ENCLAVE_AGENT_GITHUB_MCP_URL;
   const githubAgentIdPath = process.env.AWF_ENCLAVE_AGENT_GITHUB_AGENT_ID_PATH;
@@ -231,7 +300,7 @@ function loadAgentConfig(server, files = fs) {
     workDir: WORK_DIR,
     auditDir: server.auditDir,
     hostWorkDir: requireEnv('AWF_ENCLAVE_AGENT_HOST_WORK_DIR'),
-    hostSeedsDir: requireEnv('AWF_ENCLAVE_AGENT_HOST_SEEDS_DIR'),
+    hostSeedsDir: dynamicEnabled ? undefined : requireEnv('AWF_ENCLAVE_AGENT_HOST_SEEDS_DIR'),
     enclaveSeccompPath: AGENT_SECCOMP_PATH,
     enclaveMountDir: AGENT_MOUNT_DIR,
     enclaveSeedPath: AGENT_SEED_PATH,
@@ -265,6 +334,11 @@ function loadAgentConfig(server, files = fs) {
     githubAgentId,
     githubGatewayContainer: githubEnabled ? githubGatewayContainer : undefined,
     enclaveGithubAgentIdPath: '/run/awf-enclave-github/agent-id',
+    dynamicEnabled,
+    dynamicChannelDir,
+    dynamicSensitivity,
+    dynamicGithubMcpUrl,
+    enclaveGithubBearerPath: ENCLAVE_GITHUB_BEARER_PATH,
     runLabelKey: ENCLAVE_RUN_LABEL,
     invocationLabelKey: ENCLAVE_INVOCATION_LABEL,
     containerPrefix: AGENT_CONTAINER_PREFIX,
@@ -287,6 +361,8 @@ module.exports = {
   AUDIT_DIR,
   CAPABILITY_PATH,
   CONTROL_DIR,
+  DELEGATION_CHANNEL_DIR,
+  ENCLAVE_GITHUB_BEARER_PATH,
   READY_PATH,
   SEED_MAP_PATH,
   SEEDS_DIR,
@@ -294,7 +370,9 @@ module.exports = {
   WORK_DIR,
   GITHUB_AGENT_ID_FILE,
   isAgentExecutorEnabled,
+  isDynamicAdmissionEnabled,
   isScriptExecutorEnabled,
+  isSeedMapEnabled,
   loadAgentConfig,
   loadConfig,
   loadSeedMap,

--- a/containers/enclave/mcp-server/delegation-channel.js
+++ b/containers/enclave/mcp-server/delegation-channel.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { finiteSchemaHash } = require('../../bounded-execution/schema-hash');
+
+/**
+ * Broker side of the AWF-private dynamic delegation channel.
+ *
+ * The broker never holds the mcpg delegation-control endpoint or capability:
+ * gh-aw publishes that listener on the *runner's* `127.0.0.1` only, which no
+ * container can route to. Instead the broker asks the AWF host process, over a
+ * `0700` directory bind-mounted only into this container, to run canonical
+ * admission and mint the invocation's delegated identity.
+ *
+ * What the broker sends: the caller's selector verbatim, the exact finite
+ * output-schema hash, and — after the enclave finishes — the terminal outcome
+ * with its actual output-byte and execution-second usage.
+ *
+ * What the broker receives: one canonical denial, or one repository plus one
+ * short-lived executor bearer and its read mode. It never receives the control
+ * endpoint, the control capability, the identity handle, the compiler
+ * envelope, mcpg's state path, or its policy generation.
+ */
+
+const CHANNEL_VERSION = 1;
+const MAX_MESSAGE_BYTES = 8 * 1024;
+const REQUEST_SUFFIX = '.admit.json';
+const RESPONSE_SUFFIX = '.admitted.json';
+const SETTLE_SUFFIX = '.settle.json';
+const RECEIPT_SUFFIX = '.settled.json';
+const POLL_INTERVAL_MS = 20;
+
+/** Admission must resolve well inside the smallest useful timing bucket. */
+const DEFAULT_ADMISSION_TIMEOUT_MS = 60_000;
+/** Settlement is a single loopback revoke; it must not stall teardown. */
+const DEFAULT_SETTLEMENT_TIMEOUT_MS = 30_000;
+
+const TERMINAL_OUTCOMES = new Set([
+  'success',
+  'agent-failure',
+  'schema-failure',
+  'timeout',
+  'cancelled',
+  'broker-error',
+]);
+
+function writeAtomic(target, value) {
+  const temporary = `${target}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value), { mode: 0o600 });
+  fs.chmodSync(temporary, 0o600);
+  fs.renameSync(temporary, target);
+}
+
+function readBounded(target) {
+  let fd;
+  try {
+    fd = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.size > MAX_MESSAGE_BYTES) return undefined;
+    return JSON.parse(fs.readFileSync(fd, 'utf8'));
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Waits for `target` to appear, up to `timeoutMs`. Returns the parsed document
+ * or `undefined`; the caller fails closed on `undefined`.
+ */
+async function awaitDocument(target, timeoutMs, pollIntervalMs) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const document = readBounded(target);
+    if (document !== undefined) {
+      fs.rmSync(target, { force: true });
+      return document;
+    }
+    if (Date.now() >= deadline) return undefined;
+    await sleep(Math.min(pollIntervalMs, Math.max(1, deadline - Date.now())));
+  }
+}
+
+/**
+ * Creates the broker's admission client for one dynamic enclave entry.
+ *
+ * `config.dynamicSensitivity` is trusted broker configuration derived from the
+ * compiler envelope; an invocation can never express or widen it.
+ */
+function createDynamicDelegationClient(config, deps = {}) {
+  const directory = config.dynamicChannelDir;
+  const pollIntervalMs = deps.pollIntervalMs || POLL_INTERVAL_MS;
+  const admissionTimeoutMs = deps.admissionTimeoutMs || DEFAULT_ADMISSION_TIMEOUT_MS;
+  const settlementTimeoutMs = deps.settlementTimeoutMs || DEFAULT_SETTLEMENT_TIMEOUT_MS;
+
+  return {
+    sensitivity: config.dynamicSensitivity,
+
+    /**
+     * Routes one invocation through AWF's canonical admission.
+     *
+     * Returns `{ admitted: false }` for every failure — malformed selector,
+     * out-of-policy owner, exhausted quota, control denial, control outage, or
+     * a missing/unparsable reply — so the caller emits the single canonical
+     * error with no distinguishing detail.
+     */
+    async admit({ invocationId, selector, schema }) {
+      const requestPath = path.join(directory, `${invocationId}${REQUEST_SUFFIX}`);
+      const responsePath = path.join(directory, `${invocationId}${RESPONSE_SUFFIX}`);
+      try {
+        writeAtomic(requestPath, {
+          version: CHANNEL_VERSION,
+          invocationId,
+          selector,
+          schemaHash: finiteSchemaHash(schema),
+        });
+      } catch {
+        return { admitted: false };
+      }
+      const response = await awaitDocument(responsePath, admissionTimeoutMs, pollIntervalMs);
+      if (!response || response.version !== CHANNEL_VERSION) return { admitted: false };
+      if (response.invocationId !== invocationId || response.admitted !== true) {
+        return { admitted: false };
+      }
+      const { repository, executorBearer, readMode } = response;
+      if (
+        typeof repository !== 'string'
+        || repository !== selector
+        || typeof executorBearer !== 'string'
+        || executorBearer.length === 0
+        || (readMode !== 'live' && readMode !== 'pinned')
+      ) {
+        return { admitted: false };
+      }
+      return {
+        admitted: true,
+        repo: repository,
+        executorBearer,
+        readMode,
+        sensitivity: config.dynamicSensitivity,
+      };
+    },
+
+    /**
+     * Reports one invocation's terminal outcome and actual usage, and waits
+     * for AWF's receipt.
+     *
+     * `revoked !== true` means the delegated identity's state is unresolved;
+     * the caller must not return a success-shaped result, because a bearer
+     * that may still be live has already touched repository content.
+     */
+    async settle({ invocationId, outcome, outputBytes, executionSeconds }) {
+      const settlePath = path.join(directory, `${invocationId}${SETTLE_SUFFIX}`);
+      const receiptPath = path.join(directory, `${invocationId}${RECEIPT_SUFFIX}`);
+      const terminalOutcome = TERMINAL_OUTCOMES.has(outcome) ? outcome : 'broker-error';
+      try {
+        writeAtomic(settlePath, {
+          version: CHANNEL_VERSION,
+          invocationId,
+          outcome: terminalOutcome,
+          outputBytes: Math.max(0, Math.trunc(outputBytes) || 0),
+          executionSeconds: Math.max(0, Math.trunc(executionSeconds) || 0),
+        });
+      } catch {
+        return { settled: false, revoked: false };
+      }
+      const receipt = await awaitDocument(receiptPath, settlementTimeoutMs, pollIntervalMs);
+      if (
+        !receipt
+        || receipt.version !== CHANNEL_VERSION
+        || receipt.invocationId !== invocationId
+        || receipt.settled !== true
+      ) {
+        return { settled: false, revoked: false };
+      }
+      return { settled: true, revoked: receipt.revoked === true };
+    },
+  };
+}
+
+module.exports = {
+  CHANNEL_VERSION,
+  DEFAULT_ADMISSION_TIMEOUT_MS,
+  DEFAULT_SETTLEMENT_TIMEOUT_MS,
+  MAX_MESSAGE_BYTES,
+  RECEIPT_SUFFIX,
+  REQUEST_SUFFIX,
+  RESPONSE_SUFFIX,
+  SETTLE_SUFFIX,
+  createDynamicDelegationClient,
+};

--- a/containers/enclave/mcp-server/server.js
+++ b/containers/enclave/mcp-server/server.js
@@ -23,6 +23,7 @@ const {
   createAgentRunner,
 } = require('./agent-executor');
 const { AGENT_TOOL_NAME, TOOL_NAME, dispatchJsonRpc, parseJsonRpcBody } = require('./mcp-protocol');
+const { createDynamicDelegationClient } = require('./delegation-channel');
 
 const MAX_HTTP_BODY_BYTES = 420 * 1024;
 const RESPONSE_HEADERS = {
@@ -155,7 +156,14 @@ async function main() {
   fs.rmSync(serverConfig.readyPath, { force: true });
   const audit = createProtectedAuditLog(serverConfig.auditDir, 'enclave.jsonl');
   const telemetry = createRuntimeTelemetry(serverConfig.auditDir);
-  const { runId, seeds } = loadSeedMap(serverConfig.seedMapPath);
+  // A dynamic-only run stages no seed catalog at all: no clone, no seed map,
+  // no /awf/seed mount, and no job token anywhere in the topology.
+  const { runId, seeds } = serverConfig.seedMapEnabled
+    ? loadSeedMap(serverConfig.seedMapPath)
+    : { runId: serverConfig.runId, seeds: new Map() };
+  if (!runId) {
+    throw new Error('The enclave broker could not resolve this run identity');
+  }
 
   const scriptEnabled = isScriptExecutorEnabled();
   const agentEnabled = isAgentExecutorEnabled();
@@ -220,6 +228,13 @@ async function main() {
       exitCategories: ENCLAVE_EXIT_CATEGORIES,
       executorKind: 'agent',
       uniformTiming: true,
+      // Dynamic entries route every selector through AWF's canonical
+      // admission before any repository content is exposed. `enclave_run_script`
+      // is never registered for a dynamic entry, so it is neither advertised
+      // nor dispatchable.
+      ...(config.dynamicEnabled
+        ? { admission: createDynamicDelegationClient(config) }
+        : {}),
     });
     executors.push('agent');
   }

--- a/containers/enclave/script-executor/executor-handler.js
+++ b/containers/enclave/script-executor/executor-handler.js
@@ -88,6 +88,8 @@ function createExecutorHandler(params) {
   let accepting = true;
   /** Invocations already settled, so a retry can never double-settle. */
   const settledInvocations = new Set();
+  /** Invocations that reached dynamic admission and therefore own an identity. */
+  const admittedInvocations = new Set();
 
   function emitInvocationTelemetry(category) {
     telemetry.emit({
@@ -138,6 +140,20 @@ function createExecutorHandler(params) {
    */
   async function execute(request, respond) {
     const invocationId = crypto.randomBytes(12).toString('hex');
+    try {
+      await executeInvocation(request, respond, invocationId);
+    } finally {
+      // A dynamic invocation that reached admission must always settle its
+      // reservation and revoke its identity, even if an unexpected error
+      // escaped the pipeline. `settleDynamic` is a no-op once an invocation
+      // has already settled, so this can never double-charge or double-revoke.
+      if (admission && admittedInvocations.has(invocationId)) {
+        await settleDynamic(invocationId, 'broker-error', 0, 0);
+      }
+    }
+  }
+
+  async function executeInvocation(request, respond, invocationId) {
     const admissionStartMs = uniformTiming ? clock.nowMs() : undefined;
     let responded = false;
     const safeRespond = (json) => {
@@ -180,6 +196,7 @@ function createExecutorHandler(params) {
         await rejectBeforeExecution('dynamic-admission-denied', undefined);
         return;
       }
+      admittedInvocations.add(invocationId);
       // Register into the *same* live per-repository ledger the static
       // executors debit. Registration is idempotent, so re-admitting a
       // repository can never refill a budget it has already spent.

--- a/containers/enclave/script-executor/executor-handler.js
+++ b/containers/enclave/script-executor/executor-handler.js
@@ -72,6 +72,13 @@ function createExecutorHandler(params) {
   // never reach the caller; every failure is still the canonical error.
   const exitCategories = params.exitCategories || {};
 
+  // Optional dynamic repository admission client (ADR 0001). When present the
+  // executor has no static seed catalog: each invocation's selector is routed
+  // through AWF's canonical admission first, and only an admitted repository
+  // yields a short-lived delegated bearer. Absent, the executor uses the
+  // immutable static seed map exactly as before.
+  const admission = params.admission;
+
   // Optional shared serialization lane. When several executors are exposed by
   // one server they share a lane so at most one sandbox — script or agent —
   // holds private repository content at a time.
@@ -79,6 +86,8 @@ function createExecutorHandler(params) {
 
   let invocationsUsed = 0;
   let accepting = true;
+  /** Invocations already settled, so a retry can never double-settle. */
+  const settledInvocations = new Set();
 
   function emitInvocationTelemetry(category) {
     telemetry.emit({
@@ -88,6 +97,36 @@ function createExecutorHandler(params) {
       capabilityState: 'supported',
       category,
     });
+  }
+
+  /** Maps this invocation's internal result to one terminal settlement outcome. */
+  function resolveTerminalOutcome(canonicalResult, failureReason) {
+    if (canonicalResult !== undefined) return 'success';
+    const category = failureReason ? failureReason[0] : 'broker-error';
+    if (category === 'timeout') return 'timeout';
+    if (category === 'nonconformant-output' || category === 'unreadable-output') {
+      return 'schema-failure';
+    }
+    if (typeof category === 'string' && category.startsWith('enclave-')) return 'agent-failure';
+    if (category === 'non-zero-exit') return 'agent-failure';
+    return 'broker-error';
+  }
+
+  /**
+   * Settles one dynamic invocation exactly once. Reports whether AWF confirmed
+   * revocation; an unconfirmed revocation is never treated as success.
+   */
+  async function settleDynamic(invocationId, outcome, outputBytes, executionSeconds) {
+    if (!admission || settledInvocations.has(invocationId)) {
+      return { settled: true, revoked: true };
+    }
+    settledInvocations.add(invocationId);
+    try {
+      return await admission.settle({ invocationId, outcome, outputBytes, executionSeconds });
+    } catch (error) {
+      audit.failure(invocationId, 'dynamic-settlement-failed', error.message);
+      return { settled: false, revoked: false };
+    }
   }
 
   /**
@@ -129,12 +168,38 @@ function createExecutorHandler(params) {
     const payload = validation.request[payloadKey];
     const repoKey = privateRepo.toLowerCase();
 
-    const seed = seedMap.get(repoKey);
-    if (!seed) {
-      await rejectBeforeExecution('repo-not-allowed', privateRepo);
-      return;
+    let seed;
+    let admitted;
+    if (admission) {
+      // Canonical admission runs *before* any repository content is exposed:
+      // no workspace, no container, and no delegated bearer exists until AWF
+      // has matched the selector against the compiler envelope, reserved
+      // every run-wide quota, and minted exactly one identity.
+      admitted = await admission.admit({ invocationId, selector: privateRepo, schema });
+      if (!admitted || !admitted.admitted) {
+        await rejectBeforeExecution('dynamic-admission-denied', undefined);
+        return;
+      }
+      // Register into the *same* live per-repository ledger the static
+      // executors debit. Registration is idempotent, so re-admitting a
+      // repository can never refill a budget it has already spent.
+      try {
+        ledger.registerRepository(admitted.repo, admitted.sensitivity);
+      } catch (error) {
+        await settleDynamic(invocationId, 'broker-error', 0, 0);
+        await rejectBeforeExecution('dynamic-sensitivity-invalid', error.message);
+        return;
+      }
+      seed = { seedId: undefined, sensitivity: admitted.sensitivity };
+    } else {
+      seed = seedMap.get(repoKey);
+      if (!seed) {
+        await rejectBeforeExecution('repo-not-allowed', privateRepo);
+        return;
+      }
     }
     if (schemaContainsFreeformString(schema) && seed.sensitivity !== 'trusted') {
+      if (admitted) await settleDynamic(invocationId, 'schema-failure', 0, 0);
       await rejectBeforeExecution(
         'trusted-schema-required',
         `repo=${privateRepo} sensitivity=${seed.sensitivity}`,
@@ -147,7 +212,8 @@ function createExecutorHandler(params) {
     // different schema; there is no separate per-query cap — only whether
     // this charge fits the repository's remaining run balance.
     const charge = seed.sensitivity === 'trusted' ? 0 : informationChargeForSchema(schema);
-    if (!ledger.tryDebit(repoKey, charge, executorKind)) {
+    if (!ledger.tryDebit(admitted ? admitted.repo : repoKey, charge, executorKind)) {
+      if (admitted) await settleDynamic(invocationId, 'broker-error', 0, 0);
       await rejectBeforeExecution('bit-budget-exhausted', `repo=${privateRepo} charge=${charge}`);
       return;
     }
@@ -168,9 +234,12 @@ function createExecutorHandler(params) {
         runId,
         invocationId,
         seedId: seed.seedId,
-        privateRepo: repoKey,
+        privateRepo: admitted ? admitted.repo : repoKey,
         schema,
         [payloadKey]: payload,
+        ...(admitted
+          ? { executorBearer: admitted.executorBearer, readMode: admitted.readMode }
+          : {}),
       });
     } catch (error) {
       failureReason = ['workspace-create-failed', error.message];
@@ -188,6 +257,9 @@ function createExecutorHandler(params) {
             invocationId,
             seedId: seed.seedId,
             timeoutMs: remainingMs,
+            ...(admitted
+              ? { dynamic: { repository: admitted.repo, readMode: admitted.readMode } }
+              : {}),
           });
           if (run.timedOut) {
             failureReason = ['timeout'];
@@ -240,6 +312,23 @@ function createExecutorHandler(params) {
       canonicalResult = undefined;
     }
 
+    // Settle the dynamic reservation and revoke the delegated identity on
+    // *every* terminal path. An unresolved revocation downgrades an otherwise
+    // successful invocation to the canonical error: a bearer that may still be
+    // live has already touched repository content.
+    if (admitted) {
+      const settled = await settleDynamic(
+        invocationId,
+        resolveTerminalOutcome(canonicalResult, failureReason),
+        canonicalResult === undefined ? 0 : Buffer.byteLength(canonicalResult, 'utf8'),
+        Math.ceil((clock.nowMs() - startMs) / 1000),
+      );
+      if (!settled.revoked) {
+        failureReason = ['dynamic-revocation-unresolved'];
+        canonicalResult = undefined;
+      }
+    }
+
     const elapsedMs = clock.nowMs() - startMs;
     const { bucketMs, overflowed } = await waitForBucket(
       startMs,
@@ -259,10 +348,11 @@ function createExecutorHandler(params) {
     } else if (canonicalResult !== undefined) {
       audit.invocation({
         invocationId,
-        repo: privateRepo,
+        repo: admitted ? admitted.repo : privateRepo,
         sensitivity: seed.sensitivity,
         bits: charge,
         bucketMs,
+        ...(admitted ? { admission: 'dynamic', readMode: admitted.readMode } : {}),
       });
       emitInvocationTelemetry('success');
       safeRespond(canonicalSuccessJson(canonicalResult));

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -1789,11 +1789,13 @@ Each record follows the `blocked-request-diag/v<version>` schema:
 The optional top-level `enclaves` array defines AWF's sole supported private-repository execution surface. It is structurally identical to the gh-aw compiler's enclave frontmatter: every entry declares exactly one `script` or `agent` executor, its own non-empty `repos` list, and entry-level shared controls including `timeout`, `runtime`, `image`, resource limits, and disclosure limits. AWF stages immutable repository seeds on the host, starts one AWF-owned `enclave-mcp-server`, maintains one shared per-repository ledger for the run, and exposes configured executors only through compiler-launched `gh-aw-mcpg`.
 
 Dynamic repository-policy entries (`dynamic` in place of `repos` on an `agent`
-entry, per `docs/adr/0001-agent-enclaves.md`) are accepted by this
-configuration schema so AWF validates the exact compiler-emitted envelope, but
-they are **not executable in this release**: AWF rejects any run that declares
-`enclaves[].dynamic`. See §14.1a for the envelope and for exactly which
-upstream handoff is missing.
+entry, per `docs/adr/0001-agent-enclaves.md`) select one canonical repository at
+runtime, receive one short-lived `github-repository-read-v1` identity, and read
+that repository through GitHub MCP without cloning or mounting a seed. They run
+only when the gh-aw compiler has started mcpg's
+`github-repository-delegation-v1` controller and handed AWF its private control
+endpoint and capability; otherwise AWF rejects the run. See §14.1a for the
+envelope, the handoff, and the identity lifecycle.
 
 ### 14.1 Executors and shared configuration
 
@@ -1887,19 +1889,100 @@ The `dynamic` object is byte-for-byte the envelope the gh-aw compiler emits. An 
 - `auditLabels` — a non-empty, unique array of at most 32 opaque labels matching `^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$`. Labels are what AWF and mcpg reconcile dynamic state against at shutdown; they are never repository names or credentials.
 - `expiresAt` — an absolute ISO-8601 timestamp, never later than the workflow job lifetime; admission at or after this time is denied.
 
-#### Supported boundary in this release
+#### Runtime prerequisites
 
-AWF **rejects** any configuration that declares `enclaves[].dynamic`, with an error naming the missing handoff. ADR 0001 binds every dynamic invocation to a single-repository mcpg identity created through the private `github-repository-delegation-v1` control channel. The compiler mints and hands AWF the control capability (`AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY`), but no released compiler starts that controller or hands AWF a control endpoint, and a dynamic invocation has no immutable seed to fall back to. Rather than start a run in which every enclave call would fail with the canonical denial, AWF refuses the run.
+A dynamic entry runs only when the gh-aw compiler has started mcpg's
+`github-repository-delegation-v1` controller and handed AWF **both** private
+values:
 
-AWF never falls back to a static seed catalog, a job-lifetime identity, or a broader policy when the delegation contract is unavailable. Whenever `AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY` is present, AWF takes custody of it during enclave preparation — reading it once and deleting it from the inherited environment — and it is additionally in the primary agent's environment exclusion set, so it is never visible to the primary agent, an enclave, or any child process.
+- `AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT` — the loopback-only control
+  endpoint, published by Docker on the runner's own `127.0.0.1`
+  (`http://127.0.0.1:<port>/internal/awf-enclave-mcp-control/github-repository-delegation-v1`).
+  AWF accepts only the literal loopback hosts `127.0.0.1` and `[::1]`; a
+  resolver-dependent name such as `localhost`, a routable or wildcard address,
+  embedded credentials, a query string, a fragment, or any other path is
+  rejected. An omitted or explicit `:80` is accepted as port 80 (the WHATWG URL
+  parser normalizes both to the same value).
+- `AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY` — the AWF-only 256-bit
+  hex control capability.
+
+A missing, partial, or malformed handoff is a hard failure. AWF never falls
+back to a static seed catalog, a job-lifetime identity, or a broader policy.
+
+Because the control listener is published on host loopback, **only the AWF host
+process** can reach it. AWF takes custody of both values before any inherited
+environment is assembled, stages them into the `0700` enclave private root with
+exclusive `0600` files, and never mounts either one into the enclave MCP broker,
+the single-use executor, the model sidecar, the general MCP route, or the
+delegated data plane. Both variables are also in the primary agent's environment
+exclusion set.
+
+The broker routes each `enclave_run_agent` through AWF's host-side admission
+authority over a `0700` request/response directory that is bind-mounted only
+into the broker. That channel carries the caller's selector, the exact finite
+output-schema hash, and the invocation's settlement; it never carries the
+control endpoint, the control capability, the identity handle, the compiler
+envelope, mcpg's state path, or its policy generation.
+
+#### Dynamic-only runs stage nothing
+
+A dynamic-only entry needs no `GH_TOKEN`/`GITHUB_TOKEN`, clones no repository,
+writes no seed catalog (not even an empty one), and mounts neither `/awf/seed`
+nor a seed map. A run that also declares a separate static entry keeps the full
+static staging path unchanged.
 
 #### Admission semantics (enforced by the AWF registry)
 
-The admission half of the contract is implemented and tested in `src/enclave/dynamic-registry.ts`, so the control-plane client is the only remaining work once the endpoint handoff lands upstream:
+Admission runs in `src/enclave/dynamic-registry.ts` before any repository
+content is exposed and before any control call is made:
 
 - Admission is idempotent by `(run, enclave entry, invocation id, canonical repository)`. A retried request with the same key returns the previously recorded outcome, and joins an in-flight admission rather than reserving capacity a second time. A different repository under an already-bound invocation id is rejected rather than rebinding.
 - `maxRepositories` and all three quotas are reserved synchronously before any asynchronous lookup, so concurrent admissions can never both observe capacity and both commit. `maxOutputBytes` and `maxExecutionSeconds` are reserved at their per-invocation worst case (`limits.maxOutputBytes`, `limits.timeoutSeconds`) and replaced by the actual reported usage once the invocation settles. Charges committed after admission stay committed even if the invocation later fails.
 - Every outcome — malformed selector, policy denial, resolution failure, or success — is delayed to the same fixed timing bucket (§14.3's bucket list) plus secret-independent jitter, so elapsed wall-clock time cannot distinguish failure causes. Every failure returns one non-disclosing canonical denial.
+
+#### Identity lifecycle
+
+For each admitted invocation AWF calls mcpg's control API, authenticated with
+the capability in `Authorization`, using bounded request/response bodies,
+explicit timeouts, and strict JSON validation:
+
+| Operation | Path |
+| --- | --- |
+| create or confirm | `/internal/awf-enclave-mcp-control/create-or-confirm` |
+| status | `/internal/awf-enclave-mcp-control/status` |
+| reconcile | `/internal/awf-enclave-mcp-control/reconcile` |
+| revoke | `/internal/awf-enclave-mcp-control/revoke` |
+| revoke by labels | `/internal/awf-enclave-mcp-control/revoke-by-labels` |
+
+Operation paths are siblings of the controller name in the exported endpoint,
+not children of it. `requested_ttl` is a Go `time.Duration`, i.e. an integer
+number of **nanoseconds**; timestamps are RFC 3339.
+
+Every create-or-confirm response is verified before it is trusted: non-empty
+handle and executor bearer, an exact repository match against the admitted
+selector, `tool_policy` equal to `github-repository-read-v1`, tools exactly
+`list_issues` and `issue_read`, an admitted SHA that matches when one was
+requested, and an expiry no later than the requested TTL or the invocation
+deadline. Only the executor bearer leaves the AWF host process; the handle stays
+in AWF-private state.
+
+At startup AWF calls `status`, revokes any stale labelled identity, and only
+then calls the transactional `reconcile`. New admissions stay blocked until that
+sequence succeeds. Every terminal path — success, agent failure, schema failure,
+timeout, cancellation, broker error — settles the reserved quota and revokes the
+identity, and `revoke-by-labels` sweeps the run at teardown. An unresolved
+revocation re-blocks admissions and downgrades the invocation to the canonical
+error rather than returning a success-shaped result.
+
+#### Live versus pinned reads
+
+`admitted_default_branch_sha` is optional in both the ADR and mcpg's contract.
+AWF has no already-authorized, repository-confined path to resolve a
+default-branch SHA before the delegated identity exists, and
+`github-repository-read-v1` grants only `list_issues` and `issue_read`
+afterwards. AWF therefore omits the field, never widens a token or tool to
+obtain one, and audits every repository read as a **live** read. A read is
+marked `pinned` only when the control binding actually carries a resolved SHA.
 
 ### 14.2 MCP-only tool surface
 

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -1909,8 +1909,17 @@ values:
 A missing, partial, or malformed handoff is a hard failure. AWF never falls
 back to a static seed catalog, a job-lifetime identity, or a broader policy.
 
-Because the control listener is published on host loopback, **only the AWF host
-process** can reach it. AWF takes custody of both values before any inherited
+Because the control listener is published on host loopback, only the AWF host
+process can reach it **through the published port**, which is why the control
+client runs there rather than in a container. That is a property of the
+publication rather than a general routing guarantee: under network isolation the
+in-container listener binds `0.0.0.0`, and a peer co-attached to a Docker
+network with mcpg addresses the container IP directly without traversing the
+published port. The control plane is therefore protected by authentication —
+every request must carry the AWF-only capability, and mcpg rejects anything else
+with `403 delegation_access_denied`.
+
+AWF takes custody of both values before any inherited
 environment is assembled, stages them into the `0700` enclave private root with
 exclusive `0600` files, and never mounts either one into the enclave MCP broker,
 the single-use executor, the model sidecar, the general MCP route, or the

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -343,6 +343,42 @@ its address in the agent's `/etc/hosts` so the route survives environments
 where Docker's embedded DNS is unreachable. The single-use executor meets the
 same gateway on the separate `awf-enclave-agent` network at `172.31.0.40`.
 
+Network homing matters here, because one component is deliberately confined to a
+single network and another necessarily straddles several:
+
+```mermaid
+graph LR
+  subgraph host["Runner host — no Docker network"]
+    AWF["AWF host process<br/>owns control client + registry"]
+    PRIV[("/var/tmp/awf-enclave-private-*<br/>0700 · channel + 0600 custody")]
+  end
+  subgraph net["awf-net · internal 172.30.0.0/24"]
+    AGENT["agent (primary)<br/>172.30.0.20"]
+  end
+  subgraph ctrl["awf-enclave-mcp-control · internal"]
+    BROKER["enclave-mcp-server (broker)<br/>ONE network only"]
+  end
+  subgraph enc["awf-enclave-agent · internal 172.31.0.0/24"]
+    EXEC["enclave executor<br/>single-use"]
+    EPROXY["enclave-agent-api-proxy<br/>172.31.0.30"]
+  end
+  MCPG["awmg-mcpg<br/>image ghcr.io/github/gh-aw-mcpg<br/>homed on awf-net + awf-enclave-mcp-control<br/>+ awf-enclave-agent 172.31.0.40 + host loopback"]
+
+  AGENT -->|"/mcp/awf-enclave"| MCPG
+  MCPG -->|"capability"| BROKER
+  EXEC -->|"/mcp/github · delegated bearer"| MCPG
+  EXEC -->|"model only"| EPROXY
+  BROKER -.->|"docker run"| EXEC
+  AWF ==>|"control plane · 127.0.0.1 · Bearer capability"| MCPG
+  BROKER <-.->|"admission + settlement"| PRIV
+  AWF -.-> PRIV
+```
+
+The broker is homed on exactly one network, and AWF asserts that network's
+membership is precisely `{broker, mcpg}`; a third member aborts the run. mcpg,
+by contrast, is one container serving both the executor-facing data plane and
+the AWF-only control plane, so it is co-attached with every peer it serves.
+
 gh-aw publishes mcpg's delegation control listener with
 `docker run -p 127.0.0.1:<port>:<port>`, so **the published port** is reachable
 only from the runner's own loopback interface. That is why the control client

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -336,13 +336,33 @@ Trusted operators can inspect only redacted audit diagnostics.
 
 ### Dynamic runtime topology
 
+The primary agent reaches mcpg over `awf-net`, the same internal topology
+network it runs on. AWF refuses to start unless `topologyAttach` names the
+gateway container, attaches it with `docker network connect`, and pre-registers
+its address in the agent's `/etc/hosts` so the route survives environments
+where Docker's embedded DNS is unreachable. The single-use executor meets the
+same gateway on the separate `awf-enclave-agent` network at `172.31.0.40`.
+
 gh-aw publishes mcpg's delegation control listener with
-`docker run -p 127.0.0.1:<port>:<port>`, so it is reachable **only from the
-runner's own loopback interface**. Neither the enclave MCP broker, the
-single-use executor, the model sidecar, nor the primary agent can route to it.
-The control client therefore lives in the AWF host process, and the broker asks
-the host for admission over an AWF-private request/response directory inside the
-`0700` enclave private root that is bind-mounted only into the broker:
+`docker run -p 127.0.0.1:<port>:<port>`, so **the published port** is reachable
+only from the runner's own loopback interface. That is why the control client
+lives in the AWF host process: no container can reach a `127.0.0.1`-published
+port through the host.
+
+It is worth being precise that this is a property of the publication, not a
+general routing guarantee. Under network isolation gh-aw binds the
+*in-container* listener to `0.0.0.0`, because Docker NATs a published port to
+the container's bridge IP and a container-local `127.0.0.1` bind would be
+unreachable. A peer sharing a Docker network with mcpg addresses the container
+IP directly and never traverses the published port, so co-attachment — not
+publication scope — determines container-to-container reachability. The control
+plane is therefore protected by **authentication**: every request must carry the
+AWF-only capability, which is never placed in any container's environment or
+mount, and mcpg rejects anything else with `403 delegation_access_denied`.
+
+The broker asks the host for admission over an AWF-private request/response
+directory inside the `0700` enclave private root that is bind-mounted only into
+the broker:
 
 ```text
 primary agent ──mcpg /mcp/awf-enclave──▶ enclave MCP broker (container)

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -4,12 +4,12 @@
 
 Layer 5 establishes one `enclaves` subsystem, one AWF-owned MCP server, and mcpg-only access through the compiler handoff contract.
 
-Dynamic repository admission described below is a proposed, version-gated
-extension; it is not supported by the current AWF configuration or runtime.
-Current entries must declare a non-empty static `repos` list and use immutable
-seeds. Operators MUST NOT configure or rely on dynamic-policy fields until an
-AWF release implements them and the required compiler and mcpg version gates
-are available.
+Dynamic repository admission described below is implemented and version-gated.
+It runs only when the gh-aw compiler starts mcpg's
+`github-repository-delegation-v1` controller (mcpg v0.4.17 or newer) and hands
+AWF its loopback-only control endpoint and AWF-only control capability; every
+other combination fails closed before execution. Static entries continue to
+declare a non-empty `repos` list and use immutable seeds.
 
 ## Architecture
 
@@ -30,12 +30,13 @@ Repository admission has two modes, both served by this same MCP backend:
   GitHub-enabled agent enclaves keep their current job-lifetime mcpg identity,
   which covers the union of configured repositories; they do not claim the
   dynamic mode's one-repository GitHub-MCP identity guarantee.
-- **Dynamic GitHub-MCP-backed mode (planned)** — the compiler will provide a closed policy
+- **Dynamic GitHub-MCP-backed mode** — the compiler provides a closed policy
   envelope instead of enumerating repository seeds in workflow frontmatter. Each
   invocation provides only a canonical `owner/repo` selector, bounded
   agent prompt, and finite response schema. AWF admits at most one repository
-  for that invocation through the compiler-owned GitHub MCP path and records the
-  admitted default-branch SHA.
+  for that invocation, mints exactly one short-lived
+  `github-repository-read-v1` identity for it through mcpg's private control
+  channel, and hands the single-use executor only that identity's bearer.
 
 Static and dynamic modes are compatible in one workflow run but mutually
 exclusive within a single enclave entry: an entry declares either static `repos`
@@ -260,7 +261,7 @@ discovery, and any tool whose arguments cannot be mechanically confined to the
 admitted repository fail closed until a new versioned policy defines and tests
 that confinement.
 
-When implemented, the dynamic invocation flow is:
+The dynamic invocation flow is:
 
 1. The primary agent calls `enclave_run_agent` with one canonical repository
    selector, bounded prompt, and finite schema.
@@ -271,14 +272,16 @@ When implemented, the dynamic invocation flow is:
    channel to atomically create or confirm an invocation-scoped delegated
    identity bound to that run, enclave entry, admitted repository,
    `github-repository-read-v1` tool set, schema, and expiry.
-4. AWF records the admitted repository hash and default-branch SHA, stores the
-   delegated identity only in invocation-private state, and mounts it read-only
-   into the single-use executor.
+4. AWF records the admitted repository hash, stores the delegated identity's
+   handle only in AWF-private host state, and mounts *only* the executor bearer
+   read-only into the single-use executor. The admitted default-branch SHA is
+   optional: AWF has no already-authorized, repository-confined path to resolve
+   one before the identity exists, so it omits the field and audits every read
+   as live rather than widening a token or tool to obtain a snapshot.
 5. The executor may access only the admitted repository through the delegated
-   GitHub MCP identity and only with `github-repository-read-v1` tools. If a
-   GitHub MCP tool supports immutable refs, AWF uses the admitted default-branch
-   SHA; otherwise the audit record marks the data as a live read at that
-   admitted SHA.
+   GitHub MCP identity and only with `github-repository-read-v1` tools. A read
+   is marked `pinned` only when the control binding actually carries a resolved
+   SHA; otherwise the audit record marks the data as a live read.
 6. On completion, timeout, failure, or shutdown, AWF requests identity
    revocation, records the revocation state, removes invocation-private state,
    and admits no other repository until cleanup for the serialized lane is
@@ -330,6 +333,45 @@ selectors return the same canonical admission-denied error. That error omits the
 requested owner/repository, policy reason, upstream HTTP status, credential
 state, and timing detail so dynamic mode does not become an existence oracle.
 Trusted operators can inspect only redacted audit diagnostics.
+
+### Dynamic runtime topology
+
+gh-aw publishes mcpg's delegation control listener with
+`docker run -p 127.0.0.1:<port>:<port>`, so it is reachable **only from the
+runner's own loopback interface**. Neither the enclave MCP broker, the
+single-use executor, the model sidecar, nor the primary agent can route to it.
+The control client therefore lives in the AWF host process, and the broker asks
+the host for admission over an AWF-private request/response directory inside the
+`0700` enclave private root that is bind-mounted only into the broker:
+
+```text
+primary agent ──mcpg /mcp/awf-enclave──▶ enclave MCP broker (container)
+                                              │
+                          admission request   │ 0700 bind mount, no network
+                          settlement report   ▼
+                                        AWF host process
+                                              │ Authorization: <control capability>
+                                              ▼
+                    http://127.0.0.1:<port>/internal/awf-enclave-mcp-control/*
+                                              │
+                                              ▼
+                                   mcpg delegation controller
+                                              │ executor bearer
+                                              ▼
+executor (awf-enclave-agent network) ──▶ mcpg /mcp/github ──▶ admitted repository
+```
+
+The channel carries the caller's selector, the exact finite output-schema hash,
+one repository, one executor bearer, and one settlement. It never carries the
+control endpoint, the control capability, the identity handle, the compiler
+envelope, mcpg's state path, or its policy generation.
+
+A dynamic-only entry stages nothing: no `GH_TOKEN`/`GITHUB_TOKEN`, no clone, no
+seed catalog (not even an empty one), and no `/awf/seed` mount. The executor's
+GitHub MCP configuration is invocation-private and bearer-only, confined to
+`list_issues` and `issue_read` for the one admitted repository, and its system
+instructions prohibit cloning, arbitrary URLs, the GitHub CLI, writes, unscoped
+search, organization/global discovery, and sibling-repository access.
 
 ### Dynamic threat model
 

--- a/docs/enclaves-architecture.md
+++ b/docs/enclaves-architecture.md
@@ -19,6 +19,18 @@ AWF stages immutable repository seeds on the host, starts one AWF-owned `enclave
 - **Agent executor** — `enclave_run_agent` runs the pinned Copilot engine in a bounded single-use enclave. Its mandatory peer is the dedicated API proxy; `agent.tools.github` (or the deprecated legacy `agent.github.cli: issues-read-v1` marker) also permits a direct connection to compiler-owned shared mcpg.
 - **Shared controls** — the `repos` lists of the `enclaves` entries form the only trusted repository catalog; script and agent calls debit the same per-run repository ledger and share one admission lane.
 
+> **Terminology.** *Executor* and *enclave* are distinct, and this document uses
+> both. An **executor** is broker-side machinery and a configuration kind:
+> `enclaves.executors.{script,agent}`, `executorKind`, and the code under
+> `containers/enclave/{script,agent}-executor/`, which ships into the
+> `enclave-mcp-server` image and holds the Docker socket. An **enclave** is the
+> ephemeral container an executor launches per invocation — its own image
+> (`enclave-script` / `enclave-agent`), its own name
+> (`awf-enclave-agent-<run>-<invocation>`), and its own entrypoint. One executor
+> launches many enclaves; the executor is trusted, the enclave is not. Where
+> prose says "single-use executor" it means the enclave that executor launched.
+> `executor_bearer` is mcpg's wire field name and is never renamed.
+
 The primary agent never receives a broker socket, wrapper binary, direct MCP server URL, capability, repository seed, ledger state, or alternate transport.
 
 Repository admission has two modes, both served by this same MCP backend:
@@ -359,7 +371,7 @@ graph LR
     BROKER["enclave-mcp-server (broker)<br/>ONE network only"]
   end
   subgraph enc["awf-enclave-agent · internal 172.31.0.0/24"]
-    EXEC["enclave executor<br/>single-use"]
+    EXEC["enclave (single-use container)<br/>launched by the agent executor"]
     EPROXY["enclave-agent-api-proxy<br/>172.31.0.30"]
   end
   MCPG["awmg-mcpg<br/>image ghcr.io/github/gh-aw-mcpg<br/>homed on awf-net + awf-enclave-mcp-control<br/>+ awf-enclave-agent 172.31.0.40 + host loopback"]

--- a/src/cli-workflow.ts
+++ b/src/cli-workflow.ts
@@ -88,7 +88,11 @@ export async function runMainWorkflow(
 ): Promise<number> {
   const { logger, performCleanup, onHostIptablesSetup, onContainersStarted } = options;
 
-  const enclaveErrors = validateEnclavesConfig(config);
+  // Structural validation only: the dynamic delegation handoff can be read
+  // exactly once (taking custody deletes it from the environment), so that
+  // check belongs to `prepareEnclaves` below, which still runs before any
+  // container is created.
+  const enclaveErrors = validateEnclavesConfig(config, { requireDelegationHandoff: false });
   if (enclaveErrors.length > 0) {
     throw new Error(`Invalid enclave configuration:\n- ${enclaveErrors.join('\n- ')}`);
   }

--- a/src/cli-workflow.ts
+++ b/src/cli-workflow.ts
@@ -6,7 +6,7 @@ import { CLI_PROXY_IP, DOH_PROXY_IP, SQUID_IP, API_PROXY_IP } from './host-iptab
 import { buildInternalServiceHosts } from './services/internal-service-hosts';
 import { TOPOLOGY_NETWORK_NAME, getTopologyContainerIps, patchComposeWithTopologyHosts } from './topology';
 import { validateEnclavesConfig } from './enclave/preflight';
-import { isEnclaveAgentGithubToolsEnabled } from './types/enclave-options';
+import { isEnclaveAgentGithubRouteEnabled } from './types/enclave-options';
 
 /**
  * Dependencies injected into the main workflow.
@@ -54,6 +54,11 @@ export interface WorkflowDependencies {
   connectEnclaveGithubGateway?: (config: WrapperConfig) => Promise<void>;
   /** Proves the fixed TLS route through the PAT-free enclave CLI proxy. */
   assertEnclaveGithubGatewayReady?: (config: WrapperConfig) => Promise<void>;
+  /**
+   * Starts the AWF-private dynamic repository admission authority: mcpg
+   * recovery, reconciliation, and the broker admission channel.
+   */
+  startEnclaveDynamicDelegation?: (config: WrapperConfig) => Promise<void>;
 }
 
 interface WorkflowCallbacks {
@@ -212,7 +217,7 @@ export async function runMainWorkflow(
         }
         logger.info('Attaching the trusted MCP gateway to the private enclave control path...');
         await dependencies.connectEnclaveGateway(config);
-        if (isEnclaveAgentGithubToolsEnabled(config.enclaves?.executors.agent)) {
+        if (isEnclaveAgentGithubRouteEnabled(config.enclaves?.executors.agent)) {
           if (
             !dependencies.connectEnclaveGithubGateway
             || !dependencies.assertEnclaveGithubGatewayReady
@@ -228,6 +233,16 @@ export async function runMainWorkflow(
         }
         logger.info('Proving enclave tools end to end through the MCP gateway...');
         await dependencies.assertEnclaveGatewayReady(config);
+        if (config.enclaves?.executors.agent.dynamic !== undefined) {
+          if (!dependencies.startEnclaveDynamicDelegation) {
+            throw new Error(
+              'enclaves[].dynamic requires the AWF-private delegation admission authority; '
+              + 'AWF never runs a dynamic entry without it',
+            );
+          }
+          logger.info('Reconciling mcpg delegation state and opening dynamic admission...');
+          await dependencies.startEnclaveDynamicDelegation(config);
+        }
       }
     : undefined;
 

--- a/src/commands/main-action.ts
+++ b/src/commands/main-action.ts
@@ -31,6 +31,10 @@ import { adaptExternalRuntimeBackend } from '../external-runtime-backend';
 import type { ExternalAgentRuntimeBackend } from '../external-runtime-backend';
 import { resolveExternalRuntimeBackend } from '../external-runtime-backend-resolver';
 import { prepareEnclaves, teardownEnclaves } from '../enclave/manager';
+import {
+  startEnclaveDynamicDelegation,
+  stopEnclaveDynamicDelegation,
+} from '../enclave/dynamic-delegation';
 import { getStartupDiagnosticPath } from '../logs/startup-diagnostics';
 import {
   assertEnclaveGatewayReady,
@@ -171,6 +175,17 @@ function buildCleanupFn(
     // until the subsequent compose down removes them.
     if (getContainersStarted()) {
       let enclaveAuditComplete = true;
+      try {
+        // Revoke every outstanding dynamic identity before the broker and the
+        // gateway go away, so no delegated bearer can outlive the run.
+        await stopEnclaveDynamicDelegation(config);
+      } catch (error) {
+        enclaveAuditComplete = false;
+        logger.warn(
+          'Dynamic enclave delegation shutdown did not complete; mcpg state may be unreconciled.',
+          error,
+        );
+      }
       try {
         await shutdownEnclaveGateway(config);
       } catch (error) {
@@ -448,6 +463,7 @@ export function createMainAction(getOptionValueSource: OptionSourceResolver) {
         connectEnclaveGithubGateway,
         assertEnclaveGithubGatewayReady,
         prepareEnclaves,
+        startEnclaveDynamicDelegation,
       },
       {
         logger,

--- a/src/enclave/delegation-control-client.test.ts
+++ b/src/enclave/delegation-control-client.test.ts
@@ -1,0 +1,382 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import {
+  DELEGATION_TOOLS,
+  DELEGATION_TOOL_POLICY,
+  DelegationControlClient,
+  DelegationControlError,
+  secondsToGoDurationNanos,
+} from './delegation-control-client';
+import { parseEnclaveDynamicDelegationControlEndpoint } from './dynamic-delegation-handoff';
+
+const CAPABILITY = 'b'.repeat(64);
+const CONTROL_PATH = '/internal/awf-enclave-mcp-control';
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  authorization: string;
+  contentType: string;
+  body: unknown;
+}
+
+interface Responder {
+  (request: CapturedRequest): { status: number; body: string; contentType?: string };
+}
+
+async function withControlServer(
+  responder: Responder,
+  run: (client: DelegationControlClient, captured: CapturedRequest[]) => Promise<void>,
+): Promise<void> {
+  const captured: CapturedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const request: CapturedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        authorization: String(req.headers.authorization ?? ''),
+        contentType: String(req.headers['content-type'] ?? ''),
+        body: raw === '' ? undefined : JSON.parse(raw),
+      };
+      captured.push(request);
+      const reply = responder(request);
+      res.writeHead(reply.status, {
+        'content-type': reply.contentType ?? 'application/json',
+        'content-length': Buffer.byteLength(reply.body),
+      });
+      res.end(reply.body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+  const endpoint = parseEnclaveDynamicDelegationControlEndpoint(
+    `http://127.0.0.1:${port}${CONTROL_PATH}/github-repository-delegation-v1`,
+  )!;
+  try {
+    await run(new DelegationControlClient({ endpoint, capability: CAPABILITY }), captured);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+const baseRequest = {
+  runId: '42-1',
+  enclaveEntryId: 'agent',
+  invocationId: 'a1b2c3d4e5f60718',
+  repository: 'octo/private',
+  schemaHash: 'c'.repeat(64),
+  requestedTtlSeconds: 120,
+  invocationExpiresAt: new Date(Date.now() + 150_000),
+  idempotencyKey: 'd'.repeat(64),
+};
+
+function identityBody(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    handle: 'dlg_1234',
+    executor_bearer: 'dlgbearer_5678',
+    repository: 'octo/private',
+    tool_policy: DELEGATION_TOOL_POLICY,
+    tools: ['issue_read', 'list_issues'],
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  });
+}
+
+describe('mcpg delegation control wire contract', () => {
+  it('posts create-or-confirm to the sibling operation path with the capability', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: identityBody() }),
+      async (client, captured) => {
+        await client.createOrConfirm(baseRequest);
+        expect(captured).toHaveLength(1);
+        expect(captured[0].method).toBe('POST');
+        expect(captured[0].url).toBe(`${CONTROL_PATH}/create-or-confirm`);
+        expect(captured[0].authorization).toBe(`Bearer ${CAPABILITY}`);
+        expect(captured[0].contentType).toBe('application/json');
+      },
+    );
+  });
+
+  it('encodes requested_ttl as an integer number of Go nanoseconds', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: identityBody() }),
+      async (client, captured) => {
+        await client.createOrConfirm(baseRequest);
+        const body = captured[0].body as Record<string, unknown>;
+        expect(body.requested_ttl).toBe(120 * 1_000_000_000);
+        expect(Number.isInteger(body.requested_ttl)).toBe(true);
+      },
+    );
+  });
+
+  it('binds the exact envelope subset mcpg decodes with DisallowUnknownFields', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: identityBody() }),
+      async (client, captured) => {
+        await client.createOrConfirm(baseRequest);
+        expect(Object.keys(captured[0].body as object).sort()).toEqual([
+          'enclave_backend',
+          'enclave_entry_id',
+          'idempotency_key',
+          'invocation_expires_at',
+          'invocation_id',
+          'repository',
+          'requested_ttl',
+          'run_id',
+          'schema_hash',
+          'tool_policy',
+        ]);
+        expect(captured[0].body).toMatchObject({
+          run_id: '42-1',
+          enclave_backend: 'github',
+          enclave_entry_id: 'agent',
+          invocation_id: baseRequest.invocationId,
+          repository: 'octo/private',
+          tool_policy: DELEGATION_TOOL_POLICY,
+          schema_hash: baseRequest.schemaHash,
+          idempotency_key: baseRequest.idempotencyKey,
+        });
+      },
+    );
+  });
+
+  it('omits admitted_default_branch_sha when AWF resolved no confined SHA', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: identityBody() }),
+      async (client, captured) => {
+        await client.createOrConfirm(baseRequest);
+        expect(captured[0].body).not.toHaveProperty('admitted_default_branch_sha');
+      },
+    );
+  });
+
+  it('binds a resolved SHA when one was admitted', async () => {
+    const sha = 'e'.repeat(40);
+    await withControlServer(
+      () => ({ status: 200, body: identityBody({ admitted_default_branch_sha: sha }) }),
+      async (client, captured) => {
+        const identity = await client.createOrConfirm({
+          ...baseRequest,
+          admittedDefaultBranchSha: sha,
+        });
+        expect(captured[0].body).toMatchObject({ admitted_default_branch_sha: sha });
+        expect(identity.admittedDefaultBranchSha).toBe(sha);
+      },
+    );
+  });
+
+  it.each([
+    ['status', `${CONTROL_PATH}/status`],
+    ['revoke-by-labels', `${CONTROL_PATH}/revoke-by-labels`],
+  ])('sends the label pair for %s', async (operation, url) => {
+    await withControlServer(
+      () => ({
+        status: 200,
+        body: operation === 'status'
+          ? JSON.stringify({
+            recovery_incomplete: false,
+            generation: 1,
+            live_identity_count: 0,
+            labelled_handles: [],
+          })
+          : JSON.stringify({ revoked: 0 }),
+      }),
+      async (client, captured) => {
+        if (operation === 'status') await client.status('42-1', 'agent');
+        else await client.revokeByLabels('42-1', 'agent');
+        expect(captured[0].url).toBe(url);
+        expect(captured[0].body).toEqual({ run_id: '42-1', enclave_entry_id: 'agent' });
+      },
+    );
+  });
+
+  it('sends an empty body for reconcile', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: JSON.stringify({ reconciled: true }) }),
+      async (client, captured) => {
+        await client.reconcile();
+        expect(captured[0].url).toBe(`${CONTROL_PATH}/reconcile`);
+        expect(captured[0].body).toEqual({});
+      },
+    );
+  });
+
+  it('sends only the opaque handle for revoke', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: JSON.stringify({ revoked: true }) }),
+      async (client, captured) => {
+        await client.revoke('dlg_1234');
+        expect(captured[0].url).toBe(`${CONTROL_PATH}/revoke`);
+        expect(captured[0].body).toEqual({ handle: 'dlg_1234' });
+      },
+    );
+  });
+
+  it('reads mcpg status exactly, tolerating a null handle list', async () => {
+    await withControlServer(
+      () => ({
+        status: 200,
+        body: JSON.stringify({
+          recovery_incomplete: true,
+          generation: 3,
+          live_identity_count: 2,
+          labelled_handles: null,
+        }),
+      }),
+      async (client) => {
+        await expect(client.status('42-1', 'agent')).resolves.toEqual({
+          recoveryIncomplete: true,
+          generation: 3,
+          liveIdentityCount: 2,
+          labelledHandles: [],
+        });
+      },
+    );
+  });
+});
+
+describe('mcpg delegation control response validation', () => {
+  it.each([
+    ['a missing handle', identityBody({ handle: '' })],
+    ['a missing bearer', identityBody({ executor_bearer: '' })],
+    ['a different repository', identityBody({ repository: 'octo/other' })],
+    ['a different tool policy', identityBody({ tool_policy: 'github-repository-write-v1' })],
+    ['a widened tool set', identityBody({ tools: ['issue_read', 'list_issues', 'create_issue'] })],
+    ['a narrowed tool set', identityBody({ tools: ['issue_read'] })],
+    ['an unrequested pinned SHA', identityBody({ admitted_default_branch_sha: 'f'.repeat(40) })],
+    ['a missing expiry', identityBody({ expires_at: undefined })],
+    ['an unparsable expiry', identityBody({ expires_at: 'never' })],
+  ])('rejects %s as a contract violation', async (_label, body) => {
+    await withControlServer(
+      () => ({ status: 200, body }),
+      async (client) => {
+        await expect(client.createOrConfirm(baseRequest)).rejects.toMatchObject({
+          kind: 'contract-violation',
+        });
+      },
+    );
+  });
+
+  it('rejects an identity that outlives the invocation deadline', async () => {
+    await withControlServer(
+      () => ({
+        status: 200,
+        body: identityBody({ expires_at: new Date(Date.now() + 3_600_000).toISOString() }),
+      }),
+      async (client) => {
+        await expect(client.createOrConfirm(baseRequest)).rejects.toMatchObject({
+          kind: 'contract-violation',
+        });
+      },
+    );
+  });
+
+  it('rejects an identity that outlives the requested TTL', async () => {
+    await withControlServer(
+      () => ({
+        status: 200,
+        body: identityBody({ expires_at: new Date(Date.now() + 140_000).toISOString() }),
+      }),
+      async (client) => {
+        await expect(client.createOrConfirm({ ...baseRequest, requestedTtlSeconds: 60 }))
+          .rejects.toMatchObject({ kind: 'contract-violation' });
+      },
+    );
+  });
+
+  it('rejects a pinned SHA that differs from the admitted one', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: identityBody({ admitted_default_branch_sha: 'f'.repeat(40) }) }),
+      async (client) => {
+        await expect(client.createOrConfirm({
+          ...baseRequest,
+          admittedDefaultBranchSha: 'e'.repeat(40),
+        })).rejects.toMatchObject({ kind: 'contract-violation' });
+      },
+    );
+  });
+
+  it('rejects a non-JSON content type', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: identityBody(), contentType: 'text/html' }),
+      async (client) => {
+        await expect(client.createOrConfirm(baseRequest)).rejects.toMatchObject({
+          kind: 'contract-violation',
+        });
+      },
+    );
+  });
+
+  it('rejects invalid JSON', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: '{' }),
+      async (client) => {
+        await expect(client.createOrConfirm(baseRequest)).rejects.toMatchObject({
+          kind: 'contract-violation',
+        });
+      },
+    );
+  });
+
+  it('bounds the response body', async () => {
+    await withControlServer(
+      () => ({ status: 200, body: JSON.stringify({ pad: 'x'.repeat(200 * 1024) }) }),
+      async (client) => {
+        await expect(client.createOrConfirm(baseRequest)).rejects.toMatchObject({
+          kind: 'contract-violation',
+        });
+      },
+    );
+  });
+
+  it.each([
+    [403, 'denied'],
+    [400, 'malformed-request'],
+    [404, 'unsupported'],
+    [500, 'unavailable'],
+    [502, 'unavailable'],
+  ])('classifies HTTP %s as %s', async (status, kind) => {
+    await withControlServer(
+      () => ({ status, body: JSON.stringify({ error: 'x' }) }),
+      async (client) => {
+        await expect(client.createOrConfirm(baseRequest)).rejects.toMatchObject({ kind });
+      },
+    );
+  });
+
+  it('treats unresolved control state as requiring reconciliation', () => {
+    expect(new DelegationControlError('unavailable', 'revoke', 'x').requiresReconciliation)
+      .toBe(true);
+    expect(new DelegationControlError('denied', 'create-or-confirm', 'x').requiresReconciliation)
+      .toBe(false);
+  });
+
+  it.each([
+    ['revoke', JSON.stringify({ revoked: false })],
+    ['reconcile', JSON.stringify({ reconciled: false })],
+  ])('rejects an unconfirmed %s', async (operation, body) => {
+    await withControlServer(
+      () => ({ status: 200, body }),
+      async (client) => {
+        const call = operation === 'revoke'
+          ? client.revoke('dlg_1234')
+          : client.reconcile();
+        await expect(call).rejects.toMatchObject({ kind: 'contract-violation' });
+      },
+    );
+  });
+
+  it('exposes the closed v1 tool set', () => {
+    expect(DELEGATION_TOOLS).toEqual(['issue_read', 'list_issues']);
+  });
+
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER])(
+    'refuses to encode %s seconds as a Go duration',
+    (seconds) => {
+      expect(() => secondsToGoDurationNanos(seconds)).toThrow(DelegationControlError);
+    },
+  );
+});

--- a/src/enclave/delegation-control-client.ts
+++ b/src/enclave/delegation-control-client.ts
@@ -1,0 +1,460 @@
+/**
+ * Strict client for mcpg v0.4.17's `github-repository-delegation-v1` control
+ * channel (`github/gh-aw-mcpg` `internal/proxy/delegation.go`,
+ * `internal/delegation/{identity,store,envelope}.go`).
+ *
+ * Wire contract, reproduced exactly because mcpg decodes with
+ * `DisallowUnknownFields` and rejects anything outside it:
+ *
+ * - every operation is `POST {origin}/internal/awf-enclave-mcp-control/<op>`,
+ *   where `<op>` is a *sibling* of the controller name in the endpoint the
+ *   compiler exports, not a child of it;
+ * - the AWF-only capability travels in `Authorization`;
+ * - request bodies are bounded (mcpg caps them at 64 KiB);
+ * - `requested_ttl` is a Go `time.Duration`, i.e. an **integer number of
+ *   nanoseconds**, and `invocation_expires_at` / `expires_at` are RFC 3339
+ *   timestamps;
+ * - `admitted_default_branch_sha` is optional on both the request and the
+ *   response.
+ *
+ * Every response is validated before it is trusted: status, `content-type`,
+ * bounded length, strict JSON, and — for create-or-confirm — an exact match
+ * against the request's repository, tool policy, tool set, optional SHA, and
+ * TTL/expiry bounds. Anything else is terminal; the client never returns a
+ * partially trusted identity.
+ */
+
+import * as http from 'http';
+import type { EnclaveDynamicDelegationEndpoint } from './dynamic-delegation-handoff';
+
+/** The only delegated tool policy AWF understands. */
+export const DELEGATION_TOOL_POLICY = 'github-repository-read-v1';
+
+/** Exact, closed tool set `github-repository-read-v1` grants, sorted. */
+export const DELEGATION_TOOLS: readonly string[] = Object.freeze(['issue_read', 'list_issues']);
+
+/**
+ * Fixed enclave backend identifier the compiler bakes into the envelope
+ * (`buildMCPGatewayDelegationEnvelope` emits `"enclave_backend": "github"`).
+ */
+export const DELEGATION_ENCLAVE_BACKEND = 'github';
+
+const NANOSECONDS_PER_SECOND = 1_000_000_000;
+const MAX_CONTROL_RESPONSE_BYTES = 128 * 1024;
+const DEFAULT_CONTROL_TIMEOUT_MS = 10_000;
+
+/** Distinguishes a policy denial from an operator-visible internal failure. */
+export type DelegationControlFailureKind =
+  /** mcpg refused the request under the compiler envelope (HTTP 403). */
+  | 'denied'
+  /** AWF built a request mcpg could not parse; a bug, never a caller signal. */
+  | 'malformed-request'
+  /** Wrong endpoint, controller disabled, or unsupported mcpg version. */
+  | 'unsupported'
+  /** mcpg could not persist or serve; transport, timeout, or 5xx. */
+  | 'unavailable'
+  /** mcpg answered, but the answer did not match the request or the contract. */
+  | 'contract-violation';
+
+export class DelegationControlError extends Error {
+  constructor(
+    readonly kind: DelegationControlFailureKind,
+    readonly operation: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DelegationControlError';
+  }
+
+  /** Whether this failure leaves delegated state in an unknown condition. */
+  get requiresReconciliation(): boolean {
+    return this.kind === 'unavailable' || this.kind === 'contract-violation';
+  }
+}
+
+export interface DelegationCreateOrConfirmRequest {
+  runId: string;
+  enclaveEntryId: string;
+  invocationId: string;
+  repository: string;
+  schemaHash: string;
+  /** Requested identity lifetime in whole seconds; converted to nanoseconds. */
+  requestedTtlSeconds: number;
+  /** Absolute invocation deadline; an identity can never outlive it. */
+  invocationExpiresAt: Date;
+  idempotencyKey: string;
+  /** Only set when AWF actually resolved a SHA through a confined path. */
+  admittedDefaultBranchSha?: string;
+}
+
+export interface DelegationIdentity {
+  readonly handle: string;
+  readonly executorBearer: string;
+  readonly repository: string;
+  readonly toolPolicy: string;
+  readonly tools: readonly string[];
+  readonly admittedDefaultBranchSha?: string;
+  readonly expiresAt: Date;
+}
+
+export interface DelegationStatus {
+  readonly recoveryIncomplete: boolean;
+  readonly generation: number;
+  readonly liveIdentityCount: number;
+  readonly labelledHandles: readonly string[];
+}
+
+export interface DelegationControlClientOptions {
+  endpoint: EnclaveDynamicDelegationEndpoint;
+  capability: string;
+  timeoutMs?: number;
+  /** Injectable transport so tests can drive the exact wire contract. */
+  request?: typeof http.request;
+}
+
+interface ControlResponse {
+  statusCode: number;
+  contentType: string;
+  body: string;
+}
+
+/** Converts whole seconds to the integer nanoseconds Go's `time.Duration` decodes. */
+export function secondsToGoDurationNanos(seconds: number): number {
+  if (!Number.isSafeInteger(seconds) || seconds < 1) {
+    throw new DelegationControlError(
+      'malformed-request',
+      'create-or-confirm',
+      'requested TTL must be a positive whole number of seconds',
+    );
+  }
+  const nanos = seconds * NANOSECONDS_PER_SECOND;
+  if (!Number.isSafeInteger(nanos)) {
+    throw new DelegationControlError(
+      'malformed-request',
+      'create-or-confirm',
+      'requested TTL overflows a safe integer number of nanoseconds',
+    );
+  }
+  return nanos;
+}
+
+export class DelegationControlClient {
+  private readonly endpoint: EnclaveDynamicDelegationEndpoint;
+  private readonly capability: string;
+  private readonly timeoutMs: number;
+  private readonly transport: typeof http.request;
+
+  constructor(options: DelegationControlClientOptions) {
+    this.endpoint = options.endpoint;
+    this.capability = options.capability;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_CONTROL_TIMEOUT_MS;
+    this.transport = options.request ?? http.request;
+  }
+
+  /**
+   * Creates, or idempotently confirms, exactly one delegated identity for one
+   * invocation. The returned identity is verified field-by-field against the
+   * request before it is handed to a caller.
+   */
+  async createOrConfirm(request: DelegationCreateOrConfirmRequest): Promise<DelegationIdentity> {
+    const requestedTtlNanos = secondsToGoDurationNanos(request.requestedTtlSeconds);
+    const body: Record<string, unknown> = {
+      run_id: request.runId,
+      enclave_backend: DELEGATION_ENCLAVE_BACKEND,
+      enclave_entry_id: request.enclaveEntryId,
+      invocation_id: request.invocationId,
+      repository: request.repository,
+      tool_policy: DELEGATION_TOOL_POLICY,
+      schema_hash: request.schemaHash,
+      requested_ttl: requestedTtlNanos,
+      invocation_expires_at: request.invocationExpiresAt.toISOString(),
+      idempotency_key: request.idempotencyKey,
+    };
+    if (request.admittedDefaultBranchSha !== undefined) {
+      body.admitted_default_branch_sha = request.admittedDefaultBranchSha;
+    }
+    const decoded = await this.post('create-or-confirm', body);
+    return this.verifyIdentity(decoded, request, requestedTtlNanos);
+  }
+
+  /** Reads the controller's recovery state and this label pair's live handles. */
+  async status(runId: string, enclaveEntryId: string): Promise<DelegationStatus> {
+    const decoded = await this.post('status', {
+      run_id: runId,
+      enclave_entry_id: enclaveEntryId,
+    });
+    const recoveryIncomplete = decoded.recovery_incomplete;
+    const generation = decoded.generation;
+    const liveIdentityCount = decoded.live_identity_count;
+    const labelledHandles = decoded.labelled_handles;
+    if (
+      typeof recoveryIncomplete !== 'boolean'
+      || !isSafeCount(generation)
+      || !isSafeCount(liveIdentityCount)
+      || !(labelledHandles === null || isStringArray(labelledHandles))
+    ) {
+      throw new DelegationControlError(
+        'contract-violation',
+        'status',
+        'mcpg returned a malformed delegation status response',
+      );
+    }
+    return {
+      recoveryIncomplete,
+      generation,
+      liveIdentityCount,
+      labelledHandles: Object.freeze(labelledHandles === null ? [] : [...labelledHandles]),
+    };
+  }
+
+  /**
+   * Clears mcpg's recovery-incomplete flag transactionally. AWF calls this
+   * only after it has inspected — and revoked — every outstanding labelled
+   * identity, never as a way to skip that inspection.
+   */
+  async reconcile(): Promise<void> {
+    const decoded = await this.post('reconcile', {});
+    if (decoded.reconciled !== true) {
+      throw new DelegationControlError(
+        'contract-violation',
+        'reconcile',
+        'mcpg did not confirm transactional delegation reconciliation',
+      );
+    }
+  }
+
+  /** Revokes one identity by opaque handle. Idempotent in mcpg. */
+  async revoke(handle: string): Promise<void> {
+    const decoded = await this.post('revoke', { handle });
+    if (decoded.revoked !== true) {
+      throw new DelegationControlError(
+        'contract-violation',
+        'revoke',
+        'mcpg did not confirm delegated identity revocation',
+      );
+    }
+  }
+
+  /** Revokes every identity carrying this run/entry label pair. */
+  async revokeByLabels(runId: string, enclaveEntryId: string): Promise<number> {
+    const decoded = await this.post('revoke-by-labels', {
+      run_id: runId,
+      enclave_entry_id: enclaveEntryId,
+    });
+    const revoked = decoded.revoked;
+    if (!isSafeCount(revoked)) {
+      throw new DelegationControlError(
+        'contract-violation',
+        'revoke-by-labels',
+        'mcpg did not report how many delegated identities were revoked',
+      );
+    }
+    return revoked;
+  }
+
+  private verifyIdentity(
+    decoded: Record<string, unknown>,
+    request: DelegationCreateOrConfirmRequest,
+    requestedTtlNanos: number,
+  ): DelegationIdentity {
+    const fail = (detail: string): never => {
+      throw new DelegationControlError('contract-violation', 'create-or-confirm', detail);
+    };
+    const handle = decoded.handle;
+    const executorBearer = decoded.executor_bearer;
+    const repository = decoded.repository;
+    const toolPolicy = decoded.tool_policy;
+    const tools = decoded.tools;
+    const expiresAtRaw = decoded.expires_at;
+    const admittedSha = decoded.admitted_default_branch_sha;
+
+    if (typeof handle !== 'string' || handle.length === 0) fail('identity handle is missing');
+    if (typeof executorBearer !== 'string' || executorBearer.length === 0) {
+      fail('executor bearer is missing');
+    }
+    if (repository !== request.repository) {
+      fail('identity is bound to a different repository than the admitted selector');
+    }
+    if (toolPolicy !== DELEGATION_TOOL_POLICY) fail('identity carries an unexpected tool policy');
+    if (
+      !isStringArray(tools)
+      || tools.length !== DELEGATION_TOOLS.length
+      || [...tools].sort().join(',') !== DELEGATION_TOOLS.join(',')
+    ) {
+      fail('identity does not grant exactly list_issues and issue_read');
+    }
+    if (request.admittedDefaultBranchSha === undefined) {
+      if (admittedSha !== undefined && admittedSha !== '') {
+        fail('identity pinned a default-branch SHA that AWF never requested');
+      }
+    } else if (admittedSha !== request.admittedDefaultBranchSha) {
+      fail('identity pinned a different default-branch SHA than the admitted one');
+    }
+    if (typeof expiresAtRaw !== 'string') fail('identity expiry is missing');
+    const expiresAt = new Date(expiresAtRaw as string);
+    if (Number.isNaN(expiresAt.getTime())) fail('identity expiry is not a valid timestamp');
+    if (expiresAt.getTime() > request.invocationExpiresAt.getTime()) {
+      fail('identity outlives the invocation deadline');
+    }
+    // mcpg computes ExpiresAt as now + RequestedTTL, capped by the envelope and
+    // the invocation deadline, so a longer-lived identity means the controller
+    // ignored the requested bound.
+    const ttlCeilingMs = Date.now() + requestedTtlNanos / 1_000_000;
+    if (expiresAt.getTime() > ttlCeilingMs) {
+      fail('identity outlives the requested TTL');
+    }
+    return Object.freeze({
+      handle: handle as string,
+      executorBearer: executorBearer as string,
+      repository: request.repository,
+      toolPolicy: DELEGATION_TOOL_POLICY,
+      tools: Object.freeze([...DELEGATION_TOOLS]),
+      ...(request.admittedDefaultBranchSha === undefined
+        ? {}
+        : { admittedDefaultBranchSha: request.admittedDefaultBranchSha }),
+      expiresAt,
+    });
+  }
+
+  private async post(
+    operation: string,
+    body: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.send(operation, JSON.stringify(body));
+    if (response.statusCode === 403) {
+      throw new DelegationControlError(
+        'denied',
+        operation,
+        'mcpg denied the delegation control request under the compiler envelope',
+      );
+    }
+    if (response.statusCode === 400) {
+      throw new DelegationControlError(
+        'malformed-request',
+        operation,
+        'mcpg rejected the delegation control request as malformed',
+      );
+    }
+    if (response.statusCode === 404) {
+      throw new DelegationControlError(
+        'unsupported',
+        operation,
+        'mcpg does not serve the github-repository-delegation-v1 control API at this endpoint',
+      );
+    }
+    if (response.statusCode !== 200) {
+      throw new DelegationControlError(
+        'unavailable',
+        operation,
+        `mcpg delegation control returned HTTP ${response.statusCode}`,
+      );
+    }
+    if (!response.contentType.toLowerCase().startsWith('application/json')) {
+      throw new DelegationControlError(
+        'contract-violation',
+        operation,
+        'mcpg delegation control returned a non-JSON content type',
+      );
+    }
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(response.body);
+    } catch {
+      throw new DelegationControlError(
+        'contract-violation',
+        operation,
+        'mcpg delegation control returned invalid JSON',
+      );
+    }
+    if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) {
+      throw new DelegationControlError(
+        'contract-violation',
+        operation,
+        'mcpg delegation control returned a non-object response',
+      );
+    }
+    return decoded as Record<string, unknown>;
+  }
+
+  private send(operation: string, payload: string): Promise<ControlResponse> {
+    const url = new URL(`${this.endpoint.operationBasePath}${operation}`, this.endpoint.origin);
+    const encoded = Buffer.from(payload, 'utf8');
+    return new Promise<ControlResponse>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error, value?: ControlResponse): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(deadline);
+        if (error) reject(error);
+        else resolve(value as ControlResponse);
+      };
+      const request = this.transport(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.capability}`,
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'Content-Length': String(encoded.length),
+          Connection: 'close',
+        },
+        timeout: this.timeoutMs,
+      }, (response) => {
+        const chunks: Buffer[] = [];
+        let total = 0;
+        response.on('data', (chunk: Buffer) => {
+          total += chunk.length;
+          if (total > MAX_CONTROL_RESPONSE_BYTES) {
+            request.destroy();
+            finish(new DelegationControlError(
+              'contract-violation',
+              operation,
+              'mcpg delegation control response exceeded its bounded length',
+            ));
+            return;
+          }
+          chunks.push(Buffer.from(chunk));
+        });
+        response.on('end', () => finish(undefined, {
+          statusCode: response.statusCode ?? 0,
+          contentType: String(response.headers['content-type'] ?? ''),
+          body: Buffer.concat(chunks).toString('utf8'),
+        }));
+        response.on('error', () => finish(new DelegationControlError(
+          'unavailable',
+          operation,
+          'mcpg delegation control response failed',
+        )));
+      });
+      request.on('timeout', () => {
+        request.destroy();
+        finish(new DelegationControlError(
+          'unavailable',
+          operation,
+          'mcpg delegation control request timed out',
+        ));
+      });
+      request.on('error', () => finish(new DelegationControlError(
+        'unavailable',
+        operation,
+        'mcpg delegation control request failed',
+      )));
+      const deadline = setTimeout(() => {
+        request.destroy();
+        finish(new DelegationControlError(
+          'unavailable',
+          operation,
+          'mcpg delegation control request exceeded its deadline',
+        ));
+      }, this.timeoutMs);
+      request.end(encoded);
+    });
+  }
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isSafeCount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}

--- a/src/enclave/dynamic-delegation-channel.test.ts
+++ b/src/enclave/dynamic-delegation-channel.test.ts
@@ -1,0 +1,345 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createEnclaveInformationBudgetLedger } from './information-budget';
+import { parseEnclaveDynamicDelegationControlEndpoint } from './dynamic-delegation-handoff';
+import { typedDynamicEnclavePolicyFixture } from './dynamic-policy.test-utils';
+import {
+  DELEGATION_CHANNEL_VERSION,
+  parseDelegationAdmissionRequest,
+  parseDelegationSettlement,
+} from './dynamic-delegation-protocol';
+import { DynamicDelegationService } from './dynamic-delegation-service';
+import { startDynamicDelegationChannel } from './dynamic-delegation-channel';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const containersRoot = path.join(__dirname, '..', '..', 'containers');
+const {
+  createDynamicDelegationClient,
+} = require(path.join(containersRoot, 'enclave', 'mcp-server', 'delegation-channel.js'));
+const {
+  finiteSchemaHash,
+} = require(path.join(containersRoot, 'bounded-execution', 'schema-hash.js'));
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const ENDPOINT = parseEnclaveDynamicDelegationControlEndpoint(
+  'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+)!;
+
+describe('dynamic delegation channel protocol parsing', () => {
+  it('accepts a well-formed admission request', () => {
+    expect(parseDelegationAdmissionRequest({
+      version: 1,
+      invocationId: 'a'.repeat(24),
+      selector: 'octo-org/service',
+      schemaHash: 'b'.repeat(64),
+    })).toMatchObject({ selector: 'octo-org/service' });
+  });
+
+  it('forwards a malformed selector unchanged so the registry can deny it uniformly', () => {
+    expect(parseDelegationAdmissionRequest({
+      version: 1,
+      invocationId: 'a'.repeat(24),
+      selector: 'Octo-Org/Service',
+      schemaHash: 'b'.repeat(64),
+    })).toMatchObject({ selector: 'Octo-Org/Service' });
+  });
+
+  it.each([
+    ['a version mismatch', { version: 2 }],
+    ['a non-broker invocation id', { invocationId: '../escape' }],
+    ['a missing schema hash', { schemaHash: undefined }],
+    ['a truncated schema hash', { schemaHash: 'b'.repeat(63) }],
+    ['an oversized selector', { selector: 'o'.repeat(300) }],
+  ])('rejects %s', (_label, overrides) => {
+    expect(parseDelegationAdmissionRequest({
+      version: 1,
+      invocationId: 'a'.repeat(24),
+      selector: 'octo-org/service',
+      schemaHash: 'b'.repeat(64),
+      ...overrides,
+    })).toBeUndefined();
+  });
+
+  it.each([
+    ['an unknown outcome', { outcome: 'partially-ok' }],
+    ['negative output bytes', { outputBytes: -1 }],
+    ['fractional execution seconds', { executionSeconds: 1.5 }],
+  ])('rejects a settlement with %s', (_label, overrides) => {
+    expect(parseDelegationSettlement({
+      version: 1,
+      invocationId: 'a'.repeat(24),
+      outcome: 'success',
+      outputBytes: 1,
+      executionSeconds: 1,
+      ...overrides,
+    })).toBeUndefined();
+  });
+});
+
+describe('dynamic delegation channel end to end', () => {
+  let directory: string;
+  let auditPath: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-delegation-channel-'));
+    auditPath = path.join(directory, '..', `${path.basename(directory)}-audit.jsonl`);
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+    fs.rmSync(auditPath, { force: true });
+  });
+
+  function buildService(clientOverrides: Record<string, unknown> = {}) {
+    const created = { count: 0 };
+    const client = {
+      async status() {
+        return {
+          recoveryIncomplete: false,
+          generation: 1,
+          liveIdentityCount: 0,
+          labelledHandles: [] as string[],
+        };
+      },
+      async reconcile() { /* reconciled */ },
+      async revoke() { /* revoked */ },
+      async revokeByLabels() { return 0; },
+      async createOrConfirm(request: Record<string, unknown>) {
+        created.count += 1;
+        return {
+          handle: `dlg_${created.count}`,
+          executorBearer: `dlgbearer_${created.count}`,
+          repository: request.repository as string,
+          toolPolicy: 'github-repository-read-v1',
+          tools: ['issue_read', 'list_issues'],
+          expiresAt: new Date(Date.now() + 60_000),
+        };
+      },
+      ...clientOverrides,
+    };
+    return new DynamicDelegationService({
+      policy: typedDynamicEnclavePolicyFixture(),
+      identity: { runId: '42-1', entryId: 'agent' },
+      handoff: { endpoint: ENDPOINT, capability: 'c'.repeat(64) },
+      ledger: createEnclaveInformationBudgetLedger(new Map()),
+      auditPath,
+      client: client as never,
+      clock: { nowMs: () => 0, sleep: async () => undefined },
+      jitter: () => 0,
+    });
+  }
+
+  function brokerClient() {
+    return createDynamicDelegationClient(
+      { dynamicChannelDir: directory, dynamicSensitivity: 'confidential' },
+      { pollIntervalMs: 1, admissionTimeoutMs: 2_000, settlementTimeoutMs: 2_000 },
+    );
+  }
+
+  it('admits, executes, and settles one invocation across the private channel', async () => {
+    const service = buildService();
+    await service.recover();
+    const channel = startDynamicDelegationChannel({ directory, service, pollIntervalMs: 1 });
+    const broker = brokerClient();
+    try {
+      const admitted = await broker.admit({
+        invocationId: 'abc123abc123abc1',
+        selector: 'octo-org/service',
+        schema: { type: 'boolean' },
+      });
+      expect(admitted).toMatchObject({
+        admitted: true,
+        repo: 'octo-org/service',
+        executorBearer: 'dlgbearer_1',
+        readMode: 'live',
+        sensitivity: 'confidential',
+      });
+      const receipt = await broker.settle({
+        invocationId: 'abc123abc123abc1',
+        outcome: 'success',
+        outputBytes: 32,
+        executionSeconds: 2,
+      });
+      expect(receipt).toEqual({ settled: true, revoked: true });
+      expect(service.quotaUsage.outputBytes).toMatchObject({ debited: 32, reserved: 0 });
+    } finally {
+      await channel.stop();
+    }
+  });
+
+  it('sends the canonical finite-schema hash for the invocation', async () => {
+    const service = buildService();
+    await service.recover();
+    const broker = brokerClient();
+    const schema = { type: 'object', properties: { b: { type: 'boolean' }, a: { type: 'boolean' } } };
+    const pending = broker.admit({
+      invocationId: 'def456def456def4',
+      selector: 'octo-org/service',
+      schema,
+    });
+    // Read the request document before the host consumes it.
+    let raw: string | undefined;
+    for (let attempt = 0; attempt < 200 && raw === undefined; attempt += 1) {
+      try {
+        raw = fs.readFileSync(path.join(directory, 'def456def456def4.admit.json'), 'utf8');
+      } catch {
+        await new Promise((resolve) => { setTimeout(resolve, 1); });
+      }
+    }
+    expect(JSON.parse(raw!)).toMatchObject({
+      version: DELEGATION_CHANNEL_VERSION,
+      schemaHash: finiteSchemaHash(schema),
+    });
+    // Key order must not change the hash.
+    expect(finiteSchemaHash({
+      type: 'object',
+      properties: { a: { type: 'boolean' }, b: { type: 'boolean' } },
+    })).toBe(finiteSchemaHash(schema));
+
+    const channel = startDynamicDelegationChannel({ directory, service, pollIntervalMs: 1 });
+    try {
+      await expect(pending).resolves.toMatchObject({ admitted: true });
+    } finally {
+      await channel.stop();
+    }
+  });
+
+  it('never writes the control endpoint, capability, or identity handle to the channel', async () => {
+    const service = buildService();
+    await service.recover();
+    const channel = startDynamicDelegationChannel({ directory, service, pollIntervalMs: 1 });
+    const broker = brokerClient();
+    try {
+      await broker.admit({
+        invocationId: 'aaa111aaa111aaa1',
+        selector: 'octo-org/service',
+        schema: { type: 'boolean' },
+      });
+      const written = fs.readdirSync(directory)
+        .map((entry) => fs.readFileSync(path.join(directory, entry), 'utf8'))
+        .join('\n');
+      expect(written).not.toContain('c'.repeat(64));
+      expect(written).not.toContain('127.0.0.1');
+      expect(written).not.toContain('dlg_1"');
+      expect(written).not.toContain('/internal/awf-enclave-mcp-control');
+    } finally {
+      await channel.stop();
+    }
+  });
+
+  it('fails closed when the host never answers', async () => {
+    const broker = createDynamicDelegationClient(
+      { dynamicChannelDir: directory, dynamicSensitivity: 'confidential' },
+      { pollIntervalMs: 1, admissionTimeoutMs: 30, settlementTimeoutMs: 30 },
+    );
+    await expect(broker.admit({
+      invocationId: 'bbb222bbb222bbb2',
+      selector: 'octo-org/service',
+      schema: { type: 'boolean' },
+    })).resolves.toEqual({ admitted: false });
+    await expect(broker.settle({
+      invocationId: 'bbb222bbb222bbb2',
+      outcome: 'success',
+      outputBytes: 0,
+      executionSeconds: 0,
+    })).resolves.toEqual({ settled: false, revoked: false });
+  });
+
+  it('reports an unresolved revocation so the broker cannot report success', async () => {
+    const service = buildService({
+      async revoke() {
+        throw new Error('control plane down');
+      },
+    });
+    await service.recover();
+    const channel = startDynamicDelegationChannel({ directory, service, pollIntervalMs: 1 });
+    const broker = brokerClient();
+    try {
+      await broker.admit({
+        invocationId: 'ccc333ccc333ccc3',
+        selector: 'octo-org/service',
+        schema: { type: 'boolean' },
+      });
+      await expect(broker.settle({
+        invocationId: 'ccc333ccc333ccc3',
+        outcome: 'success',
+        outputBytes: 1,
+        executionSeconds: 1,
+      })).resolves.toEqual({ settled: true, revoked: false });
+    } finally {
+      await channel.stop();
+    }
+  });
+
+  it('rejects a response bound to a different invocation', async () => {
+    const broker = createDynamicDelegationClient(
+      { dynamicChannelDir: directory, dynamicSensitivity: 'confidential' },
+      { pollIntervalMs: 1, admissionTimeoutMs: 500, settlementTimeoutMs: 500 },
+    );
+    const pending = broker.admit({
+      invocationId: 'ddd444ddd444ddd4',
+      selector: 'octo-org/service',
+      schema: { type: 'boolean' },
+    });
+    fs.writeFileSync(path.join(directory, 'ddd444ddd444ddd4.admitted.json'), JSON.stringify({
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: 'eee555eee555eee5',
+      admitted: true,
+      repository: 'octo-org/service',
+      executorBearer: 'dlgbearer_x',
+      expiresAt: new Date().toISOString(),
+      readMode: 'live',
+    }));
+    await expect(pending).resolves.toEqual({ admitted: false });
+  });
+
+  it('rejects a response bound to a different repository than the selector', async () => {
+    const broker = createDynamicDelegationClient(
+      { dynamicChannelDir: directory, dynamicSensitivity: 'confidential' },
+      { pollIntervalMs: 1, admissionTimeoutMs: 500, settlementTimeoutMs: 500 },
+    );
+    const pending = broker.admit({
+      invocationId: 'fff666fff666fff6',
+      selector: 'octo-org/service',
+      schema: { type: 'boolean' },
+    });
+    fs.writeFileSync(path.join(directory, 'fff666fff666fff6.admitted.json'), JSON.stringify({
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: 'fff666fff666fff6',
+      admitted: true,
+      repository: 'octo-org/sibling',
+      executorBearer: 'dlgbearer_x',
+      expiresAt: new Date().toISOString(),
+      readMode: 'live',
+    }));
+    await expect(pending).resolves.toEqual({ admitted: false });
+  });
+
+  it('discards an oversized channel document rather than parsing it', async () => {
+    const service = buildService();
+    await service.recover();
+    fs.writeFileSync(
+      path.join(directory, '0123456789abcdef.admit.json'),
+      JSON.stringify({ pad: 'x'.repeat(16 * 1024) }),
+    );
+    const channel = startDynamicDelegationChannel({ directory, service, pollIntervalMs: 1 });
+    try {
+      await channel.poll();
+      expect(fs.existsSync(path.join(directory, '0123456789abcdef.admitted.json'))).toBe(false);
+    } finally {
+      await channel.stop();
+    }
+  });
+
+  it('creates the channel directory owner-only', async () => {
+    const nested = path.join(directory, 'nested');
+    const service = buildService();
+    const channel = startDynamicDelegationChannel({ directory: nested, service, pollIntervalMs: 1 });
+    try {
+      expect(fs.statSync(nested).mode & 0o777).toBe(0o700);
+    } finally {
+      await channel.stop();
+    }
+  });
+});

--- a/src/enclave/dynamic-delegation-channel.ts
+++ b/src/enclave/dynamic-delegation-channel.ts
@@ -1,0 +1,148 @@
+/**
+ * Host side of the AWF-private dynamic delegation channel.
+ *
+ * The loop watches one `0700` directory inside the enclave private root for
+ * broker-written admission requests and settlement reports, answers each one
+ * exactly once through {@link DynamicDelegationService}, and writes the reply
+ * atomically (temp file + `rename`) so the broker can never observe a partial
+ * document.
+ *
+ * There is no network listener and no long-lived shared secret on this path:
+ * the directory is bind-mounted only into the enclave MCP broker, which is
+ * already the trusted component that launches executors. See
+ * `./dynamic-delegation-protocol` for why the control client cannot live in
+ * the broker container.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../logger';
+import type { DynamicDelegationService } from './dynamic-delegation-service';
+import {
+  DELEGATION_CHANNEL_MAX_BYTES,
+  DELEGATION_CHANNEL_RECEIPT_SUFFIX,
+  DELEGATION_CHANNEL_REQUEST_SUFFIX,
+  DELEGATION_CHANNEL_RESPONSE_SUFFIX,
+  DELEGATION_CHANNEL_SETTLE_SUFFIX,
+  parseDelegationAdmissionRequest,
+  parseDelegationSettlement,
+} from './dynamic-delegation-protocol';
+
+/** How often the host sweeps the channel directory. */
+const POLL_INTERVAL_MS = 25;
+
+export interface DynamicDelegationChannelOptions {
+  directory: string;
+  service: DynamicDelegationService;
+  pollIntervalMs?: number;
+}
+
+export interface DynamicDelegationChannel {
+  /** Processes one sweep. Exposed so tests can drive the loop deterministically. */
+  poll(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+function readBoundedJson(target: string): unknown | undefined {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.size > DELEGATION_CHANNEL_MAX_BYTES) return undefined;
+    return JSON.parse(fs.readFileSync(fd, 'utf8'));
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function writeAtomicJson(target: string, value: unknown): void {
+  const temporary = `${target}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value), { mode: 0o600 });
+  fs.chmodSync(temporary, 0o600);
+  fs.renameSync(temporary, target);
+}
+
+/**
+ * Starts the channel loop. The returned handle keeps a single sweep in flight
+ * at a time, so a slow control call can never overlap itself.
+ */
+export function startDynamicDelegationChannel(
+  options: DynamicDelegationChannelOptions,
+): DynamicDelegationChannel {
+  const { directory, service } = options;
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  const handled = new Set<string>();
+  let stopped = false;
+  let inFlight: Promise<void> = Promise.resolve();
+
+  const handleRequest = async (entry: string): Promise<void> => {
+    const source = path.join(directory, entry);
+    const invocationId = entry.slice(0, -DELEGATION_CHANNEL_REQUEST_SUFFIX.length);
+    const request = parseDelegationAdmissionRequest(readBoundedJson(source));
+    fs.rmSync(source, { force: true });
+    if (!request || request.invocationId !== invocationId) {
+      logger.warn('Enclaves: discarded a malformed dynamic delegation admission request.');
+      return;
+    }
+    const response = await service.admit(request);
+    writeAtomicJson(
+      path.join(directory, `${invocationId}${DELEGATION_CHANNEL_RESPONSE_SUFFIX}`),
+      response,
+    );
+  };
+
+  const handleSettlement = async (entry: string): Promise<void> => {
+    const source = path.join(directory, entry);
+    const invocationId = entry.slice(0, -DELEGATION_CHANNEL_SETTLE_SUFFIX.length);
+    const settlement = parseDelegationSettlement(readBoundedJson(source));
+    fs.rmSync(source, { force: true });
+    if (!settlement || settlement.invocationId !== invocationId) {
+      logger.warn('Enclaves: discarded a malformed dynamic delegation settlement report.');
+      return;
+    }
+    const receipt = await service.settle(settlement);
+    writeAtomicJson(
+      path.join(directory, `${invocationId}${DELEGATION_CHANNEL_RECEIPT_SUFFIX}`),
+      receipt,
+    );
+  };
+
+  const poll = async (): Promise<void> => {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(directory);
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort()) {
+      if (handled.has(entry)) continue;
+      if (entry.endsWith(DELEGATION_CHANNEL_REQUEST_SUFFIX)) {
+        handled.add(entry);
+        await handleRequest(entry);
+      } else if (entry.endsWith(DELEGATION_CHANNEL_SETTLE_SUFFIX)) {
+        handled.add(entry);
+        await handleSettlement(entry);
+      }
+    }
+  };
+
+  const timer = setInterval(() => {
+    if (stopped) return;
+    inFlight = inFlight.then(poll).catch((error) => {
+      logger.warn('Enclaves: dynamic delegation channel sweep failed.', error);
+    });
+  }, options.pollIntervalMs ?? POLL_INTERVAL_MS);
+  timer.unref?.();
+
+  return {
+    poll,
+    async stop(): Promise<void> {
+      stopped = true;
+      clearInterval(timer);
+      await inFlight;
+    },
+  };
+}

--- a/src/enclave/dynamic-delegation-contract.test.ts
+++ b/src/enclave/dynamic-delegation-contract.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Cross-component contract fixture for dynamic enclave delegation.
+ *
+ * These are not AWF's own choices: every constant below is copied from the two
+ * upstream components AWF must interoperate with, so a drift in either
+ * direction fails a test instead of a workflow run.
+ *
+ * - `github/gh-aw` `pkg/workflow/mcp_setup_gateway.go` and
+ *   `pkg/workflow/enclaves.go` (PR #59046): the exported control endpoint,
+ *   the fixed control API base path, the controller name, the envelope's
+ *   `run_id` and `enclave_backend`.
+ * - `github/gh-aw-mcpg` v0.4.17 `internal/proxy/delegation.go` and
+ *   `internal/delegation/{identity,store,selector}.go` (PR #12605): the
+ *   operation paths, the `CreateOrConfirmRequest`/`IdentityResult` JSON key
+ *   sets, the status/reconcile/revoke shapes, and the closed tool set.
+ */
+
+import * as http from 'http';
+import {
+  DELEGATION_ENCLAVE_BACKEND,
+  DELEGATION_TOOLS,
+  DELEGATION_TOOL_POLICY,
+  DelegationControlClient,
+  secondsToGoDurationNanos,
+} from './delegation-control-client';
+import {
+  DELEGATION_CONTROLLER_NAME,
+  DELEGATION_CONTROL_API_BASE_PATH,
+  DELEGATION_CONTROL_ENDPOINT_PATH,
+  parseEnclaveDynamicDelegationControlEndpoint,
+} from './dynamic-delegation-handoff';
+import { resolveDynamicDelegationRunId } from './dynamic-delegation-service';
+
+/** gh-aw `enclaveDelegationControlAPIBasePath`. */
+const GH_AW_CONTROL_API_BASE_PATH = '/internal/awf-enclave-mcp-control';
+/** gh-aw `enclaveDynamicController`. */
+const GH_AW_CONTROLLER = 'github-repository-delegation-v1';
+/** gh-aw's default MCP port plus `enclaveDelegationControlPortOffset`. */
+const GH_AW_EXPORTED_ENDPOINT =
+  'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1';
+/** mcpg `delegationControlPath`. */
+const MCPG_CONTROL_PATH = '/internal/awf-enclave-mcp-control/';
+
+/** mcpg `delegation.CreateOrConfirmRequest` JSON tags, sorted. */
+const MCPG_CREATE_OR_CONFIRM_KEYS = [
+  'admitted_default_branch_sha',
+  'enclave_backend',
+  'enclave_entry_id',
+  'idempotency_key',
+  'invocation_expires_at',
+  'invocation_id',
+  'repository',
+  'requested_ttl',
+  'run_id',
+  'schema_hash',
+  'tool_policy',
+].sort();
+
+/** mcpg `delegation.IdentityResult` JSON tags, sorted. */
+const MCPG_IDENTITY_RESULT_KEYS = [
+  'admitted_default_branch_sha',
+  'executor_bearer',
+  'expires_at',
+  'handle',
+  'repository',
+  'tool_policy',
+  'tools',
+].sort();
+
+describe('gh-aw handoff contract', () => {
+  it('matches the compiler-exported control endpoint exactly', () => {
+    expect(DELEGATION_CONTROL_API_BASE_PATH).toBe(GH_AW_CONTROL_API_BASE_PATH);
+    expect(DELEGATION_CONTROLLER_NAME).toBe(GH_AW_CONTROLLER);
+    expect(DELEGATION_CONTROL_ENDPOINT_PATH)
+      .toBe(`${GH_AW_CONTROL_API_BASE_PATH}/${GH_AW_CONTROLLER}`);
+    expect(parseEnclaveDynamicDelegationControlEndpoint(GH_AW_EXPORTED_ENDPOINT))
+      .toBeDefined();
+  });
+
+  it('derives operation paths as siblings of the controller name, per mcpg routing', () => {
+    const endpoint = parseEnclaveDynamicDelegationControlEndpoint(GH_AW_EXPORTED_ENDPOINT)!;
+    expect(endpoint.operationBasePath).toBe(MCPG_CONTROL_PATH);
+    expect(new URL(`${endpoint.operationBasePath}create-or-confirm`, endpoint.origin).pathname)
+      .toBe('/internal/awf-enclave-mcp-control/create-or-confirm');
+  });
+
+  it('binds the envelope run id the compiler installed', () => {
+    // gh-aw enclaveDelegationRunID = "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}".
+    expect(resolveDynamicDelegationRunId({
+      GITHUB_RUN_ID: '18234567890',
+      GITHUB_RUN_ATTEMPT: '2',
+    })).toBe('18234567890-2');
+  });
+
+  it('binds the envelope enclave backend the compiler installed', () => {
+    // gh-aw buildMCPGatewayDelegationEnvelope: "enclave_backend": "github".
+    expect(DELEGATION_ENCLAVE_BACKEND).toBe('github');
+  });
+});
+
+describe('mcpg v0.4.17 wire contract', () => {
+  const captured: Record<string, unknown>[] = [];
+  let server: http.Server;
+  let client: DelegationControlClient;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        captured.push({
+          path: req.url,
+          body: JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}'),
+        });
+        const body = JSON.stringify({
+          handle: 'dlg_a',
+          executor_bearer: 'dlgbearer_a',
+          repository: 'octo/private',
+          tool_policy: DELEGATION_TOOL_POLICY,
+          tools: ['issue_read', 'list_issues'],
+          admitted_default_branch_sha: 'a'.repeat(40),
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        });
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        });
+        res.end(body);
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as { port: number }).port;
+    client = new DelegationControlClient({
+      endpoint: parseEnclaveDynamicDelegationControlEndpoint(
+        `http://127.0.0.1:${port}${DELEGATION_CONTROL_ENDPOINT_PATH}`,
+      )!,
+      capability: 'f'.repeat(64),
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('sends exactly the fields mcpg decodes with DisallowUnknownFields', async () => {
+    await client.createOrConfirm({
+      runId: '18234567890-2',
+      enclaveEntryId: 'agent',
+      invocationId: 'a1b2c3d4e5f60718',
+      repository: 'octo/private',
+      schemaHash: 'b'.repeat(64),
+      requestedTtlSeconds: 120,
+      invocationExpiresAt: new Date(Date.now() + 150_000),
+      idempotencyKey: 'c'.repeat(64),
+      admittedDefaultBranchSha: 'a'.repeat(40),
+    });
+    const body = captured[captured.length - 1].body as Record<string, unknown>;
+    // Every key AWF sends must exist in mcpg's struct; optional keys may be
+    // omitted, but an unknown key would make mcpg reject the whole request.
+    for (const key of Object.keys(body)) {
+      expect(MCPG_CREATE_OR_CONFIRM_KEYS).toContain(key);
+    }
+    // The only optional request field is the admitted SHA.
+    const required = MCPG_CREATE_OR_CONFIRM_KEYS
+      .filter((key) => key !== 'admitted_default_branch_sha');
+    for (const key of required) {
+      expect(body).toHaveProperty(key);
+    }
+  });
+
+  it('encodes Go time.Duration as integer nanoseconds and time.Time as RFC 3339', async () => {
+    expect(secondsToGoDurationNanos(1)).toBe(1_000_000_000);
+    await client.createOrConfirm({
+      runId: '18234567890-2',
+      enclaveEntryId: 'agent',
+      invocationId: 'a1b2c3d4e5f60718',
+      repository: 'octo/private',
+      schemaHash: 'b'.repeat(64),
+      requestedTtlSeconds: 120,
+      invocationExpiresAt: new Date('2999-01-01T00:00:00.000Z'),
+      idempotencyKey: 'c'.repeat(64),
+      admittedDefaultBranchSha: 'a'.repeat(40),
+    });
+    const body = captured[captured.length - 1].body as Record<string, unknown>;
+    expect(body.requested_ttl).toBe(120 * 1_000_000_000);
+    expect(Number.isInteger(body.requested_ttl)).toBe(true);
+    expect(body.invocation_expires_at).toBe('2999-01-01T00:00:00.000Z');
+  });
+
+  it('reads only the fields mcpg returns in IdentityResult', async () => {
+    const identity = await client.createOrConfirm({
+      runId: '18234567890-2',
+      enclaveEntryId: 'agent',
+      invocationId: 'a1b2c3d4e5f60718',
+      repository: 'octo/private',
+      schemaHash: 'b'.repeat(64),
+      requestedTtlSeconds: 120,
+      invocationExpiresAt: new Date(Date.now() + 150_000),
+      idempotencyKey: 'c'.repeat(64),
+      admittedDefaultBranchSha: 'a'.repeat(40),
+    });
+    expect(MCPG_IDENTITY_RESULT_KEYS).toEqual(expect.arrayContaining([
+      'handle',
+      'executor_bearer',
+      'repository',
+      'tool_policy',
+      'tools',
+      'expires_at',
+    ]));
+    expect(identity.tools).toEqual(DELEGATION_TOOLS);
+    expect(identity.toolPolicy).toBe(DELEGATION_TOOL_POLICY);
+  });
+
+  it('uses mcpg operation paths verbatim', async () => {
+    const seen = new Set<string>();
+    for (const call of captured) seen.add(String(call.path));
+    expect([...seen]).toEqual([`${MCPG_CONTROL_PATH}create-or-confirm`]);
+  });
+
+  it('mirrors the closed github-repository-read-v1 tool set', () => {
+    // mcpg internal/delegation/selector.go delegatedTools.
+    expect([...DELEGATION_TOOLS]).toEqual(['issue_read', 'list_issues']);
+    expect(DELEGATION_TOOL_POLICY).toBe('github-repository-read-v1');
+  });
+});

--- a/src/enclave/dynamic-delegation-handoff.test.ts
+++ b/src/enclave/dynamic-delegation-handoff.test.ts
@@ -1,0 +1,188 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveEnclavePaths } from './paths';
+import {
+  DELEGATION_CONTROL_ENDPOINT_PATH,
+  isValidEnclaveDynamicDelegationCapability,
+  parseEnclaveDynamicDelegationControlEndpoint,
+  readStagedEnclaveDynamicDelegationHandoff,
+  resolveEnclaveDynamicDelegationHandoff,
+  stageEnclaveDynamicDelegationHandoff,
+  takeEnclaveDynamicDelegationHandoff,
+} from './dynamic-delegation-handoff';
+
+const CAPABILITY = 'a'.repeat(64);
+
+function endpoint(value: string): string {
+  return `${value}${DELEGATION_CONTROL_ENDPOINT_PATH}`;
+}
+
+describe('dynamic delegation control endpoint validation', () => {
+  it('accepts the exact endpoint gh-aw exports', () => {
+    const parsed = parseEnclaveDynamicDelegationControlEndpoint(
+      'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+    );
+    expect(parsed).toMatchObject({
+      host: '127.0.0.1',
+      port: 8090,
+      origin: 'http://127.0.0.1:8090',
+      operationBasePath: '/internal/awf-enclave-mcp-control/',
+    });
+  });
+
+  it('accepts the IPv6 loopback literal', () => {
+    expect(parseEnclaveDynamicDelegationControlEndpoint(endpoint('http://[::1]:8090')))
+      .toMatchObject({ host: '[::1]', port: 8090 });
+  });
+
+  it.each([
+    ['an explicit default port', endpoint('http://127.0.0.1:80'), 80],
+    ['an omitted default port', endpoint('http://127.0.0.1'), 80],
+  ])('normalizes %s to port 80 instead of rejecting it', (_label, value, expected) => {
+    expect(parseEnclaveDynamicDelegationControlEndpoint(value)).toMatchObject({ port: expected });
+  });
+
+  it.each([
+    ['resolver-dependent localhost', endpoint('http://localhost:8090')],
+    ['a resolver-dependent hostname', endpoint('http://mcpg.internal:8090')],
+    ['a routable address', endpoint('http://10.0.0.5:8090')],
+    ['a wildcard bind address', endpoint('http://0.0.0.0:8090')],
+    ['an IPv6 wildcard', endpoint('http://[::]:8090')],
+    ['https', endpoint('https://127.0.0.1:8090')],
+    ['embedded credentials', 'http://user:pw@127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1'],
+    ['a query string', `${endpoint('http://127.0.0.1:8090')}?x=1`],
+    ['a fragment', `${endpoint('http://127.0.0.1:8090')}#f`],
+    ['a different control path', 'http://127.0.0.1:8090/internal/other/github-repository-delegation-v1'],
+    ['a bare origin with no controller path', 'http://127.0.0.1:8090'],
+    ['a data-plane MCP endpoint', 'http://127.0.0.1:8080/mcp/awf-enclave'],
+    ['an out-of-range port', endpoint('http://127.0.0.1:99999')],
+    ['a non-URL', 'not-a-url'],
+    ['an empty value', ''],
+  ])('rejects %s', (_label, value) => {
+    expect(parseEnclaveDynamicDelegationControlEndpoint(value)).toBeUndefined();
+  });
+
+  it('rejects a missing value', () => {
+    expect(parseEnclaveDynamicDelegationControlEndpoint(undefined)).toBeUndefined();
+  });
+});
+
+describe('dynamic delegation capability validation', () => {
+  it.each([
+    ['the compiler-minted 256-bit hex value', CAPABILITY, true],
+    ['an uppercase hex value', 'A'.repeat(64), false],
+    ['a short value', 'a'.repeat(63), false],
+    ['a long value', 'a'.repeat(65), false],
+    ['a non-hex value', 'z'.repeat(64), false],
+    ['an empty value', '', false],
+  ])('classifies %s', (_label, value, expected) => {
+    expect(isValidEnclaveDynamicDelegationCapability(value)).toBe(expected);
+  });
+});
+
+describe('dynamic delegation handoff custody', () => {
+  it('removes both values from the environment before anything can inherit them', () => {
+    const env: NodeJS.ProcessEnv = {
+      AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT: endpoint('http://127.0.0.1:8090'),
+      AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY: CAPABILITY,
+      UNRELATED: 'kept',
+    };
+    const taken = takeEnclaveDynamicDelegationHandoff(env);
+    expect(taken.capability).toBe(CAPABILITY);
+    expect(env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT).toBeUndefined();
+    expect(env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY).toBeUndefined();
+    expect(env.UNRELATED).toBe('kept');
+  });
+
+  it('also clears process.env when handed a detached environment', () => {
+    process.env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY = CAPABILITY;
+    try {
+      takeEnclaveDynamicDelegationHandoff({});
+      expect(process.env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY).toBeUndefined();
+    } finally {
+      delete process.env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY;
+    }
+  });
+
+  it('fails closed on a partial handoff rather than degrading', () => {
+    expect(resolveEnclaveDynamicDelegationHandoff({ capability: CAPABILITY }).handoff)
+      .toBeUndefined();
+    expect(
+      resolveEnclaveDynamicDelegationHandoff({ endpoint: endpoint('http://127.0.0.1:8090') })
+        .handoff,
+    ).toBeUndefined();
+  });
+
+  it('never echoes the capability in an error message', () => {
+    const resolution = resolveEnclaveDynamicDelegationHandoff({
+      endpoint: endpoint('http://localhost:8090'),
+      capability: CAPABILITY,
+    });
+    expect(resolution.handoff).toBeUndefined();
+    expect(resolution.errors.join('\n')).not.toContain(CAPABILITY);
+  });
+});
+
+describe('dynamic delegation handoff staging', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-delegation-handoff-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(resolveEnclavePaths(workDir).root, { recursive: true, force: true });
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function stage(): ReturnType<typeof resolveEnclavePaths> {
+    const paths = resolveEnclavePaths(workDir);
+    fs.mkdirSync(paths.root, { recursive: true, mode: 0o700 });
+    const resolution = resolveEnclaveDynamicDelegationHandoff({
+      endpoint: endpoint('http://127.0.0.1:8090'),
+      capability: CAPABILITY,
+    });
+    stageEnclaveDynamicDelegationHandoff(paths, resolution.handoff!);
+    return paths;
+  }
+
+  it('writes both values with exclusive 0600 permissions', () => {
+    const paths = stage();
+    for (const target of [paths.delegationEndpointPath, paths.delegationCapabilityPath]) {
+      expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    }
+    expect(readStagedEnclaveDynamicDelegationHandoff(paths)).toMatchObject({
+      capability: CAPABILITY,
+    });
+  });
+
+  it('refuses a staged handoff that became group or world readable', () => {
+    const paths = stage();
+    fs.chmodSync(paths.delegationCapabilityPath, 0o644);
+    expect(readStagedEnclaveDynamicDelegationHandoff(paths)).toBeUndefined();
+  });
+
+  it('refuses a staged endpoint that was tampered into a non-loopback host', () => {
+    const paths = stage();
+    fs.writeFileSync(paths.delegationEndpointPath, `${endpoint('http://10.1.2.3:8090')}\n`, {
+      mode: 0o600,
+    });
+    expect(readStagedEnclaveDynamicDelegationHandoff(paths)).toBeUndefined();
+  });
+
+  it('keeps both custody files out of every broker-visible mount point', () => {
+    const paths = stage();
+    // The broker only ever mounts the run, control, audit, work, seed, and
+    // delegation-channel paths. The custody files live directly in the private
+    // root, which is never mounted as a whole.
+    for (const target of [paths.delegationEndpointPath, paths.delegationCapabilityPath]) {
+      expect(path.dirname(target)).toBe(paths.root);
+      expect(target.startsWith(paths.delegationChannelDir)).toBe(false);
+      expect(target.startsWith(paths.runDir)).toBe(false);
+      expect(target.startsWith(paths.controlDir)).toBe(false);
+      expect(target.startsWith(paths.auditDir)).toBe(false);
+      expect(target.startsWith(paths.workDir)).toBe(false);
+    }
+  });
+});

--- a/src/enclave/dynamic-delegation-handoff.ts
+++ b/src/enclave/dynamic-delegation-handoff.ts
@@ -13,11 +13,26 @@
  *   for that control plane (`openssl rand -hex 32`).
  *
  * Because the control listener is published on host loopback, the *AWF host
- * process* is the only component that can reach it: neither the primary agent,
- * the enclave MCP broker container, the single-use executor, nor the model
- * sidecar has a route to it. AWF therefore takes custody of both values before
- * any inherited environment is assembled, keeps them in AWF-private state with
- * exclusive `0600` files, and never mounts either one into a container.
+ * process* is the only component that can reach it **through the published
+ * port**, which is why the control client lives here rather than in the broker
+ * container.
+ *
+ * That is a statement about the host publication, not a general routing
+ * guarantee, and it is worth being precise about the difference. Under network
+ * isolation gh-aw binds the in-container listener to `0.0.0.0`, because Docker
+ * NATs a published port to the container's bridge IP and so a container-local
+ * `127.0.0.1` bind would be unreachable. A peer that shares a Docker network
+ * with mcpg addresses the container IP directly and never traverses the
+ * published port at all, so co-attached peers — notably the single-use
+ * executor, which meets mcpg at `172.31.0.40` on the enclave agent network —
+ * are not kept off the control plane by publication scope.
+ *
+ * What actually protects the control plane is authentication, not
+ * unreachability: every control request must carry the AWF-only capability,
+ * mcpg rejects anything else with `403 delegation_access_denied`, and AWF takes
+ * custody of both values before any inherited environment is assembled, keeps
+ * them in AWF-private state with exclusive `0600` files, and never mounts
+ * either one into a container.
  */
 
 import * as fs from 'fs';

--- a/src/enclave/dynamic-delegation-handoff.ts
+++ b/src/enclave/dynamic-delegation-handoff.ts
@@ -1,0 +1,267 @@
+/**
+ * Compiler-to-AWF private handoff for dynamic GitHub-MCP-backed enclave
+ * repository admission (ADR 0001 `docs/adr/0001-agent-enclaves.md`).
+ *
+ * gh-aw starts mcpg's `github-repository-delegation-v1` controller and hands
+ * AWF two values that no other principal may ever observe:
+ *
+ * - `AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT`: the *control plane*,
+ *   published by Docker on the runner's own `127.0.0.1` only
+ *   (`-p 127.0.0.1:<port>:<port>`). It is deliberately distinct from the
+ *   executor-facing `AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT` data plane.
+ * - `AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY`: the AWF-only bearer
+ *   for that control plane (`openssl rand -hex 32`).
+ *
+ * Because the control listener is published on host loopback, the *AWF host
+ * process* is the only component that can reach it: neither the primary agent,
+ * the enclave MCP broker container, the single-use executor, nor the model
+ * sidecar has a route to it. AWF therefore takes custody of both values before
+ * any inherited environment is assembled, keeps them in AWF-private state with
+ * exclusive `0600` files, and never mounts either one into a container.
+ */
+
+import * as fs from 'fs';
+import type { EnclavePaths } from './paths';
+
+export const ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV =
+  'AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT';
+export const ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV =
+  'AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY';
+
+/**
+ * Fixed control API base path served by mcpg v0.4.17
+ * (`internal/proxy/delegation.go`: `delegationControlPath`). Operations are
+ * siblings of the controller name, not children of it.
+ */
+export const DELEGATION_CONTROL_API_BASE_PATH = '/internal/awf-enclave-mcp-control';
+
+/** The single delegation controller AWF understands. */
+export const DELEGATION_CONTROLLER_NAME = 'github-repository-delegation-v1';
+
+/** Exact endpoint path gh-aw exports for the controller. */
+export const DELEGATION_CONTROL_ENDPOINT_PATH =
+  `${DELEGATION_CONTROL_API_BASE_PATH}/${DELEGATION_CONTROLLER_NAME}`;
+
+/**
+ * Literal loopback hosts AWF accepts, as WHATWG `URL.hostname` renders them.
+ *
+ * `localhost` is deliberately absent: it is resolver-dependent, so a poisoned
+ * `/etc/hosts`, NSS module, or search domain could point the AWF-only control
+ * capability at an attacker-controlled listener. Only the two literal loopback
+ * addresses are trusted.
+ */
+const LITERAL_LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]']);
+
+/** Default port the WHATWG URL parser normalizes away for `http:` origins. */
+const HTTP_DEFAULT_PORT = 80;
+
+export interface EnclaveDynamicDelegationEndpoint {
+  /** Endpoint exactly as the compiler exported it, after strict validation. */
+  readonly href: string;
+  /** Literal loopback host, e.g. `127.0.0.1` or `[::1]`. */
+  readonly host: string;
+  /**
+   * Effective TCP port. `http://127.0.0.1/...` and `http://127.0.0.1:80/...`
+   * are indistinguishable after WHATWG normalization, so both resolve to 80
+   * rather than being rejected for an "absent" port.
+   */
+  readonly port: number;
+  /** Absolute origin AWF issues control requests against. */
+  readonly origin: string;
+  /** `${DELEGATION_CONTROL_API_BASE_PATH}/` — the operation path prefix. */
+  readonly operationBasePath: string;
+}
+
+export interface EnclaveDynamicDelegationHandoff {
+  readonly endpoint: EnclaveDynamicDelegationEndpoint;
+  readonly capability: string;
+}
+
+/** Whether a value is a well-formed 256-bit lowercase hex control capability. */
+export function isValidEnclaveDynamicDelegationCapability(
+  value: string | undefined,
+): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+/**
+ * Parses the compiler-issued control endpoint, or returns `undefined` when it
+ * is anything other than the exact loopback-only HTTP control endpoint mcpg
+ * publishes.
+ *
+ * Rejected: every non-`http:` scheme (including `https:`, which the controller
+ * does not serve), `localhost` and every other resolver-dependent name, any
+ * routable or wildcard address, embedded credentials, a query string, a
+ * fragment, and any path other than the fixed controller path. A wrong path is
+ * fatal rather than rewritten, because silently repointing an AWF-only
+ * capability at an unknown listener is exactly the failure this check exists
+ * to prevent.
+ */
+export function parseEnclaveDynamicDelegationControlEndpoint(
+  value: string | undefined,
+): EnclaveDynamicDelegationEndpoint | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'http:') return undefined;
+  if (!LITERAL_LOOPBACK_HOSTS.has(url.hostname)) return undefined;
+  if (url.username !== '' || url.password !== '') return undefined;
+  if (url.search !== '' || url.hash !== '') return undefined;
+  if (url.pathname !== DELEGATION_CONTROL_ENDPOINT_PATH) return undefined;
+  const port = url.port === '' ? HTTP_DEFAULT_PORT : Number(url.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined;
+  return Object.freeze({
+    href: url.href,
+    host: url.hostname,
+    port,
+    origin: url.origin,
+    operationBasePath: `${DELEGATION_CONTROL_API_BASE_PATH}/`,
+  });
+}
+
+/** Back-compatible predicate form of {@link parseEnclaveDynamicDelegationControlEndpoint}. */
+export function isValidEnclaveDynamicDelegationControlEndpoint(
+  value: string | undefined,
+): value is string {
+  return parseEnclaveDynamicDelegationControlEndpoint(value) !== undefined;
+}
+
+/**
+ * Reads and deletes both handoff values from `env`, so neither can leak into
+ * an inherited environment after this call. Returns the raw values without
+ * judging them; validity is decided by {@link resolveEnclaveDynamicDelegationHandoff}
+ * so preflight can distinguish "absent" from "present but malformed".
+ */
+export function takeEnclaveDynamicDelegationHandoff(
+  env: NodeJS.ProcessEnv,
+): { endpoint?: string; capability?: string } {
+  const endpoint = env[ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV];
+  const capability = env[ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV];
+  delete env[ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV];
+  delete env[ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV];
+  if (env !== process.env) {
+    delete process.env[ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV];
+    delete process.env[ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV];
+  }
+  return { endpoint, capability };
+}
+
+export interface EnclaveDynamicDelegationHandoffResolution {
+  handoff?: EnclaveDynamicDelegationHandoff;
+  /**
+   * Operator-facing reasons the handoff is unusable. Never contains the
+   * capability, and never contains the endpoint of a *valid* handoff.
+   */
+  errors: string[];
+}
+
+/**
+ * Validates a raw handoff pair. Both values must be present and valid: a
+ * partial handoff is a hard failure, never a degraded mode.
+ */
+export function resolveEnclaveDynamicDelegationHandoff(
+  raw: { endpoint?: string; capability?: string },
+): EnclaveDynamicDelegationHandoffResolution {
+  const errors: string[] = [];
+  const endpoint = parseEnclaveDynamicDelegationControlEndpoint(raw.endpoint);
+  if (raw.endpoint === undefined || raw.endpoint === '') {
+    errors.push(
+      `enclaves[].dynamic requires ${ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV}: the compiler `
+      + 'must start mcpg\'s "github-repository-delegation-v1" controller and hand AWF its private '
+      + 'control endpoint. AWF never falls back to a static seed catalog, a job-lifetime identity, '
+      + 'or a broader policy.',
+    );
+  } else if (!endpoint) {
+    errors.push(
+      `${ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV} must be the loopback-only mcpg control `
+      + `endpoint "http://127.0.0.1:<port>${DELEGATION_CONTROL_ENDPOINT_PATH}". AWF rejects `
+      + 'resolver-dependent hosts (including "localhost"), non-loopback and wildcard addresses, '
+      + 'embedded credentials, query strings, fragments, and any other path.',
+    );
+  }
+  if (raw.capability === undefined || raw.capability === '') {
+    errors.push(
+      `enclaves[].dynamic requires ${ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV}: the `
+      + 'AWF-only capability that authorizes create/confirm/status/reconcile/revoke on the mcpg '
+      + 'delegation control channel.',
+    );
+  } else if (!isValidEnclaveDynamicDelegationCapability(raw.capability)) {
+    errors.push(
+      `${ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV} must be a 256-bit lowercase hex `
+      + 'capability minted by the compiler.',
+    );
+  }
+  if (errors.length > 0 || !endpoint || !isValidEnclaveDynamicDelegationCapability(raw.capability)) {
+    return { errors };
+  }
+  return { handoff: { endpoint, capability: raw.capability }, errors };
+}
+
+function writeExclusivePrivateFile(target: string, content: string): void {
+  fs.rmSync(target, { force: true });
+  const fd = fs.openSync(
+    target,
+    fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    fs.writeSync(fd, content);
+    fs.fchmodSync(fd, 0o600);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Persists the handoff into AWF-private state with exclusive `0600` files
+ * inside the already-`0700` private root.
+ *
+ * These files exist so a later phase of the same AWF process (teardown,
+ * reconciliation) can re-read the handoff without keeping it in a long-lived
+ * environment variable. They are never bind-mounted into the broker, the
+ * executor, the model sidecar, the general MCP route, or the delegated data
+ * plane — `src/services/enclave-mcp-service.ts` mounts neither path, and
+ * `assertPrivateRootIsolated` keeps the whole private root out of every
+ * agent-visible mount.
+ */
+export function stageEnclaveDynamicDelegationHandoff(
+  paths: EnclavePaths,
+  handoff: EnclaveDynamicDelegationHandoff,
+): void {
+  writeExclusivePrivateFile(paths.delegationEndpointPath, `${handoff.endpoint.href}\n`);
+  writeExclusivePrivateFile(paths.delegationCapabilityPath, `${handoff.capability}\n`);
+}
+
+/**
+ * Re-reads a previously staged handoff. Returns `undefined` when either file
+ * is missing, is not a regular file, is group/other readable, or no longer
+ * contains a valid value: a tampered handoff is never used.
+ */
+export function readStagedEnclaveDynamicDelegationHandoff(
+  paths: EnclavePaths,
+): EnclaveDynamicDelegationHandoff | undefined {
+  const endpoint = parseEnclaveDynamicDelegationControlEndpoint(
+    readPrivateFile(paths.delegationEndpointPath),
+  );
+  const capability = readPrivateFile(paths.delegationCapabilityPath);
+  if (!endpoint || !isValidEnclaveDynamicDelegationCapability(capability)) return undefined;
+  return { endpoint, capability };
+}
+
+function readPrivateFile(target: string): string | undefined {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || (stat.mode & 0o077) !== 0 || stat.size > 4096) return undefined;
+    return fs.readFileSync(fd, 'ascii').trim();
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}

--- a/src/enclave/dynamic-delegation-protocol.ts
+++ b/src/enclave/dynamic-delegation-protocol.ts
@@ -1,0 +1,167 @@
+/**
+ * AWF-private admission channel between the enclave MCP broker and the AWF
+ * host process, for dynamic GitHub-MCP-backed enclaves (ADR 0001).
+ *
+ * ## Why a file channel
+ *
+ * gh-aw publishes mcpg's delegation control listener on the runner's own
+ * loopback interface (`docker run -p 127.0.0.1:<port>:<port>`), and gh-aw's own
+ * comment records the intent: "Only the AWF host process receives this
+ * variable". No container — not the broker, not the executor, not the model
+ * sidecar — can route to a `127.0.0.1`-published port, so the control client
+ * necessarily lives in the AWF host process.
+ *
+ * The broker still has to route each `enclave_run_agent` through canonical
+ * admission *before* any repository content is exposed. It therefore asks the
+ * host over an AWF-private request/response directory that is already part of
+ * the `0700` enclave private root and is bind-mounted only into the broker.
+ * There is no network listener, so nothing new becomes reachable from
+ * `awf-net`, the enclave agent network, the general MCP route, or the host's
+ * external interfaces.
+ *
+ * ## What crosses the channel
+ *
+ * Broker → host: the canonical selector chosen by the invocation, the exact
+ * finite output-schema hash, and the settlement of a finished invocation.
+ * Host → broker: one canonical denial, or one repository plus one short-lived
+ * executor bearer and its read mode.
+ *
+ * Never: the control endpoint, the control capability, the identity handle,
+ * the compiler envelope, mcpg's state path or generation, the job token, or
+ * repository content.
+ */
+
+/** Wire version. A mismatch is terminal on both sides; there is no migration. */
+export const DELEGATION_CHANNEL_VERSION = 1;
+
+/** Bound on any single channel document, in bytes. */
+export const DELEGATION_CHANNEL_MAX_BYTES = 8 * 1024;
+
+export const DELEGATION_CHANNEL_REQUEST_SUFFIX = '.admit.json';
+export const DELEGATION_CHANNEL_RESPONSE_SUFFIX = '.admitted.json';
+export const DELEGATION_CHANNEL_SETTLE_SUFFIX = '.settle.json';
+export const DELEGATION_CHANNEL_RECEIPT_SUFFIX = '.settled.json';
+
+/** Broker-generated invocation identifier shape (12 random bytes, hex). */
+export const DELEGATION_INVOCATION_ID_PATTERN = /^[0-9a-f]{16,64}$/;
+
+/** Lowercase hex SHA-256 of the invocation's canonical finite output schema. */
+export const DELEGATION_SCHEMA_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+/**
+ * Terminal outcomes the broker reports. Every one of them settles the
+ * reserved quota and revokes the delegated identity; only `success` may be
+ * paired with a success-shaped tool result, and only once the receipt confirms
+ * revocation.
+ */
+export const DELEGATION_TERMINAL_OUTCOMES = Object.freeze([
+  'success',
+  'agent-failure',
+  'schema-failure',
+  'timeout',
+  'cancelled',
+  'broker-error',
+] as const);
+
+export type DelegationTerminalOutcome = typeof DELEGATION_TERMINAL_OUTCOMES[number];
+
+/** Whether repository reads for an invocation are pinned or live. */
+export type DelegationReadMode = 'pinned' | 'live';
+
+export interface DelegationAdmissionRequestMessage {
+  version: typeof DELEGATION_CHANNEL_VERSION;
+  invocationId: string;
+  /** Caller-supplied selector, forwarded verbatim for canonical matching. */
+  selector: string;
+  schemaHash: string;
+}
+
+export type DelegationAdmissionResponseMessage =
+  | {
+    version: typeof DELEGATION_CHANNEL_VERSION;
+    invocationId: string;
+    admitted: true;
+    repository: string;
+    executorBearer: string;
+    expiresAt: string;
+    readMode: DelegationReadMode;
+    admittedDefaultBranchSha?: string;
+  }
+  | {
+    version: typeof DELEGATION_CHANNEL_VERSION;
+    invocationId: string;
+    admitted: false;
+    reason: string;
+  };
+
+export interface DelegationSettlementMessage {
+  version: typeof DELEGATION_CHANNEL_VERSION;
+  invocationId: string;
+  outcome: DelegationTerminalOutcome;
+  outputBytes: number;
+  executionSeconds: number;
+}
+
+export interface DelegationSettlementReceiptMessage {
+  version: typeof DELEGATION_CHANNEL_VERSION;
+  invocationId: string;
+  settled: true;
+  /**
+   * Whether the delegated identity is definitively revoked. `false` means the
+   * control plane is in an unresolved state: the broker must not return a
+   * success-shaped result, and AWF blocks further admissions until
+   * reconciliation succeeds.
+   */
+  revoked: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Strictly parses a broker admission request. Returns `undefined` if invalid. */
+export function parseDelegationAdmissionRequest(
+  raw: unknown,
+): DelegationAdmissionRequestMessage | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const { version, invocationId, selector, schemaHash } = raw;
+  if (version !== DELEGATION_CHANNEL_VERSION) return undefined;
+  if (typeof invocationId !== 'string' || !DELEGATION_INVOCATION_ID_PATTERN.test(invocationId)) {
+    return undefined;
+  }
+  // The selector is deliberately *not* pattern-checked here: a malformed
+  // selector must reach the registry so it produces the same canonical
+  // denial, at the same normalized timing, as an out-of-policy one.
+  if (typeof selector !== 'string' || selector.length > 256) return undefined;
+  if (typeof schemaHash !== 'string' || !DELEGATION_SCHEMA_HASH_PATTERN.test(schemaHash)) {
+    return undefined;
+  }
+  return { version: DELEGATION_CHANNEL_VERSION, invocationId, selector, schemaHash };
+}
+
+/** Strictly parses a broker settlement report. Returns `undefined` if invalid. */
+export function parseDelegationSettlement(
+  raw: unknown,
+): DelegationSettlementMessage | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const { version, invocationId, outcome, outputBytes, executionSeconds } = raw;
+  if (version !== DELEGATION_CHANNEL_VERSION) return undefined;
+  if (typeof invocationId !== 'string' || !DELEGATION_INVOCATION_ID_PATTERN.test(invocationId)) {
+    return undefined;
+  }
+  if (
+    typeof outcome !== 'string'
+    || !(DELEGATION_TERMINAL_OUTCOMES as readonly string[]).includes(outcome)
+  ) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(outputBytes) || (outputBytes as number) < 0) return undefined;
+  if (!Number.isSafeInteger(executionSeconds) || (executionSeconds as number) < 0) return undefined;
+  return {
+    version: DELEGATION_CHANNEL_VERSION,
+    invocationId,
+    outcome: outcome as DelegationTerminalOutcome,
+    outputBytes: outputBytes as number,
+    executionSeconds: executionSeconds as number,
+  };
+}

--- a/src/enclave/dynamic-delegation-service.test.ts
+++ b/src/enclave/dynamic-delegation-service.test.ts
@@ -1,0 +1,445 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CANONICAL_DENIAL_REASON } from './dynamic-registry';
+import { createEnclaveInformationBudgetLedger } from './information-budget';
+import { DelegationControlError } from './delegation-control-client';
+import { parseEnclaveDynamicDelegationControlEndpoint } from './dynamic-delegation-handoff';
+import { typedDynamicEnclavePolicyFixture } from './dynamic-policy.test-utils';
+import {
+  DELEGATION_CHANNEL_VERSION,
+  type DelegationAdmissionRequestMessage,
+} from './dynamic-delegation-protocol';
+import {
+  DynamicDelegationService,
+  ENCLAVE_DYNAMIC_ENTRY_ID,
+  deriveDelegationIdempotencyKey,
+  hashForAudit,
+  resolveDynamicDelegationRunId,
+} from './dynamic-delegation-service';
+
+const ENDPOINT = parseEnclaveDynamicDelegationControlEndpoint(
+  'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+)!;
+const CAPABILITY = 'c'.repeat(64);
+const RUN_ID = '42-1';
+
+interface ControlCall {
+  operation: string;
+  args: unknown[];
+}
+
+function fakeClient(overrides: Record<string, unknown> = {}) {
+  const calls: ControlCall[] = [];
+  let created = 0;
+  const client = {
+    calls,
+    async status(runId: string, entryId: string) {
+      calls.push({ operation: 'status', args: [runId, entryId] });
+      return {
+        recoveryIncomplete: false,
+        generation: 1,
+        liveIdentityCount: 0,
+        labelledHandles: [] as string[],
+      };
+    },
+    async reconcile() {
+      calls.push({ operation: 'reconcile', args: [] });
+    },
+    async revoke(handle: string) {
+      calls.push({ operation: 'revoke', args: [handle] });
+    },
+    async revokeByLabels(runId: string, entryId: string) {
+      calls.push({ operation: 'revoke-by-labels', args: [runId, entryId] });
+      return 0;
+    },
+    async createOrConfirm(request: Record<string, unknown>) {
+      calls.push({ operation: 'create-or-confirm', args: [request] });
+      created += 1;
+      return {
+        handle: `dlg_${created}`,
+        executorBearer: `dlgbearer_${created}`,
+        repository: request.repository as string,
+        toolPolicy: 'github-repository-read-v1',
+        tools: ['issue_read', 'list_issues'],
+        expiresAt: new Date(Date.now() + 60_000),
+      };
+    },
+    ...overrides,
+  };
+  return client;
+}
+
+function makeService(clientOverrides: Record<string, unknown> = {}, auditDir?: string) {
+  const client = fakeClient(clientOverrides);
+  const service = new DynamicDelegationService({
+    policy: typedDynamicEnclavePolicyFixture(),
+    identity: { runId: RUN_ID, entryId: ENCLAVE_DYNAMIC_ENTRY_ID },
+    handoff: { endpoint: ENDPOINT, capability: CAPABILITY },
+    ledger: createEnclaveInformationBudgetLedger(new Map()),
+    auditPath: path.join(auditDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'awf-audit-')), 'a.jsonl'),
+    client: client as never,
+    // Admission timing normalization is asserted exhaustively by the
+    // registry's own suite; here it would only make every case sleep.
+    clock: { nowMs: () => 0, sleep: async () => undefined },
+    jitter: () => 0,
+  });
+  return { service, client };
+}
+
+function request(
+  invocationId: string,
+  selector = 'octo-org/service',
+): DelegationAdmissionRequestMessage {
+  return {
+    version: DELEGATION_CHANNEL_VERSION,
+    invocationId,
+    selector,
+    schemaHash: 'd'.repeat(64),
+  };
+}
+
+describe('dynamic delegation run identity', () => {
+  it('derives the compiler envelope run id from the workflow run and attempt', () => {
+    expect(resolveDynamicDelegationRunId({ GITHUB_RUN_ID: '42', GITHUB_RUN_ATTEMPT: '1' }))
+      .toBe('42-1');
+  });
+
+  it.each([
+    ['a missing run id', { GITHUB_RUN_ATTEMPT: '1' }],
+    ['a missing attempt', { GITHUB_RUN_ID: '42' }],
+    ['a non-numeric run id', { GITHUB_RUN_ID: 'main', GITHUB_RUN_ATTEMPT: '1' }],
+  ])('fails closed for %s', (_label, env) => {
+    expect(resolveDynamicDelegationRunId(env)).toBeUndefined();
+  });
+
+  it('derives a stable idempotency key from the invocation binding', () => {
+    const key = deriveDelegationIdempotencyKey(RUN_ID, 'agent', 'abc123def4567890', 'octo/one');
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    expect(deriveDelegationIdempotencyKey(RUN_ID, 'agent', 'abc123def4567890', 'octo/one'))
+      .toBe(key);
+    expect(deriveDelegationIdempotencyKey(RUN_ID, 'agent', 'abc123def4567890', 'octo/two'))
+      .not.toBe(key);
+  });
+});
+
+describe('dynamic delegation recovery', () => {
+  it('blocks admission until status, revocation, and reconciliation complete', async () => {
+    const { service, client } = makeService();
+    expect(service.isAdmitting).toBe(false);
+    const denied = await service.admit(request('1111111111111111'));
+    expect(denied).toMatchObject({ admitted: false, reason: CANONICAL_DENIAL_REASON });
+    expect(client.calls).toEqual([]);
+
+    await service.recover();
+    expect(service.isAdmitting).toBe(true);
+    expect(client.calls.map((call) => call.operation)).toEqual(['status', 'reconcile']);
+  });
+
+  it('revokes stale labelled identities before reconciling', async () => {
+    const { service, client } = makeService({
+      async status(runId: string, entryId: string) {
+        (this as { calls: ControlCall[] }).calls.push({ operation: 'status', args: [runId, entryId] });
+        return {
+          recoveryIncomplete: true,
+          generation: 2,
+          liveIdentityCount: 1,
+          labelledHandles: ['dlg_stale'],
+        };
+      },
+    });
+    await service.recover();
+    expect(client.calls.map((call) => call.operation)).toEqual([
+      'status',
+      'revoke-by-labels',
+      'reconcile',
+    ]);
+  });
+
+  it('keeps admissions blocked when reconciliation fails', async () => {
+    const { service } = makeService({
+      async reconcile() {
+        throw new DelegationControlError('unavailable', 'reconcile', 'down');
+      },
+    });
+    await expect(service.recover()).rejects.toThrow(DelegationControlError);
+    expect(service.isAdmitting).toBe(false);
+    await expect(service.admit(request('2222222222222222'))).resolves.toMatchObject({
+      admitted: false,
+    });
+  });
+});
+
+describe('dynamic delegation admission', () => {
+  it('mints exactly one identity bound to the admitted repository', async () => {
+    const { service, client } = makeService();
+    await service.recover();
+    const response = await service.admit(request('3333333333333333'));
+    expect(response).toMatchObject({
+      admitted: true,
+      repository: 'octo-org/service',
+      executorBearer: 'dlgbearer_1',
+      readMode: 'live',
+    });
+    const createCall = client.calls.find((call) => call.operation === 'create-or-confirm');
+    expect(createCall?.args[0]).toMatchObject({
+      runId: RUN_ID,
+      enclaveEntryId: 'agent',
+      invocationId: '3333333333333333',
+      repository: 'octo-org/service',
+      schemaHash: 'd'.repeat(64),
+      requestedTtlSeconds: 120,
+    });
+    expect(createCall?.args[0]).not.toHaveProperty('admittedDefaultBranchSha');
+  });
+
+  it('never exposes the identity handle to the broker', async () => {
+    const { service } = makeService();
+    await service.recover();
+    const response = await service.admit(request('4444444444444444'));
+    expect(JSON.stringify(response)).not.toContain('dlg_1');
+    expect(JSON.stringify(response)).toContain('dlgbearer_1');
+  });
+
+  it('returns the canonical denial for an out-of-policy selector without calling mcpg', async () => {
+    const { service, client } = makeService();
+    await service.recover();
+    const before = client.calls.length;
+    await expect(service.admit(request('5555555555555555', 'other-org/not-listed')))
+      .resolves.toMatchObject({ admitted: false, reason: CANONICAL_DENIAL_REASON });
+    expect(client.calls.length).toBe(before);
+  });
+
+  it('returns the canonical denial for a malformed selector', async () => {
+    const { service } = makeService();
+    await service.recover();
+    await expect(service.admit(request('6666666666666666', 'Octo-Org/Service')))
+      .resolves.toMatchObject({ admitted: false, reason: CANONICAL_DENIAL_REASON });
+  });
+
+  it('replays the same identity for an exact retry', async () => {
+    const { service, client } = makeService();
+    await service.recover();
+    const first = await service.admit(request('7777777777777777'));
+    const second = await service.admit(request('7777777777777777'));
+    expect(second).toEqual(first);
+    expect(client.calls.filter((call) => call.operation === 'create-or-confirm')).toHaveLength(1);
+  });
+
+  it('joins a concurrent identical retry instead of minting a second identity', async () => {
+    let resolveCreate: ((value: unknown) => void) | undefined;
+    const { service, client } = makeService({
+      createOrConfirm(request: Record<string, unknown>) {
+        (this as { calls: ControlCall[] }).calls.push({
+          operation: 'create-or-confirm',
+          args: [request],
+        });
+        return new Promise((resolve) => { resolveCreate = resolve; });
+      },
+    });
+    await service.recover();
+    const first = service.admit(request('1212121212121212'));
+    const second = service.admit(request('1212121212121212'));
+    // The registry's synchronous reservation runs before the control call, so
+    // yield once to let both admissions reach create-or-confirm.
+    await new Promise((resolve) => { setImmediate(resolve); });
+    resolveCreate!({
+      handle: 'dlg_1',
+      executorBearer: 'dlgbearer_1',
+      repository: 'octo-org/service',
+      toolPolicy: 'github-repository-read-v1',
+      tools: ['issue_read', 'list_issues'],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(await second).toEqual(await first);
+    expect(client.calls.filter((call) => call.operation === 'create-or-confirm')).toHaveLength(1);
+  });
+
+  it('denies a second repository for the same invocation', async () => {
+    const { service } = makeService();
+    await service.recover();
+    await service.admit(request('8888888888888888', 'octo-org/one'));
+    await expect(service.admit(request('8888888888888888', 'octo-org/two')))
+      .resolves.toMatchObject({ admitted: false });
+  });
+
+  it('settles the reservation and denies when identity creation fails', async () => {
+    const { service } = makeService({
+      async createOrConfirm() {
+        throw new DelegationControlError('denied', 'create-or-confirm', 'outside envelope');
+      },
+    });
+    await service.recover();
+    await expect(service.admit(request('9999999999999999')))
+      .resolves.toMatchObject({ admitted: false, reason: CANONICAL_DENIAL_REASON });
+    // The invocation charge stays committed; byte/second reservations do not leak.
+    expect(service.quotaUsage.invocations.debited).toBe(1);
+    expect(service.quotaUsage.outputBytes.reserved).toBe(0);
+    expect(service.quotaUsage.executionSeconds.reserved).toBe(0);
+  });
+
+  it('blocks further admissions when identity creation leaves state unresolved', async () => {
+    const { service } = makeService({
+      async createOrConfirm() {
+        throw new DelegationControlError('unavailable', 'create-or-confirm', 'timeout');
+      },
+    });
+    await service.recover();
+    await service.admit(request('aaaaaaaaaaaaaaaa'));
+    expect(service.isAdmitting).toBe(false);
+  });
+
+  it('enforces the envelope invocation quota across admissions', async () => {
+    const { service } = makeService();
+    await service.recover();
+    for (let index = 0; index < 10; index += 1) {
+      const response = await service.admit(request(index.toString(16).padStart(16, '0')));
+      expect(response.admitted).toBe(true);
+      await service.settle({
+        version: DELEGATION_CHANNEL_VERSION,
+        invocationId: index.toString(16).padStart(16, '0'),
+        outcome: 'success',
+        outputBytes: 10,
+        executionSeconds: 1,
+      });
+    }
+    await expect(service.admit(request('bbbbbbbbbbbbbbbb')))
+      .resolves.toMatchObject({ admitted: false });
+  });
+});
+
+describe('dynamic delegation settlement', () => {
+  it('revokes the identity and settles the reserved quota on success', async () => {
+    const { service, client } = makeService();
+    await service.recover();
+    await service.admit(request('cccccccccccccccc'));
+    expect(service.quotaUsage.outputBytes.reserved).toBe(8192);
+    const receipt = await service.settle({
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: 'cccccccccccccccc',
+      outcome: 'success',
+      outputBytes: 128,
+      executionSeconds: 7,
+    });
+    expect(receipt).toMatchObject({ settled: true, revoked: true });
+    expect(client.calls.some((call) => call.operation === 'revoke')).toBe(true);
+    expect(service.quotaUsage.outputBytes).toMatchObject({ debited: 128, reserved: 0 });
+    expect(service.quotaUsage.executionSeconds).toMatchObject({ debited: 7, reserved: 0 });
+  });
+
+  it.each(['agent-failure', 'schema-failure', 'timeout', 'cancelled', 'broker-error'] as const)(
+    'revokes the identity on a %s outcome',
+    async (outcome) => {
+      const { service, client } = makeService();
+      await service.recover();
+      await service.admit(request('dddddddddddddddd'));
+      await service.settle({
+        version: DELEGATION_CHANNEL_VERSION,
+        invocationId: 'dddddddddddddddd',
+        outcome,
+        outputBytes: 0,
+        executionSeconds: 3,
+      });
+      expect(client.calls.filter((call) => call.operation === 'revoke')).toHaveLength(1);
+      // The invocation charge is never refunded after a failure.
+      expect(service.quotaUsage.invocations.debited).toBe(1);
+    },
+  );
+
+  it('reports an unresolved revocation and blocks further admissions', async () => {
+    const { service } = makeService({
+      async revoke() {
+        throw new DelegationControlError('unavailable', 'revoke', 'down');
+      },
+    });
+    await service.recover();
+    await service.admit(request('eeeeeeeeeeeeeeee'));
+    const receipt = await service.settle({
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: 'eeeeeeeeeeeeeeee',
+      outcome: 'success',
+      outputBytes: 1,
+      executionSeconds: 1,
+    });
+    expect(receipt.revoked).toBe(false);
+    expect(service.isAdmitting).toBe(false);
+  });
+
+  it('clamps reported usage to the per-invocation envelope bounds', async () => {
+    const { service } = makeService();
+    await service.recover();
+    await service.admit(request('ffffffffffffffff'));
+    await service.settle({
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: 'ffffffffffffffff',
+      outcome: 'success',
+      outputBytes: 10_000_000,
+      executionSeconds: 10_000,
+    });
+    expect(service.quotaUsage.outputBytes.debited).toBe(8192);
+    expect(service.quotaUsage.executionSeconds.debited).toBe(120);
+  });
+
+  it('sweeps every labelled identity at shutdown', async () => {
+    const { service, client } = makeService();
+    await service.recover();
+    await service.shutdown();
+    expect(client.calls[client.calls.length - 1]).toMatchObject({
+      operation: 'revoke-by-labels',
+      args: [RUN_ID, 'agent'],
+    });
+  });
+
+  it('surfaces an unresolved shutdown revocation', async () => {
+    const { service } = makeService({
+      async revokeByLabels() {
+        throw new DelegationControlError('unavailable', 'revoke-by-labels', 'down');
+      },
+    });
+    await service.recover();
+    await expect(service.shutdown()).rejects.toThrow(DelegationControlError);
+    expect(service.isAdmitting).toBe(false);
+  });
+});
+
+describe('dynamic delegation audit redaction', () => {
+  let auditDir: string;
+
+  beforeEach(() => {
+    auditDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-delegation-audit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(auditDir, { recursive: true, force: true });
+  });
+
+  it('records hashed selectors and handles, never raw private material', async () => {
+    const { service } = makeService({}, auditDir);
+    await service.recover();
+    await service.admit(request('0102030405060708'));
+    await service.settle({
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: '0102030405060708',
+      outcome: 'success',
+      outputBytes: 12,
+      executionSeconds: 1,
+    });
+    const audit = fs.readFileSync(path.join(auditDir, 'a.jsonl'), 'utf8');
+    expect(audit).toContain(hashForAudit('octo-org/service'));
+    expect(audit).not.toContain('octo-org/service');
+    expect(audit).not.toContain('dlgbearer_1');
+    expect(audit).not.toContain('dlg_1"');
+    expect(audit).not.toContain(CAPABILITY);
+    expect(audit).not.toContain('127.0.0.1');
+    for (const line of audit.trim().split('\n')) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    expect(audit).toMatch(/"readMode":"live"/);
+  });
+
+  it('writes the audit stream with owner-only permissions', async () => {
+    const { service } = makeService({}, auditDir);
+    await service.recover();
+    expect(fs.statSync(path.join(auditDir, 'a.jsonl')).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/enclave/dynamic-delegation-service.ts
+++ b/src/enclave/dynamic-delegation-service.ts
@@ -1,0 +1,484 @@
+/**
+ * Host-side runtime for dynamic GitHub-MCP-backed enclave repository
+ * admission (ADR 0001 `docs/adr/0001-agent-enclaves.md`).
+ *
+ * This is the only component that holds the mcpg delegation-control
+ * capability. It owns, for one dynamic `enclaves[]` entry:
+ *
+ *  1. **Recovery.** Before any admission is allowed it calls `status`, revokes
+ *     every stale labelled identity, and only then calls the transactional
+ *     `reconcile`. New admissions stay blocked until that sequence succeeds.
+ *  2. **Admission.** Each `enclave_run_agent` selector goes through the
+ *     `DynamicRepositoryRegistry` first — canonical form, envelope match,
+ *     `maxRepositories`, expiry, run-wide quota reservation, shared disclosure
+ *     ledger — and only an admitted selector reaches the control plane.
+ *  3. **Identity.** One `create-or-confirm` per invocation binds the run,
+ *     backend, entry, invocation, exact repository, `github-repository-read-v1`,
+ *     the exact finite-schema hash, the requested TTL, and the invocation
+ *     deadline. Only the executor bearer leaves this process; the handle stays
+ *     in AWF-private state.
+ *  4. **Settlement.** Every terminal path settles the reserved output-byte and
+ *     execution-second quotas and revokes the identity. An unresolved
+ *     revocation re-blocks admissions and is reported to the broker so it can
+ *     never emit a success-shaped result.
+ *  5. **Shutdown.** `revoke-by-labels` sweeps anything still live.
+ *
+ * Audit is bounded, structured, and redacted: selectors are hashed, and
+ * bearers, handles, capabilities, endpoints, prompts, model output, and
+ * repository content never appear.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { EnclaveDynamicPolicy } from '../types/enclave-options';
+import { logger } from '../logger';
+import type { EnclaveInformationBudgetLedger } from './information-budget';
+import {
+  CANONICAL_DENIAL_REASON,
+  DynamicRepositoryRegistry,
+  type DefaultBranchResolver,
+  type DynamicAdmissionClock,
+  type DynamicAdmissionJitterSource,
+  type DynamicAdmissionUsage,
+  type DynamicQuotaUsage,
+} from './dynamic-registry';
+import {
+  DelegationControlClient,
+  DelegationControlError,
+  type DelegationIdentity,
+} from './delegation-control-client';
+import type { EnclaveDynamicDelegationHandoff } from './dynamic-delegation-handoff';
+import {
+  DELEGATION_CHANNEL_VERSION,
+  type DelegationAdmissionRequestMessage,
+  type DelegationAdmissionResponseMessage,
+  type DelegationSettlementMessage,
+  type DelegationSettlementReceiptMessage,
+} from './dynamic-delegation-protocol';
+
+/**
+ * Stable enclave-entry identifier. AWF accepts at most one agent entry per
+ * run, so a fixed token is both stable across an AWF restart inside the same
+ * workflow run — which is what label-based reconciliation needs — and free of
+ * any private selector material.
+ */
+export const ENCLAVE_DYNAMIC_ENTRY_ID = 'agent';
+
+/** Extra seconds allowed beyond the invocation timeout for broker overhead. */
+const INVOCATION_DEADLINE_GRACE_SECONDS = 30;
+
+/** Bound on one audit line, so a pathological value cannot fill the disk. */
+const MAX_AUDIT_LINE_BYTES = 4 * 1024;
+
+export interface DynamicDelegationRunIdentity {
+  /** Must equal the compiler envelope's `run_id`. */
+  runId: string;
+  entryId: string;
+}
+
+/**
+ * Derives the delegation run id the compiler bound into the mcpg envelope:
+ * `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` (gh-aw `enclaveDelegationRunID`).
+ * Returns `undefined` when either half is missing or malformed, so AWF fails
+ * closed rather than inventing a run identity mcpg would reject.
+ */
+export function resolveDynamicDelegationRunId(env: NodeJS.ProcessEnv): string | undefined {
+  const runId = env.GITHUB_RUN_ID;
+  const attempt = env.GITHUB_RUN_ATTEMPT;
+  if (typeof runId !== 'string' || !/^[0-9]{1,20}$/.test(runId)) return undefined;
+  if (typeof attempt !== 'string' || !/^[0-9]{1,10}$/.test(attempt)) return undefined;
+  return `${runId}-${attempt}`;
+}
+
+/** Truncated SHA-256, so an audit record can correlate without disclosing. */
+export function hashForAudit(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex').slice(0, 16);
+}
+
+/**
+ * Derives the idempotency key mcpg dedupes retries on. It is a pure function
+ * of the invocation binding, so an exact retry replays the same identity and a
+ * different selector can never reuse another invocation's key.
+ */
+export function deriveDelegationIdempotencyKey(
+  runId: string,
+  entryId: string,
+  invocationId: string,
+  selector: string,
+): string {
+  return crypto
+    .createHash('sha256')
+    .update([runId, entryId, invocationId, selector].join('\u0000'), 'utf8')
+    .digest('hex');
+}
+
+export interface DynamicDelegationServiceOptions {
+  policy: EnclaveDynamicPolicy;
+  identity: DynamicDelegationRunIdentity;
+  handoff: EnclaveDynamicDelegationHandoff;
+  ledger: EnclaveInformationBudgetLedger;
+  auditPath: string;
+  /** Injected in tests; production has no confined default-branch resolver. */
+  resolveDefaultBranchSha?: DefaultBranchResolver;
+  client?: DelegationControlClient;
+  /**
+   * Injected only by tests, so admission-timing normalization (covered
+   * exhaustively by the registry's own suite) does not make every service test
+   * sleep through a fixed bucket.
+   */
+  clock?: DynamicAdmissionClock;
+  jitter?: DynamicAdmissionJitterSource;
+}
+
+interface LiveIdentity {
+  handle: string;
+  repository: string;
+  usageHandle: string;
+}
+
+/**
+ * One dynamic enclave entry's admission authority, identity lifecycle, and
+ * usage settlement.
+ */
+export class DynamicDelegationService {
+  private readonly registry: DynamicRepositoryRegistry;
+  private readonly client: DelegationControlClient;
+  private readonly policy: EnclaveDynamicPolicy;
+  private readonly identity: DynamicDelegationRunIdentity;
+  private readonly auditPath: string;
+  private readonly live = new Map<string, LiveIdentity>();
+  /**
+   * Terminal admission outcomes, keyed by `(invocation, selector)` and
+   * inserted before the first `await`, so an exact retry — including one that
+   * arrives while the first is still resolving — replays the identical result
+   * instead of issuing a second control call.
+   */
+  private readonly outcomes = new Map<string, Promise<DelegationAdmissionResponseMessage>>();
+  private recovered = false;
+  private reconciliationRequired = false;
+
+  constructor(options: DynamicDelegationServiceOptions) {
+    this.policy = options.policy;
+    this.identity = options.identity;
+    this.auditPath = options.auditPath;
+    this.client = options.client ?? new DelegationControlClient({
+      endpoint: options.handoff.endpoint,
+      capability: options.handoff.capability,
+    });
+    this.registry = new DynamicRepositoryRegistry({
+      policy: options.policy,
+      ledger: options.ledger,
+      // ADR 0001 makes the admitted default-branch SHA optional. AWF has no
+      // already-authorized, repository-confined path to resolve it before the
+      // delegated identity exists, and `github-repository-read-v1` grants only
+      // list_issues/issue_read afterwards, so production omits it and audits
+      // every read as live rather than adding a broader token or tool.
+      resolveDefaultBranchSha: options.resolveDefaultBranchSha ?? (() => undefined),
+      ...(options.clock ? { clock: options.clock } : {}),
+      ...(options.jitter ? { jitter: options.jitter } : {}),
+    });
+    // Fail closed until recovery proves the controller's state is safe.
+    this.registry.markReconciliationIncomplete();
+  }
+
+  /** Exposed for the channel loop and tests; never leaves the host process. */
+  get quotaUsage(): DynamicQuotaUsage {
+    return this.registry.quotaUsage;
+  }
+
+  /** Whether the controller and AWF agree that state is reconciled. */
+  get isAdmitting(): boolean {
+    return this.recovered && !this.reconciliationRequired;
+  }
+
+  /**
+   * Establishes a safe starting state: inspect, revoke stale labelled
+   * identities, then transactionally reconcile. Any failure leaves admissions
+   * blocked and is surfaced to the operator.
+   */
+  async recover(): Promise<void> {
+    const status = await this.client.status(this.identity.runId, this.identity.entryId);
+    this.audit('recovery-status', {
+      recoveryIncomplete: status.recoveryIncomplete,
+      generation: status.generation,
+      liveIdentityCount: status.liveIdentityCount,
+      labelledHandleCount: status.labelledHandles.length,
+    });
+    if (status.labelledHandles.length > 0) {
+      const revoked = await this.client.revokeByLabels(
+        this.identity.runId,
+        this.identity.entryId,
+      );
+      this.audit('recovery-revoked-stale', { revoked });
+    }
+    await this.client.reconcile();
+    this.recovered = true;
+    this.reconciliationRequired = false;
+    this.registry.markReconciled();
+    this.audit('recovery-complete', {});
+  }
+
+  /**
+   * Routes one invocation through canonical admission and, only if admitted,
+   * mints or confirms its delegated identity.
+   *
+   * Every failure — malformed selector, out-of-policy owner, expired envelope,
+   * exhausted quota, control denial, control outage — returns the identical
+   * canonical denial. The registry normalizes admission timing; a control
+   * failure after admission still settles the reservation so a denial can
+   * never leak capacity.
+   */
+  async admit(
+    request: DelegationAdmissionRequestMessage,
+  ): Promise<DelegationAdmissionResponseMessage> {
+    const key = `${request.invocationId}\u0000${request.selector}`;
+    const replay = this.outcomes.get(key);
+    if (replay) return replay;
+    const pending = this.resolveAdmission(request);
+    this.outcomes.set(key, pending);
+    return pending;
+  }
+
+  private async resolveAdmission(
+    request: DelegationAdmissionRequestMessage,
+  ): Promise<DelegationAdmissionResponseMessage> {
+    const selectorHash = hashForAudit(request.selector);
+    if (!this.isAdmitting) {
+      this.audit('admission-blocked', {
+        invocationId: request.invocationId,
+        selectorHash,
+        reason: this.recovered ? 'reconciliation-required' : 'recovery-incomplete',
+      });
+      return this.deny(request);
+    }
+    const outcome = await this.registry.admit({
+      runId: this.identity.runId,
+      entryId: this.identity.entryId,
+      invocationId: request.invocationId,
+      selector: request.selector,
+    });
+    if (!outcome.admitted) {
+      this.audit('admission-denied', { invocationId: request.invocationId, selectorHash });
+      return this.deny(request);
+    }
+
+    const requestedTtlSeconds = this.policy.limits.timeoutSeconds;
+    const invocationExpiresAt = new Date(
+      Date.now() + (requestedTtlSeconds + INVOCATION_DEADLINE_GRACE_SECONDS) * 1000,
+    );
+    let identity: DelegationIdentity;
+    try {
+      identity = await this.client.createOrConfirm({
+        runId: this.identity.runId,
+        enclaveEntryId: this.identity.entryId,
+        invocationId: request.invocationId,
+        repository: outcome.repo,
+        schemaHash: request.schemaHash,
+        requestedTtlSeconds,
+        invocationExpiresAt,
+        idempotencyKey: deriveDelegationIdempotencyKey(
+          this.identity.runId,
+          this.identity.entryId,
+          request.invocationId,
+          outcome.repo,
+        ),
+        ...(outcome.defaultBranchSha === undefined
+          ? {}
+          : { admittedDefaultBranchSha: outcome.defaultBranchSha }),
+      });
+    } catch (error) {
+      const kind = error instanceof DelegationControlError ? error.kind : 'unavailable';
+      // The invocation charge stays committed: the envelope revealed the
+      // opportunity to spend it the moment it admitted the repository.
+      this.settleQuota(outcome.usageHandle, { outputBytes: 0, executionSeconds: 0 });
+      if (error instanceof DelegationControlError && error.requiresReconciliation) {
+        this.requireReconciliation('identity-creation-unresolved');
+      }
+      this.audit('identity-failed', {
+        invocationId: request.invocationId,
+        selectorHash,
+        kind,
+      });
+      if (kind !== 'denied') {
+        logger.error(
+          'Enclaves: the mcpg delegation controller could not mint a dynamic repository identity. '
+          + 'Dynamic admissions are blocked; no fallback identity is issued.',
+        );
+      }
+      return this.deny(request);
+    }
+
+    this.live.set(request.invocationId, {
+      handle: identity.handle,
+      repository: identity.repository,
+      usageHandle: outcome.usageHandle,
+    });
+    const readMode = identity.admittedDefaultBranchSha === undefined ? 'live' : 'pinned';
+    this.audit('identity-created', {
+      invocationId: request.invocationId,
+      selectorHash,
+      handleHash: hashForAudit(identity.handle),
+      readMode,
+      expiresAt: identity.expiresAt.toISOString(),
+      schemaHash: request.schemaHash,
+    });
+    return {
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: request.invocationId,
+      admitted: true,
+      repository: identity.repository,
+      executorBearer: identity.executorBearer,
+      expiresAt: identity.expiresAt.toISOString(),
+      readMode,
+      ...(identity.admittedDefaultBranchSha === undefined
+        ? {}
+        : { admittedDefaultBranchSha: identity.admittedDefaultBranchSha }),
+    };
+  }
+
+  /**
+   * Settles one finished invocation: the reserved worst-case byte and
+   * execution-second capacity is replaced by the reported usage, and the
+   * delegated identity is revoked. Reports whether revocation is definitive.
+   */
+  async settle(
+    settlement: DelegationSettlementMessage,
+  ): Promise<DelegationSettlementReceiptMessage> {
+    const live = this.live.get(settlement.invocationId);
+    this.live.delete(settlement.invocationId);
+    if (live) {
+      this.settleQuota(live.usageHandle, {
+        outputBytes: Math.min(settlement.outputBytes, this.policy.limits.maxOutputBytes),
+        executionSeconds: Math.min(
+          settlement.executionSeconds,
+          this.policy.limits.timeoutSeconds,
+        ),
+      });
+    }
+    let revoked = true;
+    if (live) {
+      try {
+        await this.client.revoke(live.handle);
+      } catch (error) {
+        revoked = false;
+        this.requireReconciliation('revocation-unresolved');
+        this.audit('revocation-failed', {
+          invocationId: settlement.invocationId,
+          handleHash: hashForAudit(live.handle),
+          kind: error instanceof DelegationControlError ? error.kind : 'unavailable',
+        });
+        logger.error(
+          'Enclaves: a dynamic enclave identity could not be revoked. Further dynamic '
+          + 'admissions are blocked until reconciliation succeeds.',
+        );
+      }
+    }
+    this.audit('usage-settled', {
+      invocationId: settlement.invocationId,
+      outcome: settlement.outcome,
+      outputBytes: settlement.outputBytes,
+      executionSeconds: settlement.executionSeconds,
+      revoked,
+      quota: this.registry.quotaUsage,
+    });
+    return {
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: settlement.invocationId,
+      settled: true,
+      revoked,
+    };
+  }
+
+  /**
+   * Sweeps every identity still carrying this run/entry label pair. Called at
+   * teardown and after any unresolved revocation.
+   */
+  async shutdown(): Promise<void> {
+    try {
+      const revoked = await this.client.revokeByLabels(
+        this.identity.runId,
+        this.identity.entryId,
+      );
+      this.live.clear();
+      this.audit('shutdown-revoked', { revoked });
+    } catch (error) {
+      this.requireReconciliation('shutdown-revocation-unresolved');
+      this.audit('shutdown-revocation-failed', {
+        kind: error instanceof DelegationControlError ? error.kind : 'unavailable',
+      });
+      logger.error(
+        'Enclaves: dynamic enclave identities could not be revoked at shutdown; mcpg state '
+        + 'remains unreconciled and must be inspected by an operator.',
+      );
+      throw error;
+    }
+  }
+
+  private settleQuota(usageHandle: string, usage: DynamicAdmissionUsage): void {
+    try {
+      this.registry.commitUsage(usageHandle, usage);
+    } catch (error) {
+      // Accounting can only fail on a programming error; record it rather
+      // than letting an unsettled reservation silently strand capacity.
+      this.audit('usage-accounting-failed', {
+        message: error instanceof Error ? error.name : 'unknown',
+      });
+    }
+  }
+
+  private requireReconciliation(reason: string): void {
+    this.reconciliationRequired = true;
+    this.registry.markReconciliationIncomplete();
+    this.audit('reconciliation-required', { reason });
+  }
+
+  private deny(
+    request: DelegationAdmissionRequestMessage,
+  ): DelegationAdmissionResponseMessage {
+    return {
+      version: DELEGATION_CHANNEL_VERSION,
+      invocationId: request.invocationId,
+      admitted: false,
+      reason: CANONICAL_DENIAL_REASON,
+    };
+  }
+
+  /**
+   * Appends one bounded, structured, redacted audit record.
+   *
+   * Callers pass only hashed selectors and handles, counts, and enumerated
+   * categories. The record is truncated rather than dropped so a pathological
+   * value can neither fill the disk nor silence the stream.
+   */
+  private audit(event: string, fields: Record<string, unknown>): void {
+    let line: string;
+    try {
+      line = JSON.stringify({
+        ts: new Date().toISOString(),
+        component: 'enclave-dynamic-delegation',
+        runId: this.identity.runId,
+        entryId: this.identity.entryId,
+        event,
+        ...fields,
+      });
+    } catch {
+      line = JSON.stringify({ ts: new Date().toISOString(), event, error: 'unserializable' });
+    }
+    if (Buffer.byteLength(line, 'utf8') > MAX_AUDIT_LINE_BYTES) {
+      line = JSON.stringify({
+        ts: new Date().toISOString(),
+        component: 'enclave-dynamic-delegation',
+        event,
+        truncated: true,
+      });
+    }
+    try {
+      fs.mkdirSync(path.dirname(this.auditPath), { recursive: true, mode: 0o700 });
+      fs.appendFileSync(this.auditPath, `${line}\n`, { mode: 0o600 });
+    } catch {
+      // Audit is best-effort on a full or read-only disk; the operator-facing
+      // logger already carries every failure that blocks admissions.
+    }
+  }
+}

--- a/src/enclave/dynamic-delegation.test.ts
+++ b/src/enclave/dynamic-delegation.test.ts
@@ -91,13 +91,13 @@ async function startControlServer(
 describe('dynamic delegation runtime', () => {
   let workDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-dynamic-runtime-'));
-    enclaveDynamicDelegationTestHelpers.reset();
+    await enclaveDynamicDelegationTestHelpers.reset();
   });
 
   afterEach(async () => {
-    enclaveDynamicDelegationTestHelpers.reset();
+    await enclaveDynamicDelegationTestHelpers.reset();
     fs.rmSync(resolveEnclavePaths(workDir).root, { recursive: true, force: true });
     fs.rmSync(workDir, { recursive: true, force: true });
   });

--- a/src/enclave/dynamic-delegation.test.ts
+++ b/src/enclave/dynamic-delegation.test.ts
@@ -1,0 +1,254 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { normalizeEnclavesConfig } from '../parsers/enclave-parser';
+import type { WrapperConfig } from '../types';
+import { typedDynamicEnclavePolicyFixture } from './dynamic-policy.test-utils';
+import { resolveEnclavePaths } from './paths';
+import {
+  resolveEnclaveDynamicDelegationHandoff,
+  stageEnclaveDynamicDelegationHandoff,
+} from './dynamic-delegation-handoff';
+import {
+  enclaveDynamicDelegationTestHelpers,
+  isEnclaveDynamicEnabled,
+  startEnclaveDynamicDelegation,
+  stopEnclaveDynamicDelegation,
+} from './dynamic-delegation';
+import { DELEGATION_CHANNEL_VERSION } from './dynamic-delegation-protocol';
+
+const CAPABILITY = 'a'.repeat(64);
+
+interface Recorded {
+  path: string;
+  authorization: string;
+  body: Record<string, unknown>;
+}
+
+function dynamicConfig(workDir: string): WrapperConfig {
+  return {
+    workDir,
+    enclaves: normalizeEnclavesConfig([
+      { agent: { model: 'gpt-test' }, dynamic: typedDynamicEnclavePolicyFixture() as never },
+    ]),
+  } as WrapperConfig;
+}
+
+async function startControlServer(
+  labelledHandles: string[] = [],
+): Promise<{ port: number; recorded: Recorded[]; close: () => Promise<void> }> {
+  const recorded: Recorded[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on('end', () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+      recorded.push({
+        path: req.url ?? '',
+        authorization: String(req.headers.authorization ?? ''),
+        body,
+      });
+      let payload = '{}';
+      if ((req.url ?? '').endsWith('/status')) {
+        payload = JSON.stringify({
+          recovery_incomplete: labelledHandles.length > 0,
+          generation: 1,
+          live_identity_count: labelledHandles.length,
+          labelled_handles: labelledHandles,
+        });
+      } else if ((req.url ?? '').endsWith('/reconcile')) {
+        payload = JSON.stringify({ reconciled: true });
+      } else if ((req.url ?? '').endsWith('/revoke-by-labels')) {
+        payload = JSON.stringify({ revoked: labelledHandles.length });
+      } else if ((req.url ?? '').endsWith('/revoke')) {
+        payload = JSON.stringify({ revoked: true });
+      } else if ((req.url ?? '').endsWith('/create-or-confirm')) {
+        payload = JSON.stringify({
+          handle: 'dlg_live',
+          executor_bearer: 'dlgbearer_live',
+          repository: body.repository,
+          tool_policy: 'github-repository-read-v1',
+          tools: ['issue_read', 'list_issues'],
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        });
+      }
+      res.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+      });
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return {
+    port: (server.address() as { port: number }).port,
+    recorded,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('dynamic delegation runtime', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-dynamic-runtime-'));
+    enclaveDynamicDelegationTestHelpers.reset();
+  });
+
+  afterEach(async () => {
+    enclaveDynamicDelegationTestHelpers.reset();
+    fs.rmSync(resolveEnclavePaths(workDir).root, { recursive: true, force: true });
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function stageHandoff(port: number): ReturnType<typeof resolveEnclavePaths> {
+    const paths = resolveEnclavePaths(workDir);
+    fs.mkdirSync(paths.root, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(paths.delegationChannelDir, { recursive: true, mode: 0o700 });
+    const resolution = resolveEnclaveDynamicDelegationHandoff({
+      endpoint:
+        `http://127.0.0.1:${port}/internal/awf-enclave-mcp-control/github-repository-delegation-v1`,
+      capability: CAPABILITY,
+    });
+    stageEnclaveDynamicDelegationHandoff(paths, resolution.handoff!);
+    return paths;
+  }
+
+  const runEnv = { GITHUB_RUN_ID: '18234567890', GITHUB_RUN_ATTEMPT: '1' };
+
+  it('detects a dynamic entry', () => {
+    expect(isEnclaveDynamicEnabled(dynamicConfig(workDir))).toBe(true);
+    expect(isEnclaveDynamicEnabled({ workDir } as WrapperConfig)).toBe(false);
+  });
+
+  it('recovers with status then reconcile before opening admission', async () => {
+    const control = await startControlServer();
+    const config = dynamicConfig(workDir);
+    stageHandoff(control.port);
+    try {
+      await startEnclaveDynamicDelegation(config, runEnv);
+      expect(control.recorded.map((entry) => entry.path)).toEqual([
+        '/internal/awf-enclave-mcp-control/status',
+        '/internal/awf-enclave-mcp-control/reconcile',
+      ]);
+      expect(control.recorded[0].authorization).toBe(`Bearer ${CAPABILITY}`);
+      expect(control.recorded[0].body).toEqual({
+        run_id: '18234567890-1',
+        enclave_entry_id: 'agent',
+      });
+    } finally {
+      await stopEnclaveDynamicDelegation(config);
+      await control.close();
+    }
+  });
+
+  it('revokes stale labelled identities from a prior attempt before reconciling', async () => {
+    const control = await startControlServer(['dlg_stale']);
+    const config = dynamicConfig(workDir);
+    stageHandoff(control.port);
+    try {
+      await startEnclaveDynamicDelegation(config, runEnv);
+      expect(control.recorded.map((entry) => entry.path)).toEqual([
+        '/internal/awf-enclave-mcp-control/status',
+        '/internal/awf-enclave-mcp-control/revoke-by-labels',
+        '/internal/awf-enclave-mcp-control/reconcile',
+      ]);
+    } finally {
+      await stopEnclaveDynamicDelegation(config);
+      await control.close();
+    }
+  });
+
+  it('serves one admission and settlement through the private channel', async () => {
+    const control = await startControlServer();
+    const config = dynamicConfig(workDir);
+    const paths = stageHandoff(control.port);
+    try {
+      await startEnclaveDynamicDelegation(config, runEnv);
+      fs.writeFileSync(path.join(paths.delegationChannelDir, 'abcabcabcabcabca.admit.json'),
+        JSON.stringify({
+          version: DELEGATION_CHANNEL_VERSION,
+          invocationId: 'abcabcabcabcabca',
+          selector: 'octo-org/service',
+          schemaHash: 'b'.repeat(64),
+        }));
+      const response = await waitForJson(
+        path.join(paths.delegationChannelDir, 'abcabcabcabcabca.admitted.json'),
+      );
+      expect(response).toMatchObject({
+        admitted: true,
+        repository: 'octo-org/service',
+        executorBearer: 'dlgbearer_live',
+        readMode: 'live',
+      });
+      expect(JSON.stringify(response)).not.toContain('dlg_live"');
+
+      fs.writeFileSync(path.join(paths.delegationChannelDir, 'abcabcabcabcabca.settle.json'),
+        JSON.stringify({
+          version: DELEGATION_CHANNEL_VERSION,
+          invocationId: 'abcabcabcabcabca',
+          outcome: 'success',
+          outputBytes: 16,
+          executionSeconds: 2,
+        }));
+      const receipt = await waitForJson(
+        path.join(paths.delegationChannelDir, 'abcabcabcabcabca.settled.json'),
+      );
+      expect(receipt).toMatchObject({ settled: true, revoked: true });
+      expect(control.recorded.map((entry) => entry.path)).toContain(
+        '/internal/awf-enclave-mcp-control/revoke',
+      );
+    } finally {
+      await stopEnclaveDynamicDelegation(config);
+      await control.close();
+    }
+  }, 20_000);
+
+  it('sweeps every labelled identity at shutdown', async () => {
+    const control = await startControlServer();
+    const config = dynamicConfig(workDir);
+    stageHandoff(control.port);
+    await startEnclaveDynamicDelegation(config, runEnv);
+    await stopEnclaveDynamicDelegation(config);
+    expect(control.recorded[control.recorded.length - 1].path)
+      .toBe('/internal/awf-enclave-mcp-control/revoke-by-labels');
+    await control.close();
+  });
+
+  it('refuses to start without a staged handoff', async () => {
+    const config = dynamicConfig(workDir);
+    fs.mkdirSync(resolveEnclavePaths(workDir).root, { recursive: true, mode: 0o700 });
+    await expect(startEnclaveDynamicDelegation(config, runEnv))
+      .rejects.toThrow(/staged mcpg delegation-control handoff is missing/);
+  });
+
+  it('refuses to start without the workflow run identity mcpg bound', async () => {
+    const control = await startControlServer();
+    const config = dynamicConfig(workDir);
+    stageHandoff(control.port);
+    try {
+      await expect(startEnclaveDynamicDelegation(config, {}))
+        .rejects.toThrow(/GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT are required/);
+    } finally {
+      await control.close();
+    }
+  });
+
+  it('is a no-op for a static-only run', async () => {
+    const config = { workDir } as WrapperConfig;
+    await expect(startEnclaveDynamicDelegation(config, runEnv)).resolves.toBeUndefined();
+    await expect(stopEnclaveDynamicDelegation(config)).resolves.toBeUndefined();
+  });
+});
+
+async function waitForJson(target: string): Promise<unknown> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    try {
+      return JSON.parse(fs.readFileSync(target, 'utf8'));
+    } catch {
+      await new Promise((resolve) => { setTimeout(resolve, 10); });
+    }
+  }
+  throw new Error(`Timed out waiting for ${target}`);
+}

--- a/src/enclave/dynamic-delegation.ts
+++ b/src/enclave/dynamic-delegation.ts
@@ -1,0 +1,136 @@
+/**
+ * Process-lifetime wiring for dynamic enclave delegation.
+ *
+ * `prepareEnclaves` takes custody of the compiler handoff and stages it into
+ * AWF-private state; this module starts the admission authority once the
+ * containers and the trusted gateway are up, and stops it — revoking every
+ * outstanding identity — during teardown.
+ */
+
+import * as fs from 'fs';
+import { logger } from '../logger';
+import type { WrapperConfig } from '../types';
+import { createEnclaveInformationBudgetLedger } from './information-budget';
+import { resolveEnclavePaths } from './paths';
+import { readStagedEnclaveDynamicDelegationHandoff } from './dynamic-delegation-handoff';
+import {
+  DynamicDelegationService,
+  ENCLAVE_DYNAMIC_ENTRY_ID,
+  resolveDynamicDelegationRunId,
+} from './dynamic-delegation-service';
+import {
+  startDynamicDelegationChannel,
+  type DynamicDelegationChannel,
+} from './dynamic-delegation-channel';
+
+interface RunningDelegation {
+  service: DynamicDelegationService;
+  channel: DynamicDelegationChannel;
+}
+
+let running: RunningDelegation | undefined;
+
+/** Whether this run declares a dynamic agent enclave entry. */
+export function isEnclaveDynamicEnabled(config: WrapperConfig): boolean {
+  return config.enclaves?.enabled === true
+    && config.enclaves.executors.agent.enabled === true
+    && config.enclaves.executors.agent.dynamic !== undefined;
+}
+
+/**
+ * Starts the dynamic admission authority.
+ *
+ * Recovery runs first and must succeed: until mcpg's labelled state has been
+ * inspected, swept, and transactionally reconciled, AWF refuses to admit any
+ * dynamic repository. A recovery failure aborts the run rather than starting
+ * an agent whose every enclave call would fail.
+ */
+export async function startEnclaveDynamicDelegation(
+  config: WrapperConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (!isEnclaveDynamicEnabled(config)) return;
+  const policy = config.enclaves!.executors.agent.dynamic!;
+  const paths = resolveEnclavePaths(config.workDir);
+  const handoff = readStagedEnclaveDynamicDelegationHandoff(paths);
+  if (!handoff) {
+    throw new Error(
+      'Enclaves: the staged mcpg delegation-control handoff is missing or unreadable; dynamic '
+      + 'repository admission cannot start and never falls back to a static seed catalog, a '
+      + 'job-lifetime identity, or a broader policy.',
+    );
+  }
+  const runId = resolveDynamicDelegationRunId(env);
+  if (!runId) {
+    throw new Error(
+      'Enclaves: GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT are required to bind dynamic enclave '
+      + "identities to the compiler's delegation envelope.",
+    );
+  }
+  const service = new DynamicDelegationService({
+    policy,
+    identity: { runId, entryId: ENCLAVE_DYNAMIC_ENTRY_ID },
+    handoff,
+    // Host-side mirror of the run's per-repository disclosure balances. The
+    // broker holds the single live ledger that both executors debit; this
+    // instance records the same admissions so the host's audit and quota view
+    // stay complete without ever forking a balance.
+    ledger: createEnclaveInformationBudgetLedger(
+      new Map(config.enclaves!.privateRepos.map(
+        (repository) => [repository.repo, { sensitivity: repository.sensitivity }],
+      )),
+    ),
+    auditPath: paths.delegationAuditPath,
+  });
+  await service.recover();
+  const channel = startDynamicDelegationChannel({
+    directory: paths.delegationChannelDir,
+    service,
+  });
+  running = { service, channel };
+  logger.info('Enclaves: dynamic repository admission is live and reconciled with mcpg.');
+}
+
+/**
+ * Stops the admission authority and revokes every identity still carrying this
+ * run's labels. Failure is reported to the operator but never masks the
+ * primary run outcome; the unresolved state is already recorded in the
+ * host-private delegation audit.
+ */
+export async function stopEnclaveDynamicDelegation(config: WrapperConfig): Promise<void> {
+  const active = running;
+  running = undefined;
+  if (!active) return;
+  try {
+    await active.channel.stop();
+  } finally {
+    try {
+      await active.service.shutdown();
+    } catch {
+      logger.warn(
+        'Enclaves: dynamic enclave identities may still be live in mcpg; see the host-private '
+        + 'delegation audit for the unreconciled state.',
+      );
+    }
+    if (!config.keepContainers) {
+      try {
+        fs.rmSync(resolveEnclavePaths(config.workDir).delegationChannelDir, {
+          recursive: true,
+          force: true,
+        });
+      } catch {
+        // The private root is removed wholesale by teardownEnclaves.
+      }
+    }
+  }
+}
+
+/** @internal Test-only accessor for the running delegation runtime. */
+export const enclaveDynamicDelegationTestHelpers = {
+  reset(): void {
+    running = undefined;
+  },
+  get running(): RunningDelegation | undefined {
+    return running;
+  },
+};

--- a/src/enclave/dynamic-delegation.ts
+++ b/src/enclave/dynamic-delegation.ts
@@ -127,8 +127,11 @@ export async function stopEnclaveDynamicDelegation(config: WrapperConfig): Promi
 
 /** @internal Test-only accessor for the running delegation runtime. */
 export const enclaveDynamicDelegationTestHelpers = {
-  reset(): void {
+  /** Stops any leftover channel loop and forgets the runtime. */
+  async reset(): Promise<void> {
+    const active = running;
     running = undefined;
+    if (active) await active.channel.stop();
   },
   get running(): RunningDelegation | undefined {
     return running;

--- a/src/enclave/dynamic-executor.test.ts
+++ b/src/enclave/dynamic-executor.test.ts
@@ -1,0 +1,541 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const containersRoot = path.join(__dirname, '..', '..', 'containers');
+const {
+  DELEGATION_CHANNEL_DIR,
+  ENCLAVE_GITHUB_BEARER_PATH,
+  loadAgentConfig,
+  loadServerConfig,
+} = require(path.join(containersRoot, 'enclave', 'mcp-server', 'config.js'));
+const {
+  deriveEnclaveContainerSpec,
+} = require(path.join(containersRoot, 'enclave', 'agent-executor', 'enclave-runner-spec.js'));
+const agentWorkspace = require(path.join(containersRoot, 'enclave', 'agent-executor', 'workspace.js'));
+const {
+  createExecutorHandler,
+} = require(path.join(containersRoot, 'enclave', 'script-executor', 'executor-handler.js'));
+const {
+  createEnclaveInformationBudgetLedger,
+} = require(path.join(containersRoot, 'bounded-execution', 'sensitivity-ledger.js'));
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const BASE_ENV = {
+  AWF_ENCLAVE_PRIMARY_BACKEND: 'docker',
+  AWF_ENCLAVE_AGENT_BACKEND: 'docker',
+  AWF_ENCLAVE_AGENT_ENGINE: 'copilot',
+  AWF_ENCLAVE_AGENT_PROFILE: 'openai',
+  AWF_ENCLAVE_AGENT_MODEL: 'gpt-test',
+  AWF_ENCLAVE_AGENT_IMAGE: 'ghcr.io/example/enclave-agent:test',
+  AWF_ENCLAVE_AGENT_API_ENDPOINT: 'http://172.31.0.30:10000',
+  AWF_ENCLAVE_AGENT_NETWORK: 'awf-enclave-agent',
+  AWF_ENCLAVE_AGENT_HOST_WORK_DIR: '/var/tmp/awf-enclave-private/work',
+};
+
+const DYNAMIC_ENV = {
+  ...BASE_ENV,
+  AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+  AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR: '/run/awf-enclave-delegation',
+  AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY: 'confidential',
+  AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL: 'http://172.31.0.40:8080/mcp/github',
+  AWF_ENCLAVE_SEED_MAP_ENABLED: 'false',
+  AWF_ENCLAVE_RUN_ID: 'f'.repeat(32),
+};
+
+function withEnv(values: Record<string, string | undefined>, run: () => void): void {
+  const saved = { ...process.env };
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('AWF_ENCLAVE_')) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    run();
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, saved);
+  }
+}
+
+const serverStub = { primaryBackend: 'docker', auditDir: '/var/log/awf-enclave' };
+
+describe('dynamic broker configuration', () => {
+  it('loads a dynamic agent entry without a seed catalog or seeds directory', () => {
+    withEnv(DYNAMIC_ENV, () => {
+      const config = loadAgentConfig(serverStub);
+      expect(config).toMatchObject({
+        dynamicEnabled: true,
+        dynamicChannelDir: DELEGATION_CHANNEL_DIR,
+        dynamicSensitivity: 'confidential',
+        dynamicGithubMcpUrl: 'http://172.31.0.40:8080/mcp/github',
+        enclaveGithubBearerPath: ENCLAVE_GITHUB_BEARER_PATH,
+        githubEnabled: false,
+      });
+      expect(config.hostSeedsDir).toBeUndefined();
+    });
+  });
+
+  it('resolves the run id from AWF when no seed catalog is staged', () => {
+    withEnv(DYNAMIC_ENV, () => {
+      const server = loadServerConfig({ readFileSync: () => 'a'.repeat(64) });
+      expect(server).toMatchObject({ seedMapEnabled: false, runId: 'f'.repeat(32) });
+    });
+  });
+
+  it('keeps the static seed catalog when AWF stages one', () => {
+    withEnv({ ...BASE_ENV, AWF_ENCLAVE_AGENT_HOST_SEEDS_DIR: '/seeds' }, () => {
+      const server = loadServerConfig({ readFileSync: () => 'a'.repeat(64) });
+      expect(server.seedMapEnabled).toBe(true);
+    });
+  });
+
+  it.each([
+    ['a foreign channel directory', { AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR: '/tmp/attacker' }],
+    ['an unsupported sensitivity', { AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY: 'bogus' }],
+    ['a non-fixed MCP endpoint', { AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL: 'http://evil.example/mcp/github' }],
+    ['a static GitHub profile alongside the dynamic policy', { AWF_ENCLAVE_AGENT_GITHUB_ENABLED: 'true' }],
+  ])('fails closed for %s', (_label, overrides) => {
+    withEnv({ ...DYNAMIC_ENV, ...overrides }, () => {
+      expect(() => loadAgentConfig(serverStub)).toThrow();
+    });
+  });
+
+  it('requires a run id when no seed catalog is staged', () => {
+    withEnv({ ...DYNAMIC_ENV, AWF_ENCLAVE_RUN_ID: undefined }, () => {
+      expect(() => loadServerConfig({ readFileSync: () => 'a'.repeat(64) })).toThrow(
+        /AWF_ENCLAVE_RUN_ID is required/,
+      );
+    });
+  });
+});
+
+describe('dynamic enclave container specification', () => {
+  const config = {
+    dynamicEnabled: true,
+    dynamicGithubMcpUrl: 'http://172.31.0.40:8080/mcp/github',
+    dynamicRepository: 'octo-org/service',
+    dynamicReadMode: 'live',
+    enclaveGithubBearerPath: ENCLAVE_GITHUB_BEARER_PATH,
+    hostWorkDir: '/var/tmp/work',
+    enclaveSeccompPath: '/opt/awf/enclave-seccomp.json',
+    enclaveMountDir: '/agent',
+    enclaveSeedPath: '/awf/seed',
+    enclaveTaskPath: '/awf/task.txt',
+    enclaveSchemaPath: '/awf/schema.json',
+    enclaveUid: 65534,
+    enclaveGid: 65534,
+    enclaveImage: 'ghcr.io/example/enclave-agent:test',
+    engine: 'copilot',
+    profile: 'openai',
+    model: 'gpt-test',
+    apiEndpoint: 'http://172.31.0.30:10000',
+    network: 'awf-enclave-agent',
+    timeoutSeconds: 120,
+    memoryLimit: '1g',
+    cpuLimit: '1',
+    pidsLimit: 128,
+    tmpfsLimit: '256m',
+    maxOutputBytes: 8192,
+  };
+  const spec = deriveEnclaveContainerSpec({
+    config,
+    runId: 'a'.repeat(32),
+    invocationId: 'b'.repeat(24),
+  });
+  const args: string[] = [...spec.launchArgs];
+  const joined = args.join(' ');
+
+  it('mounts no repository seed', () => {
+    expect(joined).not.toContain('/awf/seed');
+    expect(args.filter((arg) => arg.startsWith('/var/tmp/work')).join(' ')).not.toContain('seed');
+  });
+
+  it('runs from the invocation-private runtime directory instead of a checkout', () => {
+    expect(args[args.indexOf('--workdir') + 1]).toBe('/agent');
+  });
+
+  it('mounts only the invocation-private bearer read-only', () => {
+    expect(args).toContain(
+      `/var/tmp/work/${'b'.repeat(24)}/github-bearer:${ENCLAVE_GITHUB_BEARER_PATH}:ro`,
+    );
+  });
+
+  it('exposes the admitted repository and its read mode to the executor', () => {
+    expect(args).toContain('AWF_ENCLAVE_AGENT_DYNAMIC_REPO=octo-org/service');
+    expect(args).toContain('AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE=live');
+    expect(args).toContain('AWF_ENCLAVE_AGENT_GITHUB_MCP_URL=http://172.31.0.40:8080/mcp/github');
+  });
+
+  it('keeps the executor on the dedicated api-proxy-only network', () => {
+    expect(args[args.indexOf('--network') + 1]).toBe('awf-enclave-agent');
+  });
+
+  it.each([
+    ['the delegation control endpoint', 'awf-enclave-mcp-control'],
+    ['the control capability variable', 'DELEGATION_CONTROL_CAPABILITY'],
+    ['the control endpoint variable', 'DELEGATION_CONTROL_ENDPOINT'],
+    ['an identity handle', 'dlg_'],
+    ['mcpg delegation state', 'MCP_GATEWAY_DELEGATION'],
+    ['the private admission channel', '/run/awf-enclave-delegation'],
+  ])('never hands the executor %s', (_label, needle) => {
+    expect(joined).not.toContain(needle);
+  });
+
+  it('masks every provider credential slot rather than passing a token', () => {
+    for (const masked of ['COPILOT_GITHUB_TOKEN=******', 'COPILOT_TOKEN=******']) {
+      expect(args).toContain(masked.split('=')[0] + '=' + masked.split('=')[1]);
+    }
+    expect(joined).not.toMatch(/(?:GH|GITHUB)_TOKEN=(?!\*)/);
+    expect(joined).not.toMatch(/gh[pousr]_/);
+  });
+
+  it('still requires a trusted seed id for a static entry', () => {
+    expect(() => deriveEnclaveContainerSpec({
+      config: { ...config, dynamicEnabled: false },
+      runId: 'a'.repeat(32),
+      invocationId: 'b'.repeat(24),
+    })).toThrow(/seedId/);
+  });
+});
+
+describe('dynamic invocation workspace', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-dynamic-workspace-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const config = () => ({
+    workDir,
+    enclaveUid: process.getuid?.() ?? 0,
+    enclaveGid: process.getgid?.() ?? 0,
+    dynamicEnabled: true,
+  });
+
+  it('writes the bearer invocation-private and read-only', () => {
+    const layout = agentWorkspace.createInvocationWorkspace({
+      config: config(),
+      invocationId: 'c'.repeat(24),
+      task: 'summarize',
+      schema: { type: 'boolean' },
+      executorBearer: 'dlgbearer_abcdef0123456789',
+    });
+    expect(fs.readFileSync(layout.githubBearerPath, 'utf8').trim())
+      .toBe('dlgbearer_abcdef0123456789');
+    expect(fs.statSync(layout.githubBearerPath).mode & 0o777).toBe(0o400);
+  });
+
+  it.each([
+    ['a missing bearer', undefined],
+    ['an empty bearer', ''],
+    ['a bearer with whitespace', 'dlgbearer with space'],
+  ])('refuses %s', (_label, bearer) => {
+    expect(() => agentWorkspace.createInvocationWorkspace({
+      config: config(),
+      invocationId: 'd'.repeat(24),
+      task: 'summarize',
+      schema: { type: 'boolean' },
+      executorBearer: bearer,
+    })).toThrow(/delegated executor bearer/);
+  });
+
+  it('writes no bearer for a static entry', () => {
+    const layout = agentWorkspace.createInvocationWorkspace({
+      config: { ...config(), dynamicEnabled: false },
+      invocationId: 'e'.repeat(24),
+      task: 'summarize',
+      schema: { type: 'boolean' },
+    });
+    expect(fs.existsSync(layout.githubBearerPath)).toBe(false);
+  });
+});
+
+describe('dynamic executor handler routing', () => {
+  function buildHandler(overrides: Record<string, unknown> = {}) {
+    const events: string[] = [];
+    const admissionCalls: unknown[] = [];
+    const settlements: unknown[] = [];
+    const workspaceCalls: unknown[] = [];
+    const handler = createExecutorHandler({
+      config: {
+        workDir: '/srv/awf/work',
+        primaryBackend: 'docker',
+        executorBackend: 'docker',
+        timeoutSeconds: 5,
+        maxInvocations: 8,
+        maxOutputBytes: 8192,
+        dynamicEnabled: true,
+      },
+      seedMap: new Map(),
+      runId: 'a'.repeat(32),
+      audit: {
+        failure: (_id: string, reason: string) => events.push(`failure:${reason}`),
+        invocation: () => events.push('invocation'),
+        lifecycle: () => undefined,
+      },
+      ledger: createEnclaveInformationBudgetLedger(new Map()),
+      clock: { nowMs: () => 0, sleep: async () => undefined },
+      responseJitterSource: () => 0,
+      validateRequest: (request: Record<string, unknown>) => ({
+        valid: true,
+        request: { privateRepo: request.privateRepo, schema: request.schema, prompt: 'go' },
+      }),
+      payloadKey: 'prompt',
+      executorKind: 'agent',
+      uniformTiming: true,
+      workspace: {
+        createInvocationWorkspace(params: Record<string, unknown>) {
+          workspaceCalls.push(params);
+          return { outPath: '/srv/awf/work/out' };
+        },
+        readQueryOutput: () => 'true',
+        destroyInvocationWorkspace: () => undefined,
+      },
+      runner: {
+        runScriptContainer: async () => ({ exitCode: 0, timedOut: false }),
+      },
+      admission: {
+        async admit(params: Record<string, unknown>) {
+          admissionCalls.push(params);
+          return {
+            admitted: true,
+            repo: params.selector,
+            executorBearer: 'dlgbearer_1',
+            readMode: 'live',
+            sensitivity: 'confidential',
+          };
+        },
+        async settle(params: Record<string, unknown>) {
+          settlements.push(params);
+          return { settled: true, revoked: true };
+        },
+        ...overrides,
+      },
+      ...(overrides.handlerOverrides as object ?? {}),
+    });
+    return { handler, events, admissionCalls, settlements, workspaceCalls };
+  }
+
+  function invoke(handler: { handle: (request: unknown, respond: (json: string) => void) => Promise<void> }) {
+    return new Promise<string>((resolve) => {
+      void handler.handle(
+        { privateRepo: 'octo-org/service', schema: { type: 'boolean' }, prompt: 'go' },
+        resolve,
+      );
+    });
+  }
+
+  it('admits before any workspace or container exists', async () => {
+    const { handler, admissionCalls, workspaceCalls } = buildHandler();
+    const result = await invoke(handler as never);
+    expect(JSON.parse(result)).toMatchObject({ status: 'ok' });
+    expect(admissionCalls).toHaveLength(1);
+    expect(workspaceCalls).toHaveLength(1);
+    expect(workspaceCalls[0]).toMatchObject({ executorBearer: 'dlgbearer_1', readMode: 'live' });
+  });
+
+  it('returns the canonical error and creates nothing when admission is denied', async () => {
+    const { handler, workspaceCalls, settlements } = buildHandler({
+      async admit() {
+        return { admitted: false };
+      },
+    });
+    const result = await invoke(handler as never);
+    expect(JSON.parse(result)).toEqual({ status: 'error' });
+    expect(workspaceCalls).toHaveLength(0);
+    expect(settlements).toHaveLength(0);
+  });
+
+  it('settles the invocation on the success path', async () => {
+    const { handler, settlements } = buildHandler();
+    await invoke(handler as never);
+    expect(settlements[0]).toMatchObject({ outcome: 'success' });
+  });
+
+  it('downgrades a successful invocation when revocation is unresolved', async () => {
+    const { handler } = buildHandler({
+      async settle() {
+        return { settled: false, revoked: false };
+      },
+    });
+    const result = await invoke(handler as never);
+    expect(JSON.parse(result)).toEqual({ status: 'error' });
+  });
+});
+
+describe('dynamic tool advertisement', () => {
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const {
+    AGENT_TOOL_NAME,
+    TOOL_NAME,
+    dispatchJsonRpc,
+  } = require(path.join(containersRoot, 'enclave', 'mcp-server', 'mcp-protocol.js'));
+  /* eslint-enable @typescript-eslint/no-require-imports */
+
+  it('advertises only enclave_run_agent for a dynamic entry', async () => {
+    const listed = await dispatchJsonRpc(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      { handlers: { [AGENT_TOOL_NAME]: { handle: () => undefined } }, maxPromptBytes: 4096 },
+    );
+    const names = (listed.result.tools as { name: string }[]).map((tool) => tool.name);
+    expect(names).toEqual([AGENT_TOOL_NAME]);
+    expect(names).not.toContain(TOOL_NAME);
+  });
+
+  it('refuses to dispatch enclave_run_script for a dynamic entry', async () => {
+    const called = await dispatchJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: TOOL_NAME, arguments: { privateRepo: 'octo-org/service' } },
+      },
+      { handlers: { [AGENT_TOOL_NAME]: { handle: () => undefined } }, maxPromptBytes: 4096 },
+    );
+    expect(called.error).toBeDefined();
+  });
+});
+
+describe('dynamic enclave agent instructions', () => {
+  const entrypoint = path.join(containersRoot, 'enclave', 'agent-entrypoint.py');
+
+  function runHarness(script: string, env: Record<string, string>) {
+    return spawnSync('python3', ['-c', script], {
+      encoding: 'utf8',
+      env: { ...process.env, ENTRYPOINT: entrypoint, ...env },
+    });
+  }
+
+  const loader = String.raw`
+import importlib.util, json, os
+spec = importlib.util.spec_from_file_location("agent_entrypoint", os.environ["ENTRYPOINT"])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+`;
+
+  it('tells the enclave there is no checkout and names the single admitted repository', () => {
+    const result = runHarness(
+      `${loader}print(module.build_prompt("summarize", json.dumps({"type": "boolean"})))`,
+      {
+        AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+        AWF_ENCLAVE_AGENT_DYNAMIC_REPO: 'octo-org/service',
+        AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE: 'live',
+      },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('There is no repository checkout');
+    expect(result.stdout).not.toContain('/awf/seed');
+    expect(result.stdout).toContain('octo-org/service');
+    expect(result.stdout).toContain('Reads are live');
+    for (const prohibition of [
+      'must not clone',
+      'arbitrary URLs',
+      'GitHub CLI',
+      'write or mutation',
+      'unscoped or organization-wide search',
+      'enumerate or discover repositories',
+    ]) {
+      expect(result.stdout).toContain(prohibition);
+    }
+  });
+
+  it('marks reads as pinned only when the control binding carries a SHA', () => {
+    const result = runHarness(
+      `${loader}print(module.build_prompt("summarize", json.dumps({"type": "boolean"})))`,
+      {
+        AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+        AWF_ENCLAVE_AGENT_DYNAMIC_REPO: 'octo-org/service',
+        AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE: 'pinned',
+      },
+    );
+    expect(result.stdout).toContain('Reads are pinned');
+  });
+
+  it('keeps the static seed-backed instructions unchanged', () => {
+    const result = runHarness(
+      `${loader}print(module.build_prompt("summarize", json.dumps({"type": "boolean"})))`,
+      {},
+    );
+    expect(result.stdout).toContain('mounted read-only at /awf/seed');
+  });
+
+  it('writes a bearer-only GitHub MCP config confined to the two delegated tools', () => {
+    const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-dynamic-entrypoint-'));
+    try {
+      fs.mkdirSync(path.join(stage, 'agent'));
+      fs.writeFileSync(path.join(stage, 'bearer'), 'dlgbearer_abcdef0123456789\n');
+      const result = runHarness(
+        `${loader}
+from pathlib import Path
+root = Path(os.environ["HARNESS_ROOT"])
+module.AGENT_DIR = root / "agent"
+module.GITHUB_BEARER_PATH = root / "bearer"
+module.GITHUB_MCP_CONFIG_PATH = module.AGENT_DIR / "github-mcp.json"
+module.configure_github_mcp()
+print(module.GITHUB_MCP_CONFIG_PATH.read_text())
+`,
+        {
+          HARNESS_ROOT: stage,
+          AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+          AWF_ENCLAVE_AGENT_DYNAMIC_REPO: 'octo-org/service',
+          AWF_ENCLAVE_AGENT_GITHUB_MCP_URL: 'http://172.31.0.40:8080/mcp/github',
+        },
+      );
+      expect(result.status).toBe(0);
+      const config = JSON.parse(result.stdout);
+      expect(config.mcpServers.github).toEqual({
+        type: 'http',
+        url: 'http://172.31.0.40:8080/mcp/github',
+        headers: { Authorization: 'dlgbearer_abcdef0123456789' },
+        tools: ['list_issues', 'issue_read'],
+      });
+      expect(fs.statSync(path.join(stage, 'agent', 'github-mcp.json')).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(stage, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['a non-fixed endpoint', { AWF_ENCLAVE_AGENT_GITHUB_MCP_URL: 'http://evil.example/mcp/github' }],
+    ['a non-canonical repository', { AWF_ENCLAVE_AGENT_DYNAMIC_REPO: 'Octo-Org/Service' }],
+  ])('refuses to build a dynamic MCP config with %s', (_label, overrides) => {
+    const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'awf-dynamic-entrypoint-'));
+    try {
+      fs.mkdirSync(path.join(stage, 'agent'));
+      fs.writeFileSync(path.join(stage, 'bearer'), 'dlgbearer_abcdef0123456789\n');
+      const result = runHarness(
+        `${loader}
+from pathlib import Path
+root = Path(os.environ["HARNESS_ROOT"])
+module.AGENT_DIR = root / "agent"
+module.GITHUB_BEARER_PATH = root / "bearer"
+module.GITHUB_MCP_CONFIG_PATH = module.AGENT_DIR / "github-mcp.json"
+try:
+    module.configure_github_mcp()
+    print("accepted")
+except ValueError:
+    print("rejected")
+`,
+        {
+          HARNESS_ROOT: stage,
+          AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+          AWF_ENCLAVE_AGENT_DYNAMIC_REPO: 'octo-org/service',
+          AWF_ENCLAVE_AGENT_GITHUB_MCP_URL: 'http://172.31.0.40:8080/mcp/github',
+          ...overrides,
+        },
+      );
+      expect(result.stdout.trim()).toBe('rejected');
+    } finally {
+      fs.rmSync(stage, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/enclave/dynamic-executor.test.ts
+++ b/src/enclave/dynamic-executor.test.ts
@@ -41,6 +41,7 @@ const DYNAMIC_ENV = {
   AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR: '/run/awf-enclave-delegation',
   AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY: 'confidential',
   AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL: 'http://172.31.0.40:8080/mcp/github',
+  AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER: 'awmg-mcpg',
   AWF_ENCLAVE_SEED_MAP_ENABLED: 'false',
   AWF_ENCLAVE_RUN_ID: 'f'.repeat(32),
 };
@@ -75,6 +76,9 @@ describe('dynamic broker configuration', () => {
         dynamicGithubMcpUrl: 'http://172.31.0.40:8080/mcp/github',
         enclaveGithubBearerPath: ENCLAVE_GITHUB_BEARER_PATH,
         githubEnabled: false,
+        // Needed by the per-launch network-isolation proof: a dynamic entry
+        // reaches the same shared gateway as the static profile.
+        githubGatewayContainer: 'awmg-mcpg',
       });
       expect(config.hostSeedsDir).toBeUndefined();
     });
@@ -99,6 +103,7 @@ describe('dynamic broker configuration', () => {
     ['an unsupported sensitivity', { AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY: 'bogus' }],
     ['a non-fixed MCP endpoint', { AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL: 'http://evil.example/mcp/github' }],
     ['a static GitHub profile alongside the dynamic policy', { AWF_ENCLAVE_AGENT_GITHUB_ENABLED: 'true' }],
+    ['a missing shared gateway container', { AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER: undefined }],
   ])('fails closed for %s', (_label, overrides) => {
     withEnv({ ...DYNAMIC_ENV, ...overrides }, () => {
       expect(() => loadAgentConfig(serverStub)).toThrow();
@@ -470,6 +475,134 @@ describe('dynamic tool advertisement', () => {
       { handlers: { [AGENT_TOOL_NAME]: { handle: () => undefined } }, maxPromptBytes: 4096 },
     );
     expect(called.error).toBeDefined();
+  });
+});
+
+describe('dynamic enclave runner binding', () => {
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const {
+    createAgentRunner,
+  } = require(path.join(containersRoot, 'enclave', 'mcp-server', 'agent-executor.js'));
+  /* eslint-enable @typescript-eslint/no-require-imports */
+
+  const runnerConfig = {
+    backend: 'docker',
+    dynamicEnabled: true,
+    dynamicGithubMcpUrl: 'http://172.31.0.40:8080/mcp/github',
+    githubGatewayContainer: 'awmg-mcpg',
+    enclaveGithubBearerPath: ENCLAVE_GITHUB_BEARER_PATH,
+    hostWorkDir: '/var/tmp/work',
+    enclaveSeccompPath: '/opt/awf/enclave-seccomp.json',
+    enclaveMountDir: '/agent',
+    enclaveSeedPath: '/awf/seed',
+    enclaveTaskPath: '/awf/task.txt',
+    enclaveSchemaPath: '/awf/schema.json',
+    enclaveUid: 65534,
+    enclaveGid: 65534,
+    enclaveImage: 'ghcr.io/example/enclave-agent:test',
+    engine: 'copilot',
+    profile: 'openai',
+    model: 'gpt-test',
+    apiEndpoint: 'http://172.31.0.30:10000',
+    network: 'awf-enclave-agent',
+    timeoutSeconds: 120,
+    memoryLimit: '1g',
+    cpuLimit: '1',
+    pidsLimit: 128,
+    tmpfsLimit: '256m',
+    maxOutputBytes: 8192,
+  };
+
+  const DYNAMIC_TOPOLOGY =
+    'true|bridge|172.31.0.0/24,|awf-enclave-agent-api-proxy@172.31.0.30/24,awmg-mcpg@172.31.0.40/24,';
+
+  function stubDocker(topology = DYNAMIC_TOPOLOGY) {
+    const calls: string[][] = [];
+    return {
+      calls,
+      async runDocker(args: string[]) {
+        calls.push(args);
+        if (args[0] === 'network') return { exitCode: 0, stdout: topology, timedOut: false };
+        if (args[0] === 'ps') return { exitCode: 0, stdout: '', timedOut: false };
+        return { exitCode: 0, stdout: '', timedOut: false };
+      },
+    };
+  }
+
+  it('threads the admitted repository and read mode into the launch vector', async () => {
+    const docker = stubDocker();
+    const runner = createAgentRunner(runnerConfig, { docker });
+    await runner.runScriptContainer({
+      runId: 'a'.repeat(32),
+      invocationId: 'b'.repeat(24),
+      timeoutMs: 1000,
+      dynamic: { repository: 'octo-org/service', readMode: 'live' },
+    });
+    const launch = docker.calls.find((args) => args[0] === 'run')!;
+    expect(launch).toContain('AWF_ENCLAVE_AGENT_DYNAMIC_REPO=octo-org/service');
+    expect(launch).toContain('AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE=live');
+    expect(launch.join(' ')).not.toContain('undefined');
+  });
+
+  it('carries a pinned read mode through unchanged', async () => {
+    const docker = stubDocker();
+    const runner = createAgentRunner(runnerConfig, { docker });
+    await runner.runScriptContainer({
+      runId: 'a'.repeat(32),
+      invocationId: 'c'.repeat(24),
+      timeoutMs: 1000,
+      dynamic: { repository: 'octo-org/service', readMode: 'pinned' },
+    });
+    const launch = docker.calls.find((args) => args[0] === 'run')!;
+    expect(launch).toContain('AWF_ENCLAVE_AGENT_DYNAMIC_READ_MODE=pinned');
+  });
+
+  it('accepts the steady-state topology a dynamic run actually creates', async () => {
+    const docker = stubDocker();
+    const runner = createAgentRunner(runnerConfig, { docker });
+    await expect(runner.runScriptContainer({
+      runId: 'a'.repeat(32),
+      invocationId: 'd'.repeat(24),
+      timeoutMs: 1000,
+      dynamic: { repository: 'octo-org/service', readMode: 'live' },
+    })).resolves.toMatchObject({ exitCode: 0 });
+  });
+
+  it('still refuses a network with an unexpected member', async () => {
+    const docker = stubDocker(
+      'true|bridge|172.31.0.0/24,|awf-enclave-agent-api-proxy@172.31.0.30/24,'
+      + 'awmg-mcpg@172.31.0.40/24,intruder@172.31.0.99/24,',
+    );
+    const runner = createAgentRunner(runnerConfig, { docker });
+    await expect(runner.runScriptContainer({
+      runId: 'a'.repeat(32),
+      invocationId: 'e'.repeat(24),
+      timeoutMs: 1000,
+      dynamic: { repository: 'octo-org/service', readMode: 'live' },
+    })).rejects.toThrow(/not isolated/);
+  });
+
+  it.each([
+    ['a missing binding', undefined],
+    ['a non-canonical repository', { repository: 'Octo-Org/Service', readMode: 'live' }],
+    ['an unknown read mode', { repository: 'octo-org/service', readMode: 'cached' }],
+  ])('refuses to launch a dynamic enclave with %s', async (_label, dynamic) => {
+    const docker = stubDocker();
+    const runner = createAgentRunner(runnerConfig, { docker });
+    await expect(runner.runScriptContainer({
+      runId: 'a'.repeat(32),
+      invocationId: 'f'.repeat(24),
+      timeoutMs: 1000,
+      dynamic,
+    })).rejects.toThrow();
+    expect(docker.calls.some((args) => args[0] === 'run')).toBe(false);
+  });
+
+  it('reconciles a dynamic run without an invocation binding', async () => {
+    const docker = stubDocker();
+    const runner = createAgentRunner(runnerConfig, { docker });
+    await expect(runner.reconcileRun('a'.repeat(32))).resolves.toBeUndefined();
+    expect(docker.calls.some((args) => args[0] === 'ps')).toBe(true);
   });
 });
 

--- a/src/enclave/dynamic-executor.test.ts
+++ b/src/enclave/dynamic-executor.test.ts
@@ -370,6 +370,74 @@ describe('dynamic executor handler routing', () => {
     const result = await invoke(handler as never);
     expect(JSON.parse(result)).toEqual({ status: 'error' });
   });
+
+  it('settles and revokes even when the pipeline throws after admission', async () => {
+    const settlements: unknown[] = [];
+    const handler = createExecutorHandler({
+      config: {
+        workDir: '/srv/awf/work',
+        primaryBackend: 'docker',
+        executorBackend: 'docker',
+        timeoutSeconds: 5,
+        maxInvocations: 8,
+        maxOutputBytes: 8192,
+        dynamicEnabled: true,
+      },
+      seedMap: new Map(),
+      runId: 'a'.repeat(32),
+      audit: { failure: () => undefined, invocation: () => undefined, lifecycle: () => undefined },
+      // An unexpected internal error after admission must not strand a live
+      // delegated identity.
+      ledger: {
+        registerRepository: () => undefined,
+        tryDebit: () => {
+          throw new Error('ledger exploded');
+        },
+        remainingBits: () => 0,
+      },
+      clock: { nowMs: () => 0, sleep: async () => undefined },
+      responseJitterSource: () => 0,
+      validateRequest: (request: Record<string, unknown>) => ({
+        valid: true,
+        request: { privateRepo: request.privateRepo, schema: request.schema, prompt: 'go' },
+      }),
+      payloadKey: 'prompt',
+      executorKind: 'agent',
+      uniformTiming: true,
+      workspace: {
+        createInvocationWorkspace: () => ({ outPath: '/srv/awf/work/out' }),
+        readQueryOutput: () => 'true',
+        destroyInvocationWorkspace: () => undefined,
+      },
+      runner: {
+        runScriptContainer: async () => ({ exitCode: 0, timedOut: false }),
+      },
+      admission: {
+        async admit(params: Record<string, unknown>) {
+          return {
+            admitted: true,
+            repo: params.selector,
+            executorBearer: 'dlgbearer_1',
+            readMode: 'live',
+            sensitivity: 'confidential',
+          };
+        },
+        async settle(params: Record<string, unknown>) {
+          settlements.push(params);
+          return { settled: true, revoked: true };
+        },
+      },
+    });
+    const result = await new Promise<string>((resolve) => {
+      void (handler as { handle: (request: unknown, respond: (json: string) => void) => Promise<void> })
+        .handle(
+          { privateRepo: 'octo-org/service', schema: { type: 'boolean' }, prompt: 'go' },
+          resolve,
+        );
+    });
+    expect(JSON.parse(result)).toEqual({ status: 'error' });
+    expect(settlements).toEqual([expect.objectContaining({ outcome: 'broker-error' })]);
+  });
 });
 
 describe('dynamic tool advertisement', () => {

--- a/src/enclave/dynamic-registry.test.ts
+++ b/src/enclave/dynamic-registry.test.ts
@@ -107,6 +107,25 @@ describe('DynamicRepositoryRegistry', () => {
     expect(outcome.admitted).toBe(true);
   });
 
+  it('admits without a SHA when no confined resolver is available, for a live read', async () => {
+    const outcome = await registry({ resolveDefaultBranchSha: () => undefined }).admit({
+      runId: 'run-1', entryId: 'agent', invocationId: 'inv-1', selector: 'octo-org/service',
+    });
+    expect(outcome).toEqual({
+      admitted: true,
+      repo: 'octo-org/service',
+      usageHandle: expect.any(String),
+    });
+    expect(outcome).not.toHaveProperty('defaultBranchSha');
+  });
+
+  it('denies when a resolver returns an empty SHA rather than admitting a live read', async () => {
+    const outcome = await registry({ resolveDefaultBranchSha: () => '' }).admit({
+      runId: 'run-1', entryId: 'agent', invocationId: 'inv-1', selector: 'octo-org/service',
+    });
+    expect(outcome).toEqual({ admitted: false, reason: CANONICAL_DENIAL_REASON });
+  });
+
   it('returns the same canonical denial for malformed, out-of-policy, and expired selectors', async () => {
     const live = registry();
     const malformed = await live.admit({

--- a/src/enclave/dynamic-registry.ts
+++ b/src/enclave/dynamic-registry.ts
@@ -11,14 +11,11 @@
  * repository)`, and a single non-disclosing canonical denial whose wall-clock
  * cost is normalized to a fixed bucket.
  *
- * It deliberately does **not** perform the mcpg control-channel delegation
- * calls ADR 0001 describes. No released compiler starts mcpg's
- * `github-repository-delegation-v1` controller or hands AWF its control
- * endpoint, so `validateEnclavesConfig` refuses any run that declares
- * `enclaves[].dynamic` (see `DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON` in
- * `./preflight`). This registry is the admission half of that contract, kept
- * complete and tested so the control-plane client is the only remaining work
- * once the endpoint handoff lands upstream.
+ * It is the admission half of the contract only. Minting, confirming, and
+ * revoking the delegated mcpg identity for an admitted repository lives in
+ * `./delegation-control-client`, and `./dynamic-delegation-service` composes
+ * the two: admission first, identity second, so no repository content is ever
+ * exposed before the envelope has admitted the selector.
  */
 
 import * as crypto from 'crypto';
@@ -32,59 +29,21 @@ import type { EnclaveInformationBudgetLedger } from './information-budget';
 /** Single non-disclosing outcome returned for every admission failure. */
 export const CANONICAL_DENIAL_REASON = 'enclave dynamic repository admission denied';
 
-/**
- * AWF-only mcpg delegation-control capability, minted by the compiler during
- * startup for create/confirm/revoke calls on the private mcpg control
- * channel. This value must never be mounted into the primary or enclave
- * agent; {@link takeEnclaveDynamicDelegationCapability} removes it from the
- * given environment once read.
- */
-export const ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV =
-  'AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY';
-export const ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV =
-  'AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT';
-
-/** Validates the compiler-to-AWF private control listener handoff. */
-export function isValidEnclaveDynamicDelegationControlEndpoint(
-  value: string | undefined,
-): value is string {
-  if (typeof value !== 'string' || value.length === 0) return false;
-  let endpoint: URL;
-  try {
-    endpoint = new URL(value);
-  } catch {
-    return false;
-  }
-  return endpoint.protocol === 'http:'
-    && ['localhost', '127.0.0.1', '[::1]'].includes(endpoint.hostname)
-    && !endpoint.username
-    && !endpoint.password
-    && !endpoint.search
-    && !endpoint.hash
-    && endpoint.port !== '';
-}
-
-/**
- * Reads and deletes the delegation-control capability from `env` so it can
- * never leak into an inherited environment after this call. Returns
- * `undefined` if absent.
- */
-export function takeEnclaveDynamicDelegationCapability(env: NodeJS.ProcessEnv): string | undefined {
-  const value = env[ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV];
-  delete env[ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY_ENV];
-  return value;
-}
-
-/** Whether a value is a well-formed run-scoped 256-bit lowercase hex capability. */
-export function isValidEnclaveDynamicDelegationCapability(value: string | undefined): value is string {
-  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
-}
-
 export type DynamicAdmissionOutcome =
   | {
     admitted: true;
     repo: string;
-    defaultBranchSha: string;
+    /**
+     * Admitted default-branch SHA, when AWF resolved one through an
+     * already-authorized, repository-confined path *before* content exposure.
+     *
+     * ADR 0001 makes this optional and matches mcpg's optional
+     * `admitted_default_branch_sha`. When it is absent every repository read
+     * for the invocation is audited as a live read rather than a
+     * snapshot-consistent one; AWF never fabricates a SHA and never widens a
+     * token or tool in order to obtain one.
+     */
+    defaultBranchSha?: string;
     /**
      * Opaque handle for {@link DynamicRepositoryRegistry.commitUsage}. Equal
      * to the idempotency key, so a retried admission settles the same charge.
@@ -116,8 +75,16 @@ export interface DynamicQuotaUsage {
   executionSeconds: { debited: number; reserved: number; limit: number };
 }
 
-/** Resolves the admitted repository's default-branch SHA. Injectable for tests. */
-export type DefaultBranchResolver = (repo: string) => Promise<string> | string;
+/**
+ * Resolves the admitted repository's default-branch SHA. Injectable for tests.
+ *
+ * Returning `undefined` means "AWF has no already-authorized, repository-
+ * confined way to resolve it", which is admitted as a live read rather than
+ * denied. Returning an empty string, a non-string, or throwing is a resolution
+ * *failure* and denies the admission.
+ */
+export type DefaultBranchResolver = (repo: string) =>
+  Promise<string | undefined> | string | undefined;
 
 /**
  * Injectable elapsed-time source used only for admission timing normalization,
@@ -479,7 +446,8 @@ export class DynamicRepositoryRegistry {
     if (!reservation) return this.normalizeTiming(startedMs, this.deny());
     try {
       const defaultBranchSha = await this.resolveDefaultBranchSha(request.selector);
-      if (typeof defaultBranchSha !== 'string' || defaultBranchSha.length === 0) {
+      if (defaultBranchSha !== undefined
+          && (typeof defaultBranchSha !== 'string' || defaultBranchSha.length === 0)) {
         this.rollback(reservation);
         return this.normalizeTiming(startedMs, this.deny());
       }
@@ -487,7 +455,7 @@ export class DynamicRepositoryRegistry {
       return this.normalizeTiming(startedMs, {
         admitted: true,
         repo: request.selector,
-        defaultBranchSha,
+        ...(defaultBranchSha === undefined ? {} : { defaultBranchSha }),
         usageHandle: reservation.key,
       });
     } catch {

--- a/src/enclave/github-gateway.ts
+++ b/src/enclave/github-gateway.ts
@@ -39,7 +39,17 @@ class GithubGatewayReadinessError extends Error {
 }
 
 interface EnclaveGithubGatewayContract {
-  agentId: string;
+  /**
+   * Compiler-issued static identity for the `issues-read-v1` profile.
+   *
+   * Dynamic entries have no static identity: gh-aw mints
+   * `AWF_ENCLAVE_GITHUB_MCP_AGENT_ID` only for the static profile, and a
+   * dynamic executor authenticates with a per-invocation delegated bearer
+   * instead. It is therefore absent in `dynamic` mode.
+   */
+  agentId?: string;
+  /** Which enclave GitHub route this run needs from the shared gateway. */
+  mode: 'static' | 'dynamic';
   containerName: string;
   endpoint: URL;
   identity: string;
@@ -54,10 +64,28 @@ interface JsonRpcResponse {
   error?: unknown;
 }
 
+/**
+ * Whether this run needs the shared gateway's enclave GitHub route.
+ *
+ * Two independent shapes need it: the static `issues-read-v1` profile, and a
+ * dynamic entry whose per-invocation delegated identities reach the same
+ * `github` backend (gh-aw keeps that backend registered for exactly this
+ * reason, while withholding it from the primary agent).
+ */
 function isEnclaveGithubEnabled(config: WrapperConfig): boolean {
+  return isEnclaveStaticGithubEnabled(config) || isEnclaveDynamicGithubEnabled(config);
+}
+
+function isEnclaveStaticGithubEnabled(config: WrapperConfig): boolean {
   return config.enclaves?.enabled === true
     && config.enclaves.executors.agent.enabled
     && resolveEnclaveAgentGithubAllowedTools(config.enclaves.executors.agent) !== undefined;
+}
+
+function isEnclaveDynamicGithubEnabled(config: WrapperConfig): boolean {
+  return config.enclaves?.enabled === true
+    && config.enclaves.executors.agent.enabled
+    && config.enclaves.executors.agent.dynamic !== undefined;
 }
 
 function requiredIdentity(name: string, value: string | undefined): string {
@@ -114,15 +142,26 @@ export function resolveEnclaveGithubGatewayContract(
   if (!isEnclaveGithubEnabled(config)) {
     throw new Error('Enclave GitHub gateway contract requested while issues-read-v1 is disabled');
   }
-  const allowedTools = resolveEnclaveAgentGithubAllowedTools(config.enclaves?.executors.agent);
+  const dynamic = config.enclaves?.executors.agent.dynamic;
+  const staticTools = resolveEnclaveAgentGithubAllowedTools(config.enclaves?.executors.agent);
+  const allowedTools = staticTools ?? dynamic?.githubPolicy.tools;
   if (!allowedTools || allowedTools.length === 0) {
     throw new Error('Enclave GitHub gateway contract requires a non-empty configured tool allowlist');
   }
+  const mode: 'static' | 'dynamic' = staticTools ? 'static' : 'dynamic';
   return {
-    agentId: requiredIdentity(
-      ENCLAVE_GITHUB_MCP_AGENT_ID_ENV,
-      resolveGithubAgentId(config, env),
-    ),
+    // A dynamic-only entry has no compiler-issued static identity; the
+    // executor authenticates per invocation with a delegated bearer that AWF
+    // mints through the private control channel.
+    ...(mode === 'static'
+      ? {
+        agentId: requiredIdentity(
+          ENCLAVE_GITHUB_MCP_AGENT_ID_ENV,
+          resolveGithubAgentId(config, env),
+        ),
+      }
+      : {}),
+    mode,
     containerName: requiredIdentity(
       ENCLAVE_MCP_GATEWAY_CONTAINER_ENV,
       env[ENCLAVE_MCP_GATEWAY_CONTAINER_ENV],
@@ -376,7 +415,16 @@ async function proveGithubGatewayReadiness(
   };
   await assertAgentNetworkMembership(contract);
   await assertSharedGatewayAttachment(contract);
-  const initialized = await postJsonRpc(contract.endpoint, contract.agentId, {
+  if (contract.mode === 'dynamic' || contract.agentId === undefined) {
+    // A dynamic entry has no static identity to authenticate a readiness
+    // session with: every identity is minted per invocation through the
+    // private control channel, after the primary agent has already started.
+    // Topology and attachment are still proven exactly as for the static
+    // profile; tool exposure is enforced by the delegated identity itself.
+    return;
+  }
+  const agentId = contract.agentId;
+  const initialized = await postJsonRpc(contract.endpoint, agentId, {
     jsonrpc: '2.0',
     id: 1,
     method: 'initialize',
@@ -393,11 +441,16 @@ async function proveGithubGatewayReadiness(
   ) {
     throw new Error('Shared MCP gateway rejected the enclave identity');
   }
-  await postJsonRpc(contract.endpoint, contract.agentId, {
+  await postJsonRpc(contract.endpoint, agentId, {
     jsonrpc: '2.0',
     method: 'notifications/initialized',
   }, initialized.sessionId, requestBudget());
-  const tools = await listAllGithubGatewayTools(contract, initialized.sessionId, requestBudget);
+  const tools = await listAllGithubGatewayTools(
+    contract,
+    agentId,
+    initialized.sessionId,
+    requestBudget,
+  );
   if (JSON.stringify(tools) !== JSON.stringify(contract.allowedTools)) {
     throw new Error('Shared MCP gateway did not expose exactly the configured allowed tools');
   }
@@ -414,6 +467,7 @@ const MAX_TOOLS_LIST_PAGES = 20;
  */
 async function listAllGithubGatewayTools(
   contract: EnclaveGithubGatewayContract,
+  agentId: string,
   sessionId: string,
   requestBudget: () => number,
 ): Promise<string[]> {
@@ -423,7 +477,7 @@ async function listAllGithubGatewayTools(
     if (page >= MAX_TOOLS_LIST_PAGES) {
       throw new Error('Shared MCP gateway returned too many tools/list pages');
     }
-    const listed = await postJsonRpc(contract.endpoint, contract.agentId, {
+    const listed = await postJsonRpc(contract.endpoint, agentId, {
       jsonrpc: '2.0',
       id: 2,
       method: 'tools/list',

--- a/src/enclave/manager.test.ts
+++ b/src/enclave/manager.test.ts
@@ -13,7 +13,7 @@ import {
 } from './manager';
 import { releaseSeedPermissions, type GitRunner } from './staging';
 import { resolveEnclavePaths } from './paths';
-import { DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON } from './preflight';
+
 import { typedDynamicEnclavePolicyFixture } from './dynamic-policy.test-utils';
 import * as runtimePreflight from './runtime-preflight';
 
@@ -325,7 +325,7 @@ describe('prepareEnclaves fail-closed preflight', () => {
       }),
       assertPrimaryAvailable: jest.fn(),
       assertAgentRuntimeAvailable: jest.fn(),
-    })).rejects.toThrow(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
+    })).rejects.toThrow(/AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT/);
     // Refused before any staging: nothing is written and no runtime is probed.
     expect(fs.existsSync(resolveEnclavePaths(workDir).seedMapPath)).toBe(false);
   });
@@ -342,6 +342,62 @@ describe('prepareEnclaves fail-closed preflight', () => {
     })).rejects.toThrow(/Enclave configuration is invalid/);
     expect(env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY).toBeUndefined();
     expect(env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT).toBeUndefined();
+  });
+
+  const DELEGATION_ENDPOINT =
+    'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1';
+
+  it('stages a dynamic-only run with no token, clone, seed catalog, or seed mount', async () => {
+    const env = enclaveEnv({
+      GH_TOKEN: undefined,
+      GITHUB_TOKEN: undefined,
+      AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY: 'e'.repeat(64),
+      AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT: DELEGATION_ENDPOINT,
+    });
+    const clone = jest.fn(gitRunner);
+    await prepareEnclaves(dynamicOnlyConfig(workDir), {
+      env,
+      gitRunner: clone,
+      assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
+      assertAgentRuntimeAvailable: jest.fn().mockResolvedValue(undefined),
+    });
+    const paths = resolveEnclavePaths(workDir);
+    expect(clone).not.toHaveBeenCalled();
+    expect(fs.existsSync(paths.seedMapPath)).toBe(false);
+    expect(fs.readdirSync(paths.seedsDir)).toEqual([]);
+    expect(fs.readFileSync(paths.runIdPath, 'utf8').trim()).toMatch(/^[0-9a-f]{32}$/);
+    expect(env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY).toBeUndefined();
+    expect(env.AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT).toBeUndefined();
+  });
+
+  it('takes private custody of the delegation handoff with exclusive 0600 files', async () => {
+    await prepareEnclaves(dynamicOnlyConfig(workDir), {
+      env: enclaveEnv({
+        GH_TOKEN: undefined,
+        AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY: 'e'.repeat(64),
+        AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT: DELEGATION_ENDPOINT,
+      }),
+      assertPrimaryAvailable: jest.fn().mockResolvedValue(undefined),
+      assertAgentRuntimeAvailable: jest.fn().mockResolvedValue(undefined),
+    });
+    const paths = resolveEnclavePaths(workDir);
+    expect(fs.readFileSync(paths.delegationCapabilityPath, 'utf8').trim()).toBe('e'.repeat(64));
+    expect(fs.readFileSync(paths.delegationEndpointPath, 'utf8').trim()).toBe(DELEGATION_ENDPOINT);
+    for (const target of [paths.delegationCapabilityPath, paths.delegationEndpointPath]) {
+      expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    }
+    expect(fs.statSync(paths.delegationChannelDir).mode & 0o777).toBe(0o700);
+  });
+
+  it('still requires a staging credential when a static catalog is declared', async () => {
+    await expect(prepareEnclaves(agentConfig(workDir, [{
+      agent: { model: 'gpt-test' },
+      repos: [repository],
+    }]), {
+      env: enclaveEnv({ GH_TOKEN: undefined }),
+      assertPrimaryAvailable: jest.fn(),
+      assertAgentRuntimeAvailable: jest.fn(),
+    })).rejects.toThrow(/staging credential in GH_TOKEN or GITHUB_TOKEN/);
   });
 
   it('strips the delegation-control capability even on a static-only run', async () => {

--- a/src/enclave/manager.ts
+++ b/src/enclave/manager.ts
@@ -139,7 +139,10 @@ export async function prepareEnclaves(
     takeEnclaveDynamicDelegationHandoff(env),
   );
   const dynamicDeclared = isEnclaveDynamicPolicyDeclared(config);
-  const errors = validateEnclavesConfig(config, dynamicDeclared ? delegationHandoff : undefined);
+  const errors = validateEnclavesConfig(config, {
+    delegationHandoff,
+    requireDelegationHandoff: dynamicDeclared,
+  });
   try {
     const gateway = resolveEnclaveGatewayContract(config, env);
     if (!config.networkIsolation) {

--- a/src/enclave/manager.ts
+++ b/src/enclave/manager.ts
@@ -34,9 +34,10 @@ import {
   resolveEnclaveGithubGatewayContract,
 } from './github-gateway';
 import {
-  ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV,
-  takeEnclaveDynamicDelegationCapability,
-} from './dynamic-registry';
+  resolveEnclaveDynamicDelegationHandoff,
+  stageEnclaveDynamicDelegationHandoff,
+  takeEnclaveDynamicDelegationHandoff,
+} from './dynamic-delegation-handoff';
 
 export const ENCLAVE_RUN_LABEL = 'awf.enclave.run';
 export function isEnclaveScriptEnabled(config: WrapperConfig): boolean {
@@ -49,6 +50,23 @@ export function isEnclaveAgentEnabled(config: WrapperConfig): boolean {
 
 export function isEnclavesEnabled(config: WrapperConfig): boolean {
   return config.enclaves?.enabled === true;
+}
+
+/** Whether this run's agent entry declares a dynamic repository policy. */
+export function isEnclaveDynamicPolicyDeclared(config: WrapperConfig): boolean {
+  return isEnclaveAgentEnabled(config) && config.enclaves?.executors.agent.dynamic !== undefined;
+}
+
+/**
+ * Whether this run stages immutable seeds at all.
+ *
+ * A dynamic-only entry reads live GitHub through a per-invocation delegated
+ * identity, so it needs no staging credential, no clone, no seed catalog, and
+ * no `/awf/seed` mount. Mixed runs (a static entry beside a separate dynamic
+ * entry) still stage the static catalog.
+ */
+export function isEnclaveSeedStagingRequired(config: WrapperConfig): boolean {
+  return isEnclavesEnabled(config) && (config.enclaves?.privateRepos.length ?? 0) > 0;
 }
 
 export function isEnclaveGithubEnabled(config: WrapperConfig): boolean {
@@ -114,7 +132,14 @@ export async function prepareEnclaves(
   if (!isEnclavesEnabled(config)) return;
   const enclaves = config.enclaves!;
   const env = deps.env ?? process.env;
-  const errors = validateEnclavesConfig(config);
+  // Take custody of the compiler's AWF-only delegation handoff before anything
+  // else can inherit this environment, on every run — including static-only
+  // runs, where the values must simply be discarded.
+  const delegationHandoff = resolveEnclaveDynamicDelegationHandoff(
+    takeEnclaveDynamicDelegationHandoff(env),
+  );
+  const dynamicDeclared = isEnclaveDynamicPolicyDeclared(config);
+  const errors = validateEnclavesConfig(config, dynamicDeclared ? delegationHandoff : undefined);
   try {
     const gateway = resolveEnclaveGatewayContract(config, env);
     if (!config.networkIsolation) {
@@ -144,13 +169,10 @@ export async function prepareEnclaves(
     );
   }
   const token = resolveStagingToken(env);
-  if (!token) {
+  const seedStagingRequired = isEnclaveSeedStagingRequired(config);
+  if (seedStagingRequired && !token) {
     errors.push('enclaves require a staging credential in GH_TOKEN or GITHUB_TOKEN on the AWF host');
   }
-  // Dynamic delegation is unsupported, but discard a compiler handoff before
-  // any child environment can be assembled.
-  takeEnclaveDynamicDelegationCapability(env);
-  delete env[ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT_ENV];
   const githubAgentId = env[ENCLAVE_GITHUB_MCP_AGENT_ID_ENV] ?? '';
   if (isEnclaveGithubEnabled(config)) {
     if (!/^[A-Za-z0-9_-]{32,128}$/.test(githubAgentId)) {
@@ -158,6 +180,8 @@ export async function prepareEnclaves(
         `${ENCLAVE_GITHUB_MCP_AGENT_ID_ENV} must contain the compiler-issued enclave gateway identity`,
       );
     }
+  }
+  if (isEnclaveGithubEnabled(config) || dynamicDeclared) {
     try {
       resolveEnclaveGithubGatewayContract(config, env);
     } catch (error) {
@@ -169,7 +193,7 @@ export async function prepareEnclaves(
   if (errors.length > 0) {
     throw new Error(`Enclave configuration is invalid:\n  - ${errors.join('\n  - ')}`);
   }
-  if (!token) {
+  if (seedStagingRequired && !token) {
     throw new Error('Enclave staging credential disappeared during preflight');
   }
 
@@ -198,33 +222,58 @@ export async function prepareEnclaves(
   prepareDirectories(paths);
 
   const runId = generateEnclaveRunId();
-  const staging = await stageEnclaveSeeds({
-    repos: enclaves.privateRepos,
-    paths,
-    runId,
-    token,
-    gitRunner: deps.gitRunner,
-    label: 'Enclaves',
-  });
-  const seedMap: PrivateRepositorySeedMap = {
-    version: PRIVATE_REPOSITORY_SEED_MAP_VERSION,
-    runId: staging.runId,
-    seeds: staging.seeds.map((seed) => ({
-      repo: seed.repoKey,
-      seedId: seed.seedId,
-      sensitivity: seed.sensitivity,
-    })),
-  };
-  writeExclusive(paths.seedMapPath, serializePrivateRepositorySeedMap(seedMap), 0o600);
+  writeExclusive(paths.runIdPath, `${runId}\n`, 0o600);
+  if (seedStagingRequired) {
+    const staging = await stageEnclaveSeeds({
+      repos: enclaves.privateRepos,
+      paths,
+      runId,
+      token: token!,
+      gitRunner: deps.gitRunner,
+      label: 'Enclaves',
+    });
+    const seedMap: PrivateRepositorySeedMap = {
+      version: PRIVATE_REPOSITORY_SEED_MAP_VERSION,
+      runId: staging.runId,
+      seeds: staging.seeds.map((seed) => ({
+        repo: seed.repoKey,
+        seedId: seed.seedId,
+        sensitivity: seed.sensitivity,
+      })),
+    };
+    writeExclusive(paths.seedMapPath, serializePrivateRepositorySeedMap(seedMap), 0o600);
+    logger.info(`Enclaves: staged ${staging.seeds.length} immutable seed(s); staging credential discarded.`);
+  } else {
+    // Dynamic-only: no clone, no seed catalog, not even an empty one. The
+    // broker mounts neither /awf/seed nor a seed map, and never sees a job
+    // token.
+    logger.info('Enclaves: dynamic-only entry; no repository seed is cloned, staged, or mounted.');
+  }
   writeExclusive(paths.capabilityPath, `${env[ENCLAVE_MCP_CAPABILITY_ENV]}\n`, 0o600);
   if (isEnclaveGithubEnabled(config)) {
     writeExclusive(paths.githubAgentIdPath, `${githubAgentId}\n`, 0o600);
     if (env === process.env) delete process.env[ENCLAVE_GITHUB_MCP_AGENT_ID_ENV];
   }
-  logger.info(`Enclaves: staged ${staging.seeds.length} immutable seed(s); staging credential discarded.`);
+  if (dynamicDeclared && delegationHandoff.handoff) {
+    // AWF-private custody: exclusive 0600 files inside the 0700 private root,
+    // never bind-mounted into the broker, the executor, the model sidecar, the
+    // general MCP route, or the delegated data plane.
+    stageEnclaveDynamicDelegationHandoff(paths, delegationHandoff.handoff);
+    ensureDirectory(paths.delegationChannelDir, 0o700);
+    logger.info(
+      'Enclaves: took private custody of the mcpg delegation-control handoff for dynamic '
+      + 'repository admission.',
+    );
+  }
 }
 
 function readRunId(paths: EnclavePaths): string | undefined {
+  try {
+    const raw = fs.readFileSync(paths.runIdPath, 'ascii').trim();
+    if (/^[0-9a-f]{16,64}$/.test(raw)) return raw;
+  } catch {
+    // Fall through to the seed map, which older runs wrote instead.
+  }
   try {
     const parsed = JSON.parse(fs.readFileSync(paths.seedMapPath, 'utf8')) as PrivateRepositorySeedMap;
     return typeof parsed.runId === 'string' && parsed.runId.length > 0 ? parsed.runId : undefined;

--- a/src/enclave/paths.ts
+++ b/src/enclave/paths.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as path from 'path';
 
 export interface EnclavePaths {
@@ -14,6 +15,34 @@ export interface EnclavePaths {
   runDir: string;
   capabilityPath: string;
   githubAgentIdPath: string;
+  /**
+   * AWF-private, never-mounted custody file for the mcpg delegation-control
+   * endpoint. Only the AWF host process can reach that endpoint, so this path
+   * is deliberately outside every container bind mount.
+   */
+  delegationEndpointPath: string;
+  /** AWF-private, never-mounted custody file for the control capability. */
+  delegationCapabilityPath: string;
+  /**
+   * Host-only structured audit stream for delegation admission, identity
+   * lifecycle, usage settlement, revocation, and reconciliation. It lives
+   * outside every bind mount so a compromised broker cannot read it.
+   */
+  delegationAuditPath: string;
+  /**
+   * Private request/response directory shared with the enclave MCP broker so
+   * it can route a dynamic `enclave_run_agent` through host-side admission.
+   * It carries admission requests, canonical outcomes, and settlement
+   * receipts — never the control endpoint, the control capability, an identity
+   * handle, the envelope, or repository content.
+   */
+  delegationChannelDir: string;
+  /**
+   * AWF-private record of this run's enclave run id, so teardown can reconcile
+   * orphaned containers without a seed catalog. Dynamic-only runs stage no
+   * seed map at all.
+   */
+  runIdPath: string;
 }
 
 export const ENCLAVE_PRIVATE_BASE_DIR = '/var/tmp';
@@ -28,10 +57,15 @@ export const ENCLAVE_SERVER_CAPABILITY_PATH = `${ENCLAVE_SERVER_CAPABILITY_DIR}/
 export const ENCLAVE_SERVER_GITHUB_AGENT_ID_PATH =
   `${ENCLAVE_SERVER_CAPABILITY_DIR}/${ENCLAVE_GITHUB_AGENT_ID_FILENAME}`;
 export const ENCLAVE_SERVER_CONTROL_DIR = '/run/awf-enclave-mcp-control';
-export const ENCLAVE_SERVER_DYNAMIC_DELEGATION_ENDPOINT_PATH =
-  `${ENCLAVE_SERVER_CONTROL_DIR}/delegation-endpoint`;
-export const ENCLAVE_SERVER_DYNAMIC_DELEGATION_CAPABILITY_PATH =
-  `${ENCLAVE_SERVER_CONTROL_DIR}/delegation-capability`;
+/**
+ * Broker-side mount point of {@link EnclavePaths.delegationChannelDir}.
+ *
+ * The broker writes admission requests and settlement receipts here and reads
+ * AWF's canonical outcomes back. It is intentionally *not* the control
+ * endpoint: mcpg's control listener is published on the runner's own
+ * `127.0.0.1` only, so no container can reach it.
+ */
+export const ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR = '/run/awf-enclave-delegation';
 export const ENCLAVE_SERVER_AUDIT_DIR = '/var/log/awf-enclave';
 export const ENCLAVE_SERVER_DOCKER_SOCKET_PATH = '/var/run/docker.sock';
 
@@ -61,11 +95,31 @@ export function resolveEnclavePaths(
     runDir,
     capabilityPath: path.join(runDir, ENCLAVE_CAPABILITY_FILENAME),
     githubAgentIdPath: path.join(runDir, ENCLAVE_GITHUB_AGENT_ID_FILENAME),
+    delegationEndpointPath: path.join(root, 'delegation-endpoint'),
+    delegationCapabilityPath: path.join(root, 'delegation-capability'),
+    delegationAuditPath: path.join(root, 'delegation-audit.jsonl'),
+    runIdPath: path.join(root, 'run-id'),
+    delegationChannelDir: path.join(root, 'delegation-channel'),
   };
 }
 
 export function generateEnclaveRunId(): string {
   return crypto.randomBytes(16).toString('hex');
+}
+
+/**
+ * Reads the AWF-private enclave run id staged by `prepareEnclaves`.
+ *
+ * A dynamic-only run has no seed catalog to carry the id, so it is written to
+ * its own `0600` file inside the private root.
+ */
+export function readEnclaveRunId(paths: EnclavePaths): string | undefined {
+  try {
+    const raw = fs.readFileSync(paths.runIdPath, 'ascii').trim();
+    return /^[0-9a-f]{16,64}$/.test(raw) ? raw : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function deriveEnclaveSeedId(runId: string, repo: string): string {

--- a/src/enclave/preflight.test.ts
+++ b/src/enclave/preflight.test.ts
@@ -488,10 +488,13 @@ describe('validateEnclavesConfig dynamic policy', () => {
   it('refuses a dynamic entry when the handoff is present but malformed', () => {
     const errors = validateEnclavesConfig(
       dynamicConfig(),
-      resolveEnclaveDynamicDelegationHandoff({
-        endpoint: 'http://localhost:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
-        capability: 'a'.repeat(64),
-      }),
+      {
+        delegationHandoff: resolveEnclaveDynamicDelegationHandoff({
+          endpoint:
+            'http://localhost:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+          capability: 'a'.repeat(64),
+        }),
+      },
     );
     expect(errors.join('\n')).toMatch(/must be the loopback-only mcpg control endpoint/);
     expect(errors).not.toContain(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
@@ -500,10 +503,13 @@ describe('validateEnclavesConfig dynamic policy', () => {
   it('accepts a dynamic entry once the compiler handoff is valid', () => {
     const errors = validateEnclavesConfig(
       dynamicConfig(),
-      resolveEnclaveDynamicDelegationHandoff({
-        endpoint: 'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
-        capability: 'a'.repeat(64),
-      }),
+      {
+        delegationHandoff: resolveEnclaveDynamicDelegationHandoff({
+          endpoint:
+            'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+          capability: 'a'.repeat(64),
+        }),
+      },
     );
     expect(errors).toEqual([]);
   });

--- a/src/enclave/preflight.test.ts
+++ b/src/enclave/preflight.test.ts
@@ -8,6 +8,7 @@ import {
   GH_AW_DYNAMIC_ENCLAVE_POLICY_FIXTURE,
   dynamicEnclavePolicyFixture,
 } from './dynamic-policy.test-utils';
+import { resolveEnclaveDynamicDelegationHandoff } from './dynamic-delegation-handoff';
 
 function config(overrides: Partial<WrapperConfig> = {}): WrapperConfig {
   return {
@@ -484,9 +485,27 @@ describe('validateEnclavesConfig dynamic policy', () => {
       .toMatch(/never falls back to a static seed catalog/);
   });
 
-  it('refuses a dynamic entry even when a compiler handoff is supplied', () => {
-    const errors = validateEnclavesConfig(dynamicConfig());
-    expect(errors).toContain(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
+  it('refuses a dynamic entry when the handoff is present but malformed', () => {
+    const errors = validateEnclavesConfig(
+      dynamicConfig(),
+      resolveEnclaveDynamicDelegationHandoff({
+        endpoint: 'http://localhost:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+        capability: 'a'.repeat(64),
+      }),
+    );
+    expect(errors.join('\n')).toMatch(/must be the loopback-only mcpg control endpoint/);
+    expect(errors).not.toContain(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
+  });
+
+  it('accepts a dynamic entry once the compiler handoff is valid', () => {
+    const errors = validateEnclavesConfig(
+      dynamicConfig(),
+      resolveEnclaveDynamicDelegationHandoff({
+        endpoint: 'http://127.0.0.1:8090/internal/awf-enclave-mcp-control/github-repository-delegation-v1',
+        capability: 'a'.repeat(64),
+      }),
+    );
+    expect(errors).toEqual([]);
   });
 
   it('rejects an unsupported sensitivity', () => {

--- a/src/enclave/preflight.ts
+++ b/src/enclave/preflight.ts
@@ -22,6 +22,7 @@ import {
   PRIVATE_REPOSITORY_PATTERN,
 } from '../bounded-execution';
 import { ENCLAVE_AGENT_MAX_TASK_BYTES } from './protocol';
+import type { EnclaveDynamicDelegationHandoffResolution } from './dynamic-delegation-handoff';
 import { normalizePrivateRepositoryKey } from '../bounded-execution/repository-staging';
 import { findDockerSocketExposingMount } from './mount-policy';
 
@@ -42,26 +43,23 @@ const MAX_DYNAMIC_QUOTA_OUTPUT_BYTES = 1024 * 1024;
 const MAX_DYNAMIC_QUOTA_EXECUTION_SECONDS = 86_400;
 
 /**
- * Why a validated dynamic envelope still cannot run in this AWF release.
+ * Why a validated dynamic envelope may still be refused.
  *
- * ADR 0001 binds every dynamic invocation to a single-repository mcpg
- * identity minted through the `github-repository-delegation-v1` controller on
- * the private `awf-enclave-mcp-control` channel. The compiler mints and hands
- * AWF the control capability, but no released compiler starts that controller
- * or hands AWF a control endpoint, and a dynamic invocation has no immutable
- * seed to fall back to. Rather than start a run whose every enclave call would
- * fail with the canonical denial, AWF refuses the run and says exactly which
- * handoff is missing. AWF never falls back to a static seed catalog, a
- * job-lifetime identity, or a broader policy.
+ * ADR 0001 binds every dynamic invocation to a single-repository mcpg identity
+ * minted through the `github-repository-delegation-v1` controller. AWF only
+ * runs a dynamic entry when the compiler has actually started that controller
+ * and handed AWF both private values — a loopback-only control endpoint and
+ * the AWF-only control capability. Without them a dynamic invocation has no
+ * identity to mint and no immutable seed to fall back to, so AWF refuses the
+ * run and says exactly which handoff is missing. AWF never falls back to a
+ * static seed catalog, a job-lifetime identity, or a broader policy.
  */
 export const DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON =
-  'enclaves[].dynamic repository admission is not executable in this AWF release: ADR 0001 binds '
-  + 'every dynamic invocation to a single-repository mcpg identity created through the '
-  + '"github-repository-delegation-v1" control channel, and no released compiler starts that '
-  + 'controller or hands AWF its control endpoint. AWF validates the envelope and custodies the '
-  + 'delegation-control capability, but never falls back to a static seed catalog, a job-lifetime '
-  + 'identity, or a broader policy. Remove enclaves[].dynamic, or pin an AWF release that '
-  + 'implements the full delegation contract.';
+  'enclaves[].dynamic repository admission requires the compiler-issued mcpg delegation-control '
+  + 'handoff: ADR 0001 binds every dynamic invocation to a single-repository identity created '
+  + 'through the "github-repository-delegation-v1" control channel. AWF never falls back to a '
+  + 'static seed catalog, a job-lifetime identity, or a broader policy. Upgrade to a gh-aw '
+  + 'release that starts the delegation controller, or remove enclaves[].dynamic.';
 
 /** Engines with a published, audited enclave image and a fixed AWF model loop. */
 const IMPLEMENTED_AGENT_ENGINES = new Set(['copilot']);
@@ -125,9 +123,16 @@ function validateRepositoryList(enclaves: EnclavesConfig, errors: string[]): voi
   }
 }
 
-/** Static, fail-closed checks for the unified enclave foundation. */
+/**
+ * Static, fail-closed checks for the unified enclave foundation.
+ *
+ * `delegationHandoff` carries the already-validated mcpg delegation-control
+ * handoff when one was present in the compiler-supplied environment. It is
+ * required for, and only for, an entry that declares `enclaves[].dynamic`.
+ */
 export function validateEnclavesConfig(
   config: WrapperConfig,
+  delegationHandoff?: EnclaveDynamicDelegationHandoffResolution,
 ): string[] {
   const enclaves = config.enclaves;
   if (!enclaves?.enabled) return [];
@@ -198,7 +203,11 @@ export function validateEnclavesConfig(
       errors.push('enclaves[].agent requires either a non-empty "repos" list or a "dynamic" policy');
     } else if (agent.dynamic !== undefined) {
       validateEnclaveDynamicPolicy(agent.dynamic, errors);
-      errors.push(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
+      if (!delegationHandoff) {
+        errors.push(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
+      } else if (!delegationHandoff.handoff) {
+        errors.push(...delegationHandoff.errors);
+      }
     }
     if (!config.enableApiProxy) {
       errors.push('enclaves agent executor requires the AWF API proxy');

--- a/src/enclave/preflight.ts
+++ b/src/enclave/preflight.ts
@@ -126,13 +126,25 @@ function validateRepositoryList(enclaves: EnclavesConfig, errors: string[]): voi
 /**
  * Static, fail-closed checks for the unified enclave foundation.
  *
- * `delegationHandoff` carries the already-validated mcpg delegation-control
- * handoff when one was present in the compiler-supplied environment. It is
- * required for, and only for, an entry that declares `enclaves[].dynamic`.
+ * `options.delegationHandoff` carries the already-validated mcpg
+ * delegation-control handoff, which is required for — and only for — an entry
+ * that declares `enclaves[].dynamic`.
+ *
+ * `options.requireDelegationHandoff` exists because taking custody of that
+ * handoff *consumes* it: `takeEnclaveDynamicDelegationHandoff` deletes both
+ * environment variables so nothing can inherit them, so exactly one caller
+ * (`prepareEnclaves`) may read them. Early structural validation therefore
+ * passes `false` and defers the handoff check to that single custodian, which
+ * runs before any container exists.
  */
+export interface ValidateEnclavesOptions {
+  delegationHandoff?: EnclaveDynamicDelegationHandoffResolution;
+  requireDelegationHandoff?: boolean;
+}
+
 export function validateEnclavesConfig(
   config: WrapperConfig,
-  delegationHandoff?: EnclaveDynamicDelegationHandoffResolution,
+  options: ValidateEnclavesOptions = {},
 ): string[] {
   const enclaves = config.enclaves;
   if (!enclaves?.enabled) return [];
@@ -203,10 +215,13 @@ export function validateEnclavesConfig(
       errors.push('enclaves[].agent requires either a non-empty "repos" list or a "dynamic" policy');
     } else if (agent.dynamic !== undefined) {
       validateEnclaveDynamicPolicy(agent.dynamic, errors);
-      if (!delegationHandoff) {
-        errors.push(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
-      } else if (!delegationHandoff.handoff) {
-        errors.push(...delegationHandoff.errors);
+      const { delegationHandoff, requireDelegationHandoff = true } = options;
+      if (requireDelegationHandoff) {
+        if (!delegationHandoff) {
+          errors.push(DYNAMIC_ENCLAVE_EXECUTION_UNSUPPORTED_REASON);
+        } else if (!delegationHandoff.handoff) {
+          errors.push(...delegationHandoff.errors);
+        }
       }
     }
     if (!config.enableApiProxy) {

--- a/src/enclave/workflow-integration.test.ts
+++ b/src/enclave/workflow-integration.test.ts
@@ -1,6 +1,7 @@
 import { normalizeEnclavesConfig } from '../parsers/enclave-parser';
 import type { WrapperConfig } from '../types';
 import { runMainWorkflow } from '../cli-workflow';
+import { typedDynamicEnclavePolicyFixture } from './dynamic-policy.test-utils';
 
 jest.mock('../container-runtime', () => ({
   runtimeNeedsStaticDns: jest.fn().mockReturnValue(false),
@@ -28,6 +29,18 @@ function githubConfig(): WrapperConfig {
         github: { cli: 'issues-read-v1' },
       },
       repos: [{ repo: 'octo/private', sensitivity: 'internal' }],
+    }]),
+  } as WrapperConfig;
+}
+
+function dynamicConfig(): WrapperConfig {
+  return {
+    ...config(),
+    enableApiProxy: true,
+    copilotGithubToken: 'copilot-test-token',
+    enclaves: normalizeEnclavesConfig([{
+      agent: { model: 'trusted-model' },
+      dynamic: typedDynamicEnclavePolicyFixture() as never,
     }]),
   } as WrapperConfig;
 }
@@ -124,6 +137,76 @@ describe('unified enclave workflow integration', () => {
       logger: { info: jest.fn(), success: jest.fn(), warn: jest.fn() },
       performCleanup: jest.fn(),
     })).rejects.toThrow(/enclave GitHub gateway .* requires/);
+    expect(runAgentCommand).not.toHaveBeenCalled();
+  });
+
+  it('defers the dynamic handoff check to the single custodian in prepareEnclaves', async () => {
+    // The handoff can be read exactly once, so the early structural gate must
+    // not reject a dynamic entry before prepareEnclaves has taken custody.
+    const order: string[] = [];
+    await runMainWorkflow(dynamicConfig(), {
+      ensureFirewallNetwork: jest.fn(),
+      setupHostIptables: jest.fn(),
+      prepareEnclaves: jest.fn(async () => { order.push('prepareEnclaves'); }),
+      writeConfigs: jest.fn(async () => { order.push('writeConfigs'); }),
+      startContainers: jest.fn(async (
+        _workDir: string,
+        _domains: string[],
+        _logs?: string,
+        _skipPull?: boolean,
+        _networkReady?: () => Promise<void>,
+        infrastructureReady?: () => Promise<void>,
+      ) => {
+        order.push('startContainers');
+        await infrastructureReady?.();
+      }),
+      connectEnclaveGateway: jest.fn(),
+      connectEnclaveGithubGateway: jest.fn(async () => { order.push('github-connect'); }),
+      assertEnclaveGithubGatewayReady: jest.fn(),
+      assertEnclaveGatewayReady: jest.fn(),
+      startEnclaveDynamicDelegation: jest.fn(async () => { order.push('delegation'); }),
+      runAgentCommand: jest.fn(async () => {
+        order.push('agent');
+        return { exitCode: 0 };
+      }),
+    }, {
+      logger: { info: jest.fn(), success: jest.fn(), warn: jest.fn() },
+      performCleanup: jest.fn(),
+    });
+    expect(order).toEqual([
+      'prepareEnclaves',
+      'writeConfigs',
+      'startContainers',
+      'github-connect',
+      'delegation',
+      'agent',
+    ]);
+  });
+
+  it('fails before agent startup when the dynamic admission authority is absent', async () => {
+    const runAgentCommand = jest.fn();
+    await expect(runMainWorkflow(dynamicConfig(), {
+      ensureFirewallNetwork: jest.fn(),
+      setupHostIptables: jest.fn(),
+      prepareEnclaves: jest.fn(),
+      writeConfigs: jest.fn(),
+      startContainers: jest.fn(async (
+        _workDir: string,
+        _domains: string[],
+        _logs?: string,
+        _skipPull?: boolean,
+        _networkReady?: () => Promise<void>,
+        infrastructureReady?: () => Promise<void>,
+      ) => infrastructureReady?.()),
+      connectEnclaveGateway: jest.fn(),
+      connectEnclaveGithubGateway: jest.fn(),
+      assertEnclaveGithubGatewayReady: jest.fn(),
+      assertEnclaveGatewayReady: jest.fn(),
+      runAgentCommand,
+    }, {
+      logger: { info: jest.fn(), success: jest.fn(), warn: jest.fn() },
+      performCleanup: jest.fn(),
+    })).rejects.toThrow(/dynamic requires the AWF-private delegation admission authority/);
     expect(runAgentCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/services/enclave-dynamic-service.test.ts
+++ b/src/services/enclave-dynamic-service.test.ts
@@ -126,6 +126,21 @@ describe('dynamic enclave compose topology', () => {
     expect(environment.AWF_ENCLAVE_SEED_MAP_ENABLED).toBe('true');
     expect(environment.AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED).toBeUndefined();
   });
+
+  it('translates the admission channel for a split ARC/DinD filesystem', () => {
+    // The channel is a bind mount like the seeds, so the daemon must see it at
+    // the same prefixed path the runner wrote it to. If this ever diverged,
+    // the broker would poll an empty directory and every dynamic admission
+    // would time out into the canonical denial.
+    const volumes = build(dynamicConfig({ dockerHostPathPrefix: '/host' })).service
+      .volumes as string[];
+    expect(volumes).toContain(
+      `/host${paths.delegationChannelDir}:${ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR}:rw`,
+    );
+    // The work and audit mounts are translated the same way, so the channel
+    // carries no special-case risk relative to the paths that already work.
+    expect(volumes).toContain(`/host${paths.workDir}:/srv/awf/work:rw`);
+  });
 });
 
 describe('primary agent environment exclusion', () => {

--- a/src/services/enclave-dynamic-service.test.ts
+++ b/src/services/enclave-dynamic-service.test.ts
@@ -1,0 +1,137 @@
+import { normalizeEnclavesConfig } from '../parsers/enclave-parser';
+import { parseImageTag } from '../image-tag';
+import type { WrapperConfig } from '../types';
+import { buildEnclaveMcpService } from './enclave-mcp-service';
+import { buildExclusionSet } from './agent-environment/excluded-vars';
+import { typedDynamicEnclavePolicyFixture } from '../enclave/dynamic-policy.test-utils';
+import {
+  ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR,
+  resolveEnclavePaths,
+} from '../enclave/paths';
+
+const ghcr = {
+  useGHCR: true,
+  registry: 'ghcr.io/github/gh-aw-firewall',
+  parsedTag: parseImageTag('v1'),
+  projectRoot: '/repo',
+};
+
+const networkConfig = {
+  subnet: '172.30.0.0/24',
+  squidIp: '172.30.0.10',
+  agentIp: '172.30.0.20',
+  proxyIp: '172.30.0.30',
+};
+
+const WORK_DIR = '/tmp/awf-dynamic-compose';
+
+function dynamicConfig(overrides: Partial<WrapperConfig> = {}): WrapperConfig {
+  return {
+    workDir: WORK_DIR,
+    agentCommand: 'echo enclave',
+    imageRegistry: 'ghcr.io/github/gh-aw-firewall',
+    imageTag: 'latest',
+    enclaves: normalizeEnclavesConfig([
+      {
+        agent: { model: 'trusted-model' },
+        dynamic: typedDynamicEnclavePolicyFixture() as never,
+      },
+    ]),
+    enableApiProxy: true,
+    copilotGithubToken: 'copilot-token',
+    ...overrides,
+  } as WrapperConfig;
+}
+
+function staticConfig(): WrapperConfig {
+  return {
+    workDir: WORK_DIR,
+    agentCommand: 'echo enclave',
+    imageRegistry: 'ghcr.io/github/gh-aw-firewall',
+    imageTag: 'latest',
+    enclaves: normalizeEnclavesConfig([
+      { agent: { model: 'trusted-model' }, repos: [{ repo: 'octo/private', sensitivity: 'internal' }] },
+    ]),
+    enableApiProxy: true,
+    copilotGithubToken: 'copilot-token',
+  } as WrapperConfig;
+}
+
+function build(config: WrapperConfig) {
+  const env = { ...process.env };
+  process.env.AWF_ENCLAVE_MCP_GATEWAY_CONTAINER = 'awmg-mcpg';
+  process.env.AWF_ENCLAVE_MCP_GATEWAY_ENDPOINT = 'http://127.0.0.1:8080/mcp/awf-enclave';
+  process.env.AWF_ENCLAVE_MCP_GATEWAY_IDENTITY = 'gh-aw-42-1-build';
+  try {
+    return buildEnclaveMcpService({ config, imageConfig: ghcr, networkConfig });
+  } finally {
+    process.env = env;
+  }
+}
+
+describe('dynamic enclave compose topology', () => {
+  const paths = resolveEnclavePaths(WORK_DIR);
+
+  it('mounts no repository seed and no seed catalog for a dynamic-only entry', () => {
+    const service = build(dynamicConfig()).service;
+    const volumes = service.volumes as string[];
+    expect(volumes.join('\n')).not.toContain(paths.seedsDir);
+    expect(volumes.join('\n')).not.toContain(paths.seedMapPath);
+    expect(volumes.join('\n')).not.toContain('/srv/awf/seeds');
+    expect(volumes.join('\n')).not.toContain('/srv/awf/seed-map.json');
+  });
+
+  it('mounts only the private admission channel for the broker', () => {
+    const volumes = build(dynamicConfig()).service.volumes as string[];
+    expect(volumes).toContain(
+      `${paths.delegationChannelDir}:${ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR}:rw`,
+    );
+  });
+
+  it('never mounts the AWF-private control endpoint or capability into the broker', () => {
+    const service = build(dynamicConfig()).service;
+    const rendered = JSON.stringify(service);
+    expect(rendered).not.toContain(paths.delegationEndpointPath);
+    expect(rendered).not.toContain(paths.delegationCapabilityPath);
+    expect(rendered).not.toContain(paths.delegationAuditPath);
+    expect(rendered).not.toContain('DELEGATION_CONTROL_ENDPOINT');
+    expect(rendered).not.toContain('DELEGATION_CONTROL_CAPABILITY');
+  });
+
+  it('tells the broker to admit dynamically without a seed catalog', () => {
+    const environment = build(dynamicConfig()).service.environment as Record<string, string>;
+    expect(environment).toMatchObject({
+      AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+      AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR: ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR,
+      AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY: 'confidential',
+      AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL: 'http://172.31.0.40:8080/mcp/github',
+      AWF_ENCLAVE_SEED_MAP_ENABLED: 'false',
+      AWF_ENCLAVE_AGENT_GITHUB_ENABLED: 'false',
+    });
+    expect(environment.AWF_ENCLAVE_AGENT_HOST_SEEDS_DIR).toBeUndefined();
+  });
+
+  it('attaches the shared gateway so delegated identities have a data plane', () => {
+    const environment = build(dynamicConfig()).service.environment as Record<string, string>;
+    expect(environment.AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER).toBe('awmg-mcpg');
+  });
+
+  it('keeps the static seed catalog and mounts unchanged', () => {
+    const service = build(staticConfig()).service;
+    const volumes = service.volumes as string[];
+    expect(volumes).toContain(`${paths.seedsDir}:/srv/awf/seeds:ro`);
+    expect(volumes).toContain(`${paths.seedMapPath}:/srv/awf/seed-map.json:ro`);
+    expect(volumes.join('\n')).not.toContain(ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR);
+    const environment = service.environment as Record<string, string>;
+    expect(environment.AWF_ENCLAVE_SEED_MAP_ENABLED).toBe('true');
+    expect(environment.AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED).toBeUndefined();
+  });
+});
+
+describe('primary agent environment exclusion', () => {
+  it('excludes both halves of the delegation handoff from the primary agent', () => {
+    const exclusions = buildExclusionSet(dynamicConfig());
+    expect(exclusions.has('AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_ENDPOINT')).toBe(true);
+    expect(exclusions.has('AWF_ENCLAVE_GITHUB_DELEGATION_CONTROL_CAPABILITY')).toBe(true);
+  });
+});

--- a/src/services/enclave-mcp-service.ts
+++ b/src/services/enclave-mcp-service.ts
@@ -6,10 +6,11 @@ import {
 import type { WrapperConfig } from '../types';
 import { API_PROXY_PORTS } from '../types/ports';
 import type { EnclaveAgentEngine, EnclaveAgentProfile } from '../types/enclave-options';
-import { isEnclaveAgentGithubToolsEnabled } from '../types/enclave-options';
+import { isEnclaveAgentGithubRouteEnabled, isEnclaveAgentGithubToolsEnabled } from '../types/enclave-options';
 import {
   ENCLAVE_SERVER_AUDIT_DIR,
   ENCLAVE_SERVER_CAPABILITY_PATH,
+  ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR,
   ENCLAVE_SERVER_GITHUB_AGENT_ID_PATH,
   ENCLAVE_SERVER_CONTROL_DIR,
   ENCLAVE_SERVER_DOCKER_SOCKET_PATH,
@@ -17,6 +18,7 @@ import {
   ENCLAVE_SERVER_SEEDS_DIR,
   ENCLAVE_SERVER_CAPABILITY_DIR,
   ENCLAVE_SERVER_WORK_DIR,
+  readEnclaveRunId,
   resolveEnclavePaths,
 } from '../enclave/paths';
 import {
@@ -255,6 +257,11 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
   const dockerSocketPath = resolveDockerSocketPath(config);
   const primaryBackend = resolvePrimaryRuntimeBackend(config.containerRuntime);
   const imageServiceHardening = { memLimit: '32m', pidsLimit: 16, cpuShares: 64 };
+  // A dynamic-only entry stages no repository seed at all: no clone, no seed
+  // catalog, no `/awf/seed` mount, and no staging credential anywhere in the
+  // topology.
+  const staticSeedsPresent = enclaves.privateRepos.length > 0;
+  const dynamic = agent?.enabled ? agent.dynamic : undefined;
 
   const environment: Record<string, string> = {
     AWF_ENCLAVE_PRIMARY_BACKEND: primaryBackend,
@@ -263,6 +270,8 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
     AWF_ENCLAVE_LISTEN_HOST: '0.0.0.0',
     AWF_ENCLAVE_SCRIPT_ENABLED: String(script?.enabled === true),
     AWF_ENCLAVE_AGENT_ENABLED: String(agent?.enabled === true),
+    AWF_ENCLAVE_SEED_MAP_ENABLED: String(staticSeedsPresent),
+    AWF_ENCLAVE_RUN_ID: readEnclaveRunId(paths) ?? '',
   };
   const dependsOn: Record<string, Record<string, string>> = {};
   const result: EnclaveMcpBuildResult = { service: {} };
@@ -297,7 +306,7 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
     }
     const { imageRef, source } = resolveAgentImage(imageConfig, agent.image);
     const githubEnabled = isEnclaveAgentGithubToolsEnabled(agent);
-    const githubGatewayContract = githubEnabled
+    const githubGatewayContract = isEnclaveAgentGithubRouteEnabled(agent)
       ? resolveEnclaveGithubGatewayContract(config)
       : undefined;
     result.agentImageService = {
@@ -343,6 +352,18 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
         AWF_ENCLAVE_AGENT_GITHUB_AGENT_ID_PATH: ENCLAVE_SERVER_GITHUB_AGENT_ID_PATH,
         AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER: githubGatewayContract?.containerName,
       }),
+      ...(dynamic !== undefined && {
+        // The broker advertises and dispatches only enclave_run_agent for a
+        // dynamic entry, and reaches AWF's host-side admission authority
+        // through the private channel below. It never receives the control
+        // endpoint, the control capability, an identity handle, the compiler
+        // envelope, mcpg's state path, or its policy generation.
+        AWF_ENCLAVE_AGENT_DYNAMIC_ENABLED: 'true',
+        AWF_ENCLAVE_AGENT_DYNAMIC_CHANNEL_DIR: ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR,
+        AWF_ENCLAVE_AGENT_DYNAMIC_SENSITIVITY: dynamic.sensitivity,
+        AWF_ENCLAVE_AGENT_DYNAMIC_GITHUB_MCP_URL: ENCLAVE_GITHUB_MCP_INTERNAL_URL,
+        AWF_ENCLAVE_AGENT_GITHUB_GATEWAY_CONTAINER: githubGatewayContract?.containerName,
+      }),
       ...(agent.maxModelRequests !== undefined && {
         AWF_ENCLAVE_AGENT_MAX_MODEL_REQUESTS: String(agent.maxModelRequests),
       }),
@@ -352,19 +373,33 @@ export function buildEnclaveMcpService(params: EnclaveMcpServiceParams): Enclave
       // Enclave bind-mount sources are handed to the daemon, not opened by the
       // server, so they must be daemon-visible paths.
       AWF_ENCLAVE_AGENT_HOST_WORK_DIR: toDaemonVisiblePath(paths.workDir, config.dockerHostPathPrefix),
-      AWF_ENCLAVE_AGENT_HOST_SEEDS_DIR: toDaemonVisiblePath(paths.seedsDir, config.dockerHostPathPrefix),
+      ...(staticSeedsPresent && {
+        AWF_ENCLAVE_AGENT_HOST_SEEDS_DIR: toDaemonVisiblePath(
+          paths.seedsDir,
+          config.dockerHostPathPrefix,
+        ),
+      }),
     });
   }
 
   const serverVolumes = [
-    `${paths.seedsDir}:${ENCLAVE_SERVER_SEEDS_DIR}:ro`,
     `${paths.workDir}:${ENCLAVE_SERVER_WORK_DIR}:rw`,
     `${paths.runDir}:${ENCLAVE_SERVER_CAPABILITY_DIR}:ro`,
     `${paths.controlDir}:${ENCLAVE_SERVER_CONTROL_DIR}:rw`,
     `${paths.auditDir}:${ENCLAVE_SERVER_AUDIT_DIR}:rw`,
-    `${paths.seedMapPath}:${ENCLAVE_SERVER_SEED_MAP_PATH}:ro`,
     `${dockerSocketPath}:${ENCLAVE_SERVER_DOCKER_SOCKET_PATH}:rw`,
   ];
+  if (staticSeedsPresent) {
+    serverVolumes.push(
+      `${paths.seedsDir}:${ENCLAVE_SERVER_SEEDS_DIR}:ro`,
+      `${paths.seedMapPath}:${ENCLAVE_SERVER_SEED_MAP_PATH}:ro`,
+    );
+  }
+  if (dynamic !== undefined) {
+    serverVolumes.push(
+      `${paths.delegationChannelDir}:${ENCLAVE_SERVER_DELEGATION_CHANNEL_DIR}:rw`,
+    );
+  }
   if (isEnclaveAgentGithubToolsEnabled(agent)) {
     serverVolumes.push(
       `${paths.githubAgentIdPath}:${ENCLAVE_SERVER_GITHUB_AGENT_ID_PATH}:ro`,

--- a/src/types/enclave-options.ts
+++ b/src/types/enclave-options.ts
@@ -328,6 +328,20 @@ export function isEnclaveAgentGithubToolsEnabled(
 }
 
 /**
+ * Whether the enclave agent reaches GitHub through the shared MCP gateway at
+ * all — under the static `issues-read-v1`/`agent.tools.github` profile, or
+ * through the per-invocation delegated identities of a dynamic entry.
+ *
+ * Both shapes need the gateway attached to the enclave agent network; only the
+ * static shape has a compiler-issued agent identity.
+ */
+export function isEnclaveAgentGithubRouteEnabled(
+  agent: Pick<EnclaveAgentExecutorConfig, 'github' | 'tools' | 'dynamic'> | undefined,
+): boolean {
+  return isEnclaveAgentGithubToolsEnabled(agent) || agent?.dynamic !== undefined;
+}
+
+/**
  * Resolves the closed set of GitHub MCP tools configured for this enclave
  * agent, normalizing the legacy marker to its fixed pair. Returns `undefined`
  * when the GitHub gateway is not requested.


### PR DESCRIPTION
> [!IMPORTANT]
> **Superseded on one point after merge.** This PR described `requested_ttl` and
> `max_identity_ttl` as Go `time.Duration` **nanoseconds**. The ecosystem
> resolved the units mismatch in the opposite direction: mcpg **v0.4.18** added
> `internal/delegation/wire.go`, which decodes both fields as **whole seconds**.
> AWF was realigned in #8292, gh-aw in `github/gh-aw#59292`. The sections below
> are preserved as the historical record; see
> [Post-merge units correction](#post-merge-units-correction) for the contract
> that actually shipped.

Implements the remaining AWF runtime path for dynamic, GitHub-MCP-backed agent enclaves under [ADR 0001](https://github.com/github/gh-aw-firewall/blob/main/docs/adr/0001-agent-enclaves.md).

A dynamic entry now selects one canonical repository at runtime, receives one short-lived `github-repository-read-v1` identity minted through mcpg's private delegation control channel, and reads that repository through GitHub MCP **without cloning or mounting a seed**. Dynamic script execution remains out of scope.

Refs #8195. Deliberately does not auto-close it — see [Blocked upstream](#blocked-upstream).

## Architecture

### Who holds what

The enclave subsystem is a chain of components with deliberately unequal privilege, and the topology is what keeps them apart.

| Component | Holds | Confined by |
| --- | --- | --- |
| **primary agent** | nothing enclave-related | default-deny egress; no socket, capability, URL, seed, or ledger state |
| **mcpg** (`awmg-mcpg`, image `ghcr.io/github/gh-aw-mcpg`) | the executor-facing data plane **and** the AWF-only control plane | capability authentication; compiler-launched, AWF only attaches |
| **broker** (`enclave-mcp-server`) | **the Docker socket, rw** + work/audit/seed mounts | one internal network, membership asserted, no egress |
| **executor** | one short-lived repository bearer | single-use, `--cap-drop ALL`, read-only, seccomp, one internal network |
| **AWF host process** | the delegation control capability + admission registry | never mounted into any container |

The broker is the sharp edge: a `docker.sock:rw` mount is root-equivalent on the runner, so anything that reaches *and* authenticates to it can launch arbitrary containers. That is why it joins exactly one internal network, why AWF asserts that network's membership is precisely `{broker, mcpg}` and aborts on a third member, and why the network is `internal: true` — it holds repository content and must not be able to ship it anywhere. The same threat modelled from the other end is why `enclaves` refuses `--enable-dind` or a Docker-socket volume mount: exactly one component may hold the socket, and nothing the agent controls may reach it.

Note the direction of the one permitted adjacency: mcpg is admitted as a peer *on the broker's network*. The broker never joins a network where an untrusted workload lives.

### Network homing

Several components are multi-homed, so this is stated explicitly rather than implied by a diagram:

| Component | Networks | Address / note |
| --- | --- | --- |
| agent (primary) | `awf-net` | 172.30.0.20 |
| squid | `awf-net`, `awf-ext` | 172.30.0.10 — dual-homed, sole egress |
| api-proxy | `awf-net` (+ `awf-ext`) | 172.30.0.30; `awf-ext` only when the agent is not in compose (microVM) |
| doh-proxy / cli-proxy | `awf-net` | 172.30.0.40 / 172.30.0.50 |
| **mcpg** | `awf-net`, `awf-enclave-mcp-control`, `awf-enclave-agent`, host loopback | 172.31.0.40; **four planes** |
| **broker** | `awf-enclave-mcp-control` | **one network only**; alias `awf-enclave-mcp` |
| executor | `awf-enclave-agent` | single-use |
| enclave-agent-api-proxy | `awf-enclave-agent`, `awf-enclave-agent-egress` | 172.31.0.30 — direct egress, never via Squid |
| script enclave | none | `--network none` |
| AWF host process | host — no Docker network | reaches `127.0.0.1` only |

`docs/enclaves-architecture.md` carries this as a mermaid diagram.

### Why the control client runs in the AWF host process

gh-aw starts mcpg with `docker run -p 127.0.0.1:<port>:<port>`, so **the published control port** is reachable only from the runner's own loopback interface; gh-aw's own source says as much (*"Only the AWF host process receives this variable"*). No container can reach a `127.0.0.1`-published port through the host.

That is workable because `awf` is not a fire-and-forget launcher. It blocks on `docker wait` for the whole run (`container-lifecycle.ts:446`), propagates the agent's exit code, and states the invariant outright — *"ensure the agent cannot outlive the awf process."* It already streams logs and enforces the agent timeout concurrently, so the control client and admission loop live inside a window that is already supervised.

The broker still has to route every `enclave_run_agent` through canonical admission before repository content is exposed, so it asks the host over an AWF-private request/response directory inside the `0700` enclave private root, bind-mounted only into the broker. **No new network listener is created**, so nothing new becomes reachable from `awf-net`, the enclave agent network, the general MCP route, or the host's external interfaces. If AWF dies mid-run the channel stops answering, admission times out, and the invocation fails closed.

```
primary agent ──mcpg /mcp/awf-enclave──▶ enclave MCP broker (container)
                                              │
                          admission request   │ 0700 bind mount, no network
                          settlement report   ▼
                                        AWF host process
                                              │ Authorization: <control capability>
                                              ▼
                    http://127.0.0.1:<port>/internal/awf-enclave-mcp-control/*
                                              │
                                              ▼
                                   mcpg delegation controller
                                              │ executor bearer
                                              ▼
executor (awf-enclave-agent network) ──▶ mcpg /mcp/github ──▶ admitted repository
```

The channel carries the caller's selector, the exact finite output-schema hash, one repository, one executor bearer, and one settlement. It never carries the control endpoint, the control capability, the identity handle, the compiler envelope, mcpg's state path, or its policy generation.

## What changed

### Startup and private handoff

- Strict endpoint validation: literal loopback hosts only (`127.0.0.1`, `[::1]`), the exact mcpg control path, no credentials/query/fragment. `localhost` is rejected as resolver-dependent — a poisoned `/etc/hosts` or NSS module must not be able to point an AWF-only capability at another listener. An omitted or explicit `:80` both resolve to 80, since the WHATWG URL parser normalizes them identically.
- Custody is taken before any inherited environment is assembled, on every run including static-only ones, and staged into the `0700` private root with exclusive `0600` files. Neither value is ever mounted into the broker, the executor, the model sidecar, the general MCP route, or the delegated data plane; both are in the primary agent's exclusion set.
- A missing, partial, or malformed handoff is terminal. There is no fallback to a static seed catalog, a job-lifetime identity, or a broader policy.
- Dynamic-only runs need no `GH_TOKEN`/`GITHUB_TOKEN`, clone nothing, write no seed catalog (not even an empty one), and mount neither `/awf/seed` nor a seed map. Static and separate static+dynamic behaviour is unchanged.

### mcpg v0.4.17 control client

Strict clients for `create-or-confirm`, `status`, `reconcile`, `revoke`, and `revoke-by-labels`. Operation paths are **siblings** of the controller name in the exported endpoint, not children of it. `requested_ttl` is a duration on the wire; timestamps are RFC 3339. (As merged this was nanoseconds; the shipped contract is whole seconds — see the note at the top.) Bodies are bounded, timeouts explicit, and every response is validated against the request before it is trusted: non-empty handle and bearer, exact repository match, `github-repository-read-v1`, exactly `list_issues` + `issue_read`, matching SHA when one was requested, and an expiry no later than the requested TTL or the invocation deadline.

### Broker integration and lifecycle

- One `DynamicRepositoryRegistry` per dynamic entry; `enclave_run_agent` goes through canonical admission — form, envelope, `maxRepositories`, expiry, run-wide quota reservation, shared disclosure ledger — before any workspace, container, or bearer exists.
- Recovery calls `status`, revokes stale labelled identities, then `reconcile`. Admissions stay blocked until that sequence succeeds.
- Every terminal path settles the reserved output-byte and execution-second quotas and revokes the identity: success, agent failure, schema failure, timeout, cancellation, broker error, shutdown, and an unexpected throw. `revoke-by-labels` sweeps at teardown. An unresolved revocation re-blocks admissions and downgrades the invocation to the canonical error rather than returning a success-shaped result.
- Invocation charges stay committed after a failure, per the ADR: the envelope revealed the opportunity to spend them the moment it admitted the repository.

### Dynamic executor

- Invocation-private, bearer-only GitHub MCP configuration confined to `list_issues` and `issue_read` for the one admitted repository. No job token, control capability, handle, envelope, state path, generation, or control endpoint — so it cannot *authenticate* to the control plane (see the correction below for why that is the accurate claim rather than unreachability).
- Instructions rewritten away from `/awf/seed`: no checkout exists, and cloning, arbitrary URLs, the GitHub CLI, writes, unscoped search, organization/global discovery, and sibling-repository access are all prohibited and fail closed.
- The optional admitted SHA is **omitted** rather than obtained by widening a token or tool: AWF has no already-authorized, repository-confined path to resolve one before the identity exists, and `github-repository-read-v1` grants only the two read tools afterwards. Reads are therefore audited as `live`, and marked `pinned` only when the control binding actually carries a resolved SHA.

## Review findings fixed in this PR

A code-review pass found three defects that each made the feature non-functional and were invisible to the suite because the tests entered the pipeline below the broken seam. All three are fixed in `dac7fb87` with regression coverage at the layer that was bypassed:

1. `runMainWorkflow` validated the enclave configuration *before* `prepareEnclaves` took custody of the handoff, so every dynamic run aborted at startup. Taking custody deletes both environment variables, so exactly one caller may read them; the early gate now validates structure only and defers the handoff check to that single custodian, which still runs before any container exists.
2. The per-invocation binding was passed to the runner in a config object `runEnclaveContainer` never read, so every executor launched with `AWF_ENCLAVE_AGENT_DYNAMIC_REPO=undefined`. The binding now flows through the spec builder, which revalidates the admitted repository and read mode; only those two scalars may vary per invocation, and reconciliation paths skip the launch-only checks.
3. The broker's per-launch network-isolation proof admitted the shared gateway only for the static profile, so it rejected the very topology a dynamic run creates. It now admits the gateway for either shape, with the real container name.

A follow-up pass confirmed the fixes and found nothing new.

## Correction to an inherited reachability claim

Worth flagging explicitly for review. An earlier revision of this branch stated that neither the primary agent, the broker, the executor, nor the model sidecar "can route to" mcpg's delegation control listener. That was taken from gh-aw's own comment (`enclaves.go:56-57`) and repeated without verification. It does not follow, and `4783af78` corrects the docs and source comments.

`-p 127.0.0.1:<port>:<port>` bounds who can reach the port *through the host*. Under network isolation gh-aw binds the **in-container** listener to `0.0.0.0` — it has to, since Docker NATs a published port to the container's bridge IP and a container-local `127.0.0.1` bind would be unreachable. A peer sharing a Docker network with mcpg addresses the container IP directly and never traverses the published port. Because mcpg is a single container serving both planes, and the executor sits with it on `awf-enclave-agent` at `172.31.0.40`, publication scope does not hold the executor off the control port.

Nothing in the implementation changes. The control plane was always protected by the AWF-only 256-bit capability, which is never placed in any container's environment or mount, and which mcpg checks on every request before returning `403 delegation_access_denied`. The enforced control is **authentication**, which is the stronger property; the prose simply described it as the weaker and incorrect one. The primary agent is additionally constrained by the agent container's default-deny egress (`containers/agent/setup-iptables.sh:480`); the executor is not, so it relies on capability authentication alone.

This is the asymmetry worth carrying into review: the **broker** gets two independent controls (network non-membership *plus* authentication), because it can be confined to one network. **mcpg** gets one, because a single container serving two planes must be co-attached with every peer it serves.

Two caveats: the `0.0.0.0` bind is conditional on `isAWFNetworkIsolationEnabled` in gh-aw and is not empirically confirmed here, and the executor runs `--cap-drop ALL`. This is a gap in the *description*, not a known break — but gh-aw's comment is worth correcting upstream.

## Validation

- `npm run lint` — 0 errors
- `npm run type-check` — clean
- `npm run build` — clean
- `npx jest` — **356 suites / 5801 tests pass** (up from 348 / 5600 on `main`), no leaked handles

New coverage: endpoint/capability preflight and custody, the exact mcpg wire contract and response validation, a cross-component fixture pinned to gh-aw and mcpg v0.4.17 so drift fails a test, host-side admission/recovery/settlement/shutdown, the private channel end to end against a real loopback control server, broker topology and mount absence, bearer-only executor configuration, dynamic-only staging, retry and concurrency, quota settlement, revocation on every path, audit redaction, the admission channel's translation under a split ARC/DinD filesystem, and static regression. The vacuous test added by #8233 is replaced with handoff-driven cases, and its dead validator and path constants are removed.

No enclave integration tests exist in `tests/integration` (they would need Docker plus a live mcpg and gh-aw); container behaviour is covered the way the rest of this subsystem is, by requiring the container JS directly from Jest.

## Post-merge units correction

**Resolved.** At merge time this PR was blocked: gh-aw emitted `max_identity_ttl` as an integer of seconds while mcpg v0.4.17 decoded it as `time.Duration` nanoseconds, so a 120-second enclave installed a 120-*nanosecond* ceiling and every `create-or-confirm` returned `403 delegation_request_denied`.

The fix landed as **seconds everywhere**, not nanoseconds everywhere:

| Component | Resolution |
| --- | --- |
| **mcpg v0.4.18** | Added `internal/delegation/wire.go`. `EnvelopeWire.MaxIdentityTTLSeconds` and `CreateOrConfirmRequestWire.RequestedTTLSeconds` are `int64` seconds, converted by `durationFromWireSeconds`. |
| **gh-aw** | `buildMCPGatewayDelegationEnvelope` keeps `"max_identity_ttl": enclave.Timeout` (seconds). `github/gh-aw#59290`, which had switched it to nanoseconds, was superseded by `github/gh-aw#59292` (commit `7378bee1`). |
| **AWF** | #8292 changed `requested_ttl` to whole seconds. `secondsToGoDurationNanos` is gone; the contract fixture now pins `requested_ttl: 120`. |

Verified by decoding AWF's real emitted request bytes through mcpg v0.4.18's actual `wire.go`:

```
AWF requested_ttl on wire = 120 -> decoded 2m0s
gh-aw max_identity_ttl on wire = 120 -> decoded 2m0s
PASS: AWF 120s request accepted by gh-aw 120s envelope under mcpg v0.4.18
```

The superseded nanosecond value now fails closed, confirming the direction is enforced rather than merely conventional:

```
FAIL ToRequest: requested_ttl exceeds the maximum supported duration
```

Shipped versions: AWF **v0.28.14**, mcpg **v0.4.18**, gh-aw `DefaultFirewallVersion` and `AWFDynamicRepositoryEnclaveMinVersion` both **v0.28.14**, `DefaultMCPGatewayVersion` **v0.4.18**.

## Still open

`github/gh-aw#59268` — the delegation control listener is reachable from container peers that share mcpg's bridge network, because `-p 127.0.0.1:...` bounds only host-published access. Capability authentication still holds, so this is a missing defence-in-depth guarantee rather than an authorization bypass, but #8195's network-isolation criterion is not yet satisfied.

Remaining follow-ups from the issue's release checklist are also out of this repository's scope: updating gh-aw's `AWFDynamicRepositoryEnclaveMinVersion` from the provisional `v0.28.14` to the actual AWF release, bumping `DefaultFirewallVersion`, and completing #8192.


