### PR TITLE
fix: send delegation TTLs in seconds

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -45,4 +45,4 @@ max_retries = 3
 max_concurrency = 10
 
 # Don't check mail addresses
-exclude_mail = true
+include_mail = false

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -46,3 +46,6 @@ max_concurrency = 10
 
 # Don't check mail addresses
 include_mail = false
+
+# Resolve site-root links against the deployed GitHub Pages site
+base_url = "https://github.github.io"

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -9,6 +9,10 @@ exclude = [
   "^https?://example\\.com",
   "^https?://your-",
   "^https?://grafana\\.internal",
+  # Site-root links target the generated GitHub Pages deployment, not repository files
+  "^file:///gh-aw-firewall/",
+  # Example site routes in the technical-writer agent instructions
+  "^file:///(getting-started|guides|reference)/",
   # Template variables in workflow .md files and release templates
   "%7B",
   "\\{\\{",
@@ -47,5 +51,5 @@ max_concurrency = 10
 # Don't check mail addresses
 include_mail = false
 
-# Resolve site-root links against the deployed GitHub Pages site
-base_url = "https://github.github.io"
+# Resolve root-relative URLs before excluding deployed GitHub Pages routes
+root_dir = "/"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
 

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -16,6 +16,9 @@
         "esbuild": "^0.28.1",
         "mermaid": "^11.17.2",
         "sharp": "^0.35.3"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -8161,6 +8164,19 @@
       "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
       "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha1-kCUdwAeRbpcnhsuU100VsYVXfSE=",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/typescript-auto-import-cache": {
       "version": "0.3.6",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -19,6 +19,9 @@
     "mermaid": "^11.17.2",
     "sharp": "^0.35.3"
   },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  },
   "overrides": {
     "diff": "8.0.3",
     "esbuild": "^0.28.1",

--- a/docs/awf-config-spec.md
+++ b/docs/awf-config-spec.md
@@ -1884,7 +1884,7 @@ The `dynamic` object is byte-for-byte the envelope the gh-aw compiler emits. An 
 - `executor` — fixed to `agent`; any other value is rejected.
 - `githubPolicy` — fixed to `{ version: "github-repository-read-v1", tools: ["list_issues", "issue_read"] }`. Any other version, tool set, or additional tool is rejected; this is the sole supported dynamic GitHub policy.
 - `maxRepositories` — integer `1..1000`: distinct repositories this envelope may admit for the run.
-- `limits` — per-invocation trusted bounds, all REQUIRED: `timeoutSeconds` (`1..4740`), `memoryLimit`, `cpuLimit`, `pidsLimit` (`1..4096`), `tmpfsLimit`, `maxOutputBytes` (`1..8192`), `maxTaskBytes` (`1..65536`), `maxModelRequests` (`1..64`), `maxModelTokens` (`1..32768`). These are the same resource and response controls a static agent entry declares at entry level.
+- `limits` — per-invocation trusted bounds, all REQUIRED: `timeoutSeconds` (`1..4740`, whole seconds), `memoryLimit`, `cpuLimit`, `pidsLimit` (`1..4096`), `tmpfsLimit`, `maxOutputBytes` (`1..8192`), `maxTaskBytes` (`1..65536`), `maxModelRequests` (`1..64`), `maxModelTokens` (`1..32768`). These are the same resource and response controls a static agent entry declares at entry level.
 - `quotas` — run-wide totals debited across every admission under this envelope, all REQUIRED: `maxInvocations` (`1..10000`), `maxOutputBytes` (`1..1048576`), `maxExecutionSeconds` (`1..86400`).
 - `auditLabels` — a non-empty, unique array of at most 32 opaque labels matching `^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$`. Labels are what AWF and mcpg reconcile dynamic state against at shutdown; they are never repository names or credentials.
 - `expiresAt` — an absolute ISO-8601 timestamp, never later than the workflow job lifetime; admission at or after this time is denied.
@@ -1964,8 +1964,9 @@ explicit timeouts, and strict JSON validation:
 | revoke by labels | `/internal/awf-enclave-mcp-control/revoke-by-labels` |
 
 Operation paths are siblings of the controller name in the exported endpoint,
-not children of it. `requested_ttl` is a Go `time.Duration`, i.e. an integer
-number of **nanoseconds**; timestamps are RFC 3339.
+not children of it. `requested_ttl` is a positive whole number of seconds,
+matching the user-configured `limits.timeoutSeconds` and mcpg's
+`max_identity_ttl` unit; timestamps are RFC 3339.
 
 Every create-or-confirm response is verified before it is trusted: non-empty
 handle and executor bearer, an exact repository match against the admitted

--- a/docs/awf-config.schema.json
+++ b/docs/awf-config.schema.json
@@ -1356,7 +1356,8 @@
                   "timeoutSeconds": {
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 4740
+                    "maximum": 4740,
+                    "description": "Per-invocation wall-clock budget in whole seconds. AWF forwards this value unchanged as the delegation requested_ttl."
                   },
                   "memoryLimit": {
                     "type": "string",

--- a/src/awf-config-schema.json
+++ b/src/awf-config-schema.json
@@ -1356,7 +1356,8 @@
                   "timeoutSeconds": {
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 4740
+                    "maximum": 4740,
+                    "description": "Per-invocation wall-clock budget in whole seconds. AWF forwards this value unchanged as the delegation requested_ttl."
                   },
                   "memoryLimit": {
                     "type": "string",

--- a/src/enclave/delegation-control-client.test.ts
+++ b/src/enclave/delegation-control-client.test.ts
@@ -5,7 +5,7 @@ import {
   DELEGATION_TOOL_POLICY,
   DelegationControlClient,
   DelegationControlError,
-  secondsToGoDurationNanos,
+  validateRequestedTtlSeconds,
 } from './delegation-control-client';
 import { parseEnclaveDynamicDelegationControlEndpoint } from './dynamic-delegation-handoff';
 
@@ -100,13 +100,13 @@ describe('mcpg delegation control wire contract', () => {
     );
   });
 
-  it('encodes requested_ttl as an integer number of Go nanoseconds', async () => {
+  it('encodes requested_ttl as an exact integer number of seconds', async () => {
     await withControlServer(
       () => ({ status: 200, body: identityBody() }),
       async (client, captured) => {
         await client.createOrConfirm(baseRequest);
         const body = captured[0].body as Record<string, unknown>;
-        expect(body.requested_ttl).toBe(120 * 1_000_000_000);
+        expect(body.requested_ttl).toBe(120);
         expect(Number.isInteger(body.requested_ttl)).toBe(true);
       },
     );
@@ -374,9 +374,9 @@ describe('mcpg delegation control response validation', () => {
   });
 
   it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER])(
-    'refuses to encode %s seconds as a Go duration',
+    'refuses invalid requested TTL value %s',
     (seconds) => {
-      expect(() => secondsToGoDurationNanos(seconds)).toThrow(DelegationControlError);
+      expect(() => validateRequestedTtlSeconds(seconds)).toThrow(DelegationControlError);
     },
   );
 });

--- a/src/enclave/delegation-control-client.ts
+++ b/src/enclave/delegation-control-client.ts
@@ -11,9 +11,8 @@
  *   compiler exports, not a child of it;
  * - the AWF-only capability travels in `Authorization`;
  * - request bodies are bounded (mcpg caps them at 64 KiB);
- * - `requested_ttl` is a Go `time.Duration`, i.e. an **integer number of
- *   nanoseconds**, and `invocation_expires_at` / `expires_at` are RFC 3339
- *   timestamps;
+ * - `requested_ttl` is a positive whole number of seconds, and
+ *   `invocation_expires_at` / `expires_at` are RFC 3339 timestamps;
  * - `admitted_default_branch_sha` is optional on both the request and the
  *   response.
  *
@@ -39,7 +38,6 @@ export const DELEGATION_TOOLS: readonly string[] = Object.freeze(['issue_read', 
  */
 export const DELEGATION_ENCLAVE_BACKEND = 'github';
 
-const NANOSECONDS_PER_SECOND = 1_000_000_000;
 const MAX_CONTROL_RESPONSE_BYTES = 128 * 1024;
 const DEFAULT_CONTROL_TIMEOUT_MS = 10_000;
 
@@ -78,7 +76,7 @@ export interface DelegationCreateOrConfirmRequest {
   invocationId: string;
   repository: string;
   schemaHash: string;
-  /** Requested identity lifetime in whole seconds; converted to nanoseconds. */
+  /** Requested identity lifetime in whole seconds; sent unchanged on the wire. */
   requestedTtlSeconds: number;
   /** Absolute invocation deadline; an identity can never outlive it. */
   invocationExpiresAt: Date;
@@ -118,8 +116,8 @@ interface ControlResponse {
   body: string;
 }
 
-/** Converts whole seconds to the integer nanoseconds Go's `time.Duration` decodes. */
-export function secondsToGoDurationNanos(seconds: number): number {
+/** Validates the whole-second TTL used by the control wire contract. */
+export function validateRequestedTtlSeconds(seconds: number): number {
   if (!Number.isSafeInteger(seconds) || seconds < 1) {
     throw new DelegationControlError(
       'malformed-request',
@@ -127,15 +125,14 @@ export function secondsToGoDurationNanos(seconds: number): number {
       'requested TTL must be a positive whole number of seconds',
     );
   }
-  const nanos = seconds * NANOSECONDS_PER_SECOND;
-  if (!Number.isSafeInteger(nanos)) {
+  if (!Number.isSafeInteger(seconds * 1000)) {
     throw new DelegationControlError(
       'malformed-request',
       'create-or-confirm',
-      'requested TTL overflows a safe integer number of nanoseconds',
+      'requested TTL overflows a safe integer number of milliseconds',
     );
   }
-  return nanos;
+  return seconds;
 }
 
 export class DelegationControlClient {
@@ -157,7 +154,7 @@ export class DelegationControlClient {
    * request before it is handed to a caller.
    */
   async createOrConfirm(request: DelegationCreateOrConfirmRequest): Promise<DelegationIdentity> {
-    const requestedTtlNanos = secondsToGoDurationNanos(request.requestedTtlSeconds);
+    const requestedTtlSeconds = validateRequestedTtlSeconds(request.requestedTtlSeconds);
     const body: Record<string, unknown> = {
       run_id: request.runId,
       enclave_backend: DELEGATION_ENCLAVE_BACKEND,
@@ -166,7 +163,7 @@ export class DelegationControlClient {
       repository: request.repository,
       tool_policy: DELEGATION_TOOL_POLICY,
       schema_hash: request.schemaHash,
-      requested_ttl: requestedTtlNanos,
+      requested_ttl: requestedTtlSeconds,
       invocation_expires_at: request.invocationExpiresAt.toISOString(),
       idempotency_key: request.idempotencyKey,
     };
@@ -174,7 +171,7 @@ export class DelegationControlClient {
       body.admitted_default_branch_sha = request.admittedDefaultBranchSha;
     }
     const decoded = await this.post('create-or-confirm', body);
-    return this.verifyIdentity(decoded, request, requestedTtlNanos);
+    return this.verifyIdentity(decoded, request, requestedTtlSeconds);
   }
 
   /** Reads the controller's recovery state and this label pair's live handles. */
@@ -255,7 +252,7 @@ export class DelegationControlClient {
   private verifyIdentity(
     decoded: Record<string, unknown>,
     request: DelegationCreateOrConfirmRequest,
-    requestedTtlNanos: number,
+    requestedTtlSeconds: number,
   ): DelegationIdentity {
     const fail = (detail: string): never => {
       throw new DelegationControlError('contract-violation', 'create-or-confirm', detail);
@@ -299,7 +296,7 @@ export class DelegationControlClient {
     // mcpg computes ExpiresAt as now + RequestedTTL, capped by the envelope and
     // the invocation deadline, so a longer-lived identity means the controller
     // ignored the requested bound.
-    const ttlCeilingMs = Date.now() + requestedTtlNanos / 1_000_000;
+    const ttlCeilingMs = Date.now() + requestedTtlSeconds * 1000;
     if (expiresAt.getTime() > ttlCeilingMs) {
       fail('identity outlives the requested TTL');
     }

--- a/src/enclave/dynamic-delegation-contract.test.ts
+++ b/src/enclave/dynamic-delegation-contract.test.ts
@@ -21,7 +21,7 @@ import {
   DELEGATION_TOOLS,
   DELEGATION_TOOL_POLICY,
   DelegationControlClient,
-  secondsToGoDurationNanos,
+  validateRequestedTtlSeconds,
 } from './delegation-control-client';
 import {
   DELEGATION_CONTROLLER_NAME,
@@ -168,8 +168,8 @@ describe('mcpg v0.4.17 wire contract', () => {
     }
   });
 
-  it('encodes Go time.Duration as integer nanoseconds and time.Time as RFC 3339', async () => {
-    expect(secondsToGoDurationNanos(1)).toBe(1_000_000_000);
+  it('encodes requested TTL as exact integer seconds and time.Time as RFC 3339', async () => {
+    expect(validateRequestedTtlSeconds(1)).toBe(1);
     await client.createOrConfirm({
       runId: '18234567890-2',
       enclaveEntryId: 'agent',
@@ -182,7 +182,7 @@ describe('mcpg v0.4.17 wire contract', () => {
       admittedDefaultBranchSha: 'a'.repeat(40),
     });
     const body = captured[captured.length - 1].body as Record<string, unknown>;
-    expect(body.requested_ttl).toBe(120 * 1_000_000_000);
+    expect(body.requested_ttl).toBe(120);
     expect(Number.isInteger(body.requested_ttl)).toBe(true);
     expect(body.invocation_expires_at).toBe('2999-01-01T00:00:00.000Z');
   });

--- a/src/types/enclave-options.ts
+++ b/src/types/enclave-options.ts
@@ -162,7 +162,7 @@ export interface EnclaveDynamicGithubPolicy {
  * `max-model-requests`, and `max-model-tokens` before it compiles.
  */
 export interface EnclaveDynamicLimits {
-  /** Per-invocation wall-clock budget in seconds. Named for the compiler's `timeoutSeconds`. */
+  /** Whole-second wall-clock budget, forwarded unchanged as delegation `requested_ttl`. */
   timeoutSeconds: number;
   memoryLimit: string;
   cpuLimit: string;


### PR DESCRIPTION
## Summary

- send `requested_ttl` to gh-aw-mcpg as the configured whole-second value without nanosecond conversion
- preserve positive-integer and safe expiry-bound validation
- pin the seconds-only wire contract in unit/contract tests and document it in the config schema and specification

## Coordinated contract

This PR is the `github/gh-aw-firewall` part of a coordinated seconds-only TTL wire contract across:

- `github/gh-aw`: https://github.com/github/gh-aw/pull/59292
- `github/gh-aw-firewall` (this PR)
- `github/gh-aw-mcpg`: https://github.com/github/gh-aw-mcpg/pull/12686

The user-facing configuration, mcpg `max_identity_ttl`, and control request `requested_ttl` are all expressed in seconds end to end.

## Validation

- `npm test -- --runInBand src/enclave/delegation-control-client.test.ts src/enclave/dynamic-delegation-contract.test.ts src/enclave/dynamic-delegation-service.test.ts` (77 tests)
- `npm run type-check -- --pretty false`
- `npx eslint src/enclave/delegation-control-client.ts src/enclave/delegation-control-client.test.ts src/enclave/dynamic-delegation-contract.test.ts src/types/enclave-options.ts`
- generated schema/runtime schema comparison
- `git diff --check`